### PR TITLE
Task 157

### DIFF
--- a/bindings/java/src/de/dlr/sc/tigl/CpacsConfiguration.java
+++ b/bindings/java/src/de/dlr/sc/tigl/CpacsConfiguration.java
@@ -33,6 +33,7 @@ import com.sun.jna.ptr.PointerByReference;
 
 import de.dlr.sc.tigl.Tigl.SectionAndElementIndex;
 import de.dlr.sc.tigl.Tigl.SectionAndElementUID;
+import de.dlr.sc.tigl.Tigl.SegmentXsiAndWarning;
 import de.dlr.sc.tigl.Tigl.SurfaceMaterial;
 import de.dlr.sc.tigl.Tigl.WCSFindSegmentResult;
 import de.dlr.sc.tigl.Tigl.WCSGetSegmentEtaXsiResult;
@@ -1104,10 +1105,10 @@ public class CpacsConfiguration implements AutoCloseable {
      * @param csXsi1, csXsi2 - Start and end xsi coordinates of the intersection line (given as component segment coordinates) 
      * @param segmentEta -  Eta coordinate of the iso-eta segment intersection line
      * 
-     * @return Xsi coordinate of the intersection point on the wing segment
+     * @return Xsi coordinate of the intersection point on the wing segment and a warning, if the xsi coordinate is outside valid range [0,1]
      * @throws TiglException
      */
-    public double wingComponentSegmentGetSegmentIntersection(final String componentSegmentUID,
+    public SegmentXsiAndWarning wingComponentSegmentGetSegmentIntersection(final String componentSegmentUID,
             final String segmentUID,
             final double csEta1, final double csXsi1,
             final double csEta2, final double csXsi2,
@@ -1116,17 +1117,23 @@ public class CpacsConfiguration implements AutoCloseable {
         checkTiglConfiguration();
         
         DoubleByReference c_sxsi = new DoubleByReference();
+        IntByReference c_warning = new IntByReference();
         
         errorCode = TiglNativeInterface.tiglWingComponentSegmentGetSegmentIntersection(
                 cpacsHandle, 
                 componentSegmentUID, 
                 segmentUID, 
                 csEta1, csXsi1, csEta2, csXsi2, 
-                segmentEta, c_sxsi);
+                segmentEta, c_sxsi, c_warning);
         
         throwIfError("tiglWingComponentSegmentGetSegmentIntersection", errorCode);
         
-        return c_sxsi.getValue();
+        boolean hasWarning = false;
+        if (c_warning.getValue() > 0) {
+            hasWarning = true;
+        }
+        
+        return new SegmentXsiAndWarning(c_sxsi.getValue(), hasWarning);
     }
     
     /**

--- a/bindings/java/src/de/dlr/sc/tigl/Tigl.java
+++ b/bindings/java/src/de/dlr/sc/tigl/Tigl.java
@@ -310,4 +310,14 @@ public class Tigl {
         public TiglPoint macPoint;
         public double mac;
     }
+    
+    public static class SegmentXsiAndWarning {
+        public SegmentXsiAndWarning(double segmentXsi, boolean hasWarning) {
+            this.segmentXsi = segmentXsi;
+            this.hasWarning = hasWarning;
+        }
+        
+        public double segmentXsi;
+        public boolean hasWarning; 
+    }
 }

--- a/bindings/java/src/de/dlr/sc/tigl/TiglNativeInterface.java
+++ b/bindings/java/src/de/dlr/sc/tigl/TiglNativeInterface.java
@@ -17,7 +17,7 @@
 */
 
 /* 
-* This file is automatically created from tigl.h on 2015-06-01.
+* This file is automatically created from tigl.h on 2015-06-24.
 * If you experience any bugs please contact the authors
 */
 
@@ -70,7 +70,7 @@ public class TiglNativeInterface {
     public static native int tiglWingComponentSegmentGetPoint(int cpacsHandle, String componentSegmentUID, double eta, double xsi, DoubleByReference x, DoubleByReference y, DoubleByReference z);
     public static native int tiglWingComponentSegmentPointGetSegmentEtaXsi(int cpacsHandle, String componentSegmentUID, double eta, double xsi, PointerByReference wingUID, PointerByReference segmentUID, DoubleByReference segmentEta, DoubleByReference segmentXsi, DoubleByReference errorDistance);
     public static native int tiglWingSegmentPointGetComponentSegmentEtaXsi(int cpacsHandle, String segmentUID, String componentSegmentUID, double segmentEta, double segmentXsi, DoubleByReference eta, DoubleByReference xsi);
-    public static native int tiglWingComponentSegmentGetSegmentIntersection(int cpacsHandle, String componentSegmentUID, String segmentUID, double csEta1, double csXsi1, double csEta2, double csXsi2, double segmentEta, DoubleByReference segmentXsi);
+    public static native int tiglWingComponentSegmentGetSegmentIntersection(int cpacsHandle, String componentSegmentUID, String segmentUID, double csEta1, double csXsi1, double csEta2, double csXsi2, double segmentEta, DoubleByReference segmentXsi, IntByReference hasWarning);
     public static native int tiglWingComponentSegmentGetNumberOfSegments(int cpacsHandle, String componentSegmentUID, IntByReference nsegments);
     public static native int tiglWingComponentSegmentGetSegmentUID(int cpacsHandle, String componentSegmentUID, int segmentIndex, PointerByReference segmentUID);
     public static native int tiglGetFuselageCount(int cpacsHandle, IntByReference fuselageCountPtr);

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -2034,8 +2034,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetSegmentIntersection
                                                                                  const char* segmentUID,
                                                                                  double csEta1, double csXsi1,
                                                                                  double csEta2, double csXsi2,
-                                                                                 double   segmentEta, 
-                                                                                 double * segmentXsi) 
+                                                                                 double   segmentEta,
+                                                                                 double * segmentXsi,
+                                                                                 TiglBoolean* hasWarning)
 {
     if (segmentUID == 0) {
         LOG(ERROR) << "Error: Null pointer argument for segmentUID ";
@@ -2066,6 +2067,17 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetSegmentIntersection
             try {
                 tigl::CCPACSWingComponentSegment & compSeg = (tigl::CCPACSWingComponentSegment &) wing.GetComponentSegment(componentSegmentUID);
                 compSeg.GetSegmentIntersection(segmentUID, csEta1, csXsi1, csEta2, csXsi2, segmentEta, *segmentXsi);
+
+                // check if xsi is valid
+                if (hasWarning) {
+                    if (*segmentXsi < 0. || *segmentXsi > 1.) {
+                        *hasWarning = TIGL_TRUE;
+                    }
+                    else {
+                        *hasWarning = TIGL_FALSE;
+                    }
+                }
+
                 return TIGL_SUCCESS;
             }
             catch (tigl::CTiglError& err){

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -1328,6 +1328,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingSegmentPointGetComponentSegmentEtaXsi(
 * @param[in]  csXsi1, csXsi2          Start and end xsi coordinates of the intersection line (given as component segment coordinates)
 * @param[in]  segmentEta              Eta coordinate of the iso-eta segment intersection line
 * @param[out] segmentXsi              Xsi coordinate of the intersection point on the wing segment
+* @param[out] hasWarning              The hasWarning flag is true (1), if the resulting xsi value is outside the valid
+*                                     range [0,1]. It is up to the user to handle these cases properly. This flag is only
+*                                     valid, if the function returns TIGL_SUCCESS.
 *
 * @return
 *   - TIGL_SUCCESS if no error occurred
@@ -1342,7 +1345,8 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetSegmentIntersection
                                                                                  double csEta1, double csXsi1,
                                                                                  double csEta2, double csXsi2,
                                                                                  double segmentEta, 
-                                                                                 double* segmentXsi);
+                                                                                 double* segmentXsi,
+                                                                                 TiglBoolean* hasWarning);
 
 /**
 * @brief Returns the number of segments belonging to a component segment

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -43,13 +43,13 @@
 #include "TopoDS_Edge.hxx"
 #include "TopoDS_Face.hxx"
 #include "TopoDS_Wire.hxx"
-#include "GeomAPI_IntCS.hxx"
 #include "GeomAPI_ProjectPointOnSurf.hxx"
 #include "GeomAPI_ProjectPointOnCurve.hxx"
+#include "GeomAdaptor_Curve.hxx"
+#include "Extrema_ExtCC.hxx"
 #include "Geom_Plane.hxx"
+#include "Geom_Line.hxx"
 #include "gp_Pln.hxx"
-//#include "Geom_Surface.hxx"
-#include "GeomLib.hxx"
 #include "Precision.hxx"
 #include "BRepBuilderAPI_MakeEdge.hxx"
 #include "BRepBuilderAPI_MakeFace.hxx"
@@ -59,13 +59,13 @@
 #include "BRepGProp.hxx"
 #include "GProp_GProps.hxx"
 #include "ShapeFix_Shape.hxx"
-#include "Geom_BSplineCurve.hxx"
 #include "GeomAPI_PointsToBSpline.hxx"
 #include "BRepClass3d_SolidClassifier.hxx"
-#include "BRepExtrema_DistShapeShape.hxx"
 #include "TColgp_Array1OfPnt.hxx"
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
+
+#include <cassert>
 
 namespace tigl
 {
@@ -319,126 +319,67 @@ TopoDS_Wire CCPACSWingComponentSegment::GetCSLine(double eta1, double xsi1, doub
     
 void CCPACSWingComponentSegment::GetSegmentIntersection(const std::string& segmentUID, double csEta1, double csXsi1, double csEta2, double csXsi2, double eta, double &xsi)
 {
-    // number of component segment point samples per line
-    int NSTEPS = 11;
         
     CCPACSWingSegment& segment = (CCPACSWingSegment&) wing->GetSegment(segmentUID);
-    bool hasIntersected = false;
-        
-    // we do an iterative procedure to find the segment intersection
-    // by trying to find out, what the exact intersection of the component
-    // segment with the segment is
-    int iter = 0;
-    int maxiter = 10;
-    gp_Pnt result(0,0,0);
-    gp_Pnt oldresult(100,0,0);
-        
-    while (result.Distance(oldresult) > 1e-6 && iter < maxiter){
-        oldresult = result;
-            
-        double deta = (csEta2-csEta1)/double(NSTEPS-1);
-        double dxsi = (csXsi2-csXsi1)/double(NSTEPS-1);
-        
-        std::vector<gp_Pnt> points;
-        for (int istep = 0; istep < NSTEPS; ++istep) {
-            double eta = csEta1 + (double) istep * deta;
-            double xsi = csXsi1 + (double) istep * dxsi;
-            gp_Pnt point = GetPoint(eta,xsi);
-            points.push_back(point);
-        }
-            
-        BRepBuilderAPI_MakeWire wireBuilder;
-        for (int istep = 0; istep < NSTEPS-1; ++istep) {
-            TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(points[istep], points[istep+1]);
-            wireBuilder.Add(edge);
-        }
-            
-        //return wireGen.BuildWire(container,false);
-        TopoDS_Wire csLine = wireBuilder.Wire();
-        
-        // create segments outer chord line
-        gp_Pnt leadingPoint  = segment.GetChordPoint(eta, 0.);
-        gp_Pnt trailingPoint = segment.GetChordPoint(eta, 1.);
-            
-        TopoDS_Wire outerChord = BRepBuilderAPI_MakeWire(BRepBuilderAPI_MakeEdge(leadingPoint,trailingPoint));
-            
-        BRepExtrema_DistShapeShape extrema(csLine, outerChord);
-        extrema.Perform();
-            
-        double dist = 0;
-        if (extrema.IsDone() && extrema.NbSolution() > 0) {
-            gp_Pnt p1 = extrema.PointOnShape1(1);
-            gp_Pnt p2 = extrema.PointOnShape2(1);
-            dist = p1.Distance(p2);
-            result = p2;
-            // check if the lines were really intersecting (1cm accuracy should be enough)
-            if (dist < 1e-2) {
-                hasIntersected = true;
-            }
-        }
-
-            
-        // now lets check in between which points the intersection lies
-        int ifound = -1;
-        for (int i = 0; i < NSTEPS-1; ++i) {
-            if (inBetween(result, points[i], points[i+1])) {
-                ifound = i;
-                break;
-            }
-        }
-        
-        if (ifound < 0 && iter == 0) {
-            // There is not actual intersection!
-            // Check if almost intersecting, i.e. last point or first point is near to the segment iso line
-            // This should make the algorithm more robust for small user errors
-            if (points.front().Distance(result) < 1e-5 || points.back().Distance(result) < 1e-5) {
-                break;
-            }
-            else {
-                throw CTiglError("Component segment line does not intersect iso eta line of segment in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
-            }
-        }
-            
-        // calculate new search field
-        csEta2 = csEta1 + deta*(ifound + 1);
-        csEta1 = csEta1 + deta*(ifound);
-        csXsi2 = csXsi1 + dxsi*(ifound + 1);
-        csXsi1 = csXsi1 + dxsi*(ifound);
-        ++iter;
-    }
-        
-    if (hasIntersected) {
-        // now check if we found an intersection
-        double etaTmp;
-        segment.GetEtaXsi(result, etaTmp, xsi);
-        // by design, result is inside the segment
-        // However due to numerics, eta and xsi might
-        // be a bit larger than 1 or smaller than 0
-        if (etaTmp > 1.) {
-            etaTmp = 1.;
-        }
-        else if (etaTmp < 0) {
-            etaTmp = 0.;
-        }
-        if (xsi > 1.) {
-            xsi = 1.;
-        }
-        else if (xsi < 0) {
-            xsi = 0.;
-        }
-
-        // check that etaTmp coordinate is correct
-        if (fabs(etaTmp - eta) > 1e-6) {
-            throw CTiglError("Error determining proper eta, xsi coordinates in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
-        }
-    }
-    else {
+    
+    // compute component segment line
+    gp_Pnt p1 = GetPoint(csEta1, csXsi1);
+    gp_Pnt p2 = GetPoint(csEta2, csXsi2);
+    double csLen = p1.Distance(p2);
+    
+    gp_Lin csLine(p1, p2.XYZ() - p1.XYZ());
+    
+    // compute iso eta line of segment
+    gp_Pnt pLE = segment.GetChordPoint(eta, 0.);
+    gp_Pnt pTE = segment.GetChordPoint(eta, 1.);
+    double chordDepth = pTE.Distance(pLE);
+    
+    gp_Lin etaLine(pLE, pTE.XYZ() - pLE.XYZ());
+    
+    // check, if both lines are parallel
+    if (etaLine.Direction().IsParallel(csLine.Direction(), M_PI/180.)) {
         throw CTiglError("Component segment line does not intersect iso eta line of segment in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
     }
-        
-    // test if eta,xsi is valid
-    if (segment.GetChordPoint(eta,xsi).Distance(result) > 1e-4) {
-        throw CTiglError("Error determining proper eta, xsi coordinates in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
+    
+    Handle_Geom_Curve csCurve = new Geom_Line(csLine);
+    Handle_Geom_Curve etaCurve = new Geom_Line(etaLine);
+    GeomAdaptor_Curve csAdptAcuve(csCurve);
+    GeomAdaptor_Curve etaAdptCurve(etaCurve);
+    
+    // find point on etaLine, that minimizes distance to csLine
+    Extrema_ExtCC minimizer(csAdptAcuve, etaAdptCurve);
+    
+    minimizer.Perform();
+    
+    if (!minimizer.IsDone()) {
+        throw CTiglError("Component segment line does not intersect iso eta line of segment in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
+    }
+    
+    // there should be exactly on minimum between two lines
+    // if they are not parallel
+    assert(minimizer.NbExt() == 1);
+    
+    Extrema_POnCurv pOnCSLine, pOnEtaLine;
+    minimizer.Points(1, pOnCSLine, pOnEtaLine);
+    
+    // If parameter on CS line is < 0 or larger than 
+    // Length of line, there is not actual intersection,
+    // i.e. the CS Line is choosen to small
+    // We use a tolerance here, to account for small user errors
+    double tol = 1e-5;
+    if (pOnCSLine.Parameter() < -tol || pOnCSLine.Parameter() > csLen + tol) {
+        throw CTiglError("Component segment line does not intersect iso eta line of segment in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
+    }
+    
+    // compute xsi value
+    xsi = pOnEtaLine.Parameter()/chordDepth;
+    
+    // TODO: handle invalid xsi values (xsi > 1 and xsi < 0)
+    if (xsi > 1) {
+        xsi = 1.;
+    }
+    else if (xsi < 0) {
+        xsi = 0.;
     }
 }
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -371,14 +371,6 @@ void CCPACSWingComponentSegment::GetSegmentIntersection(const std::string& segme
 
     // compute xsi value
     xsi = pOnEtaLine.Parameter()/chordDepth;
-
-    // TODO: handle invalid xsi values (xsi > 1 and xsi < 0)
-    if (xsi > 1) {
-        xsi = 1.;
-    }
-    else if (xsi < 0) {
-        xsi = 0.;
-    }
 }
 
 // get short name for loft

--- a/tests/tiglWingComponentSegment.cpp
+++ b/tests/tiglWingComponentSegment.cpp
@@ -521,26 +521,27 @@ TEST_F(WingComponentSegmentSimple, GetSegmentIntersection_cinterface)
 {
     double xsi;
     TiglReturnCode ret;
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 0.0, 0.0, 1.0, 1.0, 1.0, &xsi);
+    TiglBoolean hasWarning;
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 0.0, 0.0, 1.0, 1.0, 1.0, &xsi, &hasWarning);
     ASSERT_EQ(TIGL_SUCCESS, ret);
     ASSERT_NEAR(0.5, xsi, 1e-6);
 
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1","Cpacs2Test_Wing_Seg_2_3", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1","Cpacs2Test_Wing_Seg_2_3", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi, &hasWarning);
     ASSERT_EQ(TIGL_MATH_ERROR, ret);
 
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "","Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "","Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi, &hasWarning);
     ASSERT_EQ(TIGL_UID_ERROR, ret);
 
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi, &hasWarning);
     ASSERT_EQ(TIGL_UID_ERROR, ret);
 
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, NULL, "Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, NULL, "Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi, &hasWarning);
     ASSERT_EQ(TIGL_NULL_POINTER, ret);
 
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", NULL, 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", NULL, 0.1, 0.1, 0.9, 0.1, 1.0, &xsi, &hasWarning);
     ASSERT_EQ(TIGL_NULL_POINTER, ret);
 
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, NULL);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, NULL, &hasWarning);
     ASSERT_EQ(TIGL_NULL_POINTER, ret);
 }
 
@@ -632,9 +633,11 @@ TEST(WingComponentSegment5, GetSegmentIntersection_BUG)
     ASSERT_EQ(TIGL_SUCCESS, tiglRet);
 
     double xsi = 0;
-    tiglRet = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "wing_Cseg", "wing_Seg2", 0.0589568, 1., 0.35, 1., 1., &xsi);
+    TiglBoolean hasWarning;
+    tiglRet = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "wing_Cseg", "wing_Seg2", 0.0589568, 1., 0.35, 1., 1., &xsi, &hasWarning);
     ASSERT_EQ(TIGL_SUCCESS, tiglRet);
-    ASSERT_NEAR(1.0, xsi, 1e-6);
+    ASSERT_EQ(TIGL_TRUE, hasWarning);
+    ASSERT_NEAR(1.0, xsi, 1e-2);
 
     ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
     ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
@@ -652,11 +655,13 @@ TEST(WingComponentSegment5, GetSegmentIntersection_BUG2)
     ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
 
     double xsi = 0;
+    TiglBoolean hasWarning;
     ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentGetSegmentIntersection(
                tiglHandle, "BWB_CST_wing_CS", "BWB_CST_wingSegment49ID", 
                0.81268, 1., 0.96, 1., 1., 
-               &xsi));
+               &xsi, &hasWarning));
 
+    ASSERT_EQ(TIGL_TRUE, hasWarning);
     ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
     ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
 }
@@ -679,27 +684,27 @@ TEST(WingComponentSegment5, GetSegmentIntersection_BUG3)
     ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentGetSegmentIntersection(
                tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
                0.0, 0.7, (1. - 1e-5)/2. + 1e-6, 0.7, 1., 
-               &xsi));
+               &xsi, NULL));
 
     ASSERT_NEAR(0.7, xsi, 1e-7);
     // This is too inaccurate now
     ASSERT_EQ(TIGL_MATH_ERROR, tiglWingComponentSegmentGetSegmentIntersection(
                tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
                0.0, 0.7, (1. - 1e-5)/2. - 1e-5, 0.7, 1., 
-               &xsi));
+               &xsi, NULL));
 
     // check inner section
     // The segment border is at eta = 0.0. we test if 0.000005 is okay (all values below should fail)
     ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentGetSegmentIntersection(
                tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
                (1e-5)/2. - 1e-6, 0.7, 0.5 + 1e-5, 0.7, 0., 
-               &xsi));
+               &xsi, NULL));
 
     // This should be too inaccurate now
     ASSERT_EQ(TIGL_MATH_ERROR, tiglWingComponentSegmentGetSegmentIntersection(
                tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
                (1e-5)/2. + 1e-5, 0.7, 0.5 + 1e-5, 0.7, 0., 
-               &xsi));
+               &xsi, NULL));
 
     ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
     ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));

--- a/tests/tiglWingComponentSegment.cpp
+++ b/tests/tiglWingComponentSegment.cpp
@@ -503,13 +503,13 @@ TEST_F(WingComponentSegmentSimple, GetSegmentIntersection)
     double eta = 1.;
     double xsi = 0;
     compSegment.GetSegmentIntersection("Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, eta, xsi);
-    ASSERT_NEAR(0.1, xsi, 1e-6);
-
-    compSegment.GetSegmentIntersection("Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.8, 0.1, eta, xsi);
-    ASSERT_NEAR(0.1, xsi, 1e-6);
+    ASSERT_NEAR(0.28, xsi, 1e-6);
 
     compSegment.GetSegmentIntersection("Cpacs2Test_Wing_Seg_1_2", 0.0, 0.0, 1.0, 1.0, eta, xsi);
     ASSERT_NEAR(0.5, xsi, 1e-6);
+
+    compSegment.GetSegmentIntersection("Cpacs2Test_Wing_Seg_1_2", 0.0, 1.0, 1.0, 0.0, eta, xsi);
+    ASSERT_NEAR(0.75, xsi, 1e-6);
 
     compSegment.GetSegmentIntersection("Cpacs2Test_Wing_Seg_1_2", 0.0, 0.0, 1.0, 1.0, 0.0, xsi);
     ASSERT_NEAR(0.0, xsi, 1e-6);
@@ -521,9 +521,9 @@ TEST_F(WingComponentSegmentSimple, GetSegmentIntersection_cinterface)
 {
     double xsi;
     TiglReturnCode ret;
-    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
+    ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 0.0, 0.0, 1.0, 1.0, 1.0, &xsi);
     ASSERT_EQ(TIGL_SUCCESS, ret);
-    ASSERT_NEAR(0.1, xsi, 1e-6);
+    ASSERT_NEAR(0.5, xsi, 1e-6);
 
     ret = tiglWingComponentSegmentGetSegmentIntersection(tiglHandle, "WING_CS1","Cpacs2Test_Wing_Seg_2_3", 0.1, 0.1, 0.9, 0.1, 1.0, &xsi);
     ASSERT_EQ(TIGL_MATH_ERROR, ret);
@@ -680,13 +680,27 @@ TEST(WingComponentSegment5, GetSegmentIntersection_BUG3)
                tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
                0.0, 0.7, (1. - 1e-5)/2. + 1e-6, 0.7, 1., 
                &xsi));
-    
+
     ASSERT_NEAR(0.7, xsi, 1e-7);
     // This is too inaccurate now
     ASSERT_EQ(TIGL_MATH_ERROR, tiglWingComponentSegmentGetSegmentIntersection(
                tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
                0.0, 0.7, (1. - 1e-5)/2. - 1e-5, 0.7, 1., 
                &xsi));
+
+    // check inner section
+    // The segment border is at eta = 0.0. we test if 0.000005 is okay (all values below should fail)
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentGetSegmentIntersection(
+               tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
+               (1e-5)/2. - 1e-6, 0.7, 0.5 + 1e-5, 0.7, 0., 
+               &xsi));
+
+    // This should be too inaccurate now
+    ASSERT_EQ(TIGL_MATH_ERROR, tiglWingComponentSegmentGetSegmentIntersection(
+               tiglHandle, "WING_CS1", "Cpacs2Test_Wing_Seg_1_2", 
+               (1e-5)/2. + 1e-5, 0.7, 0.5 + 1e-5, 0.7, 0., 
+               &xsi));
+
     ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
     ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
 }


### PR DESCRIPTION
The tigl function tiglWingComponentSegmentGetSegmentIntersection now internally works on a straight line.

With this change, it might happen that the straight line leaves the wing chord surface and the intersects the iso-eta line at negative xsi values or xsi > 1. To inform the user about the problem, we added a hasWarning flag - which is true in this case.