### PR TITLE
Further implementation of new CS math and cleanup

### DIFF
--- a/src/configuration/CTiglShapeGeomComponentAdaptor.h
+++ b/src/configuration/CTiglShapeGeomComponentAdaptor.h
@@ -1,0 +1,109 @@
+/*
+* Copyright (C) 2017 German Aerospace Center (DLR/SC)
+*
+* Created: 2017-05-30 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include "tigl_internal.h"
+
+#include "ITiglGeometricComponent.h"
+#include "PNamedShape.h"
+#include "CTiglUIDManager.h"
+
+namespace tigl
+{
+
+class CTiglUIDManager;
+
+class CTiglShapeGeomComponentAdaptor : public ITiglGeometricComponent
+{
+public:
+    CTiglShapeGeomComponentAdaptor(ITiglGeometricComponent* parent, CTiglUIDManager* uidMgr)
+        : m_parent(parent)
+        , m_uid("")
+        , m_uidMgr(uidMgr)
+    {
+    }
+
+    ~CTiglShapeGeomComponentAdaptor()
+    {
+        unregisterShape();
+    }
+
+    void Reset()
+    {
+        unregisterShape();
+        m_uid = "";
+        m_shape.reset();
+    }
+
+    void SetUID(const std::string &uid)
+    {
+        unregisterShape();
+
+        m_uid = uid;
+
+        if (!m_uid.empty() && m_uidMgr) {
+            m_uidMgr->AddGeometricComponent(GetDefaultedUID(), this);
+        }
+    }
+
+
+    void SetShape(PNamedShape shape)
+    {
+
+        m_shape = shape;
+    }
+
+    // Returns the unique id of this component or an empty string if the component does not have a uid
+    virtual std::string GetDefaultedUID() const
+    {
+        return m_uid;
+    }
+
+    virtual PNamedShape GetLoft()
+    {
+        if (m_parent) {
+            // The shape has to be build somewhere
+            // This is the parent's tasl
+            m_parent->GetLoft();
+        }
+
+        return m_shape;
+    }
+
+    virtual TiglGeometricComponentType GetComponentType() const
+    {
+        return TIGL_COMPONENT_PHYSICAL;
+    }
+
+private:
+    void unregisterShape()
+    {
+        if (!m_uid.empty() && m_uidMgr && m_uidMgr->HasGeometricComponent(GetDefaultedUID())) {
+            m_uidMgr->RemoveGeometricComponent(GetDefaultedUID());
+        }
+    }
+
+    ITiglGeometricComponent* m_parent;
+    PNamedShape m_shape;
+    std::string m_uid;
+    CTiglUIDManager* m_uidMgr;
+
+};
+
+} // namespace tigl

--- a/src/generated/TixiHelper.cpp
+++ b/src/generated/TixiHelper.cpp
@@ -459,7 +459,6 @@ namespace tigl
             TixiSaveElementInternal(tixiHandle, xpath, tixiUpdateTextElement, tixiAddTextElement, value);
         }
 
-        // TODO: updating an empty text doesn't work : no error, but the text is not updated
         void TixiSaveElement(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::string& value)
         {
             TixiSaveElementInternal(tixiHandle, xpath, tixiUpdateTextElement, tixiAddTextElement, value.c_str());

--- a/src/math/CTiglOptimizer.cpp
+++ b/src/math/CTiglOptimizer.cpp
@@ -17,7 +17,6 @@
 */
 /**
 * @file
-* @brief  TODO: Describe!.
 */
 #include "CTiglOptimizer.h"
 

--- a/src/math/CTiglOptimizer.h
+++ b/src/math/CTiglOptimizer.h
@@ -17,7 +17,6 @@
 */
 /**
 * @file
-* @brief  TODO: Describe!.
 */
 
 #include "tigl.h"

--- a/src/math/ITiglObjectiveFunction.cpp
+++ b/src/math/ITiglObjectiveFunction.cpp
@@ -17,7 +17,6 @@
 */
 /**
 * @file
-* @brief  TODO: Describe!.
 */
 #include <vector>
 #include "ITiglObjectiveFunction.h"

--- a/src/math/ITiglObjectiveFunction.h
+++ b/src/math/ITiglObjectiveFunction.h
@@ -17,7 +17,6 @@
 */
 /**
 * @file
-* @brief  TODO: Describe!.
 */
 #ifndef ITIGL_OBJECTIVE_FUNCTION
 #define ITIGL_OBJECTIVE_FUNCTION

--- a/src/system/CScopedLock.h
+++ b/src/system/CScopedLock.h
@@ -31,8 +31,10 @@ class CScopedLock
 public:
     TIGL_EXPORT CScopedLock(CMutex &);
     TIGL_EXPORT ~CScopedLock();
-    // TODO: prevent copy ctor and copy assignment
 private:
+    CScopedLock(const CScopedLock&);
+    CScopedLock& operator=(const CScopedLock&);
+
     CMutex& _mutex;
 };
 

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -217,7 +217,6 @@ private:
     // Returns the trailing edge direction of the segment with the passed UID
     gp_Vec GetTrailingEdgeDirection(const std::string& segmentUID) const;
 
-    void UpdateProjectedLeadingEdge() const;
     void UpdateChordFace() const;
 
 
@@ -229,7 +228,6 @@ private:
     double               mySurfaceArea;        /**< Surface area of this segment            */
     unique_ptr<CTiglShapeGeomComponentAdaptor> upperShape; /**< Upper shape of this componentSegment */
     unique_ptr<CTiglShapeGeomComponentAdaptor> lowerShape; /**< Lower shape of this componentSegment */
-    mutable Handle(Geom_Curve) projLeadingEdge;/**< (Extended) Leading edge projected into y-z plane */
     mutable SegmentList  wingSegments;         /**< List of segments belonging to the component segment */
     TopoDS_Face          innerFace;            /**< [[CAS_AES]] added inner segment face    */
     TopoDS_Face          outerFace;            /**< [[CAS_AES]] added outer segment face    */

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -89,13 +89,7 @@ public:
     TIGL_EXPORT TopoDS_Face GetOuterFace();
 
     // Gets a point in relative wing coordinates for a given eta and xsi
-    TIGL_EXPORT gp_Pnt GetPoint(double eta, double xsi) const;
-
-    // For eta==0 or eta==1 returns the chordlinePoints, otherwise returns the
-    // eta/xsi point in the wing coordinate system (calls GetPoint)
-    // TODO (siggel): This function is duplicate to GetPoint and simply removes the global transform.
-    //                Should we just add the coordinate system as a third parameter?
-    TIGL_EXPORT gp_Pnt GetMidplaneOrChordlinePoint(double eta, double xsi) const;
+    TIGL_EXPORT gp_Pnt GetPoint(double eta, double xsi, TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM) const;
 
     // Returns the eta xsi coordinates of a points projected onto the midplane / chordface
     TIGL_EXPORT void GetEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const;
@@ -210,14 +204,6 @@ protected:
     // Method for building wires for eta-, leading edge-, trailing edge-lines
     void BuildLines() const;
 
-    // Returns an upper or lower point on the segment surface in
-    // dependence of parameters eta and xsi, which range from 0.0 to 1.0.
-    // For eta = 0.0, xsi = 0.0 point is equal to leading edge on the
-    // inner wing profile. For eta = 1.0, xsi = 1.0 point is equal to the trailing
-    // edge on the outer wing profile. If fromUpper is true, a point
-    // on the upper surface is returned, otherwise from the lower.
-//  gp_Pnt GetPoint(double eta, double xsi, bool fromUpper);
-
 private:
     // get short name for loft
     std::string GetShortShapeName();
@@ -231,7 +217,6 @@ private:
     gp_Vec GetTrailingEdgeDirection(const std::string& segmentUID) const;
 
     void UpdateProjectedLeadingEdge() const;
-    void UpdateExtendedChordFaces();
     void UpdateChordFace() const;
 
 
@@ -247,19 +232,13 @@ private:
     mutable SegmentList  wingSegments;         /**< List of segments belonging to the component segment */
     TopoDS_Face          innerFace;            /**< [[CAS_AES]] added inner segment face    */
     TopoDS_Face          outerFace;            /**< [[CAS_AES]] added outer segment face    */
-    CTiglPointTranslator extendedOuterChord;   /**< Extended outer segment chord face */
-    CTiglPointTranslator extendedInnerChord;   /**< Extended inner segment chord face */
     mutable unique_ptr<CTiglWingChordface> chordFace;
     Handle(Geom_Surface) upperSurface;
     Handle(Geom_Surface) lowerSurface;
-    bool                 surfacesAreValid;
 
     mutable TopoDS_Wire  etaLine;                  // 2d version (in YZ plane) of leadingEdgeLine
-    mutable TopoDS_Wire  extendedEtaLine;          // 2d version (in YZ plane) of extendedLeadingEdgeLine
     mutable TopoDS_Wire  leadingEdgeLine;          // leading edge as wire
-    mutable TopoDS_Wire  extendedLeadingEdgeLine;  // leading edge extended along y-axis, see CPACS spar geometry definition
     mutable TopoDS_Wire  trailingEdgeLine;         // trailing edge as wire
-    mutable TopoDS_Wire  extendedTrailingEdgeLine; // trailing edge extended along y-axis, see CPACS spar geometry definition
     mutable bool         linesAreValid;
 };
 

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -53,6 +53,7 @@ namespace tigl
 class CCPACSWing;
 class CCPACSWingSegment;
 class CTiglWingChordface;
+class CTiglShapeGeomComponentAdaptor;
 
 typedef std::vector<const CCPACSMaterial*>    MaterialList;
 typedef std::vector<CCPACSWingSegment*>       SegmentList;
@@ -226,15 +227,13 @@ private:
     CCPACSWing*          wing;                 /**< Parent wing                             */
     double               myVolume;             /**< Volume of this segment                  */
     double               mySurfaceArea;        /**< Surface area of this segment            */
-    TopoDS_Shape         upperShape;           /**< Upper shape of this componentSegment    */
-    TopoDS_Shape         lowerShape;           /**< Lower shape of this componentSegment    */
+    unique_ptr<CTiglShapeGeomComponentAdaptor> upperShape; /**< Upper shape of this componentSegment */
+    unique_ptr<CTiglShapeGeomComponentAdaptor> lowerShape; /**< Lower shape of this componentSegment */
     mutable Handle(Geom_Curve) projLeadingEdge;/**< (Extended) Leading edge projected into y-z plane */
     mutable SegmentList  wingSegments;         /**< List of segments belonging to the component segment */
     TopoDS_Face          innerFace;            /**< [[CAS_AES]] added inner segment face    */
     TopoDS_Face          outerFace;            /**< [[CAS_AES]] added outer segment face    */
     mutable unique_ptr<CTiglWingChordface> chordFace;
-    Handle(Geom_Surface) upperSurface;
-    Handle(Geom_Surface) lowerSurface;
 
     mutable TopoDS_Wire  etaLine;                  // 2d version (in YZ plane) of leadingEdgeLine
     mutable TopoDS_Wire  leadingEdgeLine;          // leading edge as wire

--- a/src/wing/CCPACSWingRibsDefinition.cpp
+++ b/src/wing/CCPACSWingRibsDefinition.cpp
@@ -817,7 +817,7 @@ TopoDS_Face CCPACSWingRibsDefinition::GetSectionRibGeometry(const std::string& e
         TopoDS_Shape cutShape = sparSegment.GetSparCutGeometry(WING_COORDINATE_SYSTEM);
         TopoDS_Shape cutResult = SplitShape(ribFace, cutShape);
         // get face from split result which is nearest to trailing edge
-        ribFace = GetNearestFace(cutResult, wingStructureReference.GetMidplaneOrChordlinePoint(eta, 1));
+        ribFace = GetNearestFace(cutResult, wingStructureReference.GetPoint(eta, 1, WING_COORDINATE_SYSTEM));
     }
     
     // cut rib face in case it ends at spar
@@ -828,7 +828,7 @@ TopoDS_Face CCPACSWingRibsDefinition::GetSectionRibGeometry(const std::string& e
         TopoDS_Shape cutShape = sparSegment.GetSparCutGeometry(WING_COORDINATE_SYSTEM);
         TopoDS_Shape cutResult = SplitShape(ribFace, cutShape);
         // get face from split result which is nearest to leading edge
-        ribFace = GetNearestFace(cutResult, wingStructureReference.GetMidplaneOrChordlinePoint(eta, 0));
+        ribFace = GetNearestFace(cutResult, wingStructureReference.GetPoint(eta, 0, WING_COORDINATE_SYSTEM));
     }
 
     return ribFace;

--- a/src/wing/CCPACSWingSparSegment.cpp
+++ b/src/wing/CCPACSWingSparSegment.cpp
@@ -489,7 +489,7 @@ gp_Pnt CCPACSWingSparSegment::GetMidplanePoint(const std::string& positionUID) c
         midplanePoint = getSectionElementChordlinePoint(componentSegment, position.GetElementUID(), position.GetXsi());
     }
     else if (position.GetInputType() == CCPACSWingSparPosition::Eta) {
-        midplanePoint = wingStructureReference.GetMidplaneOrChordlinePoint(position.GetEta(), position.GetXsi());
+        midplanePoint = wingStructureReference.GetPoint(position.GetEta(), position.GetXsi(), WING_COORDINATE_SYSTEM);
     }
     else {
         throw CTiglError("Unkwnonw SparPosition InputType found in CCPACSWingSparSegment::GetMidplanePoint");

--- a/src/wing/CTiglWingChordface.cpp
+++ b/src/wing/CTiglWingChordface.cpp
@@ -196,6 +196,13 @@ const std::vector<double>& CTiglWingChordface::GetElementEtas() const
     return _elementEtas;
 }
 
+const Handle(Geom_BSplineSurface) CTiglWingChordface::GetSurface() const
+{
+    BuildChordSurface();
+
+    return _chordSurface;
+}
+
 
 
 } // namespace tigl

--- a/src/wing/CTiglWingChordface.h
+++ b/src/wing/CTiglWingChordface.h
@@ -62,6 +62,8 @@ public:
      */
     TIGL_EXPORT const std::vector<double>& GetElementEtas() const;
 
+    TIGL_EXPORT const Handle(Geom_BSplineSurface) GetSurface() const;
+
 protected:
     virtual PNamedShape BuildLoft() OVERRIDE;
 

--- a/src/wing/CTiglWingStructureReference.cpp
+++ b/src/wing/CTiglWingStructureReference.cpp
@@ -19,6 +19,8 @@
 //#include "CCPACSTrailingEdgeDevice.h"
 #include "CCPACSWingComponentSegment.h"
 #include "CCPACSWing.h"
+#include "CNamedShape.h"
+#include <BRepTools.hxx>
 
 
 namespace tigl
@@ -51,9 +53,35 @@ const boost::optional<CCPACSWingCSStructure>& CTiglWingStructureReference::GetSt
     DISPATCH(GetStructure())
 }
 
-PNamedShape CTiglWingStructureReference::GetLoft() const
+PNamedShape CTiglWingStructureReference::GetLoft(TiglCoordinateSystem reference) const
 {
-    DISPATCH(GetLoft())
+    PNamedShape loft;
+    switch (type) {
+        case ComponentSegmentType:
+            loft = componentSegment->GetLoft()->DeepCopy();
+            break;
+/*        case TrailingEdgeDeviceType:
+            loft = trailingEdgeDevice->GetLoft()->DeepCopy();
+            break;*/
+        default: throw CTiglError("Internal Error in CTiglWingStructureReference: unknown type passed to GetLoft method!");
+    }
+
+    // apply inverse wing transform to go to local coordinates
+    CTiglTransformation transform;
+
+    switch(reference) {
+    case WING_COORDINATE_SYSTEM:
+        // apply inverse wing transform to go to local coordinates
+        transform = GetWing().GetTransformation().getTransformationMatrix().Inverted();
+        loft->SetShape(transform.Transform(loft->Shape()));
+        break;
+    case GLOBAL_COORDINATE_SYSTEM:
+        break;
+    default:
+        throw CTiglError("Wrong coordinate system given in CTiglWingStructureReference::GetLoft");
+    }
+
+    return loft;
 }
 
 gp_Pnt CTiglWingStructureReference::GetPoint(double eta, double xsi, TiglCoordinateSystem reference) const
@@ -121,14 +149,64 @@ TopoDS_Shape CTiglWingStructureReference::GetMidplaneShape() const
     DISPATCH(GetMidplaneShape())
 }
 
-TopoDS_Shape CTiglWingStructureReference::GetUpperShape() const
+TopoDS_Shape CTiglWingStructureReference::GetUpperShape(TiglCoordinateSystem reference) const
 {
-    DISPATCH(GetUpperShape())
+    TopoDS_Shape loft;
+    switch (type) {
+        case ComponentSegmentType:
+            loft = componentSegment->GetUpperShape();
+            break;
+/*        case TrailingEdgeDeviceType:
+            loft = trailingEdgeDevice->GetUpperShape();
+            break;*/
+        default: throw CTiglError("Internal Error in CTiglWingStructureReference: unknown type passed to GetUpperShape method!");
+    }
+
+    CTiglTransformation transform;
+
+    switch(reference) {
+    case WING_COORDINATE_SYSTEM:
+        // apply inverse wing transform to go to local coordinates
+        transform = GetWing().GetTransformation().getTransformationMatrix().Inverted();
+        loft = transform.Transform(loft);
+        break;
+    case GLOBAL_COORDINATE_SYSTEM:
+        break;
+    default:
+        throw CTiglError("Wrong coordinate system given in CTiglWingStructureReference::GetUpperShape");
+    }
+
+    return loft;
 }
 
-TopoDS_Shape CTiglWingStructureReference::GetLowerShape() const
+TopoDS_Shape CTiglWingStructureReference::GetLowerShape(TiglCoordinateSystem reference) const
 {
-    DISPATCH(GetLowerShape())
+    TopoDS_Shape loft;
+    switch (type) {
+        case ComponentSegmentType:
+            loft = componentSegment->GetLowerShape();
+            break;
+/*        case TrailingEdgeDeviceType:
+            loft = trailingEdgeDevice->GetLowerShape();
+            break;*/
+        default: throw CTiglError("Internal Error in CTiglWingStructureReference: unknown type passed to GetLowerShape method!");
+    }
+
+    CTiglTransformation transform;
+
+    switch(reference) {
+    case WING_COORDINATE_SYSTEM:
+        // apply inverse wing transform to go to local coordinates
+        transform = GetWing().GetTransformation().getTransformationMatrix().Inverted();
+        loft = transform.Transform(loft);
+        break;
+    case GLOBAL_COORDINATE_SYSTEM:
+        break;
+    default:
+        throw CTiglError("Wrong coordinate system given in CTiglWingStructureReference::GetLowerShape");
+    }
+
+    return loft;
 }
 
 TopoDS_Face CTiglWingStructureReference::GetInnerFace() const

--- a/src/wing/CTiglWingStructureReference.cpp
+++ b/src/wing/CTiglWingStructureReference.cpp
@@ -56,9 +56,9 @@ PNamedShape CTiglWingStructureReference::GetLoft() const
     DISPATCH(GetLoft())
 }
 
-gp_Pnt CTiglWingStructureReference::GetPoint(double eta, double xsi) const
+gp_Pnt CTiglWingStructureReference::GetPoint(double eta, double xsi, TiglCoordinateSystem reference) const
 {
-    DISPATCH(GetPoint(eta, xsi))
+    DISPATCH(GetPoint(eta, xsi, reference))
 }
 
 double CTiglWingStructureReference::GetLeadingEdgeLength() const
@@ -114,11 +114,6 @@ gp_Vec CTiglWingStructureReference::GetMidplaneEtaDir(double eta) const
 gp_Vec CTiglWingStructureReference::GetMidplaneNormal(double eta) const
 {
     DISPATCH(GetMidplaneNormal(eta))
-}
-
-gp_Pnt CTiglWingStructureReference::GetMidplaneOrChordlinePoint(double eta, double xsi) const
-{
-    DISPATCH(GetMidplaneOrChordlinePoint(eta, xsi))
 }
 
 TopoDS_Shape CTiglWingStructureReference::GetMidplaneShape() const

--- a/src/wing/CTiglWingStructureReference.h
+++ b/src/wing/CTiglWingStructureReference.h
@@ -54,7 +54,7 @@ public:
     TIGL_EXPORT CCPACSWing& GetWing() const;
     TIGL_EXPORT boost::optional<CCPACSWingCSStructure>& GetStructure();
     TIGL_EXPORT const boost::optional<CCPACSWingCSStructure>& GetStructure() const;
-    TIGL_EXPORT PNamedShape GetLoft() const;
+    TIGL_EXPORT PNamedShape GetLoft(TiglCoordinateSystem reference = WING_COORDINATE_SYSTEM) const;
     TIGL_EXPORT gp_Pnt GetPoint(double eta, double xsi, TiglCoordinateSystem reference) const;
     TIGL_EXPORT double GetLeadingEdgeLength() const;
     TIGL_EXPORT double GetTrailingEdgeLength() const;
@@ -68,8 +68,8 @@ public:
     TIGL_EXPORT gp_Vec GetMidplaneEtaDir(double eta) const;
     TIGL_EXPORT gp_Vec GetMidplaneNormal(double eta) const;
     TIGL_EXPORT TopoDS_Shape GetMidplaneShape() const;
-    TIGL_EXPORT TopoDS_Shape GetUpperShape() const;
-    TIGL_EXPORT TopoDS_Shape GetLowerShape() const;
+    TIGL_EXPORT TopoDS_Shape GetUpperShape(TiglCoordinateSystem reference = WING_COORDINATE_SYSTEM) const;
+    TIGL_EXPORT TopoDS_Shape GetLowerShape(TiglCoordinateSystem reference = WING_COORDINATE_SYSTEM) const;
     TIGL_EXPORT TopoDS_Face GetInnerFace() const;
     TIGL_EXPORT TopoDS_Face GetOuterFace() const;
     TIGL_EXPORT TopoDS_Wire GetMidplaneLine(const gp_Pnt& startPoint, const gp_Pnt& endPoint) const;

--- a/src/wing/CTiglWingStructureReference.h
+++ b/src/wing/CTiglWingStructureReference.h
@@ -25,6 +25,7 @@
 #include <boost/optional.hpp>
 
 #include "tigl_internal.h"
+#include "tigl.h"
 
 #include "PNamedShape.h"
 #include "TopoDS_Shape.hxx"
@@ -54,7 +55,7 @@ public:
     TIGL_EXPORT boost::optional<CCPACSWingCSStructure>& GetStructure();
     TIGL_EXPORT const boost::optional<CCPACSWingCSStructure>& GetStructure() const;
     TIGL_EXPORT PNamedShape GetLoft() const;
-    TIGL_EXPORT gp_Pnt GetPoint(double eta, double xsi) const;
+    TIGL_EXPORT gp_Pnt GetPoint(double eta, double xsi, TiglCoordinateSystem reference) const;
     TIGL_EXPORT double GetLeadingEdgeLength() const;
     TIGL_EXPORT double GetTrailingEdgeLength() const;
     TIGL_EXPORT gp_Pnt GetLeadingEdgePoint(double relativePos) const;
@@ -66,7 +67,6 @@ public:
     TIGL_EXPORT void GetMidplaneEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const;
     TIGL_EXPORT gp_Vec GetMidplaneEtaDir(double eta) const;
     TIGL_EXPORT gp_Vec GetMidplaneNormal(double eta) const;
-    TIGL_EXPORT gp_Pnt GetMidplaneOrChordlinePoint(double eta, double xsi) const;
     TIGL_EXPORT TopoDS_Shape GetMidplaneShape() const;
     TIGL_EXPORT TopoDS_Shape GetUpperShape() const;
     TIGL_EXPORT TopoDS_Shape GetLowerShape() const;

--- a/src/wing/tigletaxsifunctions.cpp
+++ b/src/wing/tigletaxsifunctions.cpp
@@ -66,10 +66,10 @@ gp_Pnt getSectionElementChordlinePoint(const CCPACSWingComponentSegment& cs, con
 TopoDS_Face buildEtaCutFace(const CTiglWingStructureReference& wsr, double eta)
 {
     // NOTE: we have to determine the cut plane by using the 
-    // GetMidplaneOrChordlinePoint methods for handling the case when the eta line
+    // GetPoint methods for handling the case when the eta line
     // is extended because of an z-rotation of the outer or inner sections
-    gp_Pnt startPnt = wsr.GetMidplaneOrChordlinePoint(eta, 0);
-    gp_Pnt endPnt = wsr.GetMidplaneOrChordlinePoint(eta, 1);
+    gp_Pnt startPnt = wsr.GetPoint(eta, 0., WING_COORDINATE_SYSTEM);
+    gp_Pnt endPnt = wsr.GetPoint(eta, 1., WING_COORDINATE_SYSTEM);
     gp_Vec midplaneNormal = wsr.GetMidplaneNormal(eta);
     gp_Dir cutPlaneNormal = midplaneNormal.Crossed(gp_Vec(startPnt, endPnt));
     gp_Pln etaCutPlane = gp_Pln(startPnt, cutPlaneNormal);

--- a/src/wing/tiglwingribhelperfunctions.cpp
+++ b/src/wing/tiglwingribhelperfunctions.cpp
@@ -286,7 +286,7 @@ gp_Pnt GetSparMidplanePoint(const CCPACSWingSparPosition& sparPos, const CCPACSW
         midplanePoint = getSectionElementChordlinePoint(componentSegment, sparPos.GetElementUID(), sparPos.GetXsi());
     }
     else if (sparPos.GetInputType() == CCPACSWingSparPosition::Eta) {
-        midplanePoint = wingStructureReference.GetMidplaneOrChordlinePoint(sparPos.GetEta(), sparPos.GetXsi());
+        midplanePoint = wingStructureReference.GetPoint(sparPos.GetEta(), sparPos.GetXsi(), WING_COORDINATE_SYSTEM);
     }
     else {
         throw CTiglError("Unknown SparPosition InputType found in CCPACSWingRibsDefinition::GetSparMidplanePoint");

--- a/tests/tiglWingComponentSegment.cpp
+++ b/tests/tiglWingComponentSegment.cpp
@@ -691,28 +691,28 @@ TEST_F(WingComponentSegmentSimple, InterpolateOnLine)
     ASSERT_NEAR(0.0, error, 1e-6);
 
     // check cases in first segment
-    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.25, xsi, error);
+    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.5 / (1. + sqrt(17./16.)), xsi, error);
     ASSERT_NEAR(0.25, xsi, 1e-6);
     ASSERT_NEAR(0.0, error, 1e-6);
 
-    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.4, xsi, error);
+    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.8 / (1. + sqrt(17./16.)), xsi, error);
     ASSERT_NEAR(0.4, xsi, 1e-6);
     ASSERT_NEAR(0.0, error, 1e-6);
 
     // now check the not so trivial cases in second segment
-    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.5, xsi, error);
+    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 1.0 / (1. + sqrt(17./16.)), xsi, error);
     ASSERT_NEAR(0.5, xsi, 1e-6);
     ASSERT_NEAR(0.0, error, 1e-6);
 
-    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.75, xsi, error);
+    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, (1 + 0.5*sqrt(17./16.)) / (1. + sqrt(17./16.)), xsi, error);
     ASSERT_NEAR(0.5/0.75, xsi, 1e-6);
     ASSERT_NEAR(0.0, error, 1e-6);
 
-    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.6, xsi, error);
+    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, (1 + 0.2*sqrt(17./16.)) / (1. + sqrt(17./16.)), xsi, error);
     ASSERT_NEAR(0.5/0.9, xsi, 1e-6);
     ASSERT_NEAR(0.0, error, 1e-6);
 
-    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, 0.9, xsi, error);
+    compSegment.InterpolateOnLine(0.0, 0.0, 1.0, 1.0, (1 + 0.8*sqrt(17./16.)) / (1. + sqrt(17./16.)), xsi, error);
     ASSERT_NEAR(0.5/0.6, xsi, 1e-6);
     ASSERT_NEAR(0.0, error, 1e-6);
 }
@@ -721,7 +721,7 @@ TEST_F(WingComponentSegmentSimple, IntersectEta_cinterface)
 {
     double xsi;
     TiglBoolean hasWarning;
-    ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "WING_CS1", 0.0, 0.0, 1.0, 1.0, 0.9, &xsi, &hasWarning));
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "WING_CS1", 0.0, 0.0, 1.0, 1.0, (1 + 0.8*sqrt(17./16.)) / (1. + sqrt(17./16.)), &xsi, &hasWarning));
     ASSERT_NEAR(0.5/0.6, xsi, 1e-6);
     ASSERT_EQ(TIGL_FALSE, hasWarning);
     ASSERT_EQ(TIGL_SUCCESS, tiglWingComponentSegmentComputeEtaIntersection(tiglHandle, "WING_CS1", 0.0, 0.0, 1.0, 1.0, 0.9, &xsi, NULL));


### PR DESCRIPTION
I implemented the new CS math for the method CCPACSWingComponentSegment::InterpolateOnLine.

Also I cleaned up much of the component segment code by removing:
 - extended chord faces
 - projected leading edge
 - duplicate functions

The GetLoft method of the WingComponentSegment returns the Shape now in global coordinates. This has to compensated in WingStructureReference, which typically uses the Wing Shape in local Coordinates.