### PR TITLE
CPACS 2.3 conform external components

### DIFF
--- a/src/cpacs_other/CCPACSExternalObject.cpp
+++ b/src/cpacs_other/CCPACSExternalObject.cpp
@@ -92,7 +92,7 @@ void CCPACSExternalObject::ReadCPACS(TixiDocumentHandle tixiHandle, const std::s
     transformation.ReadCPACS(tixiHandle, objectXPath);
 
     // Get File Path, and type
-    std::string fileXPath  = objectXPath + "/file";
+    std::string fileXPath  = objectXPath + "/linkToFile";
     if (tixiCheckElement(tixiHandle, fileXPath.c_str()) == SUCCESS) {
         char *cFilePath = NULL, *cCPACSPath = NULL;
 
@@ -112,14 +112,14 @@ void CCPACSExternalObject::ReadCPACS(TixiDocumentHandle tixiHandle, const std::s
         }
         
         char* cFileType = NULL;
-        if (tixiGetTextAttribute(tixiHandle, fileXPath.c_str(), "type", &cFileType) == SUCCESS) {
+        if (tixiGetTextAttribute(tixiHandle, fileXPath.c_str(), "format", &cFileType) == SUCCESS) {
             _fileType = cFileType;
             if (!fileTypeSupported(_fileType)) {
-                throw tigl::CTiglError("File type " + _fileType + " not supported for external components!");
+                throw tigl::CTiglError("File format " + _fileType + " not supported for external components!");
             }
         }
         else {
-            throw tigl::CTiglError("No file type attribute specified in " + fileXPath + " !");
+            throw tigl::CTiglError("No file format attribute specified in " + fileXPath + " !");
         }
     }
 
@@ -172,7 +172,7 @@ PNamedShape CCPACSExternalObject::BuildLoft()
         return shapeGroup;
     }
     else {
-        throw CTiglError("Cannot open externalComponent. Unknown file type " + _fileType);
+        throw CTiglError("Cannot open externalComponent. Unknown file format " + _fileType);
     }
 }
 

--- a/src/cpacs_other/CCPACSExternalObjects.cpp
+++ b/src/cpacs_other/CCPACSExternalObjects.cpp
@@ -21,8 +21,8 @@
 #include "CCPACSExternalObject.h"
 #include "CTiglError.h"
 
-#define CPACS_EXTERNAL_COMPONENTS_NODE "externalComponents"
-#define CPACS_EXTERNAL_COMPONENT_NODE "externalComponent"
+#define CPACS_EXTERNAL_COMPONENTS_NODE "genericGeometryComponents"
+#define CPACS_EXTERNAL_COMPONENT_NODE "genericGeometryComponent"
 
 namespace tigl
 {

--- a/tests/TestData/external_component.xml
+++ b/tests/TestData/external_component.xml
@@ -1,5 +1,5 @@
 <root>
-  <externalComponent uID = "nacelle">
+  <genericGeometryComponent uID = "nacelle">
     <transformation>
     <scaling>
       <x>1.0</x>
@@ -17,9 +17,9 @@
       <z>0</z>
     </translation>
     </transformation>
-    <file type = "step">nacelle.stp</file>
-  </externalComponent>
-    <externalComponent uID = "nacelle2">
-    <file type = "unknownformat">nacelle.x3x</file>
-  </externalComponent>
+    <linkToFile format = "Step">nacelle.stp</linkToFile>
+  </genericGeometryComponent>
+    <genericGeometryComponent uID = "nacelle2">
+    <linkToFile format = "unknownformat">nacelle.x3x</linkToFile>
+  </genericGeometryComponent>
 </root>

--- a/tests/TestData/simpletest-nacelle.xml
+++ b/tests/TestData/simpletest-nacelle.xml
@@ -60,7 +60,7 @@
                   <translation refType="absLocal">
                     <x>0</x>
                     <y>0</y>
-                    <z>0</z>
+s                    <z>0</z>
                   </translation>
                 </transformation>
                 <elements>
@@ -451,8 +451,8 @@
             </componentSegments>
           </wing>
         </wings>
-        <externalComponents>
-          <externalComponent uID = "nacelle" symmetry="x-z-plane">
+        <genericGeometryComponents>
+          <genericGeometryComponent uID = "nacelle" symmetry="x-z-plane">
             <parentUID>Wing</parentUID>
             <transformation>
               <scaling>
@@ -471,9 +471,9 @@
                 <z>-0.3</z>
               </translation>
             </transformation>
-            <file type = "step">nacelle.stp</file>
-          </externalComponent>
-        </externalComponents>
+            <linkToFile format = "Step">nacelle.stp</linkToFile>
+          </genericGeometryComponent>
+        </genericGeometryComponents>
       </model>
     </aircraft>
     <profiles>

--- a/tests/TestData/simpletest-nacelle.xml
+++ b/tests/TestData/simpletest-nacelle.xml
@@ -60,7 +60,7 @@
                   <translation refType="absLocal">
                     <x>0</x>
                     <y>0</y>
-s                    <z>0</z>
+                    <z>0</z>
                   </translation>
                 </transformation>
                 <elements>

--- a/tests/tiglExternalComponent.cpp
+++ b/tests/tiglExternalComponent.cpp
@@ -55,7 +55,7 @@ protected:
 TEST_F(TiglExternalComponent, getFileNameRelative)
 {
     tigl::CCPACSExternalObject object;
-    object.ReadCPACS(tixiHandle, "/root/externalComponent[1]");
+    object.ReadCPACS(tixiHandle, "/root/genericGeometryComponent[1]");
     
     ASSERT_STREQ("TestData/nacelle.stp", object.GetFilePath().c_str());
 }
@@ -63,7 +63,7 @@ TEST_F(TiglExternalComponent, getFileNameRelative)
 TEST_F(TiglExternalComponent, getShape)
 {
     tigl::CCPACSExternalObject object;
-    object.ReadCPACS(tixiHandle, "/root/externalComponent[1]");
+    object.ReadCPACS(tixiHandle, "/root/genericGeometryComponent[1]");
     
     PNamedShape shape = object.GetLoft();
     ASSERT_TRUE(shape != NULL);
@@ -73,7 +73,7 @@ TEST_F(TiglExternalComponent, getShape)
 TEST_F(TiglExternalComponent, invalidFiletype)
 {
     tigl::CCPACSExternalObject object;
-    ASSERT_THROW(object.ReadCPACS(tixiHandle, "/root/externalComponent[2]"), tigl::CTiglError);
+    ASSERT_THROW(object.ReadCPACS(tixiHandle, "/root/genericGeometryComponent[2]"), tigl::CTiglError);
 }
 
 TEST(TiglExternalComponentInternal, getPathRelativeToApp)


### PR DESCRIPTION
Changed the element and attribute names of the external components to be CPACS 2.3 conform.