### PR TITLE
fix tiglFuselageGetPointAngle bug

### DIFF
--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -2677,7 +2677,12 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetPointAngle(TiglCPACSConfigurati
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageIndex);
         tigl::CCPACSFuselageSegment& segment = (tigl::CCPACSFuselageSegment &) fuselage.GetSegment(segmentIndex);
-        gp_Pnt point = segment.GetPointAngle(eta, alpha, 0.0, 0.0);        
+
+        // get cross section center
+        TopoDS_Shape crossSection = segment.getWireOnLoft(eta);
+        gp_Pnt csc = GetCenterOfMass(crossSection);
+
+        gp_Pnt point = segment.GetPointAngle(eta, alpha, csc.Y(), csc.Z());
         if ((point.X() == 0.0) && (point.Y() == 0.0) && (point.Z() == 0.0)) {
             return TIGL_ERROR;
         }

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -1667,7 +1667,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetPointAngle(TiglCPACSConfigurati
 * segment, for eta = 1.0 it lies on the end profile of the segment.
 * The angle alpha is calculated in degrees. It's orientation is the mathematical negative rotation direction around the X-axis, i.e. looking
 * in flight direction, an angle of 45 degrees resembles a point on the top-left fuselage.
-* The parameters x_cs and z_cs must be in absolute world coordinates.
+* The parameters y_cs and z_cs must be in absolute world coordinates.
 * The point is returned in absolute world coordinates.
 *
 *

--- a/src/fuselage/CCPACSFuselageSegment.cpp
+++ b/src/fuselage/CCPACSFuselageSegment.cpp
@@ -713,7 +713,7 @@ int CCPACSFuselageSegment::GetNumPointsOnXPlane(double eta, double xpos)
 
 
 // Gets a point on the fuselage segment in dependence of an angle alpha (degree).
-// The origin of the angle could be set via the parameters x_cs and z_cs,
+// The origin of the angle could be set via the parameters y_cs and z_cs,
 // but in most cases x_cs and z_cs will be zero get the get center line of the profile.
 gp_Pnt CCPACSFuselageSegment::GetPointAngle(double eta, double alpha, double y_cs, double z_cs)
 {


### PR DESCRIPTION
The function GetPointAngle now takes the cross section center as starting point for the angle, rather than the origin of the yz-plane at the current eta

fixes #264