### PR TITLE
Fix for rotorcraft regression in cpacs_3 branch

### DIFF
--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -282,7 +282,7 @@ if (WIN32 OR APPLE)
 endif()
 
 # install shader files from opencascade
-if (NOT OCC_VERSION_STRING VERSION_LESS "6.7.0")
+if (OpenCASCADE_SHADER_DIRECTORY)
    file(GLOB SHADER_FILES PATH "${OpenCASCADE_SHADER_DIRECTORY}/*")
    if (APPLE)
      install(FILES ${SHADER_FILES} DESTINATION ${PROGNAME}.app/Contents/Resources/ COMPONENT viewer)

--- a/src/common/to_string.h
+++ b/src/common/to_string.h
@@ -21,7 +21,7 @@
 namespace tigl
 {
 
-// TODO: replace by std_to_string() when C++11 is available
+// TODO: replace by std::to_string() when C++11 is available
 template<typename T>
 std::string std_to_string(T value)
 {

--- a/src/configuration/CCPACSConfiguration.cpp
+++ b/src/configuration/CCPACSConfiguration.cpp
@@ -138,7 +138,7 @@ void CCPACSConfiguration::ReadCPACS(const std::string& configurationUID)
 // Write CPACS structure to tixiHandle
 void CCPACSConfiguration::WriteCPACS(const std::string& configurationUID)
 {
-    header.WriteCPACS(tixiDocumentHandle, "/cpacs/header");
+    header.WriteCPACS(tixiDocumentHandle, headerXPath);
     if (aircraftModel) {
         tixihelper::TixiSaveAttribute(tixiDocumentHandle, "/cpacs/vehicles/aircraft/model", "uID", configurationUID); // patch uid in tixi, so xpath below is valid
         aircraftModel->SetUID(configurationUID);
@@ -218,7 +218,7 @@ int CCPACSConfiguration::GetWingProfileCount() const
     int count = 0;
     if (profiles) {
         if (profiles->GetWingAirfoils())
-            count += profiles->GetWingAirfoils()->GetProfileCount();
+            count += profiles->GetWingAirfoils()->GetWingAirfoils().size();
         if (profiles->GetRotorAirfoils())
             count += static_cast<int>(profiles->GetRotorAirfoils()->GetRotorAirfoils().size());
     }

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -52,20 +52,14 @@
 namespace tigl
 {
 
-// Constructor
-CCPACSFuselage::CCPACSFuselage(CCPACSConfiguration* config)
-    : generated::CPACSFuselage(&config->GetFuselages())
-    , CTiglRelativelyPositionedComponent(&m_parentUID, &m_transformation, &m_symmetry)
-    , configuration(config)
-{
-    Cleanup();
-}
-
 CCPACSFuselage::CCPACSFuselage(CCPACSFuselages* parent)
     : generated::CPACSFuselage(parent)
-    , CTiglRelativelyPositionedComponent(&m_parentUID, &m_transformation, &m_symmetry)
-    , configuration(&parent->GetParent<CCPACSAircraftModel>()->GetConfiguration()) {
+    , CTiglRelativelyPositionedComponent(&m_parentUID, &m_transformation, &m_symmetry) {
     Cleanup();
+    if (parent->IsParent<CCPACSAircraftModel>())
+        configuration = &parent->GetParent<CCPACSAircraftModel>()->GetConfiguration();
+    else
+        configuration = &parent->GetParent<CCPACSRotorcraftModel>()->GetConfiguration();
 }
 
 // Destructor

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -50,7 +50,6 @@ class CCPACSFuselage : public generated::CPACSFuselage, public CTiglRelativelyPo
 {
 public:
     // Constructor
-    TIGL_EXPORT CCPACSFuselage(CCPACSConfiguration* config);
     TIGL_EXPORT CCPACSFuselage(CCPACSFuselages* parent);
 
     // Virtual Destructor

--- a/src/fuselage/CCPACSFuselages.cpp
+++ b/src/fuselage/CCPACSFuselages.cpp
@@ -36,9 +36,7 @@ CCPACSFuselages::CCPACSFuselages(CCPACSAircraftModel* parent)
     : generated::CPACSFuselages(parent) {}
 
 CCPACSFuselages::CCPACSFuselages(CCPACSRotorcraftModel* parent)
-    : generated::CPACSFuselages(parent) {
-    throw CTiglError("Instantiating CCPACSFuselages with CPACSRotorcraftModel as parent is not implemented");
-}
+    : generated::CPACSFuselages(parent) {}
 
 // Invalidates internal state
 void CCPACSFuselages::Invalidate()
@@ -74,11 +72,17 @@ int CCPACSFuselages::GetProfileCount() const
 
 CCPACSFuselageProfiles& CCPACSFuselages::GetProfiles() 
 {
-    return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetFuselageProfiles();
+    if (IsParent<CCPACSAircraftModel>())
+        return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetFuselageProfiles();
+    else
+        return static_cast<CCPACSRotorcraftModel*>(m_parent)->GetConfiguration().GetFuselageProfiles();
 }
 
 const CCPACSFuselageProfiles& CCPACSFuselages::GetProfiles() const {
-    return static_cast<const CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetFuselageProfiles();
+    if (IsParent<CCPACSAircraftModel>())
+        return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetFuselageProfiles();
+    else
+        return static_cast<CCPACSRotorcraftModel*>(m_parent)->GetConfiguration().GetFuselageProfiles();
 }
 
 // Returns the fuselage profile for a given index.

--- a/src/logging/CTiglLogSplitter.cpp
+++ b/src/logging/CTiglLogSplitter.cpp
@@ -37,7 +37,7 @@ void CTiglLogSplitter::AddLogger(PTiglLogger logger)
     }
 }
 
-// OVERRIDE from ITIglLogger
+// override from ITIglLogger
 void CTiglLogSplitter::LogMessage(TiglLogLevel level, const char * message) 
 {
     if (level<=verbosity) {

--- a/src/wing/CCPACSWingRibsDefinition.cpp
+++ b/src/wing/CCPACSWingRibsDefinition.cpp
@@ -139,7 +139,7 @@ int CCPACSWingRibsDefinition::GetNumberOfRibs() const
         numberOfRibs = ribSetDataCache.numberOfRibs;
         break;
     default:
-        throw CTiglError("Unknown GetRibPositioningType() found in CCPACSWingRibsDefinition::GetNumberOfRibs()!");
+        throw CTiglError("Unknown ribPositioningType found in CCPACSWingRibsDefinition::GetNumberOfRibs()!");
     }
     return numberOfRibs;
 }
@@ -313,8 +313,8 @@ void CCPACSWingRibsDefinition::BuildAuxiliaryGeometry() const
         BuildAuxGeomExplicitRibPositioning();
         break;
     default:
-        LOG(ERROR) << "Invalid GetRibPositioningType() found in CCPACSWingRibsDefinition::BuildAuxiliaryGeometry!";
-        throw CTiglError("Invalid GetRibPositioningType() found in CCPACSWingRibsDefinition::BuildAuxiliaryGeometry!");
+        LOG(ERROR) << "Invalid ribPositioningType found in CCPACSWingRibsDefinition::BuildAuxiliaryGeometry!";
+        throw CTiglError("Invalid ribPositioningType found in CCPACSWingRibsDefinition::BuildAuxiliaryGeometry!");
     }
 
     auxGeomCache.valid = true;
@@ -452,7 +452,7 @@ void CCPACSWingRibsDefinition::BuildAuxGeomExplicitRibPositioning() const
     else {
         // check whether the startReference is a spar
         if (startReference != "leadingEdge" && startReference != "trailingEdge") {
-            CCPACSWingSparSegment& spar = structure.GetSparSegment(startReference);
+            const CCPACSWingSparSegment& spar = structure.GetSparSegment(startReference);
             TopoDS_Shape sparShape = spar.GetSparGeometry(WING_COORDINATE_SYSTEM);
             double midplaneEta, dummy;
             wingStructureReference.GetMidplaneEtaXsi(startPnt, midplaneEta, dummy);

--- a/src/wing/CCPACSWingSparPositions.h
+++ b/src/wing/CCPACSWingSparPositions.h
@@ -27,9 +27,6 @@ class CCPACSWingSpars;
 
 class CCPACSWingSparPositions : public generated::CPACSSparPositions
 {
-private:
-    typedef std::vector<CCPACSWingSparPosition*> CCPACSWingSparPositionContainer;
-
 public:
     TIGL_EXPORT CCPACSWingSparPositions(CCPACSWingSpars* parent);
 

--- a/src/wing/CCPACSWings.cpp
+++ b/src/wing/CCPACSWings.cpp
@@ -41,9 +41,7 @@ void CCPACSWings::Invalidate()
 }
 
 CCPACSWings::CCPACSWings(CCPACSRotorcraftModel* parent)
-    : generated::CPACSWings(parent) {
-    throw CTiglError("Instantiating CCPACSWings with CPACSRotorcraftModel as parent is not implemented");
-}
+    : generated::CPACSWings(parent) {}
 
 CCPACSWings::CCPACSWings(CCPACSAircraftModel* parent)
     : generated::CPACSWings(parent) {}
@@ -61,11 +59,17 @@ int CCPACSWings::GetProfileCount() const
 
 CCPACSWingProfiles& CCPACSWings::GetProfiles()
 {
-    return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetWingProfiles();
+    if (IsParent<CCPACSAircraftModel>())
+        return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetWingProfiles();
+    else
+        return static_cast<CCPACSRotorcraftModel*>(m_parent)->GetConfiguration().GetWingProfiles();
 }
 
 const CCPACSWingProfiles& CCPACSWings::GetProfiles() const {
-    return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetWingProfiles();
+    if (IsParent<CCPACSAircraftModel>())
+        return static_cast<CCPACSAircraftModel*>(m_parent)->GetConfiguration().GetWingProfiles();
+    else
+        return static_cast<CCPACSRotorcraftModel*>(m_parent)->GetConfiguration().GetWingProfiles();
 }
 
 

--- a/src/wing/tiglwingribhelperfunctions.cpp
+++ b/src/wing/tiglwingribhelperfunctions.cpp
@@ -40,7 +40,7 @@
 namespace tigl
 {
 
-TopoDS_Shape ApplyWingTransformation(CCPACSWingCSStructure& structure, const TopoDS_Shape& shape)
+TopoDS_Shape ApplyWingTransformation(const CCPACSWingCSStructure& structure, const TopoDS_Shape& shape)
 {
     return structure.GetWingStructureReference().GetWing().GetWingTransformation().Transform(shape);
 }

--- a/src/wing/tiglwingribhelperfunctions.h
+++ b/src/wing/tiglwingribhelperfunctions.h
@@ -36,7 +36,7 @@ class CCPACSWingSparPosition;
 // Applies the wing transformation to the passed Shape and returns the
 // the transformed shape
 // TODO: const correctness of CCPACSWingCSStructure
-TopoDS_Shape ApplyWingTransformation(CCPACSWingCSStructure& structure, const TopoDS_Shape& shape);
+TopoDS_Shape ApplyWingTransformation(const CCPACSWingCSStructure& structure, const TopoDS_Shape& shape);
 
 // Cuts the passed shape with all spars found in the passed structure and
 // returns the splitted shape


### PR DESCRIPTION
* a few small refactorings
* improves rotorcraft support (better handling of some parent pointers)

@rainman110 this fixes loading the file you sent me via email. However, TiGLViewer still crashes when displaying one of the shapes (it seems to be null internally).

Can you do the further investiation?
I'll probably be away until next week.