### PR TITLE
Integrated OCCT shaders into TiGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,12 @@ find_package(OCE 0.15 COMPONENTS ${OCC_LIBS} QUIET)
 if(OCE_FOUND)
   set(OpenCASCADE_LIBRARIES ${OCC_LIBS})
   set(OpenCASCADE_INCLUDE_DIR ${OCE_INCLUDE_DIRS})
+  # get opencascade version
+  IF(EXISTS "${OpenCASCADE_INCLUDE_DIR}/Standard_Version.hxx")
+    FILE(STRINGS "${OpenCASCADE_INCLUDE_DIR}/Standard_Version.hxx" occ_version_str REGEX "^#define[\t ]+OCC_VERSION_COMPLETE[\t ]+\".*\"")
+    STRING(REGEX REPLACE "^#define[\t ]+OCC_VERSION_COMPLETE[\t ]+\"([^\"]*)\".*" "\\1" OCC_VERSION_STRING "${occ_version_str}")
+    UNSET(occ_version_str)
+  ENDIF()
   # get directory of shared libs
   get_target_property(TKERNEL_LOCATION TKernel LOCATION)
   get_filename_component(OpenCASCADE_DLL_DIRECTORY ${TKERNEL_LOCATION} PATH)

--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -284,6 +284,16 @@ if (WIN32 OR APPLE)
   endif()
 endif()
 
+# install shader files from opencascade
+if (NOT OCC_VERSION_STRING VERSION_LESS "6.9.0")
+   file(GLOB SHADER_FILES PATH "${OpenCASCADE_SHADER_DIRECTORY}/*")
+   if (APPLE)
+     install(FILES ${SHADER_FILES} DESTINATION ${PROGNAME}.app/Contents/Resources/ COMPONENT viewer)
+   else()
+     install(FILES ${SHADER_FILES} DESTINATION share/tigl/shaders COMPONENT viewer)
+   endif(APPLE)
+endif()
+
 else (QT4_FOUND OR Qt5Widgets_FOUND)
 message(STATUS "No qt was found. TIGLViewer will not be build!")
 endif(QT4_FOUND OR Qt5Widgets_FOUND)

--- a/TIGLViewer/src/main.cpp
+++ b/TIGLViewer/src/main.cpp
@@ -57,8 +57,25 @@ int main(int argc, char *argv[])
 #else
     shaderDir += "/../share/tigl/shaders";
 #endif
-    if (qgetenv("CSF_ShadersDirectory").isNull()) {
+    
+    QByteArray envVar = qgetenv("CSF_ShadersDirectory");
+    if (envVar.isNull()) {
         qputenv("CSF_ShadersDirectory", shaderDir.toUtf8());
+    }
+    else {
+        shaderDir = envVar;
+    }
+    
+    // check existance of shader dir
+    if (!QFile(shaderDir+"/PhongShading.fs").exists()) {
+        std::stringstream str;
+        str << "Illegal or non existing shader directory "
+            << "<p><b>" << shaderDir.toStdString() << "</b></p>"
+            << "Set the enviroment variable <b>CSF_ShadersDirectory</b> to provide a path for the OpenCASCADE shaders.";
+        QMessageBox::critical(0, "Startup error...",
+                                  str.str().c_str(),
+                                  QMessageBox::Ok );
+        return 1;
     }
 
     int retval = parseArguments(app.arguments());

--- a/TIGLViewer/src/main.cpp
+++ b/TIGLViewer/src/main.cpp
@@ -49,6 +49,17 @@ int main(int argc, char *argv[])
 #elif defined __APPLE__
     setlocale(LC_NUMERIC, "C");
 #endif
+    
+    // set shader file location
+    QString shaderDir = QCoreApplication::applicationDirPath();
+#ifdef __APPLE__
+    shaderDir += "/../Resources";
+#else
+    shaderDir += "/../share/tigl/shaders";
+#endif
+    if (qgetenv("CSF_ShadersDirectory").isNull()) {
+        qputenv("CSF_ShadersDirectory", shaderDir.toUtf8());
+    }
 
     int retval = parseArguments(app.arguments());
     if (retval != 0) {

--- a/TIGLViewer/src/main.cpp
+++ b/TIGLViewer/src/main.cpp
@@ -29,6 +29,8 @@
 #include "TIGLViewerWindow.h"
 #include "CommandLineParameters.h"
 
+#include <Standard_Version.hxx>
+
 using namespace std;
 
 int parseArguments(QStringList);
@@ -66,7 +68,9 @@ int main(int argc, char *argv[])
         shaderDir = envVar;
     }
     
+#if OCC_VERSION_HEX >= 0x060900
     // check existance of shader dir
+    // This is only required for OpenCASCADE 6.9.0 and newer
     if (!QFile(shaderDir+"/PhongShading.fs").exists()) {
         std::stringstream str;
         str << "Illegal or non existing shader directory "
@@ -77,6 +81,7 @@ int main(int argc, char *argv[])
                                   QMessageBox::Ok );
         return 1;
     }
+#endif
 
     int retval = parseArguments(app.arguments());
     if (retval != 0) {

--- a/cmake/FindOpenCASCADE.cmake
+++ b/cmake/FindOpenCASCADE.cmake
@@ -96,9 +96,9 @@ IF( OpenCASCADE_FOUND )
   IF(OpenCASCADE_INCLUDE_DIR)
 	FOREACH(_occ_version_header Standard_Version.hxx)
      IF(EXISTS "${OpenCASCADE_INCLUDE_DIR}/${_occ_version_header}")
-      FILE(STRINGS "${OpenCASCADE_INCLUDE_DIR}/${_occ_version_header}" occ_version_str REGEX "^#define[\t ]+OCC_VERSION_STRING[\t ]+\".*\"")
+      FILE(STRINGS "${OpenCASCADE_INCLUDE_DIR}/${_occ_version_header}" occ_version_str REGEX "^#define[\t ]+OCC_VERSION_COMPLETE[\t ]+\".*\"")
 
-      STRING(REGEX REPLACE "^#define[\t ]+OCC_VERSION_STRING[\t ]+\"([^\"]*)\".*" "\\1" OCC_VERSION_STRING "${occ_version_str}")
+      STRING(REGEX REPLACE "^#define[\t ]+OCC_VERSION_COMPLETE[\t ]+\"([^\"]*)\".*" "\\1" OCC_VERSION_STRING "${occ_version_str}")
       UNSET(occ_version_str)
       BREAK()
      ENDIF()
@@ -113,6 +113,21 @@ IF( OpenCASCADE_FOUND )
       MESSAGE(STATUS "OCC Version: ${OCC_VERSION_STRING}")
   ENDIF( _firsttime STREQUAL TRUE )  
    
+  # We need to find the shader directory for OCCT 6.9.0 and newer
+  IF ( NOT OCC_VERSION_STRING VERSION_LESS "6.9.0" )
+      FIND_PATH(OpenCASCADE_SHADER_DIRECTORY
+                NAMES PhongShading.fs
+                PATH_SUFFIXES src/Shaders share/opencascade-${OCC_VERSION_STRING}/resources/Shaders share/opencascade-${OCC_VERSION_STRING}.beta/resources/Shaders
+                HINTS ${CASROOT}
+      )
+      IF(OpenCASCADE_SHADER_DIRECTORY STREQUAL OpenCASCADE_SHADER_DIRECTORY-NOTFOUND)
+        MESSAGE( FATAL_ERROR "Cannot find OCC shader directory." )
+      ENDIF(OpenCASCADE_SHADER_DIRECTORY STREQUAL OpenCASCADE_SHADER_DIRECTORY-NOTFOUND)
+      IF( _firsttime STREQUAL TRUE )
+        MESSAGE( STATUS "Found OCC shader dir: " ${OpenCASCADE_SHADER_DIRECTORY})
+      ENDIF( _firsttime STREQUAL TRUE )
+  ENDIF()
+
   IF( DEFINED OpenCASCADE_FIND_COMPONENTS )
     FOREACH( _libname ${OpenCASCADE_FIND_COMPONENTS} )
       #look for libs in OpenCASCADE_LINK_DIRECTORY


### PR DESCRIPTION
Newer OpenCASCADE version (>=6.9.0) require shaders for visualization.

These commits copy the shader files into the TiGL install path. Also, TiGL Viewer check this shader path on startup. If the shaders are not found, an error message is displayed.