### PR TITLE
Fixed bug in TiGLViewer when loading a cpacs file with multiple models.

### DIFF
--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -150,7 +150,9 @@ TiglReturnCode TIGLViewerDocument::openCpacsConfiguration(const QString fileName
     tixiRet = tixiGetNamedChildrenCount( tixiHandle, CPACS_XPATH_ROTORCRAFT, "model", &countRotorcrafts );
     for (int i = 0; i < countAircrafts; i++) {
         char *text;
-        tixiRet = tixiGetTextAttribute( tixiHandle, CPACS_XPATH_AIRCRAFT_MODEL, "uID", &text);
+        char xpath[90];
+        sprintf(xpath, "%s[%d]", CPACS_XPATH_AIRCRAFT_MODEL, i+1);
+        tixiRet = tixiGetTextAttribute( tixiHandle, xpath, "uID", &text);
         if (tixiRet == SUCCESS) {
             configurations << text;
         }
@@ -161,7 +163,9 @@ TiglReturnCode TIGLViewerDocument::openCpacsConfiguration(const QString fileName
     }    
     for (int i = 0; i < countRotorcrafts; i++) {
         char *text;
-        tixiRet = tixiGetTextAttribute(tixiHandle, CPACS_XPATH_ROTORCRAFT_MODEL, "uID", &text);
+        char xpath[90];
+        sprintf(xpath, "%s[%d]", CPACS_XPATH_ROTORCRAFT_MODEL, i+1);
+        tixiRet = tixiGetTextAttribute(tixiHandle, xpath, "uID", &text);
         if (tixiRet == SUCCESS) {
             configurations << text;
         }


### PR DESCRIPTION
Not sure if setting the char length to a constant 90 is adviseable, but my C++ skills have suffert from a couple of years of python. :)
