### PR TITLE
Fixed an issue in tiglWingComponentSegmentComputeEtaIntersection

### DIFF
--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -68,6 +68,8 @@
 #include <Geom2dAPI_InterCurveCurve.hxx>
 #include <Geom_TrimmedCurve.hxx>
 #include <GeomConvert.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
 
 #include "ShapeAnalysis_FreeBounds.hxx"
 
@@ -404,6 +406,30 @@ ListPNamedShape GroupFaces(const PNamedShape shape, tigl::ShapeGroupMode groupTy
 Standard_Real ProjectPointOnLine(gp_Pnt p, gp_Pnt lineStart, gp_Pnt lineStop)
 {
     return gp_Vec(lineStart, p) * gp_Vec(lineStart, lineStop) / gp_Vec(lineStart, lineStop).SquareMagnitude();
+}
+
+IntStatus IntersectLinePlane(gp_Pnt p1, gp_Pnt p2, gp_Pln plane, gp_Pnt& result) {
+    gp_Vec normal = plane.Axis().Direction();
+    gp_Pnt center = plane.Axis().Location();
+
+    double denominator = gp_Vec(p2.XYZ() - p1.XYZ())*normal;
+    if (fabs(denominator) < 1e-8) {
+        return NoIntersection;
+    }
+
+    double alpha = gp_Vec(center.XYZ() - p1.XYZ())*normal / denominator ;
+    result = p1.XYZ() + alpha*(p2.XYZ()-p1.XYZ());
+
+    if (alpha >= 0. && alpha <= 1.) {
+        return BetweenPoints;
+    }
+    else if (alpha < 0.){
+        return OutsideBefore;
+    }
+    else {
+        // alpha > 1.
+        return OutsideAfter;
+    }
 }
 
 // Returns the coordinates of the bounding box of the shape

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -55,6 +55,16 @@ TIGL_EXPORT Standard_Real ProjectPointOnWire(const TopoDS_Wire& wire, gp_Pnt p);
 // projects a point onto the line (lineStart<->lineStop) and returns the projection parameter
 TIGL_EXPORT Standard_Real ProjectPointOnLine(gp_Pnt p, gp_Pnt lineStart, gp_Pnt lineStop);
 
+enum IntStatus {
+    BetweenPoints, // The intersection point lies between p1 and p2
+    OutsideBefore, // The intersection point lies before p1
+    OutsideAfter,  // The intersection point lies after p2
+    NoIntersection // the plane and the line are parallel to each other
+};
+
+// returns the intersection point between a line (p1-p2) and the plane
+TIGL_EXPORT IntStatus IntersectLinePlane(gp_Pnt p1, gp_Pnt p2, gp_Pln plane, gp_Pnt& result);
+
 // returns the number of edges of the current shape
 TIGL_EXPORT unsigned int GetNumberOfEdges(const TopoDS_Shape& shape);
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -419,6 +419,7 @@ void CCPACSWingComponentSegment::InterpolateOnLine(double csEta1, double csXsi1,
             segment = GetSegmentList().front();
             extendedOuterChord.translate(curEta, curXsi, &nearestPointTmp);
             nearestPoint = nearestPointTmp.Get_gp_Pnt();
+            xsi = curXsi;
         }
         else {
             retValProj = extendedInnerChord.translate(intersectionPoint.XYZ(), &curEta, &curXsi);
@@ -427,16 +428,18 @@ void CCPACSWingComponentSegment::InterpolateOnLine(double csEta1, double csXsi1,
                 segment = GetSegmentList().back();
                 extendedInnerChord.translate(curEta, curXsi, &nearestPointTmp);
                 nearestPoint = nearestPointTmp.Get_gp_Pnt();
+                xsi = curXsi;
             }
             else {
                 throw CTiglError("The requested point lies outside the wing chord surface.", TIGL_MATH_ERROR);
             }
         }
     }
-
-    double etaRes, xsiRes;
-    segment->GetEtaXsi(nearestPoint, etaRes, xsiRes);
-    xsi = xsiRes;
+    else {
+        double etaRes, xsiRes;
+        segment->GetEtaXsi(nearestPoint, etaRes, xsiRes);
+        xsi = xsiRes;
+    }
 
     // compute the error distance
     // This is the distance from the line to the nearest point on the chord face

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -35,6 +35,7 @@
 #include "CCPACSWingCSStructure.h"
 #include "CTiglPoint.h"
 #include "CTiglAbstractSegment.h"
+#include "CTiglPointTranslator.h"
 
 #include "TopoDS_Shape.hxx"
 #include "TopoDS_Wire.hxx"
@@ -139,6 +140,7 @@ private:
     std::vector<int> findPath(const std::string& fromUid, const::std::string& toUID, const std::vector<int>& curPath, bool forward) const;
 
     void UpdateProjectedLeadingEdge();
+    void UpdateExtendedChordFaces();
 
     // create short name
     std::string MakeShortName();
@@ -152,7 +154,9 @@ private:
     double               mySurfaceArea;        /**< Surface area of this segment            */
     TopoDS_Shape         upperShape;           /**< Upper shape of this componentSegment    */
     TopoDS_Shape         lowerShape;           /**< Lower shape of this componentSegment    */
-    Handle(Geom_Curve)    projLeadingEdge;      /**< (Extended) Leading edge projected into y-z plane */
+    Handle(Geom_Curve)   projLeadingEdge;      /**< (Extended) Leading edge projected into y-z plane */
+    CTiglPointTranslator extendedOuterChord;   /**< Extended outer segment chord face */
+    CTiglPointTranslator extendedInnerChord;   /**< Extended inner segment chord face */
     SegmentList          wingSegments;         /**< List of segments belonging to the component segment */
     Handle(Geom_Surface) upperSurface;
     Handle(Geom_Surface) lowerSurface;

--- a/tests/TestData/compseg-rotated.xml
+++ b/tests/TestData/compseg-rotated.xml
@@ -49,14 +49,14 @@
                                 <name>D150_wing_1Section1</name>
                                 <transformation>
                                     <scaling>
-                                        <x>1</x>
+                                        <x>1.4142135624</x>
                                         <y>1</y>
                                         <z>1</z>
                                     </scaling>
                                     <rotation>
                                         <x>0</x>
                                         <y>0.0</y>
-                                        <z>0</z>
+                                        <z>45.</z>
                                     </rotation>
                                     <translation refType = "absLocal">
                                         <x>0</x>
@@ -135,7 +135,7 @@
                                 <name>D150_wing_1Section3</name>
                                 <transformation>
                                     <scaling>
-                                        <x>1.41421</x>
+                                        <x>1.4142135624</x>
                                         <y>1</y>
                                         <z>1</z>
                                     </scaling>

--- a/tests/TestData/compseg-rotated.xml
+++ b/tests/TestData/compseg-rotated.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="cpacs_2_01.xsl"?>
+<cpacs xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation = "cpacs_schema_v201.xsd">
+    <header>
+        <name>D150 for CPACS 1.3</name>
+        <description>copied some stuff from other versions. Mission is just an example as the D150 might not make it to Newark with Mach 0.84</description>
+        <creator>Daniel Boehnke, DLR-LK</creator>
+        <timestamp>2010-07-07T12:00:00</timestamp>
+        <version>1.0</version>
+        <cpacsVersion>2.0</cpacsVersion>
+	</header>
+    <vehicles>
+        <aircraft>
+            <model uID = "D150modelID">
+                <name>DLR's D150 Release Bird for CPACS 2.0</name>
+                <description>Conventional medium range public jet transport aircraft</description>
+                <reference>
+                    <area>122.4</area>
+                    <length>4.2</length>
+                    <point>
+                        <x>0.0</x>
+                        <y>0.0</y>
+                        <z>0.0</z>
+                    </point>
+                </reference>
+                <wings>
+                    <wing symmetry = "x-z-plane" uID = "D150_wing_1ID">
+                        <name>D150_wing_1</name>
+                        <description>imported from P2C</description>
+                        <transformation>
+                            <scaling>
+                                <x>1.0</x>
+                                <y>1.0</y>
+                                <z>1.0</z>
+                            </scaling>
+                            <rotation>
+                                <x>0</x>
+                                <y>0</y>
+                                <z>0</z>
+                            </rotation>
+                            <translation refType = "absLocal">
+                                <x>0</x>
+                                <y>0</y>
+                                <z>0</z>
+                            </translation>
+                        </transformation>
+                        <sections>
+                            <section uID = "D150_wing_1Section1ID">
+                                <name>D150_wing_1Section1</name>
+                                <transformation>
+                                    <scaling>
+                                        <x>1</x>
+                                        <y>1</y>
+                                        <z>1</z>
+                                    </scaling>
+                                    <rotation>
+                                        <x>0</x>
+                                        <y>0.0</y>
+                                        <z>0</z>
+                                    </rotation>
+                                    <translation refType = "absLocal">
+                                        <x>0</x>
+                                        <y>0</y>
+                                        <z>0</z>
+                                    </translation>
+                                </transformation>
+                                <elements>
+                                    <element uID = "D150_wing_1Section1IDElement1">
+                                        <name>D150_wing_1Section1</name>
+                                        <airfoilUID>Profile_wing_1</airfoilUID>
+                                        <transformation>
+                                            <scaling>
+                                                <x>10.</x>
+                                                <y>10.</y>
+                                                <z>10.</z>
+                                            </scaling>
+                                            <rotation>
+                                                <x>0.0</x>
+                                                <y>0</y>
+                                                <z>0</z>
+                                            </rotation>
+                                            <translation refType = "absLocal">
+                                                <x>0</x>
+                                                <y>0</y>
+                                                <z>0</z>
+                                            </translation>
+                                        </transformation>
+                                    </element>
+                                </elements>
+                            </section>
+                            <section uID = "D150_wing_1Section2ID">
+                                <name>D150_wing_1Section2</name>
+                                <transformation>
+                                    <scaling>
+                                        <x>1</x>
+                                        <y>1</y>
+                                        <z>1</z>
+                                    </scaling>
+                                    <rotation>
+                                        <x>0</x>
+                                        <y>0.0</y>
+                                        <z>0</z>
+                                    </rotation>
+                                    <translation refType = "absLocal">
+                                        <x>0</x>
+                                        <y>0</y>
+                                        <z>0</z>
+                                    </translation>
+                                </transformation>
+                                <elements>
+                                    <element uID = "D150_wing_1Section2IDElement1">
+                                        <name>D150_wing_1Section2</name>
+                                        <airfoilUID>Profile_wing_1</airfoilUID>
+                                        <transformation>
+                                            <scaling>
+                                                <x>10.0</x>
+                                                <y>10.0</y>
+                                                <z>10.0</z>
+                                            </scaling>
+                                            <rotation>
+                                                <x>0.0</x>
+                                                <y>0</y>
+                                                <z>0</z>
+                                            </rotation>
+                                            <translation refType = "absLocal">
+                                                <x>0</x>
+                                                <y>0</y>
+                                                <z>0</z>
+                                            </translation>
+                                        </transformation>
+                                    </element>
+                                </elements>
+                            </section>
+                            <section uID = "D150_wing_1Section3ID">
+                                <name>D150_wing_1Section3</name>
+                                <transformation>
+                                    <scaling>
+                                        <x>1.41421</x>
+                                        <y>1</y>
+                                        <z>1</z>
+                                    </scaling>
+                                    <rotation>
+                                        <x>0</x>
+                                        <y>0.0</y>
+                                        <z>45.0</z>
+                                    </rotation>
+                                    <translation refType = "absLocal">
+                                        <x>0</x>
+                                        <y>0</y>
+                                        <z>0</z>
+                                    </translation>
+                                </transformation>
+                                <elements>
+                                    <element uID = "D150_wing_1Section3IDElement1">
+                                        <name>D150_wing_1Section3</name>
+                                        <airfoilUID>Profile_wing_1</airfoilUID>
+                                        <transformation>
+                                            <scaling>
+                                                <x>10.0</x>
+                                                <y>10.0</y>
+                                                <z>10.0</z>
+                                            </scaling>
+                                            <rotation>
+                                                <x>0.0</x>
+                                                <y>0</y>
+                                                <z>0</z>
+                                            </rotation>
+                                            <translation refType = "absLocal">
+                                                <x>0</x>
+                                                <y>0</y>
+                                                <z>0</z>
+                                            </translation>
+                                        </transformation>
+                                    </element>
+                                </elements>
+                            </section>
+                        </sections>
+                        <positionings>
+                            <positioning uID = "D150_wing_1Positioning1ID">
+                                <name>D150_wing_1Positioning1</name>
+                                <length>0.0</length>
+                                <sweepAngle>0.0</sweepAngle>
+                                <dihedralAngle>0.0</dihedralAngle>
+                                <toSectionUID>D150_wing_1Section1ID</toSectionUID>
+                            </positioning>
+                            <positioning uID = "D150_wing_1Positioning2ID">
+                                <name>D150_wing_1Positioning2</name>
+                                <length>20</length>
+                                <sweepAngle>0.0</sweepAngle>
+                                <dihedralAngle>0.0</dihedralAngle>
+                                <fromSectionUID>D150_wing_1Section1ID</fromSectionUID>
+                                <toSectionUID>D150_wing_1Section2ID</toSectionUID>
+                            </positioning>
+                            <positioning uID = "D150_wing_1Positioning3ID">
+                                <name>D150_wing_1Positioning3</name>
+                                <length>10</length>
+                                <sweepAngle>0</sweepAngle>
+                                <dihedralAngle>0</dihedralAngle>
+                                <fromSectionUID>D150_wing_1Section2ID</fromSectionUID>
+                                <toSectionUID>D150_wing_1Section3ID</toSectionUID>
+                            </positioning>
+                        </positionings>
+                        <segments>
+                            <segment uID = "D150_wing_1Segment2ID">
+                                <name>D150_wing_1Segment2ID</name>
+                                <fromElementUID>D150_wing_1Section1IDElement1</fromElementUID>
+                                <toElementUID>D150_wing_1Section2IDElement1</toElementUID>
+                            </segment>
+                            <segment uID = "D150_wing_1Segment3ID">
+                                <name>D150_wing_1Segment3ID</name>
+                                <fromElementUID>D150_wing_1Section2IDElement1</fromElementUID>
+                                <toElementUID>D150_wing_1Section3IDElement1</toElementUID>
+                            </segment>
+                        </segments>
+                        <componentSegments>
+                            <componentSegment uID = "D150_wing_CS">
+                                <name>D150_wing</name>
+                                <fromElementUID>D150_wing_1Section1IDElement1</fromElementUID>
+                                <toElementUID>D150_wing_1Section3IDElement1</toElementUID>
+							</componentSegment>
+                        </componentSegments>
+					</wing>
+                </wings>
+			</model>
+        </aircraft>
+		<profiles>
+			<wingAirfoils>
+                <wingAirfoil uID = "Profile_wing_1">
+                    <name>NameProfile_wing_1</name>
+                    <description>Profile generated automaticallz bz WingLib</description>
+                    <pointList>
+                        <x mapType = "vector">1.0;0.99318065;0.97290862;0.93973687;0.89457025;0.83864078;0.77347407;0.7008477;0.62274273;0.54128966;0.45871032;0.37725724;0.29915227;0.22652591;0.1613592;0.10542973;0.06026312;0.02709137;0.00681934;0.0;0.00681934;0.02709137;0.06026312;0.10542973;0.1613592;0.22652591;0.29915227;0.37725724;0.45871032;0.54128966;0.62274273;0.7008477;0.77347407;0.83864078;0.89457025;0.93973687;0.97290862;0.99318065;1.0</x>
+                        <y mapType = "vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+                        <z mapType = "vector">0.0;0.00156842;0.00478703;0.01009993;0.01704458;0.02471343;0.03240848;0.03960558;0.04610725;0.0520147;0.05732852;0.06187089;0.06527812;0.06697582;0.06600959;0.06200228;0.05427176;0.04144676;0.02344718;0.0;-0.02033238;-0.0377444;-0.05467523;-0.06753082;-0.07701615;-0.08345515;-0.08659188;-0.08618776;-0.08202661;-0.07386881;-0.06198569;-0.0477972;-0.03348007;-0.02095115;-0.01177135;-0.00582898;-0.00238273;-0.00057906;0.0</z>
+                    </pointList>
+                </wingAirfoil>
+            </wingAirfoils>
+		</profiles>
+	</vehicles>
+</cpacs>

--- a/tests/tiglCommonFunctions.cpp
+++ b/tests/tiglCommonFunctions.cpp
@@ -18,7 +18,7 @@
 #include "tiglcommonfunctions.h"
 #include "test.h"
 
-
+#include <gp_Pln.hxx>
 
 TEST(TiglCommonFunctions, isPathRelative)
 {
@@ -42,3 +42,19 @@ TEST(TiglCommonFunctions, isFileReadable)
     ASSERT_FALSE(IsFileReadable("invalidfile.txt"));
 }
 
+TEST(TiglCommonFunctions, IntersectLinePlane)
+{
+    gp_Pln plane(gp_Pnt(10., 2., 0.), gp_Dir(0., 1., 0));
+
+    gp_Pnt result;
+    ASSERT_EQ(BetweenPoints, IntersectLinePlane(gp_Pnt(0., 0., 0.), gp_Pnt(0., 4., 0.), plane, result));
+    ASSERT_NEAR(0., result.Distance(gp_Pnt(0., 2., 0)), 1e-10);
+
+    ASSERT_EQ(OutsideBefore, IntersectLinePlane(gp_Pnt(1., 3., 0.), gp_Pnt(1., 4., 0.), plane, result));
+    ASSERT_NEAR(0., result.Distance(gp_Pnt(1., 2., 0)), 1e-10);
+
+    ASSERT_EQ(OutsideAfter, IntersectLinePlane(gp_Pnt(1., 0., 0.), gp_Pnt(1., 1., 0.), plane, result));
+    ASSERT_NEAR(0., result.Distance(gp_Pnt(1., 2., 0)), 1e-10);
+
+    ASSERT_EQ(NoIntersection, IntersectLinePlane(gp_Pnt(1., 3., 0.), gp_Pnt(10., 3., 0.), plane, result));
+}

--- a/tests/tiglWingComponentSegment.cpp
+++ b/tests/tiglWingComponentSegment.cpp
@@ -837,6 +837,15 @@ TEST(WingComponentSegment5, IntersectEta_bug)
     ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", 0.0, 0.5, 1.0, 0.5, 0.9, &xsi, &hasWarning));
     ASSERT_NEAR(0.5, xsi, 1e-6);
 
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", 0.0, 0.5, 1.0, 0.5, 0.1, &xsi, &hasWarning));
+    ASSERT_NEAR(0.5, xsi, 1e-6);
+
+    // Test some invalid inputs
+    ASSERT_EQ(TIGL_MATH_ERROR, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", 0.0, 0.5, 1.0, 0.5, 1.1, &xsi, &hasWarning));
+    ASSERT_EQ(TIGL_MATH_ERROR, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", 0.0, 0.5, 1.0, 0.5, -0.1, &xsi, &hasWarning));
+    ASSERT_EQ(TIGL_ERROR, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", -0.1, 0.5, 1.0, 0.5, 0.7, &xsi, &hasWarning));
+    ASSERT_EQ(TIGL_ERROR, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", 0.0, 0.5, 1.1, 0.5, 0.7, &xsi, &hasWarning));
+
     ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
     ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
 }

--- a/tests/tiglWingComponentSegment.cpp
+++ b/tests/tiglWingComponentSegment.cpp
@@ -817,3 +817,26 @@ TEST(WingComponentSegment5, GetPointPerformance)
     ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
     ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
 }
+
+TEST(WingComponentSegment5, IntersectEta_bug)
+{
+    const char* filename = "TestData/compseg-rotated.xml";
+    ReturnCode tixiRet;
+    TiglReturnCode tiglRet;
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    TixiDocumentHandle tixiHandle = -1;
+
+    tixiRet = tixiOpenDocument(filename, &tixiHandle);
+    ASSERT_EQ (SUCCESS, tixiRet);
+    tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle);
+    ASSERT_EQ(TIGL_SUCCESS, tiglRet);
+
+    double xsi;
+    TiglBoolean hasWarning;
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "D150_wing_CS", 0.0, 0.5, 1.0, 0.5, 0.9, &xsi, &hasWarning));
+    ASSERT_NEAR(0.5, xsi, 1e-6);
+
+    ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
+    ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
+}


### PR DESCRIPTION
The full description of the bug can be read in #206.

With the current component segment definition, the coordinate system can be larger than the actual wing plan form. This PR adds the extended outer and inner segment chord faces. Now we can check, whether a point lies on the extended chords or is completely outside of the wing.
