### PR TITLE
Automatically deploy nightlies and release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,24 @@ env:
     - secure: "x+x2IMHk0IJKuvDAWcNMi5ifR0dNwpvAkM2axK67YqN2zb0CJzpj87daiEGvf+4268gHk5nBtHQtVxTIjk6B6LmUnya6OwOcs55ZBMrkgc6NiWVxB9+i6n2phdVNbXogWknOBDZhQqTtqqdvbQBJAO3UppdFrDZQF3eb9j+YWMs="
     - secure: "lijVVp4jRIfDkV67yPFdANoAv9oONJSISM/QO7uScMyNUkyDKwCgZbuFsOziJsqZUyGbM3GFCdSK7ufpzM3mlEFQyPckaPCnHyifgzixLlWTn7Krijgt5jMFGqwbSONqLENBhUJi5eAmj2m2lP3Pdmg4U4PPAOTwd5EQvY8uwRU="
 
+deploy:
+  provider: releases
+  api_key:
+    secure: sUJ1hPLgEJosx0JGo9A5bGbAfoigXCK4+Bo5OGUkjiHtx4UmQ72fy9EPAFQpGp2b9MGP1fSkGJGWVR7hRvCE682cu3kICncXLIs4/jsrC4CKjNmZ9W9Ua/dgZ1tG6I4/l/Aecf4OgXZTOn6RqqXtQdpiyHz5neDh+Rf4ZxcY+hw=
+  file_glob: true
+  file: build/*.dmg
+  skip_cleanup: true
+  tag_name: "$TRAVIS_TAG"
+  condition: $TRAVIS_OS_NAME == osx
+  draft: true
+  on:
+    repo: DLR-SC/tigl
+    tags: true
+
 before_install:
   # Linux steps
   - '[ "$TRAVIS_OS_NAME" != linux ] || curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/Release.key | sudo apt-key add - '
   - '[ "$TRAVIS_OS_NAME" != linux ] || echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/ /" | sudo tee -a /etc/apt/sources.list '
-  - '[ "$TRAVIS_OS_NAME" != linux ] || sudo add-apt-repository ppa:george-edison55/precise-backports -y'
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-get update -qq '
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-get install -y --force-yes libtixi-dev liboce-dev cmake cmake-data sshpass'
 # oce ships a faulty config file, we have to remove it and use standard opencascade detection
@@ -50,3 +63,5 @@ script:
 
 after_success:
     - ../ci/travis/deploy.sh
+    - cd ..
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - '[ "$TRAVIS_OS_NAME" != osx ] || tar xf oce.0.17.2.macos_static.tar.gz'
   - '[ "$TRAVIS_OS_NAME" != osx ] || tar xf TIXI-2.2.4-macOS.tar.gz '
   # If a tag/release is build, disable the nighty build flag
-  - export TIGL_NIGHTLY=$([ -z "$TRAVIS_TAG" ] && echo "ON" || echo "OFF")
+  - export TIGL_NIGHTLY=$([ "$TRAVIS_EVENT_TYPE" == "cron" ] && echo "ON" || echo "OFF")
 
 before_script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - '[ "$TRAVIS_OS_NAME" != linux ] || curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/Release.key | sudo apt-key add - '
   - '[ "$TRAVIS_OS_NAME" != linux ] || echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_12.04/ /" | sudo tee -a /etc/apt/sources.list '
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-get update -qq '
-  - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-get install -y --force-yes libtixi-dev liboce-dev cmake cmake-data sshpass'
+  - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-get install -y --force-yes libtixi-dev liboce-dev doxygen cmake cmake-data sshpass'
 # oce ships a faulty config file, we have to remove it and use standard opencascade detection
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo rm /usr/lib/oce-*/OCEConfig.cmake '
   # macOS steps
@@ -53,6 +53,7 @@ script:
   - '[ "$TRAVIS_OS_NAME" != linux ] || jdk_switcher use oraclejdk8'
   - cmake -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=$TIGL_NIGHTLY -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
   - make -j 4
+  - '[ "$TRAVIS_OS_NAME" != linux ] || make doc'
   - make install
   - '[ "$TRAVIS_OS_NAME" != osx ] || make package'
   - '[ "$TRAVIS_OS_NAME" != osx ] || export DYLD_LIBRARY_PATH=`pwd`/../TIXI-2.2.4-macOS/lib '

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ before_install:
   - '[ "$TRAVIS_OS_NAME" != osx ] || export MACOSX_DEPLOYMENT_TARGET=10.8'
   - '[ "$TRAVIS_OS_NAME" != osx ] || ci/travis/get_qt_macOS.sh'
   - '[ "$TRAVIS_OS_NAME" != osx ] || /usr/bin/curl -o sshpass-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/sshpass-macOS.tar.gz'
+  - '[ "$TRAVIS_OS_NAME" != osx ] || /usr/bin/curl -o doxygen-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/doxygen-macOS.tar.gz'
   - '[ "$TRAVIS_OS_NAME" != osx ] || /usr/bin/curl -o oce.0.17.2.macos_static.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/oce.0.17.2.macos_static.tar.gz'
   - '[ "$TRAVIS_OS_NAME" != osx ] || /usr/bin/curl -O -L https://github.com/DLR-SC/tixi/releases/download/v2.2.4/TIXI-2.2.4-macOS.tar.gz '
   - '[ "$TRAVIS_OS_NAME" != osx ] || tar xf sshpass-macOS.tar.gz -C /tmp && export PATH=$PATH:/tmp'
+  - '[ "$TRAVIS_OS_NAME" != osx ] || tar xf doxygen-macOS.tar.gz -C /tmp && export PATH=$PATH:/tmp/doxygen'
   - '[ "$TRAVIS_OS_NAME" != osx ] || tar xf oce.0.17.2.macos_static.tar.gz'
   - '[ "$TRAVIS_OS_NAME" != osx ] || tar xf TIXI-2.2.4-macOS.tar.gz '
   # If a tag/release is build, disable the nighty build flag
@@ -53,7 +55,7 @@ script:
   - '[ "$TRAVIS_OS_NAME" != linux ] || jdk_switcher use oraclejdk8'
   - cmake -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=$TIGL_NIGHTLY -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
   - make -j 4
-  - '[ "$TRAVIS_OS_NAME" != linux ] || make doc'
+  - make doc
   - make install
   - '[ "$TRAVIS_OS_NAME" != osx ] || make package'
   - '[ "$TRAVIS_OS_NAME" != osx ] || export DYLD_LIBRARY_PATH=`pwd`/../TIXI-2.2.4-macOS/lib '

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,21 @@ build:
   verbosity: minimal
 
 artifacts:
-  - path: '_build/*.zip'
+  - path: '*.zip'
     name: binaries
+
+deploy:
+  - provider: FTP
+    protocol: sftp
+    host: frs.sourceforge.net
+    username:
+      secure: HZlK5sZGRgSoPQQI6EgdtsFtTj/ZAfdSPdLLxt8FeuE=
+    password:
+      secure: z0kfNd+oRq/PHvJumrSOpA==
+    folder: files/Nightlies-Windows
+#   on:
+#     appveyor_scheduled_build: true
+
 
 install:
   - ps: |
@@ -87,6 +100,7 @@ after_test:
 - ps: |
     & cmake --build . --config $env:CONFIGURATION --target doc
     & cpack -G ZIP
+    & mv *.zip ..
 
 cache:
  - c:\oce -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ build:
 artifacts:
   - path: '*.zip'
     name: binaries
+  - path: '*.exe'
+    name: installer
 
 deploy:
   - provider: FTP
@@ -25,8 +27,13 @@ deploy:
     password:
       secure: z0kfNd+oRq/PHvJumrSOpA==
     folder: files/Nightlies-Windows
-#   on:
-#     appveyor_scheduled_build: true
+    on:
+      appveyor_scheduled_build: true
+
+  - provider: Environment
+    name: GitHub
+    on:
+      appveyor_repo_tag: true
 
 
 install:
@@ -64,14 +71,21 @@ install:
         Write-Output "Extract Doxygen"
         & 7z x -y "c:\doxygen-win.zip" -oC:\ > null
       }
-
+  # check if release build, if yes we need nsis
+  - ps: |
+      $BUILD_RELEASE = $($env:appveyor_repo_tag -eq "true")
+      $BUILD_NIGHTLY = "ON"
+      if ($BUILD_RELEASE) {
+        $BUILD_NIGHTLY = "OFF"
+        Write-Output "Release builds enabled."
+      }
 
 build_script:
 - ps: |
     md _build -Force | Out-Null
     cd _build
-    Write-Output "Running cmake: -DCMAKE_INSTALL_PREFIX=install -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=ON -DQT_PATH=c:\Qt\5.4.1\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe .."
-    & cmake -G "$generator" -DCMAKE_INSTALL_PREFIX=install -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=ON -DQT_PATH=c:\Qt\5.4.1\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe ..
+    Write-Output "Running cmake: -DCMAKE_INSTALL_PREFIX=install -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=$BUILD_NIGHTLY -DQT_PATH=c:\Qt\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe .."
+    & cmake -G "$generator" -DCMAKE_INSTALL_PREFIX=install -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY="$BUILD_NIGHTLY" -DQT_PATH=c:\Qt\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe ..
     if ($LastExitCode -ne 0) {
         throw "Exec: $ErrorMessage"
     }
@@ -101,6 +115,12 @@ after_test:
     & cmake --build . --config $env:CONFIGURATION --target doc
     & cpack -G ZIP
     & mv *.zip ..
+- ps : |
+    if ($BUILD_RELEASE)
+    {
+        cpack -G NSIS
+        mv *.exe ..
+    }
 
 cache:
  - c:\oce -> appveyor.yml

--- a/ci/travis/deploy.sh
+++ b/ci/travis/deploy.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_OS_NAME" == osx && -n "$FTP_PASSWORD" ]]; then
+# only deploy nightly builds, not regular builds 
+if [[ "$TRAVIS_OS_NAME" == osx && -n "$FTP_PASSWORD" && "$TIGL_NIGHTLY" == "ON" ]]; then
     files=( "*.dmg" )
     PACKAGE="${files[0]}"
-    ln -s $PACKAGE TiGL-LatestNightly-Darwin.dmg
-    sshpass -p $FTP_PASSWORD scp -o StrictHostKeyChecking=no $PACKAGE TiGL-LatestNightly-Darwin.dmg $FTP_USER@frs.sourceforge.net:/home/frs/project/tigl/Nightlies-macOS
+    ln -s $PACKAGE TiGL-Nightly-Latest-Darwin.dmg
+    sshpass -p $FTP_PASSWORD scp -o StrictHostKeyChecking=no $PACKAGE TiGL-Nightly-Latest-Darwin.dmg $FTP_USER@frs.sourceforge.net:/home/frs/project/tigl/Nightlies-macOS
 fi

--- a/ci/travis/deploy.sh
+++ b/ci/travis/deploy.sh
@@ -7,3 +7,8 @@ if [[ "$TRAVIS_OS_NAME" == osx && -n "$FTP_PASSWORD" && "$TIGL_NIGHTLY" == "ON" 
     ln -s $PACKAGE TiGL-Nightly-Latest-Darwin.dmg
     sshpass -p $FTP_PASSWORD scp -o StrictHostKeyChecking=no $PACKAGE TiGL-Nightly-Latest-Darwin.dmg $FTP_USER@frs.sourceforge.net:/home/frs/project/tigl/Nightlies-macOS
 fi
+
+# only deploy documentation on release builds
+if [[ "$TRAVIS_OS_NAME" == linux && -n "$FTP_PASSWORD"  && -n "$TRAVIS_TAG" ]]; then
+    sshpass -p $FTP_PASSWORD scp -r -o StrictHostKeyChecking=no install/share/doc/tigl3/html/* $FTP_USER@frs.sourceforge.net:/home/project-web/tigl/htdocs/Doc
+fi


### PR DESCRIPTION
This PR enables the following:
 - CRON based nightly builds
 - The windows and macOS nightlies are uploaded to sourceforge
 - Releases - defined by a new tag - are uploaded to the github release page