### PR TITLE
Fixed guide curves not in x-z plane (bug 125)

### DIFF
--- a/src/fuselage/CCPACSFuselageProfile.cpp
+++ b/src/fuselage/CCPACSFuselageProfile.cpp
@@ -331,7 +331,7 @@ void CCPACSFuselageProfile::BuildWires(void)
                 continue;
             }
             curP.SetY(-1. * curP.Y());
-            //tmpPoints.push_back(curP);
+            tmpPoints.push_back(curP);
         }
         points = tmpPoints;
     }

--- a/src/geometry/CTiglSymetricSplineBuilder.cpp
+++ b/src/geometry/CTiglSymetricSplineBuilder.cpp
@@ -1,0 +1,125 @@
+/* 
+* Copyright (C) 2015 German Aerospace Center (DLR/SC)
+*
+* Created: 2015-06-10 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "CTiglSymetricSplineBuilder.h"
+
+#include "CTiglError.h"
+
+#include <TColgp_HArray1OfPnt.hxx>
+#include <GeomAPI_Interpolate.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <GeomConvert.hxx>
+#include <Precision.hxx>
+
+#include <cassert>
+
+namespace
+{
+    // Symmetrizes two control points along the x-z plane
+    void symPole(Handle_Geom_BSplineCurve c, int i1, int i2) {
+        gp_Pnt p1 = c->Pole(i1);
+        gp_Pnt p2 = c->Pole(i2);
+
+        assert(fabs(p1.Y() + p2.Y()) < Precision::Confusion());
+        // z will be symmetrized
+        double pmeanz = (p1.Z() + p2.Z())/2.;
+        double pmeany = (p1.Y() - p2.Y())/2.;
+
+        p1.SetY(pmeany);
+        p2.SetY(-pmeany);
+        p1.SetZ(pmeanz);
+        p2.SetZ(pmeanz);
+
+        c->SetPole(i1, p1);
+        c->SetPole(i2, p2);
+    }
+}
+
+namespace tigl
+{
+
+CTiglSymetricSplineBuilder::CTiglSymetricSplineBuilder(const CTiglSymetricSplineBuilder::CPointContainer& points)
+    : _points(points)
+{
+}
+
+Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSpline() const
+{
+    checkInputData();
+
+    CPointContainer points = _points;
+
+    // mirror each point at x-z plane i.e. mirror y coordinate to close the profile
+    // and skip first point
+    for (int i = _points.size() - 1; i > 0; i--) {
+        gp_Pnt curP = _points[i];
+        if (i == _points.size()-1 && fabs(curP.Y()) < 1e-6) {
+            // do not add the same points twice
+            continue;
+        }
+        curP.SetY(-1. * curP.Y());
+        points.push_back(curP);
+    }
+
+    // build interpolation curve
+    Handle_TColgp_HArray1OfPnt pnts = new TColgp_HArray1OfPnt(1,points.size());
+    for (unsigned int i = 0; i < points.size(); ++i) {
+        pnts->SetValue(i+1, points[i]);
+    }
+
+    // The interpolation gives a closed but unsymmetric result
+    GeomAPI_Interpolate interpolator(pnts, true, 1e-7);
+    interpolator.Perform();
+
+    Handle_Geom_BSplineCurve c = interpolator.Curve();
+    // This is required in order to get a clamped bspline
+    // with symmetric knots
+    c->SetNotPeriodic();
+
+    // symmetrize control points
+    for (int icp = 1; 2*icp <= c->NbPoles(); ++icp) {
+        int i1 = icp;
+        int i2 = c->NbPoles() - icp + 1;
+        symPole(c, i1, i2);
+    }
+
+    // trim the curve to the first half
+    double umin, umax;
+    umin = c->FirstParameter();
+    umax = c->LastParameter();
+    assert(fabs(c->Value((umin+umax)/2.).Y()) < Precision::Confusion());
+
+    c = GeomConvert::CurveToBSplineCurve(new Geom_TrimmedCurve(c, umin, (umin+umax)/2.));
+
+    return c;
+}
+
+void CTiglSymetricSplineBuilder::checkInputData() const
+{
+    gp_Pnt pstart = _points[0];
+    
+    // the first point must start at the symmetry plane
+    if (fabs(pstart.Y()) > Precision::Confusion()) {
+        throw CTiglError("First point does not lie on x-z Plane (CTiglSymetricSplineBuilder::GetBSpline)!");
+    }
+}
+
+
+} // namespace tigl
+

--- a/src/geometry/CTiglSymetricSplineBuilder.h
+++ b/src/geometry/CTiglSymetricSplineBuilder.h
@@ -39,7 +39,7 @@ namespace tigl
  * it matches the input data)
  * 
  * Currently, only splines symmetric to the x-z plane are supported.
- * The y-Coordinate of the first point must be exactly zero!
+ * The y-Coordinate of the first and the last point must be exactly zero!
  */
 class CTiglSymetricSplineBuilder
 {
@@ -51,6 +51,7 @@ public:
     TIGL_EXPORT Handle_Geom_BSplineCurve GetBSpline() const;
 
 private:
+    Handle_Geom_BSplineCurve GetBSplineInternal(const CPointContainer& inputPoints) const;
     void checkInputData() const;
 
     const CPointContainer& _points;

--- a/src/geometry/CTiglSymetricSplineBuilder.h
+++ b/src/geometry/CTiglSymetricSplineBuilder.h
@@ -1,0 +1,61 @@
+/* 
+* Copyright (C) 2015 German Aerospace Center (DLR/SC)
+*
+* Created: 2015-06-10 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef CTIGLSYMETRICSPLINEBUILDER_H
+#define CTIGLSYMETRICSPLINEBUILDER_H
+
+#include "tigl_internal.h"
+
+#include <gp_Pnt.hxx>
+#include <vector>
+
+class Handle_Geom_BSplineCurve;
+
+namespace tigl
+{
+
+/**
+ * @brief CTiglSymetricSplineBuilder creates an interpolating
+ * BSpline, that is symmetric to a main axis plane.
+ * 
+ * The algorithm mirrors each point at the symmetry plane
+ * and computes the bspline and symmetrizes it. Finally,
+ * the BSpline is trimmed to the first half of the curve (i.e.
+ * it matches the input data)
+ * 
+ * Currently, only splines symmetric to the x-z plane are supported.
+ * The y-Coordinate of the first point must be exactly zero!
+ */
+class CTiglSymetricSplineBuilder
+{
+public:
+    typedef std::vector<gp_Pnt> CPointContainer;
+
+    TIGL_EXPORT CTiglSymetricSplineBuilder(const CPointContainer& points);
+
+    TIGL_EXPORT Handle_Geom_BSplineCurve GetBSpline() const;
+
+private:
+    void checkInputData() const;
+
+    const CPointContainer& _points;
+};
+
+} //namespace tigl
+
+#endif // CTIGLSYMETRICSPLINEBUILDER_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -25,7 +25,7 @@
 #endif
 
 // make tixi quiet
-void tixiSilentMessage(MessageType , const char *, ...){}
+void tixiSilentMessage(MessageType , const char *){}
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
This fix makes sure, that half profiles are perpendicular to the x-z plane and are thus symmetric. This allows a correct creation of the guide curves.
A new interpolation algorithm had to be implemented that forces symmetric B-Splines.

Please check, if the bug is really closed.