### PR TITLE
Ported to OpenCASCADE 7.0.0

### DIFF
--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -98,6 +98,7 @@ set(tv_src
     TIGLViewerScreenshotDialog.cpp
     TIGLViewerDrawVectorDialog.cpp
     TIGLViewerScopedCommand.cpp
+    TIGLQAspectWindow.cpp
 )
 	
 # normal header files
@@ -114,6 +115,7 @@ set(tv_hdr
     TIGLViewerLogHistory.h
     TIGLViewerLoggerHTMLDecorator.h
     TIGLViewerScopedCommand.h
+    TIGLQAspectWindow.h
 )
 
 # qobject header files that have to be moced

--- a/TIGLViewer/src/ISession_Direction.cpp
+++ b/TIGLViewer/src/ISession_Direction.cpp
@@ -37,7 +37,6 @@
 #include <AIS_Drawer.hxx>
 #endif
 
-IMPLEMENT_STANDARD_HANDLE(ISession_Direction,AIS_InteractiveObject)
 IMPLEMENT_STANDARD_RTTIEXT(ISession_Direction,AIS_InteractiveObject)
 
 //////////////////////////////////////////////////////////////////////

--- a/TIGLViewer/src/ISession_Direction.h
+++ b/TIGLViewer/src/ISession_Direction.h
@@ -26,6 +26,8 @@
 
 #include <AIS_InteractiveObject.hxx>
 #include <TCollection_ExtendedString.hxx>
+#include <Prs3d_LineAspect.hxx>
+#include "occt_compat.h"
 
 DEFINE_STANDARD_HANDLE(ISession_Direction,AIS_InteractiveObject)
 class ISession_Direction : public AIS_InteractiveObject

--- a/TIGLViewer/src/ISession_Direction.h
+++ b/TIGLViewer/src/ISession_Direction.h
@@ -26,7 +26,6 @@
 
 #include <AIS_InteractiveObject.hxx>
 #include <TCollection_ExtendedString.hxx>
-#include <Handle_Prs3d_LineAspect.hxx>
 
 DEFINE_STANDARD_HANDLE(ISession_Direction,AIS_InteractiveObject)
 class ISession_Direction : public AIS_InteractiveObject
@@ -44,7 +43,7 @@ public:
     ISession_Direction (const gp_Pnt2d& aPnt2d,const gp_Vec2d& aVec2d);
 
     virtual ~ISession_Direction();
-    DEFINE_STANDARD_RTTI(ISession_Direction)
+    DEFINE_STANDARD_RTTIEXT(ISession_Direction,AIS_InteractiveObject)
 
 private:
     void Compute         (const Handle(PrsMgr_PresentationManager3d)& aPresentationManager,

--- a/TIGLViewer/src/ISession_Point.h
+++ b/TIGLViewer/src/ISession_Point.h
@@ -42,7 +42,7 @@ public:
     ISession_Point(gp_Pnt& aPoint);
 
     virtual ~ISession_Point();
-    DEFINE_STANDARD_RTTI(ISession_Point)
+    DEFINE_STANDARD_RTTIEXT(ISession_Point,AIS_InteractiveObject)
 
 private :
 

--- a/TIGLViewer/src/ISession_Point.h
+++ b/TIGLViewer/src/ISession_Point.h
@@ -31,6 +31,7 @@
 
 #include <AIS_InteractiveObject.hxx>
 #include <gp_Pnt.hxx>
+#include <occt_compat.h>
 
 DEFINE_STANDARD_HANDLE(ISession_Point,AIS_InteractiveObject)
 class ISession_Point : public AIS_InteractiveObject  

--- a/TIGLViewer/src/ISession_Text.h
+++ b/TIGLViewer/src/ISession_Text.h
@@ -64,7 +64,7 @@ public:
     inline   void                    SetScale  (const Quantity_Factor aNewScale) ;
 
 
-DEFINE_STANDARD_RTTI(ISession_Text)
+DEFINE_STANDARD_RTTIEXT(ISession_Text,AIS_InteractiveObject)
 
 private: 
 

--- a/TIGLViewer/src/ISession_Text.h
+++ b/TIGLViewer/src/ISession_Text.h
@@ -18,6 +18,8 @@
 #include <Standard_CString.hxx>
 #include <SelectMgr_SelectableObject.hxx>
 
+#include <occt_compat.h>
+
 class TCollection_AsciiString;
 class SelectMgr_Selection;
 

--- a/TIGLViewer/src/TIGLAISTriangulation.cpp
+++ b/TIGLViewer/src/TIGLAISTriangulation.cpp
@@ -170,7 +170,7 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
         case 0: {
             const TColgp_Array1OfPnt& nodes = myTriangulation->Nodes();
             const Poly_Array1OfTriangle& triangles = myTriangulation->Triangles();
-            Handle_Graphic3d_AspectLine3d aspect = myDrawer->WireAspect()->Aspect();
+            Handle(Graphic3d_AspectLine3d) aspect = myDrawer->WireAspect()->Aspect();
      
             Handle(Graphic3d_ArrayOfPrimitives) segments =  new Graphic3d_ArrayOfSegments(nodes.Length(),triangles.Length()*6);
             for (Standard_Integer i = nodes.Lower(); i <= nodes.Upper(); i++ ) {
@@ -204,7 +204,7 @@ void TIGLAISTriangulation::ComputeSelection(const Handle(SelectMgr_Selection)& a
     Handle(SelectMgr_EntityOwner) eown = new SelectMgr_EntityOwner(this,0);
 
     TopLoc_Location loc;
-    Handle_Select3D_SensitiveTriangulation aSensitiveTria = new Select3D_SensitiveTriangulation(eown, myTriangulation, loc);
+    Handle(Select3D_SensitiveTriangulation) aSensitiveTria = new Select3D_SensitiveTriangulation(eown, myTriangulation, loc);
     aSelection->Add(aSensitiveTria);
 }
 

--- a/TIGLViewer/src/TIGLAISTriangulation.h
+++ b/TIGLViewer/src/TIGLAISTriangulation.h
@@ -18,8 +18,11 @@
 #define _TIGLAISTriangulation_HeaderFile
 
 #include <Standard_DefineHandle.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TColStd_HArray1OfInteger.hxx>
 
 #include <AIS_InteractiveObject.hxx>
+#include <occt_compat.h>
 
 DEFINE_STANDARD_HANDLE(TIGLAISTriangulation,AIS_InteractiveObject)
 

--- a/TIGLViewer/src/TIGLAISTriangulation.h
+++ b/TIGLViewer/src/TIGLAISTriangulation.h
@@ -20,8 +20,6 @@
 #include <Standard_DefineHandle.hxx>
 
 #include <AIS_InteractiveObject.hxx>
-#include <Handle_Poly_Triangulation.hxx>
-#include <Handle_TColStd_HArray1OfInteger.hxx>
 
 DEFINE_STANDARD_HANDLE(TIGLAISTriangulation,AIS_InteractiveObject)
 
@@ -44,13 +42,13 @@ public:
   
 //! Get the color for each node. <br>
 //! Each 32-bit color is Alpha << 24 + Blue << 16 + Green << 8 + Red <br>
-  Standard_EXPORT     Handle_TColStd_HArray1OfInteger GetColors() const;
+  Standard_EXPORT     Handle(TColStd_HArray1OfInteger) GetColors() const;
   
   Standard_EXPORT     void SetTriangulation(const Handle(Poly_Triangulation)& aTriangulation) ;
   //! Returns Poly_Triangulation . <br>
-  Standard_EXPORT     Handle_Poly_Triangulation GetTriangulation() const;
+  Standard_EXPORT     Handle(Poly_Triangulation) GetTriangulation() const;
 
-  DEFINE_STANDARD_RTTI(TIGLAISTriangulation)
+  DEFINE_STANDARD_RTTIEXT(TIGLAISTriangulation,AIS_InteractiveObject)
 
 protected:
 
@@ -70,8 +68,8 @@ private:
 //! after glColorMaterial(GL_AMBIENT_AND_DIFFUSE). Without it, colors look unnatural and flat. <br>
   Standard_EXPORT     Standard_Integer AttenuateColor(const Standard_Integer aColor,const Standard_Real aComponent) ;
 
-Handle_Poly_Triangulation myTriangulation;
-Handle_TColStd_HArray1OfInteger myColor;
+Handle(Poly_Triangulation) myTriangulation;
+Handle(TColStd_HArray1OfInteger) myColor;
 Standard_Integer myFlagColor;
 Standard_Integer myNbNodes;
 Standard_Integer myNbTriangles;

--- a/TIGLViewer/src/TIGLQAspectWindow.cpp
+++ b/TIGLViewer/src/TIGLQAspectWindow.cpp
@@ -1,0 +1,190 @@
+/*
+* Copyright (C) 2015 German Aerospace Center (DLR/SC)
+*
+* Created: 2015-01-05 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Source taken from OpenCASCADE qt sample file OcctWindow.cxx
+*/
+
+#include "TIGLQAspectWindow.h"
+
+IMPLEMENT_STANDARD_RTTIEXT(QtAspectWindow, Aspect_Window)
+
+// =======================================================================
+// function : OcctWindow
+// purpose  :
+// =======================================================================
+QtAspectWindow::QtAspectWindow ( QWidget* theWidget, const Quantity_NameOfColor theBackColor )
+    : Aspect_Window(),
+      myWidget( theWidget )
+{
+    SetBackground (theBackColor);
+    myXLeft   = myWidget->rect().left();
+    myYTop    = myWidget->rect().top();
+    myXRight  = myWidget->rect().right();
+    myYBottom = myWidget->rect().bottom();
+}
+
+// =======================================================================
+// function : Destroy
+// purpose  :
+// =======================================================================
+void QtAspectWindow::Destroy()
+{
+    myWidget = NULL;
+}
+
+// =======================================================================
+// function : NativeParentHandle
+// purpose  :
+// =======================================================================
+Aspect_Drawable QtAspectWindow::NativeParentHandle() const
+{
+    QWidget* aParentWidget = myWidget->parentWidget();
+    if ( aParentWidget != NULL )
+        return (Aspect_Drawable)aParentWidget->winId();
+    else
+        return 0;
+}
+
+// =======================================================================
+// function : NativeHandle
+// purpose  :
+// =======================================================================
+Aspect_Drawable QtAspectWindow::NativeHandle() const
+{
+    return (Aspect_Drawable)myWidget->winId();
+}
+
+// =======================================================================
+// function : IsMapped
+// purpose  :
+// =======================================================================
+Standard_Boolean QtAspectWindow::IsMapped() const
+{
+    return !( myWidget->isMinimized() || myWidget->isHidden() );
+}
+
+// =======================================================================
+// function : Map
+// purpose  :
+// =======================================================================
+void QtAspectWindow::Map() const
+{
+    myWidget->show();
+    myWidget->update();
+}
+
+// =======================================================================
+// function : Unmap
+// purpose  :
+// =======================================================================
+void QtAspectWindow::Unmap() const
+{
+    myWidget->hide();
+    myWidget->update();
+}
+
+// =======================================================================
+// function : DoResize
+// purpose  :
+// =======================================================================
+Aspect_TypeOfResize QtAspectWindow::DoResize() const
+{
+    int                 aMask = 0;
+    Aspect_TypeOfResize aMode = Aspect_TOR_UNKNOWN;
+
+    if ( !myWidget->isMinimized() )
+    {
+        if ( Abs ( myWidget->rect().left()   - myXLeft   ) > 2 ) aMask |= 1;
+        if ( Abs ( myWidget->rect().right()  - myXRight  ) > 2 ) aMask |= 2;
+        if ( Abs ( myWidget->rect().top()    - myYTop    ) > 2 ) aMask |= 4;
+        if ( Abs ( myWidget->rect().bottom() - myYBottom ) > 2 ) aMask |= 8;
+
+        switch ( aMask )
+        {
+        case 0:
+            aMode = Aspect_TOR_NO_BORDER;
+            break;
+        case 1:
+            aMode = Aspect_TOR_LEFT_BORDER;
+            break;
+        case 2:
+            aMode = Aspect_TOR_RIGHT_BORDER;
+            break;
+        case 4:
+            aMode = Aspect_TOR_TOP_BORDER;
+            break;
+        case 5:
+            aMode = Aspect_TOR_LEFT_AND_TOP_BORDER;
+            break;
+        case 6:
+            aMode = Aspect_TOR_TOP_AND_RIGHT_BORDER;
+            break;
+        case 8:
+            aMode = Aspect_TOR_BOTTOM_BORDER;
+            break;
+        case 9:
+            aMode = Aspect_TOR_BOTTOM_AND_LEFT_BORDER;
+            break;
+        case 10:
+            aMode = Aspect_TOR_RIGHT_AND_BOTTOM_BORDER;
+            break;
+        default:
+            break;
+        }  // end switch
+
+        *( ( Standard_Integer* )&myXLeft  ) = myWidget->rect().left();
+        *( ( Standard_Integer* )&myXRight ) = myWidget->rect().right();
+        *( ( Standard_Integer* )&myYTop   ) = myWidget->rect().top();
+        *( ( Standard_Integer* )&myYBottom) = myWidget->rect().bottom();
+    }
+
+    return aMode;
+}
+
+// =======================================================================
+// function : Ratio
+// purpose  :
+// =======================================================================
+Quantity_Ratio QtAspectWindow::Ratio() const
+{
+    QRect aRect = myWidget->rect();
+    return Quantity_Ratio( aRect.right() - aRect.left() ) / Quantity_Ratio( aRect.bottom() - aRect.top() );
+}
+
+// =======================================================================
+// function : Size
+// purpose  :
+// =======================================================================
+void QtAspectWindow::Size ( Standard_Integer& theWidth, Standard_Integer& theHeight ) const
+{
+    QRect aRect = myWidget->rect();
+    theWidth  = aRect.right();
+    theHeight = aRect.bottom();
+}
+
+// =======================================================================
+// function : Position
+// purpose  :
+// =======================================================================
+void QtAspectWindow::Position ( Standard_Integer& theX1, Standard_Integer& theY1,
+                            Standard_Integer& theX2, Standard_Integer& theY2 ) const
+{
+    theX1 = myWidget->rect().left();
+    theX2 = myWidget->rect().right();
+    theY1 = myWidget->rect().top();
+    theY2 = myWidget->rect().bottom();
+}

--- a/TIGLViewer/src/TIGLQAspectWindow.h
+++ b/TIGLViewer/src/TIGLQAspectWindow.h
@@ -1,0 +1,113 @@
+/*
+* Copyright (C) 2015 German Aerospace Center (DLR/SC)
+*
+* Created: 2015-01-05 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Source taken from OpenCASCADE qt sample file OcctWindow.cxx
+*/
+
+#ifndef QTASPECTWINDOW_H
+#define QTASPECTWINDOW_H
+
+
+#include <Aspect_Window.hxx>
+#include <Aspect_Drawable.hxx>
+#include "occt_compat.h"
+
+#include <QWidget>
+
+/**
+  QtAspectWindow class implements Aspect_Window interface using Qt API
+  as a platform-independent source of window geometry information. 
+  A similar class should be used instead of platform-specific OCCT 
+  classes (WNT_Window, Xw_Window) in any Qt 5 application using OCCT 
+  3D visualization.
+  
+  With Qt 5, the requirement for a Qt-based application to rely fully 
+  on Qt public API and stop using platform-specific APIs looks mandatory. 
+  An example of this is changed QWidget event sequence: when a widget is 
+  first shown on the screen, a resize event is generated before the 
+  underlying native window is resized correctly, however the QWidget instance
+  already holds correct size information at that moment. The OCCT classes 
+  acting as a source of window geometry for V3d_View class (WNT_Window, Xw_Window) 
+  are no longer compatible with changed Qt behavior because they rely on 
+  platform-specific API that cannot return correct window geometry information 
+  in some cases. A reasonable solution is to provide a Qt-based implementation 
+  of Aspect_Window interface at application level.
+*/
+class QtAspectWindow : public Aspect_Window
+{
+public:
+    
+    QtAspectWindow( QWidget* theWidget, const Quantity_NameOfColor theBackColor = Quantity_NOC_MATRAGRAY );
+    
+    virtual void Destroy();
+    
+    //! Destructor
+    ~QtAspectWindow()
+    {
+        Destroy();
+    }
+    
+    //! Returns native Window handle
+    virtual Aspect_Drawable NativeHandle() const;
+    
+    //! Returns parent of native Window handle.
+    virtual Aspect_Drawable NativeParentHandle() const;
+    
+    //! Applies the resizing to the window <me>
+    virtual Aspect_TypeOfResize DoResize() const;
+    
+    //! Returns True if the window <me> is opened
+    //! and False if the window is closed.
+    virtual Standard_Boolean IsMapped() const;
+    
+    //! Apply the mapping change to the window <me>
+    //! and returns TRUE if the window is mapped at screen.
+    virtual Standard_Boolean DoMapping() const { return Standard_True; }
+    
+    //! Opens the window <me>.
+    virtual void Map() const;
+    
+    //! Closes the window <me>.
+    virtual void Unmap() const;
+    
+    virtual void Position( Standard_Integer& theX1, Standard_Integer& theY1,
+                           Standard_Integer& theX2, Standard_Integer& theY2 ) const;
+    
+    //! Returns The Window RATIO equal to the physical
+    //! WIDTH/HEIGHT dimensions.
+    virtual Quantity_Ratio Ratio() const;
+    
+    virtual void Size( Standard_Integer& theWidth, Standard_Integer& theHeight ) const;
+    
+#if OCC_VERSION_HEX >= 0x070000
+    virtual Aspect_FBConfig NativeFBConfig() const Standard_OVERRIDE { return NULL; }
+#endif
+    
+    DEFINE_STANDARD_RTTIEXT( OcctWindow, Aspect_Window )
+    
+protected:
+    Standard_Integer myXLeft;
+    Standard_Integer myYTop;
+    Standard_Integer myXRight;
+    Standard_Integer myYBottom;
+    QWidget* myWidget;
+};
+
+DEFINE_STANDARD_HANDLE(QtAspectWindow, Aspect_Window)
+
+
+#endif // QTASPECTWINDOW_H

--- a/TIGLViewer/src/TIGLViewer.h
+++ b/TIGLViewer/src/TIGLViewer.h
@@ -29,7 +29,6 @@
 #include <Aspect_Drawable.hxx>
 #include <Aspect_GridDrawMode.hxx>
 #include <Aspect_GridType.hxx>
-#include <Aspect_GraphicCallbackProc.hxx>
 #include <Standard_TypeDef.hxx>
 #include <Quantity_Factor.hxx>
 #include <Quantity_Length.hxx>

--- a/TIGLViewer/src/TIGLViewer.h
+++ b/TIGLViewer/src/TIGLViewer.h
@@ -30,11 +30,6 @@
 #include <Aspect_GridDrawMode.hxx>
 #include <Aspect_GridType.hxx>
 #include <Aspect_GraphicCallbackProc.hxx>
-#include <Handle_AIS_InteractiveContext.hxx>
-#include <Handle_V3d_View.hxx>
-#include <Handle_V3d_Viewer.hxx>
-#include <Handle_Visual3d_Layer.hxx>
-#include <Handle_TopTools_HSequenceOfShape.hxx>
 #include <Standard_TypeDef.hxx>
 #include <Quantity_Factor.hxx>
 #include <Quantity_Length.hxx>

--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -228,8 +228,8 @@ void TIGLViewerContext::displayShape(const TopoDS_Shape& loft, Quantity_Color co
 {
     TIGLViewerSettings& settings = TIGLViewerSettings::Instance();
     Handle(AIS_Shape) shape = new AIS_Shape(loft);
-    shape->SetMaterial(Graphic3d_NOM_METALIZED);
-    shape->SetColor(color);
+    myContext->SetMaterial(shape, Graphic3d_NOM_METALIZED, Standard_False);
+    myContext->SetColor(shape, color, Standard_False);
     shape->SetOwnDeviationCoefficient(settings.tesselationAccuracy());
     myContext->Display(shape, Standard_True);
     

--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -38,7 +38,6 @@ TIGLViewerContext::TIGLViewerContext()
     TCollection_ExtendedString a3DName("Visual3D");
     myViewer = createViewer( a3DName.ToExtString(), "", 1000.0 );
     myViewer->SetDefaultLights();
-    myViewer->SetZBufferManagment(Standard_False);
     myViewer->SetDefaultViewProj( V3d_Zpos );    // Top view
     myContext = new AIS_InteractiveContext( myViewer );
 

--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -61,17 +61,17 @@ TIGLViewerContext::~TIGLViewerContext()
 
 }
 
-Handle_V3d_Viewer& TIGLViewerContext::getViewer()
+Handle(V3d_Viewer)& TIGLViewerContext::getViewer()
 { 
     return myViewer; 
 }
 
-Handle_AIS_InteractiveContext& TIGLViewerContext::getContext()
+Handle(AIS_InteractiveContext)& TIGLViewerContext::getContext()
 { 
     return myContext; 
 }
 
-Handle_V3d_Viewer TIGLViewerContext::createViewer( const Standard_ExtString aName,
+Handle(V3d_Viewer) TIGLViewerContext::createViewer( const Standard_ExtString aName,
                                                    const Standard_CString aDomain,
                                                    const Standard_Real ViewSize )
 {

--- a/TIGLViewer/src/TIGLViewerContext.h
+++ b/TIGLViewer/src/TIGLViewerContext.h
@@ -22,6 +22,8 @@
 #define TIGLVIEWERCONTEXT_H
 
 #include <AIS_Shape.hxx>
+#include <AIS_InteractiveContext.hxx>
+#include <V3d_Viewer.hxx>
 #include <QObject>
 #include "TIGLViewer.h"
 #include "TIGLViewerColors.h"

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -35,7 +35,6 @@
 #include <string.h>
 
 // OpenCascade Stuff
-#include <Handle_AIS_Shape.hxx>
 #include <AIS_Shape.hxx>
 #include <AIS_InteractiveContext.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>

--- a/TIGLViewer/src/TIGLViewerDocument.h
+++ b/TIGLViewer/src/TIGLViewerDocument.h
@@ -26,7 +26,6 @@
 #include "TIGLViewer.h"
 #include "CCPACSConfiguration.h"
 
-#include <Handle_AIS_Shape.hxx>
 #include <Quantity_Color.hxx>
 
 class TIGLViewerWindow;

--- a/TIGLViewer/src/TIGLViewerInputoutput.cpp
+++ b/TIGLViewer/src/TIGLViewerInputoutput.cpp
@@ -32,6 +32,9 @@
 #include <Poly_Triangulation.hxx>
 #include <IGESData_IGESModel.hxx>
 #include <AIS_ListIteratorOfListOfInteractive.hxx>
+#include <AIS_Shape.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_Line.hxx>
 
 TIGLViewerInputOutput::TIGLViewerInputOutput(void)
 {
@@ -48,7 +51,7 @@ bool TIGLViewerInputOutput::importModel( const QString fileName,
 
     QApplication::setOverrideCursor( Qt::WaitCursor );
     scene.getContext()->SetDisplayMode(AIS_Shaded,Standard_False);
-    Handle_TopTools_HSequenceOfShape shapes = importModel( format, fileName );
+    Handle(TopTools_HSequenceOfShape) shapes = importModel( format, fileName );
     QApplication::restoreOverrideCursor();
 
     if ( shapes.IsNull() || !shapes->Length() ) {
@@ -98,9 +101,9 @@ bool TIGLViewerInputOutput::importTriangulation( const QString fileName,
 
     return true;
 }
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importModel( const FileFormat format, const QString& file )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::importModel( const FileFormat format, const QString& file )
 {
-    Handle_TopTools_HSequenceOfShape shapes;
+    Handle(TopTools_HSequenceOfShape) shapes;
     try {
         switch ( format ) {
         case FormatBREP:
@@ -135,10 +138,10 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importModel( const FileF
 
 bool TIGLViewerInputOutput::exportModel( const QString fileName,
                                          const FileFormat format,
-                                         const Handle_AIS_InteractiveContext& ic )
+                                         const Handle(AIS_InteractiveContext)& ic )
 {
 
-    Handle_TopTools_HSequenceOfShape shapes = getShapes( ic );
+    Handle(TopTools_HSequenceOfShape) shapes = getShapes( ic );
     if ( shapes.IsNull() || !shapes->Length() ) {
         return false;
     }
@@ -149,7 +152,7 @@ bool TIGLViewerInputOutput::exportModel( const QString fileName,
     return stat;
 }
 
-bool TIGLViewerInputOutput::exportModel( const FileFormat format, const QString& file, const Handle_TopTools_HSequenceOfShape& shapes )
+bool TIGLViewerInputOutput::exportModel( const FileFormat format, const QString& file, const Handle(TopTools_HSequenceOfShape)& shapes )
 {
     bool status = false;
     try {
@@ -176,15 +179,15 @@ bool TIGLViewerInputOutput::exportModel( const FileFormat format, const QString&
     return status;
 }
 
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::getShapes( const Handle_AIS_InteractiveContext& ic )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::getShapes( const Handle(AIS_InteractiveContext)& ic )
 {
-    Handle_TopTools_HSequenceOfShape aSequence;
-    Handle_AIS_InteractiveObject picked;
+    Handle(TopTools_HSequenceOfShape) aSequence;
+    Handle(AIS_InteractiveObject) picked;
     // export selected objects
     for ( ic->InitCurrent(); ic->MoreCurrent(); ic->NextCurrent() ) {
-        Handle_AIS_InteractiveObject obj = ic->Current();
+        Handle(AIS_InteractiveObject) obj = ic->Current();
         if ( obj->IsKind( STANDARD_TYPE( AIS_Shape ) ) ) {
-            TopoDS_Shape shape = Handle_AIS_Shape::DownCast(obj)->Shape();
+            TopoDS_Shape shape = Handle(AIS_Shape)::DownCast(obj)->Shape();
             if ( aSequence.IsNull() ) {
                 aSequence = new TopTools_HSequenceOfShape();
             }
@@ -200,9 +203,9 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::getShapes( const Handle_
     ic->DisplayedObjects(listAISShapes);
     AIS_ListIteratorOfListOfInteractive iter(listAISShapes);
     for (; iter.More(); iter.Next()) {
-        Handle_AIS_InteractiveObject obj = iter.Value();
+        Handle(AIS_InteractiveObject) obj = iter.Value();
         if ( obj->IsKind( STANDARD_TYPE( AIS_Shape ) ) ) {
-            TopoDS_Shape shape = Handle_AIS_Shape::DownCast(obj)->Shape();
+            TopoDS_Shape shape = Handle(AIS_Shape)::DownCast(obj)->Shape();
             if ( aSequence.IsNull() ) {
                 aSequence = new TopTools_HSequenceOfShape();
             }
@@ -213,9 +216,9 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::getShapes( const Handle_
 }
 
 
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importBREP( const QString& file )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::importBREP( const QString& file )
 {
-    Handle_TopTools_HSequenceOfShape aSequence;
+    Handle(TopTools_HSequenceOfShape) aSequence;
     TopoDS_Shape aShape;
     BRep_Builder aBuilder;
 
@@ -236,9 +239,9 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importBREP( const QStrin
     return aSequence;
 }
 
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importIGES( const QString& file )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::importIGES( const QString& file )
 {
-    Handle_TopTools_HSequenceOfShape aSequence;
+    Handle(TopTools_HSequenceOfShape) aSequence;
     IGESControl_Reader Reader;
     Interface_Static::SetCVal("xstep.cascade.unit", "M");
     int status = Reader.ReadFile( file.toLatin1().data() );
@@ -257,9 +260,9 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importIGES( const QStrin
     return aSequence;
 }
 
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importSTL( const QString& file )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::importSTL( const QString& file )
 {
-    Handle_TopTools_HSequenceOfShape aSequence = NULL;
+    Handle(TopTools_HSequenceOfShape) aSequence = NULL;
     TopoDS_Shape aShape;
     StlAPI_Reader Reader;
     Reader.Read(aShape, file.toStdString().c_str());
@@ -273,9 +276,9 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importSTL( const QString
     return aSequence;
 }
 
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importMESH( const QString& file )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::importMESH( const QString& file )
 {
-    Handle_TopTools_HSequenceOfShape aSequence = NULL;
+    Handle(TopTools_HSequenceOfShape) aSequence = NULL;
 
     CHotsoseMeshReader meshReader;
     tigl::CTiglPolyData mesh;
@@ -290,9 +293,9 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importMESH( const QStrin
     return aSequence;
 }
 
-Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importSTEP( const QString& file )
+Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::importSTEP( const QString& file )
 {
-    Handle_TopTools_HSequenceOfShape aSequence = new TopTools_HSequenceOfShape;
+    Handle(TopTools_HSequenceOfShape) aSequence = new TopTools_HSequenceOfShape;
 
     STEPControl_Reader aReader;
     Interface_Static::SetCVal("xstep.cascade.unit", "M");
@@ -327,7 +330,7 @@ Handle_TopTools_HSequenceOfShape TIGLViewerInputOutput::importSTEP( const QStrin
 }
 
 
-bool TIGLViewerInputOutput::exportBREP( const QString& file, const Handle_TopTools_HSequenceOfShape& shapes )
+bool TIGLViewerInputOutput::exportBREP( const QString& file, const Handle(TopTools_HSequenceOfShape)& shapes )
 {
     if ( shapes.IsNull() || shapes->IsEmpty() ){
         return false;
@@ -350,7 +353,7 @@ bool TIGLViewerInputOutput::exportBREP( const QString& file, const Handle_TopToo
     return BRepTools::Write( shape, file.toLatin1().data() );
 }
 
-bool TIGLViewerInputOutput::exportIGES( const QString& file, const Handle_TopTools_HSequenceOfShape& shapes )
+bool TIGLViewerInputOutput::exportIGES( const QString& file, const Handle(TopTools_HSequenceOfShape)& shapes )
 {
     if ( shapes.IsNull() || shapes->IsEmpty() ) {
         return false;
@@ -372,7 +375,7 @@ bool TIGLViewerInputOutput::exportIGES( const QString& file, const Handle_TopToo
     return writer.Write( file.toLatin1().data() );
 }
 
-bool TIGLViewerInputOutput::exportSTEP( const QString& file, const Handle_TopTools_HSequenceOfShape& shapes )
+bool TIGLViewerInputOutput::exportSTEP( const QString& file, const Handle(TopTools_HSequenceOfShape)& shapes )
 {
     if ( shapes.IsNull() || shapes->IsEmpty() ) {
         return false;
@@ -408,7 +411,7 @@ bool TIGLViewerInputOutput::exportSTEP( const QString& file, const Handle_TopToo
     return status == IFSelect_RetDone;
 }
 
-bool TIGLViewerInputOutput::exportSTL( const QString& file, const Handle_TopTools_HSequenceOfShape& shapes )
+bool TIGLViewerInputOutput::exportSTL( const QString& file, const Handle(TopTools_HSequenceOfShape)& shapes )
 {
     if ( shapes.IsNull() || shapes->IsEmpty() ) {
         return false;
@@ -433,7 +436,7 @@ bool TIGLViewerInputOutput::exportSTL( const QString& file, const Handle_TopTool
     return true;
 }
 
-bool TIGLViewerInputOutput::checkFacetedBrep( const Handle_TopTools_HSequenceOfShape& shapes )
+bool TIGLViewerInputOutput::checkFacetedBrep( const Handle(TopTools_HSequenceOfShape)& shapes )
 {
     bool err = false;
     for ( int i = 1; i <= shapes->Length(); i++ ) {

--- a/TIGLViewer/src/TIGLViewerInputoutput.h
+++ b/TIGLViewer/src/TIGLViewerInputoutput.h
@@ -24,6 +24,7 @@
 #include <QtCore/QObject>
 #include "TIGLViewer.h"
 #include "TIGLViewerContext.h"
+#include <TopTools_HSequenceOfShape.hxx>
 
 class TIGLViewerWidget;
 

--- a/TIGLViewer/src/TIGLViewerInternal.h
+++ b/TIGLViewer/src/TIGLViewerInternal.h
@@ -123,7 +123,6 @@
 #include <SelectMgr_SelectableObject.hxx>
 #include <SelectMgr_Selection.hxx>
 #include <SelectMgr_SelectionManager.hxx>
-#include <ShapeSchema.hxx>
 #include <Standard_Boolean.hxx>
 #include <Standard_CString.hxx>
 #include <Standard_ErrorHandler.hxx>
@@ -155,12 +154,9 @@
 #include <TopTools_ListIteratorOfListOfShape.hxx>
 #include <TopTools_HSequenceOfShape.hxx>
 #include <UnitsAPI.hxx>
-#include <V3d_ColorScale.hxx>
 #include <V3d_RectangularGrid.hxx>
 #include <V3d_View.hxx>
 #include <V3d_Viewer.hxx>
-#include <Visual3d_View.hxx>
-#include <Visual3d_ViewManager.hxx>
 
 // specific to ISession2D_Shape
 #include <TopTools_ListOfShape.hxx>
@@ -194,17 +190,6 @@
 #include <IGESControl_Reader.hxx>
 #include <IGESToBRep_Actor.hxx>
 #include <IGESToBRep_Reader.hxx>
-
-// specific CSFDB
-#include <FSD_File.hxx>
-#include <MgtBRep.hxx>
-#include <PTColStd_PersistentTransientMap.hxx>
-#include <PTColStd_TransientPersistentMap.hxx>
-#include <PTopoDS_HShape.hxx>
-#include <Storage_Data.hxx>
-#include <Storage_Error.hxx>
-#include <Storage_HSeqOfRoot.hxx>
-#include <Storage_Root.hxx>
 
 // specific STL
 #include <StlAPI_Writer.hxx>

--- a/TIGLViewer/src/TIGLViewerWidget.cpp
+++ b/TIGLViewer/src/TIGLViewerWidget.cpp
@@ -606,9 +606,7 @@ void TIGLViewerWidget::setBGImage(const QString& filename)
 void TIGLViewerWidget::eraseSelected()
 {
     if (!myView.IsNull()) {
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-            myContext->Erase(myContext->Current());
-        }
+        myContext->EraseSelected(Standard_False);
 
         myContext->ClearCurrents();
     }

--- a/TIGLViewer/src/TIGLViewerWidget.cpp
+++ b/TIGLViewer/src/TIGLViewerWidget.cpp
@@ -72,7 +72,7 @@ TIGLViewerWidget::TIGLViewerWidget(QWidget * parent)
     initialize();
 }
 
-TIGLViewerWidget::TIGLViewerWidget( const Handle_AIS_InteractiveContext& aContext,
+TIGLViewerWidget::TIGLViewerWidget( const Handle(AIS_InteractiveContext)& aContext,
                                     QWidget *parent, 
                                     Qt::WindowFlags f ) :
     myView            ( NULL ),
@@ -145,13 +145,13 @@ TIGLViewerWidget::~TIGLViewerWidget()
 {
 }
 
-void TIGLViewerWidget::setContext(const Handle_AIS_InteractiveContext& aContext)
+void TIGLViewerWidget::setContext(const Handle(AIS_InteractiveContext)& aContext)
 {
     myContext = aContext;
 }
 
 
-void TIGLViewerWidget::initializeOCC(const Handle_AIS_InteractiveContext& aContext)
+void TIGLViewerWidget::initializeOCC(const Handle(AIS_InteractiveContext)& aContext)
 {
     if (myView.IsNull()) {
         Aspect_RenderingContext rc = 0;

--- a/TIGLViewer/src/TIGLViewerWidget.cpp
+++ b/TIGLViewer/src/TIGLViewerWidget.cpp
@@ -617,6 +617,7 @@ void TIGLViewerWidget::eraseSelected()
         myContext->EraseSelected(Standard_False);
 
         myContext->ClearCurrents();
+        myContext->UpdateCurrentViewer();
     }
 }
 

--- a/TIGLViewer/src/TIGLViewerWidget.cpp
+++ b/TIGLViewer/src/TIGLViewerWidget.cpp
@@ -59,7 +59,11 @@
   #include <GL/glu.h>
 #endif
 
+
+#if OCC_VERSION_HEX < 0x070000
 #include "Visual3d_Layer.hxx"
+#endif
+
 #include "V3d_DirectionalLight.hxx"
 #include "V3d_AmbientLight.hxx"
 
@@ -77,7 +81,9 @@ TIGLViewerWidget::TIGLViewerWidget( const Handle(AIS_InteractiveContext)& aConte
                                     Qt::WindowFlags f ) :
     myView            ( NULL ),
     myViewer          ( NULL ),
+#if OCC_VERSION_HEX < 0x070000
     myLayer           ( NULL ),
+#endif
     myViewResized      ( Standard_False ),
     myViewInitialized ( Standard_False ),
     myMode              ( CurAction3d_Undefined ),
@@ -96,7 +102,10 @@ void TIGLViewerWidget::initialize()
 {
     myView            = NULL;
     myViewer          = NULL;
+    
+#if OCC_VERSION_HEX < 0x070000
     myLayer           = NULL;
+#endif
     myMode              = CurAction3d_Undefined;
     myGridSnap        = Standard_False;
     myViewResized      = Standard_False;
@@ -154,7 +163,6 @@ void TIGLViewerWidget::setContext(const Handle(AIS_InteractiveContext)& aContext
 void TIGLViewerWidget::initializeOCC(const Handle(AIS_InteractiveContext)& aContext)
 {
     if (myView.IsNull()) {
-        Aspect_RenderingContext rc = 0;
         myContext = aContext;
         myViewer  = myContext->CurrentViewer();
         myView    = myViewer->CreateView();
@@ -170,7 +178,7 @@ void TIGLViewerWidget::initializeOCC(const Handle(AIS_InteractiveContext)& aCont
 #endif
 
         // Set my window (Hwnd) into the OCC view
-        myView->SetWindow( myWindow, rc , paintCallBack, this  );
+        myView->SetWindow( myWindow );
         // Set up axes (Trihedron) in lower left corner.
         myView->SetScale( 2 );            // Choose a "nicer" initial scale
 
@@ -191,7 +199,9 @@ void TIGLViewerWidget::initializeOCC(const Handle(AIS_InteractiveContext)& aCont
         // This is to signal any connected slots that the view is ready.
         myViewInitialized = Standard_True;
 
+#if OCC_VERSION_HEX < 0x070000
         myLayer   = new Visual3d_Layer (myViewer->Viewer(), Aspect_TOL_OVERLAY, Standard_True /*aSizeDependant*/);
+#endif
 
         setBackgroundGradient(myBGColor.red(), myBGColor.green(), myBGColor.blue());
 
@@ -1055,6 +1065,7 @@ Standard_Boolean TIGLViewerWidget::convertToPlane(Standard_Integer Xs,
 
 void TIGLViewerWidget::drawRubberBand( const QPoint origin, const QPoint position )
 {
+#if OCC_VERSION_HEX < 0x070000
     if ( !myLayer.IsNull() && !myView.IsNull() ) {
 
         double left   = origin.x();
@@ -1096,33 +1107,19 @@ void TIGLViewerWidget::drawRubberBand( const QPoint origin, const QPoint positio
         myLayer->ClosePrimitive();
         myLayer->End();
     }
+#endif
+//TODO: selection using the new rubberband class
 }
 
 
 void TIGLViewerWidget::hideRubberBand( void )
 {
+#if OCC_VERSION_HEX < 0x070000
     if (!myLayer.IsNull() ) {
         myLayer->Clear();
     }
-}
-
-
-int TIGLViewerWidget::paintCallBack (Aspect_Drawable /* drawable */,
-                                     void* aPointer,
-                                     Aspect_GraphicCallbackStruct* /* data */)
-{
-  TIGLViewerWidget *aWidget = (TIGLViewerWidget *) aPointer;
-  aWidget->paintOCC();
-  return 0;
-}
-
-
-// TODO: this routine prevents setting the background color
-// either we should set it back here or we should skip it.
-// Also, this code confuses the ftgl renderer introduced in
-// OCC 6.4.0. Thus we should only use it with old OCC
-void TIGLViewerWidget::paintOCC( void )
-{
+#endif
+//TODO: selection using the new rubberband class
 }
 
 

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -27,9 +27,7 @@
 #include <Quantity_Color.hxx>
 
 #if defined WNT
-#include <Handle_WNT_Window.hxx>
 #else
-#include <Handle_Aspect_Window.hxx>
 #endif
 
 #include "TIGLViewer.h"
@@ -43,10 +41,10 @@
 
 #define VALZWMIN 1 /** For elastic bean selection */
 
-class Handle_AIS_InteractiveContext;
-class Handle_V3d_View;
-class Handle_Visual3d_Layer;
-class Handle_AIS_Shape;
+#include <AIS_InteractiveContext.hxx>
+#include <V3d_View.hxx>
+#include <Visual3d_Layer.hxx>
+#include <AIS_Shape.hxx>
 class TopoDS_Shape;
 class gp_Pnt;
 class gp_Vec;

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -27,12 +27,6 @@
 #include <Quantity_Color.hxx>
 #include <Standard_Version.hxx>
 
-#if defined WNT
-#include <WNT_Window.hxx>
-#else
-#include <Aspect_Window.hxx>
-#endif
-
 #include "TIGLViewer.h"
 
 
@@ -175,12 +169,6 @@ protected: // methods
 
 private: // members
     void initializeOCC(const Handle_AIS_InteractiveContext& aContext = NULL);
-
-#if defined WNT
-    Handle_WNT_Window               myWindow;
-#else
-    Handle_Aspect_Window            myWindow;
-#endif // WNT
 
     Handle_V3d_View                 myView;
     Handle_V3d_Viewer               myViewer;

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -49,7 +49,11 @@
 #include <AIS_Shape.hxx>
 #if OCC_VERSION_HEX < 0x070000
 #include <Visual3d_Layer.hxx>
+#else
+#include <AIS_RubberBand.hxx>
+#define Handle_AIS_RubberBand Handle(AIS_RubberBand)
 #endif
+
 class TopoDS_Shape;
 class gp_Pnt;
 class gp_Vec;
@@ -183,6 +187,8 @@ private: // members
     Handle_AIS_InteractiveContext   myContext;
 #if OCC_VERSION_HEX < 0x070000
     Handle_Visual3d_Layer           myLayer;
+#else
+    Handle_AIS_RubberBand           whiteRect, blackRect;
 #endif
 
     Standard_Boolean                myViewResized;

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -25,9 +25,12 @@
 #include <QWidget>
 #include <QMetaType>
 #include <Quantity_Color.hxx>
+#include <Standard_Version.hxx>
 
 #if defined WNT
+#include <WNT_Window.hxx>
 #else
+#include <Aspect_Window.hxx>
 #endif
 
 #include "TIGLViewer.h"
@@ -43,8 +46,10 @@
 
 #include <AIS_InteractiveContext.hxx>
 #include <V3d_View.hxx>
-#include <Visual3d_Layer.hxx>
 #include <AIS_Shape.hxx>
+#if OCC_VERSION_HEX < 0x070000
+#include <Visual3d_Layer.hxx>
+#endif
 class TopoDS_Shape;
 class gp_Pnt;
 class gp_Vec;
@@ -176,8 +181,10 @@ private: // members
     Handle_V3d_View                 myView;
     Handle_V3d_Viewer               myViewer;
     Handle_AIS_InteractiveContext   myContext;
+#if OCC_VERSION_HEX < 0x070000
     Handle_Visual3d_Layer           myLayer;
-                    
+#endif
+
     Standard_Boolean                myViewResized;
     Standard_Boolean                myViewInitialized;
     CurrentAction3d                 myMode;
@@ -231,10 +238,6 @@ private: // methods
                                     Standard_Real& Y,
                                     Standard_Real& Z);
                                           
-    void paintOCC();
-    static int paintCallBack (Aspect_Drawable, 
-                              void*, 
-                              Aspect_GraphicCallbackStruct*);
 
 };
 

--- a/TIGLViewer/src/TIGLViewerWindow.cpp
+++ b/TIGLViewer/src/TIGLViewerWindow.cpp
@@ -32,7 +32,6 @@
 
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <TopoDS_Vertex.hxx>
-#include <Handle_AIS_Shape.hxx>
 #include <AIS_Shape.hxx>
 #include <AIS_InteractiveContext.hxx>
 #include <Aspect_RectangularGrid.hxx>
@@ -61,10 +60,10 @@
 
 #include <cstdlib>
 
-void ShowOrigin ( Handle_AIS_InteractiveContext theContext );
-void AddVertex  ( double x, double y, double z, Handle_AIS_InteractiveContext theContext );
+void ShowOrigin ( Handle(AIS_InteractiveContext) theContext );
+void AddVertex  ( double x, double y, double z, Handle(AIS_InteractiveContext) theContext );
 
-void AddVertex (double x, double y, double z, Handle_AIS_InteractiveContext theContext)
+void AddVertex (double x, double y, double z, Handle(AIS_InteractiveContext) theContext)
 {
     TopoDS_Vertex aVertex=BRepBuilderAPI_MakeVertex( gp_Pnt(x,y,z) );
     Handle(AIS_Shape) AISVertex = new AIS_Shape(aVertex);
@@ -72,7 +71,7 @@ void AddVertex (double x, double y, double z, Handle_AIS_InteractiveContext theC
     theContext->Display(AISVertex);
 }
 
-void ShowOrigin ( Handle_AIS_InteractiveContext theContext )
+void ShowOrigin ( Handle(AIS_InteractiveContext) theContext )
 {
     AddVertex ( 0.0, 0.0, 0.0, theContext);
 }

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -456,7 +456,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglProfileGetBSplineDataSizes(TiglCPACSConfig
         // profile found, lets get bspline data
         
         if (!e.IsNull()) {
-             Handle_Geom_BSplineCurve bspl = GetBSplineCurve(e);
+             Handle(Geom_BSplineCurve) bspl = GetBSplineCurve(e);
              *degree = bspl->Degree();
              *ncontrolPoints = bspl->NbPoles();
              
@@ -550,7 +550,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglProfileGetBSplineData(TiglCPACSConfigurati
         // profile found, lets get bspline data
         
         if (!e.IsNull()) {
-            Handle_Geom_BSplineCurve bspl = GetBSplineCurve(e);
+            Handle(Geom_BSplineCurve) bspl = GetBSplineCurve(e);
             // check correct sizes
             if (ncp != bspl->NbPoles()) {
                 return TIGL_ERROR;

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -99,7 +99,7 @@ Standard_Real GetWireLength(const TopoDS_Wire& wire)
 Standard_Real GetEdgeLength(const TopoDS_Edge &edge)
 {
     Standard_Real umin, umax;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(edge, umin, umax);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, umin, umax);
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real length = GCPnts_AbscissaPoint::Length(adaptorCurve, umin, umax);
     return length;
@@ -188,7 +188,7 @@ void EdgeGetPointTangent(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, g
     }
     // ETA 3D point
     Standard_Real umin, umax;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(edge, umin, umax);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, umin, umax);
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
     GCPnts_AbscissaPoint algo(adaptorCurve, len*alpha, umin);
@@ -260,14 +260,14 @@ gp_Pnt GetCentralFacePoint(const TopoDS_Face& face)
 
     gp_Pnt p;
 
-    Handle_Geom_Surface surface = BRep_Tool::Surface(face);
+    Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
     BRepTools::UVBounds(face, umin, umax, vmin, vmax);
     Standard_Real umean = 0.5*(umin+umax);
     Standard_Real vmean = 0.5*(vmin+vmax);
 
 
     // compute intersection of u-iso line with face boundaries
-    Handle_Geom2d_Curve uiso = new Geom2d_Line(
+    Handle(Geom2d_Curve) uiso = new Geom2d_Line(
                 gp_Pnt2d(umean,0.),
                 gp_Dir2d(0., 1.)
                 );
@@ -279,7 +279,7 @@ gp_Pnt GetCentralFacePoint(const TopoDS_Face& face)
         Standard_Real first, last;
 
         // Get geomteric curve from edge
-        Handle_Geom2d_Curve hcurve = BRep_Tool::CurveOnSurface(edge, face, first, last);
+        Handle(Geom2d_Curve) hcurve = BRep_Tool::CurveOnSurface(edge, face, first, last);
         hcurve = new Geom2d_TrimmedCurve(hcurve, first, last);
 
         Geom2dAPI_InterCurveCurve intersector(uiso, hcurve);
@@ -443,14 +443,14 @@ TopoDS_Edge GetEdge(const TopoDS_Shape &shape, int iEdge)
     }
 }
 
-Handle_Geom_BSplineCurve GetBSplineCurve(const TopoDS_Edge& e)
+Handle(Geom_BSplineCurve) GetBSplineCurve(const TopoDS_Edge& e)
 {
     double u1, u2;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(e, u1, u2);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(e, u1, u2);
     curve = new Geom_TrimmedCurve(curve, u1, u2);
     
     // convert to bspline
-    Handle_Geom_BSplineCurve bspl =  GeomConvert::CurveToBSplineCurve(curve);
+    Handle(Geom_BSplineCurve) bspl =  GeomConvert::CurveToBSplineCurve(curve);
     return bspl;
 }
 

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -63,7 +63,7 @@ TIGL_EXPORT unsigned int GetNumberOfFaces(const TopoDS_Shape& shape);
 
 TIGL_EXPORT TopoDS_Edge GetEdge(const TopoDS_Shape& shape, int iEdge);
 
-TIGL_EXPORT Handle_Geom_BSplineCurve GetBSplineCurve(const TopoDS_Edge& e);
+TIGL_EXPORT Handle(Geom_BSplineCurve) GetBSplineCurve(const TopoDS_Edge& e);
 
 // Returns the number of subshapes, if the shape is a compound
 TIGL_EXPORT unsigned int GetNumberOfSubshapes(const TopoDS_Shape& shape);

--- a/src/exports/CTiglExportIges.cpp
+++ b/src/exports/CTiglExportIges.cpp
@@ -64,7 +64,7 @@ namespace
     /**
      * @brief WriteIGESFaceNames takes the names of each face and writes it into the IGES model.
      */
-    void WriteIGESFaceNames(Handle_Transfer_FinderProcess FP, const PNamedShape shape, int level)
+    void WriteIGESFaceNames(Handle(Transfer_FinderProcess) FP, const PNamedShape shape, int level)
     {
         if (!shape) {
             return;
@@ -102,7 +102,7 @@ namespace
         }
     }
     
-    void WriteIGESShapeNames(Handle_Transfer_FinderProcess FP, const PNamedShape shape, int level)
+    void WriteIGESShapeNames(Handle(Transfer_FinderProcess) FP, const PNamedShape shape, int level)
     {
         if (!shape) {
             return;
@@ -131,7 +131,7 @@ namespace
         }
     }
     
-    void WriteIgesWireName(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteIgesWireName(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         if (!shape) {
             return;
@@ -155,7 +155,7 @@ namespace
         }
     }
     
-    void WriteIgesNames(Handle_Transfer_FinderProcess FP, const PNamedShape shape, int level)
+    void WriteIgesNames(Handle(Transfer_FinderProcess) FP, const PNamedShape shape, int level)
     {
         WriteIGESFaceNames(FP, shape, level);
         WriteIGESShapeNames(FP, shape, level);

--- a/src/exports/CTiglExportIges.cpp
+++ b/src/exports/CTiglExportIges.cpp
@@ -97,7 +97,8 @@ namespace
             if ( FP->FindTypedTransient ( mapper, STANDARD_TYPE(IGESData_IGESEntity), entity ) ) {
                 Handle(TCollection_HAsciiString) str = new TCollection_HAsciiString(faceName.c_str());
                 entity->SetLabel(str);
-                entity->InitLevel(0, level);
+                Handle(IGESData_LevelListEntity) lle;
+                entity->InitLevel(lle, level);
             }
         }
     }
@@ -127,7 +128,8 @@ namespace
         if ( FP->FindTypedTransient ( mapper, STANDARD_TYPE(IGESData_IGESEntity), entity ) ) {
             Handle(TCollection_HAsciiString) str = new TCollection_HAsciiString(shapeName.c_str());
             entity->SetLabel(str);
-            entity->InitLevel(0, level);
+            Handle(IGESData_LevelListEntity) lle;
+            entity->InitLevel(lle, level);
         }
     }
     

--- a/src/exports/CTiglExportStep.cpp
+++ b/src/exports/CTiglExportStep.cpp
@@ -79,7 +79,7 @@ namespace
     /**
      * @brief WriteSTEPProductName writes the shape names as the step product identifier
      */
-    void WriteStepProductName(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteStepProductName(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         if (!shape) {
             return;
@@ -108,7 +108,7 @@ namespace
         product->SetName ( str );
     }
     
-    void WriteStepSolidName(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteStepSolidName(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         if (!shape) {
             return;
@@ -130,7 +130,7 @@ namespace
         }
     }
     
-    void WriteStepWireName(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteStepWireName(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         if (!shape) {
             return;
@@ -155,14 +155,14 @@ namespace
             // name edges
             for (int i = 1; i <= SGC->NbElements(); ++i) {
                 StepShape_GeometricSetSelect elem = SGC->ElementsValue(i);
-                Handle_StepGeom_Curve curve = Handle(StepGeom_Curve)::DownCast(elem.Value());
+                Handle(StepGeom_Curve) curve = Handle(StepGeom_Curve)::DownCast(elem.Value());
                 
                 if (!curve.IsNull()) {
                     curve->SetName(str);
                 }
                 
                 // CATIA does only show the basis curves. Hence we must name them too
-                Handle_StepGeom_TrimmedCurve tcurve = Handle(StepGeom_TrimmedCurve)::DownCast(elem.Value());
+                Handle(StepGeom_TrimmedCurve) tcurve = Handle(StepGeom_TrimmedCurve)::DownCast(elem.Value());
                 if (!tcurve.IsNull() && !tcurve->BasisCurve().IsNull()) {
                     tcurve->BasisCurve()->SetName(str);
                 }
@@ -170,7 +170,7 @@ namespace
         }
     }
     
-    void WriteStepShellName(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteStepShellName(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         if (!shape) {
             return;
@@ -201,7 +201,7 @@ namespace
      * @brief WriteSTEPFaceNames takes the names of each face and writes it into the STEP model
      * as an advanced face property
      */
-    void WriteStepFaceNames(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteStepFaceNames(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         if (!shape) {
             return;
@@ -223,7 +223,7 @@ namespace
         }
     }
 
-    void WriteStepNames(Handle_Transfer_FinderProcess FP, const PNamedShape shape)
+    void WriteStepNames(Handle(Transfer_FinderProcess) FP, const PNamedShape shape)
     {
         WriteStepFaceNames(FP, shape);
         WriteStepShellName(FP, shape);

--- a/src/fuselage/CCPACSFuselageProfile.cpp
+++ b/src/fuselage/CCPACSFuselageProfile.cpp
@@ -322,7 +322,7 @@ void CCPACSFuselageProfile::BuildWires(void)
     if (mirrorSymmetry) {
         try {
             CTiglSymetricSplineBuilder builder(points);
-            Handle_Geom_BSplineCurve c = builder.GetBSpline();
+            Handle(Geom_BSplineCurve) c = builder.GetBSpline();
 
             TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(c);
             gp_Pnt pstart = c->Value(c->FirstParameter());

--- a/src/fuselage/CCPACSFuselageProfile.h
+++ b/src/fuselage/CCPACSFuselageProfile.h
@@ -29,7 +29,6 @@
 #include "tixi.h"
 #include "TopoDS_Wire.hxx"
 
-#include <Handle_Geom2d_TrimmedCurve.hxx>
 #include <gp_Pnt.hxx>
 
 #include <vector>

--- a/src/geometry/CCSTCurveBuilder.cpp
+++ b/src/geometry/CCSTCurveBuilder.cpp
@@ -103,7 +103,7 @@ std::vector<double> CCSTCurveBuilder::B() const
     return _b;
 }
 
-Handle_Geom_BSplineCurve CCSTCurveBuilder::Curve()
+Handle(Geom_BSplineCurve) CCSTCurveBuilder::Curve()
 {
     CSTFunction function(this);
     CFunctionToBspline approximator(function, 0., 1., 4, 1e-5, 10);

--- a/src/geometry/CCSTCurveBuilder.h
+++ b/src/geometry/CCSTCurveBuilder.h
@@ -21,7 +21,6 @@
 
 #include "tigl_internal.h"
 
-#include <Handle_Geom_BSplineCurve.hxx>
 
 #include <vector>
 
@@ -41,7 +40,7 @@ public:
     TIGL_EXPORT double N2() const;
     TIGL_EXPORT std::vector<double> B() const;
 
-    TIGL_EXPORT Handle_Geom_BSplineCurve Curve();
+    TIGL_EXPORT Handle(Geom_BSplineCurve) Curve();
 
 private:
     double _n1, _n2;

--- a/src/geometry/CCSTCurveBuilder.h
+++ b/src/geometry/CCSTCurveBuilder.h
@@ -24,6 +24,8 @@
 
 #include <vector>
 
+#include <Geom_BSplineCurve.hxx>
+
 namespace tigl
 {
 

--- a/src/geometry/CFunctionToBspline.cpp
+++ b/src/geometry/CFunctionToBspline.cpp
@@ -119,13 +119,13 @@ public:
         _err = 0.;
     }
     
-    Handle_Geom_BSplineCurve Curve();
+    Handle(Geom_BSplineCurve) Curve();
     
     /// approximates the curve in the subrange [a, b]
     std::vector<ChebSegment> approxSegment(double a, double b, int depth);
     
     /// smooth concatenation the bspline curves to one curve
-    Handle_Geom_BSplineCurve concatC1(const std::vector<Handle_Geom_BSplineCurve>& curves);
+    Handle(Geom_BSplineCurve) concatC1(const std::vector<Handle(Geom_BSplineCurve)>& curves);
     
     /// members
     FuncAdaptor _xfunc, _yfunc, _zfunc;
@@ -149,7 +149,7 @@ CFunctionToBspline::~CFunctionToBspline()
     delete pimpl;
 }
 
-Handle_Geom_BSplineCurve CFunctionToBspline::Curve()
+Handle(Geom_BSplineCurve) CFunctionToBspline::Curve()
 {
     return pimpl->Curve();
 }
@@ -201,7 +201,7 @@ std::vector<ChebSegment> CFunctionToBspline::CFunctionToBsplineImpl::approxSegme
     
 }
 
-Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::Curve()
+Handle(Geom_BSplineCurve) CFunctionToBspline::CFunctionToBsplineImpl::Curve()
 {
     bool interpolate = true;
     
@@ -211,7 +211,7 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::Curve()
     math_Matrix Mt = monimial_to_bezier(N)*cheb_to_monomial(N);
     
     // get estimated error and create bspline segments
-    std::vector<Handle_Geom_BSplineCurve> curves;
+    std::vector<Handle(Geom_BSplineCurve)> curves;
     double errTotal = 0.;
     std::vector<ChebSegment>::iterator it = segments.begin();
     for (; it != segments.end(); ++it) {
@@ -243,7 +243,7 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::Curve()
         mults.SetValue(1, _degree+1);
         mults.SetValue(2, _degree+1);
         
-        Handle_Geom_BSplineCurve curve = new Geom_BSplineCurve(cp, knots, mults, _degree);
+        Handle(Geom_BSplineCurve) curve = new Geom_BSplineCurve(cp, knots, mults, _degree);
         curves.push_back(curve);
         
         if (seg.error > errTotal) {
@@ -253,7 +253,7 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::Curve()
     _err = errTotal;
      
     // concatenate c1 the bspline curves
-    Handle_Geom_BSplineCurve result = concatC1(curves);
+    Handle(Geom_BSplineCurve) result = concatC1(curves);
 
 #ifdef DEBUG
     LOG(INFO) << "Result of BSpline approximation of function:";
@@ -269,7 +269,7 @@ double CFunctionToBspline::ApproxError()
     return pimpl->_err;
 }
 
-Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::concatC1(const std::vector<Handle_Geom_BSplineCurve>& curves)
+Handle(Geom_BSplineCurve) CFunctionToBspline::CFunctionToBsplineImpl::concatC1(const std::vector<Handle(Geom_BSplineCurve)>& curves)
 {
     if (curves.size() == 0) {
         return NULL;
@@ -281,8 +281,8 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::concatC1(co
 #ifdef DEBUG
     // check range connectivities
     for (size_t i = 1; i < curves.size(); ++i) {
-        Handle_Geom_BSplineCurve lastCurve = curves[i-1];
-        Handle_Geom_BSplineCurve thisCurve = curves[i];
+        Handle(Geom_BSplineCurve) lastCurve = curves[i-1];
+        Handle(Geom_BSplineCurve) thisCurve = curves[i];
         assert(lastCurve->LastParameter() == thisCurve->FirstParameter());
     }
 #endif
@@ -290,9 +290,9 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::concatC1(co
     // count control points
     int ncp = 2;
     int nkn = 1;
-    std::vector<Handle_Geom_BSplineCurve>::const_iterator curveIt;
+    std::vector<Handle(Geom_BSplineCurve)>::const_iterator curveIt;
     for (curveIt = curves.begin(); curveIt != curves.end(); ++curveIt) {
-        Handle_Geom_BSplineCurve curve = *curveIt;
+        Handle(Geom_BSplineCurve) curve = *curveIt;
         ncp += curve->NbPoles() - 2;
         nkn += curve->NbKnots() - 1;
     }
@@ -305,7 +305,7 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::concatC1(co
     int iknotT = 1, imultT = 1, icpT = 1;
     int icurve = 0;
     for (curveIt = curves.begin(); curveIt != curves.end(); ++curveIt, ++icurve) {
-        Handle_Geom_BSplineCurve curve = *curveIt;
+        Handle(Geom_BSplineCurve) curve = *curveIt;
 
         // special handling of the first knot, control point
         knots.SetValue(iknotT++, curve->Knot(1));
@@ -331,12 +331,12 @@ Handle_Geom_BSplineCurve CFunctionToBspline::CFunctionToBsplineImpl::concatC1(co
     }
 
     // special handling of the last point and knot
-    Handle_Geom_BSplineCurve lastCurve = curves[curves.size()-1];
+    Handle(Geom_BSplineCurve) lastCurve = curves[curves.size()-1];
     knots.SetValue(iknotT, lastCurve->Knot(lastCurve->NbKnots()));
     mults.SetValue(imultT,  lastCurve->Multiplicity(lastCurve->NbKnots()));
     cpoints.SetValue(icpT, lastCurve->Pole(lastCurve->NbPoles()));
 
-    Handle_Geom_BSplineCurve result = new Geom_BSplineCurve(cpoints, knots, mults, _degree);
+    Handle(Geom_BSplineCurve) result = new Geom_BSplineCurve(cpoints, knots, mults, _degree);
     return result;
 }
 

--- a/src/geometry/CFunctionToBspline.h
+++ b/src/geometry/CFunctionToBspline.h
@@ -22,6 +22,8 @@
 #include "tiglmathfunctions.h"
 #include "tigl_internal.h"
 
+#include <Geom_BSplineCurve.hxx>
+
 namespace tigl
 {
 

--- a/src/geometry/CFunctionToBspline.h
+++ b/src/geometry/CFunctionToBspline.h
@@ -19,7 +19,6 @@
 #ifndef FUNCTIONTOBSPLINE_H
 #define FUNCTIONTOBSPLINE_H
 
-#include <Handle_Geom_BSplineCurve.hxx>
 #include "tiglmathfunctions.h"
 #include "tigl_internal.h"
 
@@ -55,7 +54,7 @@ public:
     ~CFunctionToBspline();
 
     /// Computes the B-Spline approximation
-    Handle_Geom_BSplineCurve Curve();
+    Handle(Geom_BSplineCurve) Curve();
 
     /// returns the error made by spline approximation
     double ApproxError();

--- a/src/geometry/CPointsToLinearBSpline.cpp
+++ b/src/geometry/CPointsToLinearBSpline.cpp
@@ -31,7 +31,7 @@ CPointsToLinearBSpline::CPointsToLinearBSpline(const std::vector<gp_Pnt>& points
 {
 }
 
-Handle_Geom_BSplineCurve CPointsToLinearBSpline::Curve() const
+Handle(Geom_BSplineCurve) CPointsToLinearBSpline::Curve() const
 {
     int ncp = (int) _points.size();
     std::vector<gp_Pnt>::const_iterator iter;
@@ -73,7 +73,7 @@ Handle_Geom_BSplineCurve CPointsToLinearBSpline::Curve() const
     return new Geom_BSplineCurve(cp, knots, mults, 1, false);
 }
 
-CPointsToLinearBSpline::operator Handle_Geom_BSplineCurve() const
+CPointsToLinearBSpline::operator Handle(Geom_BSplineCurve)() const
 {
     return Curve();
 }

--- a/src/geometry/CPointsToLinearBSpline.h
+++ b/src/geometry/CPointsToLinearBSpline.h
@@ -23,7 +23,6 @@
 
 #include <vector>
 #include <gp_Pnt.hxx>
-#include <Handle_Geom_BSplineCurve.hxx>
 
 namespace tigl
 {
@@ -37,9 +36,9 @@ class CPointsToLinearBSpline
 public:
     TIGL_EXPORT CPointsToLinearBSpline(const std::vector<gp_Pnt>& points);
 
-    TIGL_EXPORT Handle_Geom_BSplineCurve Curve() const;
+    TIGL_EXPORT Handle(Geom_BSplineCurve) Curve() const;
 
-    TIGL_EXPORT operator Handle_Geom_BSplineCurve() const;
+    TIGL_EXPORT operator Handle(Geom_BSplineCurve)() const;
 
     TIGL_EXPORT ~CPointsToLinearBSpline();
 

--- a/src/geometry/CPointsToLinearBSpline.h
+++ b/src/geometry/CPointsToLinearBSpline.h
@@ -24,6 +24,8 @@
 #include <vector>
 #include <gp_Pnt.hxx>
 
+#include <Geom_BSplineCurve.hxx>
+
 namespace tigl
 {
 

--- a/src/geometry/CTiglIntersectionCalculation.cpp
+++ b/src/geometry/CTiglIntersectionCalculation.cpp
@@ -57,7 +57,6 @@
 #include "BRepBuilderAPI_MakeFace.hxx"
 #include "BRepAlgoAPI_Section.hxx"
 #include "ShapeAnalysis_Wire.hxx"
-#include "Handle_TopTools_HSequenceOfShape.hxx"
 #include "TopTools_HSequenceOfShape.hxx"
 #include "ShapeAnalysis_FreeBounds.hxx"
 #include "BRepBuilderAPI_MakeWire.hxx"

--- a/src/geometry/CTiglIntersectionCalculation.h
+++ b/src/geometry/CTiglIntersectionCalculation.h
@@ -36,7 +36,6 @@
 
 #include "GeomAPI_IntSS.hxx"
 #include "ShapeAnalysis_Wire.hxx"
-#include "Handle_TopTools_HSequenceOfShape.hxx"
 #include "TopTools_HSequenceOfShape.hxx"
 #include "ShapeAnalysis_FreeBounds.hxx"
 

--- a/src/geometry/CTiglPolyDataTools.h
+++ b/src/geometry/CTiglPolyDataTools.h
@@ -22,7 +22,6 @@
 
 #include "tigl_internal.h"
 #include <TopoDS_Shape.hxx>
-#include <Handle_Poly_Triangulation.hxx>
 #include <CTiglPolyData.h>
 
 namespace tigl 

--- a/src/geometry/CTiglPolyDataTools.h
+++ b/src/geometry/CTiglPolyDataTools.h
@@ -24,6 +24,8 @@
 #include <TopoDS_Shape.hxx>
 #include <CTiglPolyData.h>
 
+#include <Poly_Triangulation.hxx>
+
 namespace tigl 
 {
 

--- a/src/geometry/CTiglSymetricSplineBuilder.cpp
+++ b/src/geometry/CTiglSymetricSplineBuilder.cpp
@@ -34,7 +34,7 @@
 namespace
 {
     // Symmetrizes two control points along the x-z plane
-    void symPole(Handle_Geom_BSplineCurve c, int i1, int i2) {
+    void symPole(Handle(Geom_BSplineCurve) c, int i1, int i2) {
         gp_Pnt p1 = c->Pole(i1);
         gp_Pnt p2 = c->Pole(i2);
 
@@ -61,7 +61,7 @@ CTiglSymetricSplineBuilder::CTiglSymetricSplineBuilder(const CPointContainer& po
 {
 }
 
-Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSpline() const
+Handle(Geom_BSplineCurve) CTiglSymetricSplineBuilder::GetBSpline() const
 {
     checkInputData();
 
@@ -70,13 +70,13 @@ Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSpline() const
     // symmetry wrt x-y plane
 
     // forward spline
-    Handle_Geom_BSplineCurve c1 =  GetBSplineInternal(_points);
+    Handle(Geom_BSplineCurve) c1 =  GetBSplineInternal(_points);
 
     CPointContainer pointsRev = _points;
     std::reverse(pointsRev.begin(), pointsRev.end());
 
     // backward spline
-    Handle_Geom_BSplineCurve c2 =  GetBSplineInternal(pointsRev);
+    Handle(Geom_BSplineCurve) c2 =  GetBSplineInternal(pointsRev);
     // reverse it, to achieve same direction as c1
     c2->Reverse();
 
@@ -99,7 +99,7 @@ Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSpline() const
     return c1;
 }
 
-Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSplineInternal(const CPointContainer& inputPoints) const
+Handle(Geom_BSplineCurve) CTiglSymetricSplineBuilder::GetBSplineInternal(const CPointContainer& inputPoints) const
 {
     CPointContainer points = inputPoints;
 
@@ -116,7 +116,7 @@ Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSplineInternal(const CP
     }
 
     // build interpolation curve
-    Handle_TColgp_HArray1OfPnt pnts = new TColgp_HArray1OfPnt(1,points.size());
+    Handle(TColgp_HArray1OfPnt) pnts = new TColgp_HArray1OfPnt(1,points.size());
     for (unsigned int i = 0; i < points.size(); ++i) {
         pnts->SetValue(i+1, points[i]);
     }
@@ -125,7 +125,7 @@ Handle_Geom_BSplineCurve CTiglSymetricSplineBuilder::GetBSplineInternal(const CP
     GeomAPI_Interpolate interpolator(pnts, true, 1e-7);
     interpolator.Perform();
 
-    Handle_Geom_BSplineCurve c = interpolator.Curve();
+    Handle(Geom_BSplineCurve) c = interpolator.Curve();
     // This is required in order to get a clamped bspline
     // with symmetric knots
     c->SetNotPeriodic();

--- a/src/geometry/CTiglSymetricSplineBuilder.h
+++ b/src/geometry/CTiglSymetricSplineBuilder.h
@@ -24,7 +24,7 @@
 #include <gp_Pnt.hxx>
 #include <vector>
 
-class Geom_BSplineCurve;
+#include <Geom_BSplineCurve.hxx>
 
 namespace tigl
 {

--- a/src/geometry/CTiglSymetricSplineBuilder.h
+++ b/src/geometry/CTiglSymetricSplineBuilder.h
@@ -24,7 +24,7 @@
 #include <gp_Pnt.hxx>
 #include <vector>
 
-class Handle_Geom_BSplineCurve;
+class Geom_BSplineCurve;
 
 namespace tigl
 {
@@ -48,10 +48,10 @@ public:
 
     TIGL_EXPORT CTiglSymetricSplineBuilder(const CPointContainer& points);
 
-    TIGL_EXPORT Handle_Geom_BSplineCurve GetBSpline() const;
+    TIGL_EXPORT Handle(Geom_BSplineCurve) GetBSpline() const;
 
 private:
-    Handle_Geom_BSplineCurve GetBSplineInternal(const CPointContainer& inputPoints) const;
+    Handle(Geom_BSplineCurve) GetBSplineInternal(const CPointContainer& inputPoints) const;
     void checkInputData() const;
 
     const CPointContainer& _points;

--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -400,7 +400,7 @@ TopoDS_Shape CTiglTransformation::Transform(const TopoDS_Shape& shape) const
         return trafo.Shape();
     }
     else {
-        const BRepBuilderAPI_GTransform brepBuilderGTransform(shape, Get_gp_GTrsf(), Standard_True);
+        BRepBuilderAPI_GTransform brepBuilderGTransform(shape, Get_gp_GTrsf(), Standard_True);
         const TopoDS_Shape& transformedShape = brepBuilderGTransform.Shape();
         return transformedShape;
     }

--- a/src/geometry/CWireToCurve.h
+++ b/src/geometry/CWireToCurve.h
@@ -23,6 +23,8 @@
 
 #include "tigl_internal.h"
 
+#include <Geom_BSplineCurve.hxx>
+
 namespace tigl
 {
 

--- a/src/geometry/CWireToCurve.h
+++ b/src/geometry/CWireToCurve.h
@@ -19,7 +19,6 @@
 #ifndef WIRETOCURVE_H
 #define WIRETOCURVE_H
 
-#include <Handle_Geom_BSplineCurve.hxx>
 #include <TopoDS_Wire.hxx>
 
 #include "tigl_internal.h"
@@ -48,11 +47,11 @@ public:
 
     /// Returns the resulting spline
     /// Returns NULL Handle in case of an error
-    TIGL_EXPORT operator Handle_Geom_BSplineCurve ();
-    TIGL_EXPORT Handle_Geom_BSplineCurve curve();
+    TIGL_EXPORT operator Handle(Geom_BSplineCurve) ();
+    TIGL_EXPORT Handle(Geom_BSplineCurve) curve();
 
 private:
-    Handle_Geom_BSplineCurve ShiftCurveRange(Handle_Geom_BSplineCurve curve, double umin, double umax);
+    Handle(Geom_BSplineCurve) ShiftCurveRange(Handle(Geom_BSplineCurve) curve, double umin, double umax);
 
     TopoDS_Wire _wire;
     double _tolerance;

--- a/src/system/occt_compat.h
+++ b/src/system/occt_compat.h
@@ -1,0 +1,12 @@
+#ifndef OCCT_COMPAT_H
+#define OCCT_COMPAT_H
+
+#include <Standard_Version.hxx>
+
+#if OCC_VERSION_HEX < 0x070000
+  #define DEFINE_STANDARD_RTTIEXT(C1,C2) DEFINE_STANDARD_RTTI(C1)
+  #define DEFINE_STANDARD_RTTI_INLINE(C1,C2) DEFINE_STANDARD_RTTI(C1)
+#endif
+
+#endif // OCCT_COMPAT_H
+

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -340,8 +340,8 @@ void CCPACSWingComponentSegment::GetSegmentIntersection(const std::string& segme
         throw CTiglError("Component segment line does not intersect iso eta line of segment in CCPACSWingComponentSegment::GetSegmentIntersection.", TIGL_MATH_ERROR);
     }
 
-    Handle_Geom_Curve csCurve = new Geom_Line(csLine);
-    Handle_Geom_Curve etaCurve = new Geom_Line(etaLine);
+    Handle(Geom_Curve) csCurve = new Geom_Line(csLine);
+    Handle(Geom_Curve) etaCurve = new Geom_Line(etaLine);
     GeomAdaptor_Curve csAdptAcuve(csCurve);
     GeomAdaptor_Curve etaAdptCurve(etaCurve);
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -570,7 +570,7 @@ void CCPACSWingComponentSegment::UpdateProjectedLeadingEdge()
     LEPointsProjected[0]         = innew;
 
     // build projected leading edge curve
-    projLeadingEdge = CPointsToLinearBSpline(LEPointsProjected);
+    projLeadingEdge = CPointsToLinearBSpline(LEPointsProjected).Curve();
 }
 
 

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -38,7 +38,6 @@
 
 #include "TopoDS_Shape.hxx"
 #include "TopoDS_Wire.hxx"
-#include "Handle_Geom_Curve.hxx"
 #include "Geom_BSplineSurface.hxx"
 #include "CCPACSMaterial.h"
 
@@ -153,7 +152,7 @@ private:
     double               mySurfaceArea;        /**< Surface area of this segment            */
     TopoDS_Shape         upperShape;           /**< Upper shape of this componentSegment    */
     TopoDS_Shape         lowerShape;           /**< Lower shape of this componentSegment    */
-    Handle_Geom_Curve    projLeadingEdge;      /**< (Extended) Leading edge projected into y-z plane */
+    Handle(Geom_Curve)    projLeadingEdge;      /**< (Extended) Leading edge projected into y-z plane */
     SegmentList          wingSegments;         /**< List of segments belonging to the component segment */
     Handle(Geom_Surface) upperSurface;
     Handle(Geom_Surface) lowerSurface;

--- a/src/wing/CCPACSWingProfile.h
+++ b/src/wing/CCPACSWingProfile.h
@@ -40,7 +40,6 @@
 #include "PTiglWingProfileAlgo.h"
 
 #include <gp_Pnt.hxx>
-#include <Handle_Geom2d_TrimmedCurve.hxx>
 
 
 namespace tigl 

--- a/src/wing/CCPACSWingProfile.h
+++ b/src/wing/CCPACSWingProfile.h
@@ -41,6 +41,7 @@
 
 #include <gp_Pnt.hxx>
 
+#include <Geom2d_TrimmedCurve.hxx>
 
 namespace tigl 
 {

--- a/src/wing/CCPACSWingProfileCST.cpp
+++ b/src/wing/CCPACSWingProfileCST.cpp
@@ -138,7 +138,7 @@ void CCPACSWingProfileCST::BuildWires()
     
     // Build upper wire
     CCSTCurveBuilder upperBuilder(upperN1, upperN2, upperB);
-    Handle_Geom_BSplineCurve upperCurve = upperBuilder.Curve();
+    Handle(Geom_BSplineCurve) upperCurve = upperBuilder.Curve();
     upperCurve->Transform(yzSwitch);
     upperWire = BRepBuilderAPI_MakeEdge(upperCurve);
     
@@ -149,7 +149,7 @@ void CCPACSWingProfileCST::BuildWires()
     }
     
     CCSTCurveBuilder lowerBuilder(lowerN1, lowerN2, binv);
-    Handle_Geom_BSplineCurve lowerCurve = lowerBuilder.Curve();
+    Handle(Geom_BSplineCurve) lowerCurve = lowerBuilder.Curve();
     lowerCurve->Transform(yzSwitch);
     lowerCurve->Reverse();
     lowerWire = BRepBuilderAPI_MakeEdge(lowerCurve);
@@ -158,7 +158,7 @@ void CCPACSWingProfileCST::BuildWires()
     TopoDS_Wire upperLowerWire = upperLowerWireMaker.Wire();
     
     // conatenate wire
-    Handle_Geom_Curve upperLowerCurve = CWireToCurve(upperLowerWire).curve();
+    Handle(Geom_Curve) upperLowerCurve = CWireToCurve(upperLowerWire).curve();
     upperLowerEdge = BRepBuilderAPI_MakeEdge(upperLowerCurve);
     
     tePoint = gp_Pnt(1,0,0);

--- a/src/wing/CCPACSWingProfilePointList.cpp
+++ b/src/wing/CCPACSWingProfilePointList.cpp
@@ -238,7 +238,7 @@ void CCPACSWingProfilePointList::BuildWires()
 
     // Get the curve of the wire
     Standard_Real u1,u2;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(profileEdgeTmp, u1, u2);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(profileEdgeTmp, u1, u2);
     curve = new Geom_TrimmedCurve(curve, u1, u2);
     
     // Get Leading edge parameter on curve

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -184,7 +184,7 @@ namespace
      */
     TopoDS_Edge getFaceTrimmingEdge(const TopoDS_Face& face, double ustart, double vstart, double uend, double vend)
     {
-        Handle_Geom_Surface surf = BRep_Tool::Surface(face);
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
         Handle(Geom2d_TrimmedCurve) line = GCE2d_MakeSegment(gp_Pnt2d(ustart,vstart), gp_Pnt2d(uend,vend));
     
         BRepBuilderAPI_MakeEdge edgemaker(line, surf);
@@ -513,7 +513,7 @@ void CCPACSWingSegment::etaXsiToUV(bool isFromUpper, double eta, double xsi, dou
 {
     gp_Pnt pnt = GetPoint(eta,xsi, isFromUpper);
 
-    Handle_Geom_Surface surf;
+    Handle(Geom_Surface) surf;
     if (isFromUpper) {
         surf = upperSurface;
     }

--- a/tests/tiglBSplines.cpp
+++ b/tests/tiglBSplines.cpp
@@ -32,7 +32,7 @@ TEST(BSplines, pointsToLinear)
     points.push_back(gp_Pnt(2,1,0));
     points.push_back(gp_Pnt(1,1,0));
     
-    Handle_Geom_BSplineCurve curve;
+    Handle(Geom_BSplineCurve) curve;
     ASSERT_NO_THROW(curve = tigl::CPointsToLinearBSpline(points));
     
     ASSERT_NEAR(0, curve->Value(0.  ).Distance(gp_Pnt(0,0,0)), 1e-10);
@@ -64,7 +64,7 @@ TEST(BSplines, symmetricBSpline)
     points.push_back(gp_Pnt(0,-sqrt(0.5),-sqrt(0.5)));
     points.push_back(gp_Pnt(0,0,-1));
 
-    Handle_Geom_BSplineCurve curve;
+    Handle(Geom_BSplineCurve) curve;
     tigl::CTiglSymetricSplineBuilder builder(points);
 
     ASSERT_NO_THROW(curve = builder.GetBSpline());
@@ -108,7 +108,7 @@ TEST(BSplines, symmetricBSpline_interp)
     points.push_back(gp_Pnt(0,-sqrt(0.5),-sqrt(0.5)));
     points.push_back(gp_Pnt(0,0,-1));
 
-    Handle_Geom_BSplineCurve curve;
+    Handle(Geom_BSplineCurve) curve;
     tigl::CTiglSymetricSplineBuilder builder(points);
 
     ASSERT_NO_THROW(curve = builder.GetBSpline());
@@ -136,7 +136,7 @@ TEST(BSplines, symmetricBSpline_invalidInput)
     points.push_back(gp_Pnt(0,-sqrt(0.5),-sqrt(0.5)));
     points.push_back(gp_Pnt(0,0,-1));
 
-    Handle_Geom_BSplineCurve curve;
+    Handle(Geom_BSplineCurve) curve;
     tigl::CTiglSymetricSplineBuilder builder(points);
 
     ASSERT_THROW(curve = builder.GetBSpline(), tigl::CTiglError);
@@ -152,7 +152,7 @@ TEST(BSplines, symmetricBSpline_invalidInput2)
     // the last point should have y == 0
     points.push_back(gp_Pnt(0,-0.1,-1));
 
-    Handle_Geom_BSplineCurve curve;
+    Handle(Geom_BSplineCurve) curve;
     tigl::CTiglSymetricSplineBuilder builder(points);
 
     ASSERT_THROW(curve = builder.GetBSpline(), tigl::CTiglError);

--- a/tests/tiglWingCSTProfile.cpp
+++ b/tests/tiglWingCSTProfile.cpp
@@ -162,7 +162,7 @@ TEST(CSTApprox, simpleAirfoil)
     B.push_back(1.0);
     
     tigl::CCSTCurveBuilder builder(N1, N2, B);
-    Handle_Geom_BSplineCurve curve = builder.Curve();
+    Handle(Geom_BSplineCurve) curve = builder.Curve();
 
     double devmax=0.0;
     // project sample points on curve and calculate distance
@@ -193,7 +193,7 @@ TEST(CSTApprox, ellipticBody)
     B.push_back(1.0);
     
     tigl::CCSTCurveBuilder builder(N1, N2, B);
-    Handle_Geom_BSplineCurve curve = builder.Curve();
+    Handle(Geom_BSplineCurve) curve = builder.Curve();
 
     double devmax=0.0;
     // project sample points on curve and calculate distance
@@ -224,7 +224,7 @@ TEST(CSTApprox, hypersonicAirfoil)
     B.push_back(1.0);
     
     tigl::CCSTCurveBuilder builder(N1, N2, B);
-    Handle_Geom_BSplineCurve curve = builder.Curve();
+    Handle(Geom_BSplineCurve) curve = builder.Curve();
 
     double devmax=0.0;
     // project sample points on curve and calculate distance


### PR DESCRIPTION
This port included:
  - Support for the new Handles
  - New Rubberband implementation
  - Use of native QtWidget window

Since OpenCASCADE 6.9.0, the meshing with BrepMesh changed. This makes the meshing of some test fuselages slower by a factor 4 (mesh nodes are increased though). This can be fixed by decreasing the deflection in the tests.