### PR TITLE
Fixed Internal Python Interface build

### DIFF
--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -69,6 +69,8 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
         set(EXTENSION "so")
     endif(WIN32)
 
+    add_definitions(-DTIGL_INTERNAL_IMPORTS)
+
     foreach(MODULE ${MODULES})
         set_source_files_properties(${MODULE}.i PROPERTIES CPLUSPLUS ON)
         set(SWIG_MODULE_${MODULE}_EXTRA_DEPS common.i doc.i)

--- a/bindings/python_internal/common.i
+++ b/bindings/python_internal/common.i
@@ -20,6 +20,10 @@
 %include std_vector.i
 
 %include tigl_config.h
+
+// swig cannot handle c++ 11 properly yet
+#undef HAVE_CPP11
+
 %include tigl_internal.h
 
 #ifdef HAVE_STDSHARED_PTR

--- a/src/api/tigl_internal.h
+++ b/src/api/tigl_internal.h
@@ -26,6 +26,8 @@
   // api to the dll interface (just for testing purposes!)
   #if defined (TIGL_INTERNAL_EXPORTS)
     #define TIGL_EXPORT __declspec (dllexport)
+  #elif defined (TIGL_INTERNAL_IMPORTS)
+    #define TIGL_EXPORT __declspec (dllimport)
   #else
     #define TIGL_EXPORT
   #endif

--- a/src/common/typename.cpp
+++ b/src/common/typename.cpp
@@ -1,20 +1,40 @@
+/*
+* Copyright (c) 2016 RISC Software GmbH
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "typename.h"
 
 #include <boost/core/demangle.hpp>
 
 #include <stdexcept>
 
-namespace tigl {
-    auto typeName(const std::type_info& ti) -> std::string {
-        // name holds fully qualified class name
-        // boost::demangle is required for GCC, just passes through string on VC++
-        auto name = boost::core::demangle(ti.name()); // e.g. "[class] tigl::CCPACSWing"
+namespace tigl
+{
 
-        // strip leading "class" (VC++)
-        const auto pos = name.find_last_of(' ');
-        if (pos != std::string::npos)
-            name = name.substr(pos + 1); // e.g. "tigl::CCPACSWing"
+std::string typeName(const std::type_info& ti)
+{
+	// name holds fully qualified class name
+	// boost::demangle is required for GCC, just passes through string on VC++
+	std::string name = boost::core::demangle(ti.name()); // e.g. "[class] tigl::CCPACSWing"
 
-        return name;
-    }
+	// strip leading "class" (VC++)
+	const size_t  pos = name.find_last_of(' ');
+	if (pos != std::string::npos)
+		name = name.substr(pos + 1); // e.g. "tigl::CCPACSWing"
+
+	return name;
 }
+
+} // namespace tigl

--- a/src/common/typename.cpp
+++ b/src/common/typename.cpp
@@ -25,16 +25,17 @@ namespace tigl
 
 std::string typeName(const std::type_info& ti)
 {
-	// name holds fully qualified class name
-	// boost::demangle is required for GCC, just passes through string on VC++
-	std::string name = boost::core::demangle(ti.name()); // e.g. "[class] tigl::CCPACSWing"
+    // name holds fully qualified class name
+    // boost::demangle is required for GCC, just passes through string on VC++
+    std::string name = boost::core::demangle(ti.name()); // e.g. "[class] tigl::CCPACSWing"
 
-	// strip leading "class" (VC++)
-	const size_t  pos = name.find_last_of(' ');
-	if (pos != std::string::npos)
-		name = name.substr(pos + 1); // e.g. "tigl::CCPACSWing"
+    // strip leading "class" (VC++)
+    const size_t  pos = name.find_last_of(' ');
+    if (pos != std::string::npos) {
+        name = name.substr(pos + 1); // e.g. "tigl::CCPACSWing"
+    }
 
-	return name;
+    return name;
 }
 
 } // namespace tigl

--- a/src/common/typename.h
+++ b/src/common/typename.h
@@ -28,7 +28,7 @@ std::string typeName(const std::type_info& ti);
 template <typename T>
 std::string typeName()
 {
-	return typeName(typeid(T));
+    return typeName(typeid(T));
 }
 
 }

--- a/src/common/typename.h
+++ b/src/common/typename.h
@@ -1,13 +1,36 @@
-#pragma once
+/*
+* Copyright (c) 2016 RISC Software GmbH
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TYPENAME_H
+#define TYPENAME_H
 
 #include <string>
 #include <typeinfo>
 
-namespace tigl {
-    auto typeName(const std::type_info& ti) -> std::string;
+namespace tigl
+{
 
-    template <typename T>
-    auto typeName() -> std::string {
-        return typeName(typeid(T));
-    }
+std::string typeName(const std::type_info& ti);
+
+template <typename T>
+std::string typeName()
+{
+	return typeName(typeid(T));
 }
+
+}
+
+#endif // TYPENAME_H

--- a/src/cpacs_other/CTiglUIDManager.h
+++ b/src/cpacs_other/CTiglUIDManager.h
@@ -56,7 +56,7 @@ public:
     TIGL_EXPORT void RegisterObject(const std::string& uid, void* object, const std::type_info& typeInfo);
 
     template<typename T>
-    TIGL_EXPORT void RegisterObject(const std::string& uid, T& object)
+    void RegisterObject(const std::string& uid, T& object)
     {
         RegisterObject(uid, &object, typeid(object));
     }
@@ -65,13 +65,13 @@ public:
     TIGL_EXPORT TypedPtr ResolveObject(const std::string& uid, const std::type_info& typeInfo) const;
 
     template<typename T>
-    TIGL_EXPORT T& ResolveObject(const std::string& uid) const
+    T& ResolveObject(const std::string& uid) const
     {
         return *static_cast<T* const>(ResolveObject(uid, typeid(T)).ptr);
     }
 
     template<typename T>
-    TIGL_EXPORT std::vector<T*> ResolveObjects() const
+    std::vector<T*> ResolveObjects() const
     {
         const std::type_info* ti = &typeid(T);
         std::vector<T*> objects;

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -87,7 +87,7 @@ public:
 
 
     // Options
-    static bool normalsEnabled;
+    TIGL_EXPORT static bool normalsEnabled;
 
 private:
     class CCPACSConfiguration & myConfig;       /**< TIGL configuration object */

--- a/src/generated/CPACSFuselages.h
+++ b/src/generated/CPACSFuselages.h
@@ -48,13 +48,13 @@ namespace tigl
             TIGL_EXPORT virtual ~CPACSFuselages();
             
             template<typename P>
-            TIGL_EXPORT bool IsParent() const
+            bool IsParent() const
             {
                 return m_parentType != NULL && *m_parentType == typeid(P);
             }
             
             template<typename P>
-            TIGL_EXPORT P* GetParent() const
+            P* GetParent() const
             {
                 #ifdef HAVE_STDIS_SAME
                 static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSFuselages");

--- a/src/generated/CPACSWing.h
+++ b/src/generated/CPACSWing.h
@@ -53,13 +53,13 @@ namespace tigl
             TIGL_EXPORT virtual ~CPACSWing();
             
             template<typename P>
-            TIGL_EXPORT bool IsParent() const
+            bool IsParent() const
             {
                 return m_parentType != NULL && *m_parentType == typeid(P);
             }
             
             template<typename P>
-            TIGL_EXPORT P* GetParent() const
+            P* GetParent() const
             {
                 #ifdef HAVE_STDIS_SAME
                 static_assert(std::is_same<P, CCPACSRotorBlades>::value || std::is_same<P, CCPACSWings>::value, "template argument for P is not a parent class of CPACSWing");

--- a/src/generated/CPACSWings.h
+++ b/src/generated/CPACSWings.h
@@ -48,13 +48,13 @@ namespace tigl
             TIGL_EXPORT virtual ~CPACSWings();
             
             template<typename P>
-            TIGL_EXPORT bool IsParent() const
+            bool IsParent() const
             {
                 return m_parentType != NULL && *m_parentType == typeid(P);
             }
             
             template<typename P>
-            TIGL_EXPORT P* GetParent() const
+            P* GetParent() const
             {
                 #ifdef HAVE_STDIS_SAME
                 static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSWings");


### PR DESCRIPTION
The internal python interface could not access the new member variable of the VTK exporter. Since this is a data member, the functions and datas must be imported using declspec(dllimport).

This required to remove also the (incorrect) exports on inline functions.