### PR TITLE
Added API func. tiglFuselageGetCrossSectionArea

### DIFF
--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -1548,6 +1548,25 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetSectionCenter(TiglCPACSConfigur
                                                                double *pointZ);
 
 /**
+* @brief Returns the value of the area of a cross section of a fuselage
+* @param[in] cpacsHandle        Handle for the CPACS configuration
+* @param[in] fuselageSegmentUID UID of the segment
+* @param[in] eta                Parameter value from where on the given object the section is cut out, eta in the range 0.0 <= eta <= 1.0
+* @param[out] area              the area of the given cross section of a given fuselage
+* @return
+*   - TIGL_SUCCESS if the area was found
+*   - TIGL_NOT_FOUND if no configuration was found for the given handle
+*   - TIGL_UID_ERROR if UID is invalid or not a fuselage segment
+*   - TIGL_NULL_POINTER if area is a null pointer
+*   - TIGL_MATH_ERROR if eta is out of range, i.e., not in [0, 1]
+*   - TIGL_ERROR if some other error occurred
+*/
+TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetCrossSectionArea(TiglCPACSConfigurationHandle cpacsHandle,
+                                                                  const char *fuselageSegmentUID,
+                                                                  double eta,
+                                                                  double *area);
+
+/**
 * @brief Returns a point on a fuselage surface for a given fuselage and segment index.
 *
 * Returns a point on a fuselage segment of a given fuselage in dependence of parameters eta and zeta with

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1089,6 +1089,18 @@ gp_Pnt GetCenterOfMass(const TopoDS_Shape &shape)
      return centerPoint;
 }
 
+double GetArea(const TopoDS_Shape &shape)
+{
+    // get surface properties of the shape
+     GProp_GProps SProps;
+     BRepGProp::SurfaceProperties(shape, SProps);
+
+     // compute the area of the shape or the area that is framed by the shape
+     double area = SProps.Mass();
+
+     return area;
+}
+
 TopoDS_Shape RemoveDuplicateEdges(const TopoDS_Shape& shape)
 {
     TopTools_ListOfShape initialEdgeList, newEdgeList;

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -197,6 +197,9 @@ TIGL_EXPORT TopoDS_Face GetNearestFace(const TopoDS_Shape& src, const gp_Pnt& pn
 // Method for finding the center of mass of a shape
 TIGL_EXPORT gp_Pnt GetCenterOfMass(const TopoDS_Shape& shape);
 
+// Method for finding the area of a shape or the area that is framed by the shape
+TIGL_EXPORT double GetArea(const TopoDS_Shape &shape);
+
 // Method for checking for duplicate edges in the passed shape.
 // The method returns a shape with only unique edges
 // NOTE: THIS METHOD ONLY CHECKS THE VERTEX POSITIONS, AND THE MIDDLE POINT 

--- a/tests/tiglFuselageSegment.cpp
+++ b/tests/tiglFuselageSegment.cpp
@@ -26,6 +26,9 @@
 #include "test.h" // Brings in the GTest framework
 #include "tigl.h"
 
+#define _USE_MATH_DEFINES
+#include "math.h"
+
 
 /***************************************************************************************************/
 
@@ -648,50 +651,50 @@ TEST_F(TiglFuselageSegmentSimple, getSectionCenter)
 
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
-    EXPECT_NEAR(pointX, -0.5, 1e-15);
-    EXPECT_NEAR(pointY, 0, 1e-2);
-    EXPECT_NEAR(pointZ, 0, 1e-2);
+    EXPECT_NEAR(-0.5, pointX, 1e-15);
+    EXPECT_NEAR(0, pointY, 1e-2);
+    EXPECT_NEAR(0, pointZ, 1e-2);
 
     eta = 0.5;
 
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
-    EXPECT_NEAR(pointX, 0, 1e-15);
-    EXPECT_NEAR(pointY, 0, 1e-2);
-    EXPECT_NEAR(pointZ, 0, 1e-2);
+    EXPECT_NEAR(0, pointX, 1e-15);
+    EXPECT_NEAR(0, pointY, 1e-2);
+    EXPECT_NEAR(0, pointZ, 1e-2);
 
     eta = 1;
 
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
-    EXPECT_NEAR(pointX, 0.5, 1e-15);
-    EXPECT_NEAR(pointY, 0, 1e-2);
-    EXPECT_NEAR(pointZ, 0, 1e-2);
+    EXPECT_NEAR(0.5, pointX, 1e-15);
+    EXPECT_NEAR(0, pointY, 1e-2);
+    EXPECT_NEAR(0, pointZ, 1e-2);
 
     // test second fuselage segment
     eta = 0.;
 
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &pointX, &pointY, &pointZ));
-    EXPECT_NEAR(pointX, 0.5, 1e-15);
-    EXPECT_NEAR(pointY, 0, 1e-2);
-    EXPECT_NEAR(pointZ, 0, 1e-2);
+    EXPECT_NEAR(0.5, pointX, 1e-15);
+    EXPECT_NEAR(0, pointY, 1e-2);
+    EXPECT_NEAR(0, pointZ, 1e-2);
 
     eta = 0.5;
 
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &pointX, &pointY, &pointZ));
-    EXPECT_NEAR(pointX, 1, 1e-15);
-    EXPECT_NEAR(pointY, 0, 1e-2);
-    EXPECT_NEAR(pointZ, 0, 1e-2);
+    EXPECT_NEAR(1, pointX, 1e-15);
+    EXPECT_NEAR(0, pointY, 1e-2);
+    EXPECT_NEAR(0, pointZ, 1e-2);
 
     eta = 1;
 
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &pointX, &pointY, &pointZ));
-    EXPECT_NEAR(pointX, 1.5, 1e-15);
-    EXPECT_NEAR(pointY, 0, 1e-2);
-    EXPECT_NEAR(pointZ, 0, 1e-2);
+    EXPECT_NEAR(1.5, pointX, 1e-15);
+    EXPECT_NEAR(0, pointY, 1e-2);
+    EXPECT_NEAR(0, pointZ, 1e-2);
 
     // some other tests: make sure that right error codes are returned in case of the corresponding errors
     ASSERT_EQ(TIGL_UID_ERROR, tiglFuselageGetSectionCenter(tiglHandle, "invalidUID", eta, &pointX, &pointY, &pointZ));
@@ -719,36 +722,35 @@ TEST_F(TiglFuselageSegmentSimple, getSectionArea)
 
     double area = 0.;
 
-    double pi = 3.14159265359;
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
-    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+    EXPECT_NEAR(M_PI * 0.5 * 0.5, area, 3e-2);
 
     eta = 0.5;
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
-    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+    EXPECT_NEAR(M_PI * 0.5 * 0.5, area, 3e-2);
 
     eta = 1.;
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
-    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+    EXPECT_NEAR(M_PI * 0.5 * 0.5, area, 3e-2);
 
     // test second fuselage segment
     eta = 0.;
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
-    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+    EXPECT_NEAR(M_PI * 0.5 * 0.5, area, 3e-2);
 
     eta = 0.5;
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
-    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+    EXPECT_NEAR(M_PI * 0.5 * 0.5, area, 3e-2);
 
     eta = 1.;
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
-    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+    EXPECT_NEAR(M_PI * 0.5 * 0.5, area, 3e-2);
 
     // some other tests: make sure that right error codes are returned in case of the corresponding errors
     ASSERT_EQ(TIGL_UID_ERROR, tiglFuselageGetCrossSectionArea(tiglHandle, "invalidUID", eta, &area));

--- a/tests/tiglFuselageSegment.cpp
+++ b/tests/tiglFuselageSegment.cpp
@@ -712,3 +712,55 @@ TEST_F(TiglFuselageSegmentSimple, getSectionCenter)
     ASSERT_EQ(TIGL_MATH_ERROR, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta_out_of_range, &pointX, &pointY, &pointZ));
 }
 
+TEST_F(TiglFuselageSegmentSimple, getSectionArea)
+{
+    // test first fuselage segment
+    double eta = 0.;
+
+    double area = 0.;
+
+    double pi = 3.14159265359;
+    ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+    ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+
+    eta = 0.5;
+    ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+    ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+
+    eta = 1.;
+    ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+    ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+
+    // test second fuselage segment
+    eta = 0.;
+    ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
+    ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
+    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+
+    eta = 0.5;
+    ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
+    ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
+    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+
+    eta = 1.;
+    ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
+    ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment3ID", eta, &area));
+    EXPECT_NEAR(area, pi * 0.5 * 0.5, 3e-2);
+
+    // some other tests: make sure that right error codes are returned in case of the corresponding errors
+    ASSERT_EQ(TIGL_UID_ERROR, tiglFuselageGetCrossSectionArea(tiglHandle, "invalidUID", eta, &area));
+
+    ASSERT_EQ(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, NULL));
+    ASSERT_EQ(TIGL_NULL_POINTER, tiglFuselageGetCrossSectionArea(tiglHandle, NULL, eta, &area));
+
+    ASSERT_EQ(TIGL_NOT_FOUND, tiglFuselageGetCrossSectionArea(-1, "segmentD150_Fuselage_1Segment2ID", eta, &area));
+
+    double eta_out_of_range = -0.5;
+    ASSERT_EQ(TIGL_MATH_ERROR, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta_out_of_range, &area));
+    eta_out_of_range = 2;
+    ASSERT_EQ(TIGL_MATH_ERROR, tiglFuselageGetCrossSectionArea(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta_out_of_range, &area));
+}
+


### PR DESCRIPTION
The function tiglFuselageGetCrossSectionArea is committed which
computes the area of a fuselage section. A helper function GetArea
which computes the area of a TopoDS_Shape and the test for
tiglFuselageGetCrossSectionArea are committed as well.

Fixes issue #259