### PR TITLE
Added function to set VTK specific options

### DIFF
--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -95,6 +95,7 @@ set(tv_src
     TIGLViewerDrawVectorDialog.cpp
     TIGLViewerScopedCommand.cpp
     TIGLQAspectWindow.cpp
+    TIGLViewerVTKExportDialog.cpp
 )
 	
 # normal header files
@@ -135,6 +136,7 @@ set(tv_hdr_qobj
 	TIGLViewerFuseDialog.h
 	TIGLViewerShapeIntersectionDialog.h
 	TIGLViewerScreenshotDialog.h
+	TIGLViewerVTKExportDialog.h
 )
 
 set(tv_ui_comp
@@ -146,6 +148,7 @@ set(tv_ui_comp
 	src/TIGLViewerShapeIntersectionDialog.ui
 	src/TIGLViewerScreenshotDialog.ui
 	src/TIGLViewerDrawVectorDialog.ui
+	src/TIGLViewerVTKExportDialog.ui
 )
 	
 foreach ( _fname ${tv_src})

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -51,6 +51,7 @@
 
 // TIGLViewer includes
 #include "TIGLViewerInternal.h"
+#include "TIGLViewerVTKExportDialog.h"
 #include "CCPACSConfigurationManager.h"
 #include "CCPACSFarField.h"
 #include "CCPACSExternalObject.h"
@@ -1293,12 +1294,24 @@ void TIGLViewerDocument::exportMeshedWingVTK()
 
     fileName = QFileDialog::getSaveFileName(app, tr("Save as..."), myLastFolder, tr("Export VTK(*.vtp)"));
 
-    if (!fileName.isEmpty()) {
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    double deflection = 1.0;
+    if (1) {
         START_COMMAND();
         tigl::CCPACSWing& wing = GetConfiguration().GetWing(qstringToCstring(wingUid));
-        double deflection = wing.GetWingspan()/2. * TIGLViewerSettings::Instance().triangulationAccuracy();
+        deflection = wing.GetWingspan()/2. * TIGLViewerSettings::Instance().triangulationAccuracy();
+    }
 
-        TiglReturnCode err = tiglExportMeshedWingVTKByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), deflection);
+    TIGLViewerVTKExportDialog settings(app);
+    settings.setDeflection(deflection);
+    settings.exec();
+
+    if (1) {
+        START_COMMAND();
+        TiglReturnCode err = tiglExportMeshedWingVTKByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), settings.getDeflection());
         if (err != TIGL_SUCCESS) {
             displayError(QString("Error in function <u>tiglExportMeshedWingVTKByIndex</u>. Error code: %1").arg(err), "TIGL Error");
         }
@@ -1322,11 +1335,23 @@ void TIGLViewerDocument::exportMeshedWingVTKsimple()
 
     fileName = QFileDialog::getSaveFileName(app, tr("Save as..."), myLastFolder, tr("Export VTK(*.vtp)"));
 
-    if (!fileName.isEmpty()) {
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    double deflection = 1.0;
+    if (1) {
         START_COMMAND();
         tigl::CCPACSWing& wing = GetConfiguration().GetWing(qstringToCstring(wingUid));
-        double deflection = wing.GetWingspan()/2. * TIGLViewerSettings::Instance().triangulationAccuracy();
+        deflection = wing.GetWingspan()/2. * TIGLViewerSettings::Instance().triangulationAccuracy();
+    }
 
+    TIGLViewerVTKExportDialog settings(app);
+    settings.setDeflection(deflection);
+    settings.exec();
+
+    if (1) {
+        START_COMMAND();
         TiglReturnCode err = tiglExportMeshedWingVTKSimpleByUID(m_cpacsHandle, qstringToCstring(wingUid), qstringToCstring(fileName), deflection);
         if (err != TIGL_SUCCESS) {
             displayError(QString("Error in function <u>tiglExportMeshedWingVTKSimpleByUID</u>. Error code: %1").arg(err), "TIGL Error");
@@ -1409,22 +1434,32 @@ void TIGLViewerDocument::exportConfigCollada()
 void TIGLViewerDocument::exportMeshedFuselageVTK()
 {
     QString     fileName;
-    QString        fileType;
-    QFileInfo    fileInfo;
-    TIGLViewerInputOutput writer;
 
     QString wingUid = dlgGetFuselageSelection();
     if (wingUid == "") {
         return;
     }
 
-    writeToStatusBar(tr("Saving meshed Fuselage as VTK file with TIGL..."));
-
     fileName = QFileDialog::getSaveFileName(app, tr("Save as..."), myLastFolder, tr("Export VTK(*.vtp)"));
 
-    if (!fileName.isEmpty()) {
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    double deflection = 1.0;
+    if (1) {
         START_COMMAND();
-        TiglReturnCode err = tiglExportMeshedFuselageVTKByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), 0.1);
+        deflection = GetConfiguration().GetAirplaneLenth()
+                * TIGLViewerSettings::Instance().triangulationAccuracy();
+    }
+
+    TIGLViewerVTKExportDialog settings(app);
+    settings.setDeflection(deflection);
+
+    if (settings.exec()) {
+        writeToStatusBar(tr("Saving meshed Fuselage as VTK file with TIGL..."));
+        START_COMMAND();
+        TiglReturnCode err = tiglExportMeshedFuselageVTKByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), settings.getDeflection());
         if (err != TIGL_SUCCESS) {
             displayError(QString("Error in function <u>tiglExportMeshedFuselageVTKByIndex</u>. Error code: %1").arg(err), "TIGL Error");
         }
@@ -1437,13 +1472,26 @@ void TIGLViewerDocument::exportMeshedFuselageVTKsimple()
     QString fileName;
     QString fuselageUid = dlgGetFuselageSelection();
 
-    writeToStatusBar(tr("Saving meshed Fuselage as simple VTK file with TIGL..."));
-
     fileName = QFileDialog::getSaveFileName(app, tr("Save as..."), myLastFolder, tr("Export VTK(*.vtp)"));
 
-    if (!fileName.isEmpty()) {
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    double deflection = 1.0;
+    if (1) {
         START_COMMAND();
-        TiglReturnCode err = tiglExportMeshedFuselageVTKSimpleByUID(m_cpacsHandle, qstringToCstring(fuselageUid), qstringToCstring(fileName), 0.1);
+        deflection = GetConfiguration().GetAirplaneLenth()
+                * TIGLViewerSettings::Instance().triangulationAccuracy();
+    }
+
+    TIGLViewerVTKExportDialog settings(app);
+    settings.setDeflection(deflection);
+
+    if (settings.exec()) {
+        writeToStatusBar(tr("Saving meshed Fuselage as simple VTK file with TIGL..."));
+        START_COMMAND();
+        TiglReturnCode err = tiglExportMeshedFuselageVTKSimpleByUID(m_cpacsHandle, qstringToCstring(fuselageUid), qstringToCstring(fileName), settings.getDeflection());
         if (err != TIGL_SUCCESS) {
             displayError(QString("Error in function <u>tiglExportMeshedFuselageVTKSimpleByUID</u>. Error code: %1").arg(err), "TIGL Error");
         }
@@ -1455,7 +1503,21 @@ void TIGLViewerDocument::exportMeshedConfigVTK()
     QString     fileName;
     fileName = QFileDialog::getSaveFileName(app, tr("Save as..."), myLastFolder, tr("Export VTK(*.vtp)"));
 
-    if (!fileName.isEmpty()) {
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    double deflection = 1.0;
+    if (1) {
+        START_COMMAND();
+        deflection = GetConfiguration().GetAirplaneLenth()
+                        * TIGLViewerSettings::Instance().triangulationAccuracy();
+    }
+
+    TIGLViewerVTKExportDialog settings(app);
+    settings.setDeflection(deflection);
+
+    if (settings.exec()) {
         START_COMMAND();
         writeToStatusBar("Calculating fused airplane, this can take a while");
         // calculating loft, is cached afterwards
@@ -1467,11 +1529,9 @@ void TIGLViewerDocument::exportMeshedConfigVTK()
         }
         writeToStatusBar("Writing meshed vtk file");
         tigl::CTiglExportVtk exporter(GetConfiguration());
-        
-        double deflection = GetConfiguration().GetAirplaneLenth() 
-                * TIGLViewerSettings::Instance().triangulationAccuracy();
-        exporter.ExportMeshedGeometryVTK(fileName.toStdString(), deflection);
-        
+
+        exporter.ExportMeshedGeometryVTK(fileName.toStdString(), settings.getDeflection());
+
         writeToStatusBar("");
     }
 }
@@ -1481,14 +1541,26 @@ void TIGLViewerDocument::exportMeshedConfigVTKNoFuse()
     QString     fileName;
     fileName = QFileDialog::getSaveFileName(app, tr("Save as..."), myLastFolder, tr("Export VTK(*.vtp)"));
 
-    if (!fileName.isEmpty()) {
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    double deflection = 1.0;
+    if (1) {
+        START_COMMAND();
+        deflection = GetConfiguration().GetAirplaneLenth()
+                        * TIGLViewerSettings::Instance().triangulationAccuracy();
+    }
+
+    TIGLViewerVTKExportDialog settings(app);
+    settings.setDeflection(deflection);
+
+    if (settings.exec()) {
         QApplication::setOverrideCursor( Qt::WaitCursor );
         writeToStatusBar("Writing meshed vtk file");
         tigl::CTiglExportVtk exporter(GetConfiguration());
 
-        double deflection = GetConfiguration().GetAirplaneLenth() 
-                * TIGLViewerSettings::Instance().triangulationAccuracy();
-        exporter.ExportMeshedGeometryVTKNoFuse(fileName.toStdString(), deflection);
+        exporter.ExportMeshedGeometryVTKNoFuse(fileName.toStdString(), settings.getDeflection());
 
         writeToStatusBar("");
         QApplication::restoreOverrideCursor();

--- a/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
+++ b/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
@@ -1,0 +1,68 @@
+/*
+* Copyright (C) 2017 German Aerospace Center (DLR/SC)
+*
+* Created: 2017-06-23 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "TIGLViewerVTKExportDialog.h"
+#include "ui_TIGLViewerVTKExportDialog.h"
+
+#include <tigl.h>
+
+TIGLViewerVTKExportDialog::TIGLViewerVTKExportDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::TIGLViewerVTKExportDialog)
+{
+    ui->setupUi(this);
+
+    setNormalsEnabled(true);
+    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(onOkayPressed()));
+}
+
+void TIGLViewerVTKExportDialog::setDeflection(double d)
+{
+    ui->sbDeflection->setValue(d);
+}
+
+double TIGLViewerVTKExportDialog::getDeflection() const
+{
+    return ui->sbDeflection->value();
+}
+
+void TIGLViewerVTKExportDialog::setNormalsEnabled(bool enabled)
+{
+    ui->cbWriteNormals->setChecked(enabled);
+}
+
+bool TIGLViewerVTKExportDialog::normalsEnabled() const
+{
+    return ui->cbWriteNormals->isChecked();
+}
+
+TIGLViewerVTKExportDialog::~TIGLViewerVTKExportDialog()
+{
+    delete ui;
+}
+
+void TIGLViewerVTKExportDialog::onOkayPressed() const
+{
+    bool enabled = normalsEnabled();
+    if (enabled) {
+        tiglExportVTKSetOptions("normals_enabled", "1");
+    }
+    else {
+        tiglExportVTKSetOptions("normals_enabled", "0");
+    }
+}

--- a/TIGLViewer/src/TIGLViewerVTKExportDialog.h
+++ b/TIGLViewer/src/TIGLViewerVTKExportDialog.h
@@ -1,0 +1,50 @@
+/*
+* Copyright (C) 2017 German Aerospace Center (DLR/SC)
+*
+* Created: 2017-06-23 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TIGLVIEWERVTKEXPORTDIALOG_H
+#define TIGLVIEWERVTKEXPORTDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class TIGLViewerVTKExportDialog;
+}
+
+class TIGLViewerVTKExportDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TIGLViewerVTKExportDialog(QWidget *parent = 0);
+
+    void setDeflection(double d);
+    double getDeflection() const;
+
+    void setNormalsEnabled(bool enabled);
+    bool normalsEnabled() const;
+
+    ~TIGLViewerVTKExportDialog();
+
+private slots:
+    void onOkayPressed() const;
+
+private:
+    Ui::TIGLViewerVTKExportDialog *ui;
+};
+
+#endif // TIGLVIEWERVTKEXPORTDIALOG_H

--- a/TIGLViewer/src/TIGLViewerVTKExportDialog.ui
+++ b/TIGLViewer/src/TIGLViewerVTKExportDialog.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TIGLViewerVTKExportDialog</class>
+ <widget class="QDialog" name="TIGLViewerVTKExportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>216</width>
+    <height>142</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Save VTK</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Export options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbWriteNormals">
+        <property name="toolTip">
+         <string>Normals can lead to duplicate points, but improve visual quality.</string>
+        </property>
+        <property name="text">
+         <string>Write normal vectors</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="toolTip">
+         <string>Maximum deviation of a triangle from the true geometry in meter.</string>
+        </property>
+        <property name="text">
+         <string>Deflection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="sbDeflection">
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>0.000100000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.001000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.001000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TIGLViewerVTKExportDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TIGLViewerVTKExportDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/bindings/java/src/de/dlr/sc/tigl/TiglNativeInterface.java
+++ b/bindings/java/src/de/dlr/sc/tigl/TiglNativeInterface.java
@@ -17,7 +17,7 @@
 */
 
 /* 
-* This file is automatically created from tigl.h on 2016-01-06.
+* This file is automatically created from tigl.h on 2017-06-21.
 * If you experience any bugs please contact the authors
 */
 
@@ -34,6 +34,7 @@ public class TiglNativeInterface {
     }
 
     public static native int tiglOpenCPACSConfiguration(int tixiHandle, String configurationUID, IntByReference cpacsHandlePtr);
+    public static native int tiglSaveCPACSConfiguration(String configurationUID, int cpacsHandle);
     public static native int tiglCloseCPACSConfiguration(int cpacsHandle);
     public static native int tiglGetCPACSTixiHandle(int cpacsHandle, IntByReference tixiHandlePtr);
     public static native int tiglIsCPACSConfigurationHandleValid(int cpacsHandle, IntByReference isValidPtr);
@@ -101,6 +102,28 @@ public class TiglNativeInterface {
     public static native int tiglFuselageGetSectionUID(int cpacsHandle, int fuselageIndex, int sectionIndex, PointerByReference uidNamePtr);
     public static native int tiglFuselageGetSymmetry(int cpacsHandle, int fuselageIndex, IntByReference symmetryAxisPtr);
     public static native int tiglFuselageGetMinumumDistanceToGround(int cpacsHandle, String fuselageUID, double axisPntX, double axisPntY, double axisPntZ, double axisDirX, double axisDirY, double axisDirZ, double angle, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
+    public static native int tiglGetRotorCount(int cpacsHandle, IntByReference rotorCountPtr);
+    public static native int tiglRotorGetUID(int cpacsHandle, int rotorIndex, PointerByReference uidNamePtr);
+    public static native int tiglRotorGetIndex(int cpacsHandle, String rotorUID, IntByReference rotorIndexPtr);
+    public static native int tiglRotorGetRadius(int cpacsHandle, int rotorIndex, DoubleByReference radiusPtr);
+    public static native int tiglRotorGetReferenceArea(int cpacsHandle, int rotorIndex, DoubleByReference referenceAreaPtr);
+    public static native int tiglRotorGetTotalBladePlanformArea(int cpacsHandle, int rotorIndex, DoubleByReference totalBladePlanformAreaPtr);
+    public static native int tiglRotorGetSolidity(int cpacsHandle, int rotorIndex, DoubleByReference solidityPtr);
+    public static native int tiglRotorGetSurfaceArea(int cpacsHandle, int rotorIndex, DoubleByReference surfaceAreaPtr);
+    public static native int tiglRotorGetVolume(int cpacsHandle, int rotorIndex, DoubleByReference volumePtr);
+    public static native int tiglRotorGetTipSpeed(int cpacsHandle, int rotorIndex, DoubleByReference tipSpeedPtr);
+    public static native int tiglRotorGetRotorBladeCount(int cpacsHandle, int rotorIndex, IntByReference rotorBladeCountPtr);
+    public static native int tiglRotorBladeGetWingIndex(int cpacsHandle, int rotorIndex, int rotorBladeIndex, IntByReference wingIndexPtr);
+    public static native int tiglRotorBladeGetWingUID(int cpacsHandle, int rotorIndex, int rotorBladeIndex, PointerByReference wingUIDPtr);
+    public static native int tiglRotorBladeGetAzimuthAngle(int cpacsHandle, int rotorIndex, int rotorBladeIndex, DoubleByReference azimuthAnglePtr);
+    public static native int tiglRotorBladeGetRadius(int cpacsHandle, int rotorIndex, int rotorBladeIndex, DoubleByReference radiusPtr);
+    public static native int tiglRotorBladeGetPlanformArea(int cpacsHandle, int rotorIndex, int rotorBladeIndex, DoubleByReference planformAreaPtr);
+    public static native int tiglRotorBladeGetSurfaceArea(int cpacsHandle, int rotorIndex, int rotorBladeIndex, DoubleByReference surfaceAreaPtr);
+    public static native int tiglRotorBladeGetVolume(int cpacsHandle, int rotorIndex, int rotorBladeIndex, DoubleByReference volumePtr);
+    public static native int tiglRotorBladeGetTipSpeed(int cpacsHandle, int rotorIndex, int rotorBladeIndex, DoubleByReference tipSpeedPtr);
+    public static native int tiglRotorBladeGetLocalRadius(int cpacsHandle, int rotorIndex, int rotorBladeIndex, int segmentIndex, double eta, DoubleByReference radiusPtr);
+    public static native int tiglRotorBladeGetLocalChord(int cpacsHandle, int rotorIndex, int rotorBladeIndex, int segmentIndex, double eta, DoubleByReference chordPtr);
+    public static native int tiglRotorBladeGetLocalTwistAngle(int cpacsHandle, int rotorIndex, int rotorBladeIndex, int segmentIndex, double eta, DoubleByReference twistAnglePtr);
     public static native int tiglComponentIntersectionPoint(int cpacsHandle, String componentUidOne, String componentUidTwo, int lineID, double eta, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglComponentIntersectionPoints(int cpacsHandle, String componentUidOne, String componentUidTwo, int lineID, Pointer etaArray, int numberOfPoints, Pointer pointXArray, Pointer pointYArray, Pointer pointZArray);
     public static native int tiglComponentIntersectionLineCount(int cpacsHandle, String componentUidOne, String componentUidTwo, IntByReference numWires);
@@ -117,6 +140,7 @@ public class TiglNativeInterface {
     public static native int tiglExportMeshedFuselageSTL(int cpacsHandle, int fuselageIndex, String filenamePtr, double deflection);
     public static native int tiglExportMeshedFuselageSTLByUID(int cpacsHandle, String fuselageUID, String filenamePtr, double deflection);
     public static native int tiglExportMeshedGeometrySTL(int cpacsHandle, String filenamePtr, double deflection);
+    public static native int tiglExportVTKSetOptions(String key, String value);
     public static native int tiglExportMeshedWingVTKByIndex(int cpacsHandle, int wingIndex, String filenamePtr, double deflection);
     public static native int tiglExportMeshedWingVTKByUID(int cpacsHandle, String wingUID, String filenamePtr, double deflection);
     public static native int tiglExportMeshedFuselageVTKByIndex(int cpacsHandle, int fuselageIndex, String filenamePtr, double deflection);

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -5015,6 +5015,37 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
     }
 }
 
+TIGL_COMMON_EXPORT TiglReturnCode tiglExportVTKSetOptions(const char *key, const char *value)
+{
+    if (!key) {
+        LOG(ERROR) << "Error: Null pointer argument for key ";
+        LOG(ERROR) << "in function call to tiglExportVTKSetOptions." << std::endl;
+        return TIGL_NULL_POINTER;
+    }
+
+    if (!value) {
+        LOG(ERROR) << "Error: Null pointer argument for value ";
+        LOG(ERROR) << "in function call to tiglExportVTKSetOptions." << std::endl;
+        return TIGL_NULL_POINTER;
+    }
+
+    try {
+        tigl::CTiglExportVtk::SetOptions(key, value);
+        return TIGL_SUCCESS;
+    }
+    catch (std::exception & ex) {
+        LOG(ERROR) << ex.what() << std::endl;
+        return TIGL_ERROR;
+    }
+    catch (tigl::CTiglError & ex) {
+        LOG(ERROR) << ex.getError() << std::endl;
+        return ex.getCode();
+    }
+    catch (...) {
+        LOG(ERROR) << "Caught an unknown exception in tiglExportVTKSetOptions" << std::endl;
+        return TIGL_ERROR;
+    }
+}
 
 TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByIndex(const TiglCPACSConfigurationHandle cpacsHandle, const int wingIndex,
                                                                  const char* filenamePtr, const double deflection)
@@ -6381,3 +6412,4 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglLogSetVerbosity(TiglLogLevel consoleVerbos
 
     return TIGL_SUCCESS;
 }
+

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -3391,6 +3391,26 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
 
 
 /**
+ * @brief Sets options for the VTK Export
+ *
+ * **Available Settings**:
+ *
+ *   - *key*: "normals_enabled" *valid values*: "0 or 1" *default*: "1".
+ *
+ *       Enables or disables the output of normal vectors.
+ *       A Normal vector and a vertex belong to the same logical structure. If there
+ *       are two identical vertices but with different normal vectors, the VTK export stores
+ *       them as two entries. Thus, a VTK file may have "duplicate" vertices. To disable this
+ *       behavior, set "normal_enabled" to "0".
+ *
+ * @return
+ *   - TIGL_SUCCESS if no error occurred
+ *   - TIGL_NULL_POINTER if key or value are a null pointer
+ *   - TIGL_ERROR if the specified key/value pair is invalid
+ */
+TIGL_COMMON_EXPORT TiglReturnCode tiglExportVTKSetOptions(const char* key, const char* value);
+
+/**
 * @brief Exports the boolean fused geometry of a wing (selected by id) meshed to VTK format.
 *
 *

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -25,6 +25,7 @@
 
 // standard libraries
 #include <iostream>
+#include <algorithm>
 
 #include "CTiglLogging.h"
 #include "CTiglExportVtk.h"
@@ -44,8 +45,29 @@
 #include "CTiglPolyData.h"
 #include "CTiglTriangularizer.h"
 
+namespace
+{
+    tigl::CTiglTriangularizerOptions getOptions(const tigl::CTiglExportVtk& /* exporter */)
+    {
+        tigl::CTiglTriangularizerOptions options;
+        options.setNormalsEnabled(tigl::CTiglExportVtk::normalsEnabled);
+
+        return options ;
+    }
+
+    std::string to_lower(const std::string& str)
+    {
+        std::string result = str;
+        std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+
+        return result;
+    }
+}
+
 namespace tigl 
 {
+
+bool CTiglExportVtk::normalsEnabled = true;
 
 // Constructor
 CTiglExportVtk::CTiglExportVtk(CCPACSConfiguration& config)
@@ -70,7 +92,7 @@ void CTiglExportVtk::ExportMeshedWingVTKByIndex(const int wingIndex, const std::
 void CTiglExportVtk::ExportMeshedWingVTKByUID(const std::string& wingUID, const std::string& filename, const double deflection)
 {
     tigl::CCPACSWing& wing = myConfig.GetWing(wingUID);
-    CTiglTriangularizer wingTrian(wing, deflection, SEGMENT_INFO);
+    CTiglTriangularizer wingTrian(wing, deflection, SEGMENT_INFO, getOptions(*this));
     wingTrian.writeVTK(filename.c_str());
 }
 
@@ -88,7 +110,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
 {
     CTiglAbstractPhysicalComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
-    CTiglTriangularizer trian(shape, deflection);
+    CTiglTriangularizer trian(shape, deflection, getOptions(*this));
     trian.writeVTK(filename.c_str());
 }
 
@@ -96,7 +118,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
 // Exports a whole geometry, boolean fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTK(const std::string& filename, const double deflection)
 {
-    tigl::CTiglTriangularizer trian(myConfig, true, deflection, SEGMENT_INFO);
+    tigl::CTiglTriangularizer trian(myConfig, true, deflection, SEGMENT_INFO, getOptions(*this));
     trian.writeVTK(filename.c_str());
 }
 
@@ -106,7 +128,7 @@ void CTiglExportVtk::ExportMeshedWingVTKSimpleByUID(const std::string& wingUID, 
 {
     CCPACSWing & component = dynamic_cast<CCPACSWing&>(myConfig.GetWing(wingUID));
     TopoDS_Shape& loft = component.GetLoftWithLeadingEdge();
-    CTiglTriangularizer loftTrian(loft, deflection);
+    CTiglTriangularizer loftTrian(loft, deflection, getOptions(*this));
     loftTrian.writeVTK(filename.c_str());
 }
 
@@ -123,7 +145,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByUID(const std::string& fusel
 {
     CTiglAbstractPhysicalComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
-    CTiglTriangularizer loftTrian(shape, deflection);
+    CTiglTriangularizer loftTrian(shape, deflection, getOptions(*this));
     loftTrian.writeVTK(filename.c_str());
 }
 
@@ -138,15 +160,34 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByIndex(const int fuselageInde
 // Exports a whole geometry, boolean fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTKSimple(const std::string& filename, const double deflection)
 {
-    tigl::CTiglTriangularizer trian(myConfig, true, deflection, NO_INFO);
+    tigl::CTiglTriangularizer trian(myConfig, true, deflection, NO_INFO, getOptions(*this));
     trian.writeVTK(filename.c_str());
 }
 
 // Exports a whole geometry, not fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTKNoFuse(const std::string& filename, const double deflection)
 {
-    tigl::CTiglTriangularizer trian(myConfig, false, deflection, NO_INFO);
+    tigl::CTiglTriangularizer trian(myConfig, false, deflection, NO_INFO, getOptions(*this));
     trian.writeVTK(filename.c_str());
+}
+
+void CTiglExportVtk::SetOptions(const std::string &key, const std::string &value)
+{
+    if (key == "normals_enabled") {
+        if (value == "1" || to_lower(value) == "true") {
+            CTiglExportVtk::normalsEnabled = true;
+        }
+        else if (value == "0" || to_lower(value) == "false") {
+            CTiglExportVtk::normalsEnabled = false;
+        }
+        else {
+            throw CTiglError("Wrong value for 'normals_enabled' in vtk export: " + value);
+        }
+    }
+
+    else {
+        throw CTiglError("Invalid key in vtk export: " + key);
+    }
 }
 
 } // end namespace tigl

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -88,7 +88,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
 {
     CTiglAbstractPhysicalComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
-    CTiglTriangularizer trian(shape, deflection, false);
+    CTiglTriangularizer trian(shape, deflection);
     trian.writeVTK(filename.c_str());
 }
 

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -83,6 +83,11 @@ public:
 
     TIGL_EXPORT void ExportMeshedGeometryVTKNoFuse(const std::string& filename, const double deflection = 0.1);
 
+    TIGL_EXPORT static void SetOptions(const std::string& key, const std::string& value);
+
+
+    // Options
+    static bool normalsEnabled;
 
 private:
     class CCPACSConfiguration & myConfig;       /**< TIGL configuration object */

--- a/src/geometry/CTiglPolyData.cpp
+++ b/src/geometry/CTiglPolyData.cpp
@@ -437,7 +437,7 @@ void CTiglPolyData::writeVTKPiece(TixiDocumentHandle& handle, unsigned int iObje
         for (unsigned int i = 0; i < nPoints; ++i) {
             const CTiglPoint& p = co.getVertexPoint(i);
             setMinMax(p, &min_coord, &max_coord);
-            stream1 << "    " <<  p.x << " " << p.y << " " << p.z << std::endl;
+            stream1 << "    " << std::setprecision(10) << p.x << " " << p.y << " " << p.z << std::endl;
             stream1 << "         ";
         }
         std::string tmpPath = piecepath + "/Points";

--- a/src/geometry/CTiglPolyData.cpp
+++ b/src/geometry/CTiglPolyData.cpp
@@ -850,6 +850,11 @@ unsigned long ObjectImpl::addPointNorm(const CTiglPoint& p, const CTiglPoint& n)
 
 unsigned long ObjectImpl::addTriangleByVertexIndex(unsigned long i1, unsigned long i2, unsigned long i3 )
 {
+    // if we don't have a true triangle / 2 indices are the same, report error
+    if (i1 == i2 || i1 == i3 || i2 == i3) {
+        return ULONG_MAX;
+    }
+
     unsigned long nPolys = static_cast<unsigned long>(polys.size());
     polys.push_back(PolyIndexList(nPolys));
     

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -368,11 +368,6 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
         index2 = indexBuffer[occindex2-ilower];
         index3 = indexBuffer[occindex3-ilower];
         
-        // @TODO: in some rare cases, 2 indices are the same
-        // which means, that we dont have a true triangle.
-        // This behaviour might break some export functions.
-        // What should we do?
-        
         unsigned int iPolyIndex = 0;
         
         if (face.Orientation() != TopAbs_REVERSED && face.Orientation() != TopAbs_INTERNAL) {
@@ -382,6 +377,13 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
             iPolyIndex = currentObject().addTriangleByVertexIndex(index1, index3, index2);
         }
         
+        // In some rare cases, 2 indices are the same
+        // which means, that we dont have a true triangle.
+        // Ignore this triangle
+        if (iPolyIndex == ULONG_MAX) {
+            continue;
+        }
+
         if (iPolyIndex > iPolyUpper) {
             iPolyUpper = iPolyIndex;
         }

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -38,17 +38,52 @@ enum ComponentTraingMode
     SEGMENT_INFO
 };
 
+class CTiglTriangularizerOptions {
+public:
+    CTiglTriangularizerOptions()
+        : m_useMultipleObjects(false),
+          m_normalsEnabled(true)
+    {
+    }
+
+    bool useMultipleObjects() const
+    {
+        return m_useMultipleObjects;
+    }
+
+    bool normalsEnabled() const
+    {
+        return m_normalsEnabled;
+    }
+
+    void setNormalsEnabled(bool enabled)
+    {
+        m_normalsEnabled = enabled;
+    }
+
+    void setMutipleObjectsEnabled(bool enabled)
+    {
+        m_useMultipleObjects = enabled;
+    }
+
+private:
+    bool m_useMultipleObjects;
+    bool m_normalsEnabled;
+};
+
 class CTiglTriangularizer : public CTiglPolyData
 {
 public:
-    TIGL_EXPORT CTiglTriangularizer();
-    TIGL_EXPORT CTiglTriangularizer(const TopoDS_Shape&, double deflection);
-    TIGL_EXPORT CTiglTriangularizer(class CTiglAbstractPhysicalComponent &comp, double deflection, ComponentTraingMode mode);
-    TIGL_EXPORT CTiglTriangularizer(class CCPACSConfiguration& config, bool fuseShapes, double deflection, ComponentTraingMode mode);
-    
-    TIGL_EXPORT static void useMultipleObjects(bool);
-    TIGL_EXPORT static void setNormalsEnabled(bool);
-    
+    TIGL_EXPORT CTiglTriangularizer(const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+
+    TIGL_EXPORT CTiglTriangularizer(const TopoDS_Shape&, double deflection, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+
+    TIGL_EXPORT CTiglTriangularizer(class CTiglAbstractPhysicalComponent &comp, double deflection,
+                                    ComponentTraingMode mode, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+
+    TIGL_EXPORT CTiglTriangularizer(class CCPACSConfiguration& config, bool fuseShapes, double deflection, ComponentTraingMode mode,
+                                    const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+
 private:
     int triangularizeComponent(class CTiglAbstractPhysicalComponent &, bool includeChilds, const TopoDS_Shape& shape, double deflection, ComponentTraingMode = NO_INFO);
     int triangularizeShape(const TopoDS_Shape &);
@@ -57,8 +92,7 @@ private:
     int computeVTKMetaData(class CCPACSWing&);
 
     // some options
-    static bool _useMultipleObjects;
-    static bool _normalsEnabled;
+    CTiglTriangularizerOptions m_options;
 };
 
 }

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -42,11 +42,12 @@ class CTiglTriangularizer : public CTiglPolyData
 {
 public:
     TIGL_EXPORT CTiglTriangularizer();
-    TIGL_EXPORT CTiglTriangularizer(const TopoDS_Shape&, double deflection, bool useMultipleObjects = false);
+    TIGL_EXPORT CTiglTriangularizer(const TopoDS_Shape&, double deflection);
     TIGL_EXPORT CTiglTriangularizer(class CTiglAbstractPhysicalComponent &comp, double deflection, ComponentTraingMode mode);
     TIGL_EXPORT CTiglTriangularizer(class CCPACSConfiguration& config, bool fuseShapes, double deflection, ComponentTraingMode mode);
     
-    TIGL_EXPORT void useMultipleObjects(bool);
+    TIGL_EXPORT static void useMultipleObjects(bool);
+    TIGL_EXPORT static void setNormalsEnabled(bool);
     
 private:
     int triangularizeComponent(class CTiglAbstractPhysicalComponent &, bool includeChilds, const TopoDS_Shape& shape, double deflection, ComponentTraingMode = NO_INFO);
@@ -54,8 +55,10 @@ private:
     void annotateWingSegment(class CCPACSWingSegment &segment, gp_Pnt centralP, bool pointOnMirroredShape, unsigned long iPolyLow, unsigned long iPolyUp);
     int triangularizeFace(const TopoDS_Face &, unsigned long& nVertices, unsigned long& iPolyLow, unsigned long& iPolyUp);
     int computeVTKMetaData(class CCPACSWing&);
-    
-    bool _useMultipleObjects;
+
+    // some options
+    static bool _useMultipleObjects;
+    static bool _normalsEnabled;
 };
 
 }

--- a/tests/tiglExports.cpp
+++ b/tests/tiglExports.cpp
@@ -158,6 +158,18 @@ TiglCPACSConfigurationHandle tiglExportRectangularWing::tiglRectangularWingHandl
 //    writer.ExportMeshedWingVTK
 //}
 
+TEST_F(tiglExport, vtkOptions)
+{
+    ASSERT_EQ(TIGL_SUCCESS, tiglExportVTKSetOptions("normals_enabled", "0"));
+    ASSERT_EQ(TIGL_SUCCESS, tiglExportVTKSetOptions("normals_enabled", "1"));
+
+    ASSERT_EQ(TIGL_ERROR, tiglExportVTKSetOptions("normals_enabled", "no"));
+    ASSERT_EQ(TIGL_ERROR, tiglExportVTKSetOptions("invalid options", "0"));
+
+    ASSERT_EQ(TIGL_NULL_POINTER, tiglExportVTKSetOptions(NULL, "0"));
+    ASSERT_EQ(TIGL_NULL_POINTER, tiglExportVTKSetOptions("normals_enabled", NULL));
+}
+
 /**
 * Tests tiglWingGetProfileName with invalid CPACS handle.
 */


### PR DESCRIPTION
The only option right now is to enable/disable normal vectors.

This is required, as normals and vertices are pairs in the VTK file format. When we have two equal vertices with different normals, two points are inserted into the VTK file. Codes that rely on having each point only once can disable writing the normal vectors now.

Also fixed some minor issues in the VTK export.

Fixes #254 and fixes #255