### PR TITLE
Various refactorings

### DIFF
--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -864,26 +864,29 @@ void TIGLViewerDocument::drawFuselageProfiles()
     TopoDS_Wire wire        = profile.GetWire();
     app->getScene()->displayShape(wire, true,  Quantity_NOC_WHITE);
 
-    if (profile.GetCoordinateContainer().size() < 15) {
-        for (unsigned int i = 0; i < profile.GetCoordinateContainer().size(); ++i) {
-            tigl::CTiglPoint * p = profile.GetCoordinateContainer().at(i);
-            std::stringstream str;
-            str << i << ": (" << p->x << ", " << p->y << ", " << p->z << ")";
-            gp_Pnt pnt = p->Get_gp_Pnt();
-            app->getScene()->displayPoint(pnt, str.str().c_str(), Standard_False, 0., 0., 0., 6.);
-        }
-    }
-    else {
-        for (double zeta = 0.0; zeta <= 1.0; zeta += 0.1) {
-            try {
-              gp_Pnt wirePoint = profile.GetPoint(zeta);
-              std::ostringstream text;
-              text << "PT(" << zeta << ")";
-              app->getScene()->displayPoint(wirePoint, const_cast<char*>(text.str().c_str()), Standard_False, 0.0, 0.0, 0.0, 2.0);
-              text.str("");
+    if (profile.GetPointList_choice1()) {
+        const std::vector<tigl::CTiglPoint>& points = profile.GetPointList_choice1()->AsVector();
+        if (points.size() < 15) {
+            for (unsigned int i = 0; i < points.size(); ++i) {
+                const tigl::CTiglPoint& p = points.at(i);
+                std::stringstream str;
+                str << i << ": (" << p.x << ", " << p.y << ", " << p.z << ")";
+                gp_Pnt pnt = p.Get_gp_Pnt();
+                app->getScene()->displayPoint(pnt, str.str().c_str(), Standard_False, 0., 0., 0., 6.);
             }
-            catch (tigl::CTiglError& ex) {
-              displayError(ex.what());
+        }
+        else {
+            for (double zeta = 0.0; zeta <= 1.0; zeta += 0.1) {
+                try {
+                  gp_Pnt wirePoint = profile.GetPoint(zeta);
+                  std::ostringstream text;
+                  text << "PT(" << zeta << ")";
+                  app->getScene()->displayPoint(wirePoint, const_cast<char*>(text.str().c_str()), Standard_False, 0.0, 0.0, 0.0, 2.0);
+                  text.str("");
+                }
+                catch (tigl::CTiglError& ex) {
+                  displayError(ex.what());
+                }
             }
         }
     }

--- a/TIGLViewer/src/TIGLViewerInputoutput.h
+++ b/TIGLViewer/src/TIGLViewerInputoutput.h
@@ -56,7 +56,7 @@ public:
 
     bool exportModel( const QString fileName, 
                       const FileFormat format, 
-                      const Handle_AIS_InteractiveContext& ic);
+                      const Handle(AIS_InteractiveContext)& ic);
 
     QString info() const;
 
@@ -66,28 +66,28 @@ signals:
 
 private:
 
-    Handle_TopTools_HSequenceOfShape  importModel( const FileFormat format, 
+    Handle(TopTools_HSequenceOfShape) importModel( const FileFormat format, 
                                                    const QString& fileName);
     bool                              exportModel( const FileFormat format, 
                                                    const QString&,
-                                                   const Handle_TopTools_HSequenceOfShape& );
+                                                   const Handle(TopTools_HSequenceOfShape)& );
     
-    Handle_TopTools_HSequenceOfShape getShapes( const Handle_AIS_InteractiveContext& oc);
+    Handle(TopTools_HSequenceOfShape) getShapes( const Handle(AIS_InteractiveContext)& oc);
 
-    Handle_TopTools_HSequenceOfShape importBREP ( const QString& );
+    Handle(TopTools_HSequenceOfShape) importBREP ( const QString& );
 
-    Handle_TopTools_HSequenceOfShape importIGES ( const QString& );
-    Handle_TopTools_HSequenceOfShape importSTL  ( const QString& );
-    Handle_TopTools_HSequenceOfShape importSTEP ( const QString& );
-    Handle_TopTools_HSequenceOfShape importMESH ( const QString& );
+    Handle(TopTools_HSequenceOfShape) importIGES ( const QString& );
+    Handle(TopTools_HSequenceOfShape) importSTL  ( const QString& );
+    Handle(TopTools_HSequenceOfShape) importSTEP ( const QString& );
+    Handle(TopTools_HSequenceOfShape) importMESH ( const QString& );
 
-    bool exportBREP ( const QString& fileName, const Handle_TopTools_HSequenceOfShape& shapes );
-    bool exportIGES ( const QString& fileName, const Handle_TopTools_HSequenceOfShape& shapes );
-    bool exportSTEP ( const QString& fileName, const Handle_TopTools_HSequenceOfShape& shapes );
-    bool exportSTL  ( const QString& fileName, const Handle_TopTools_HSequenceOfShape& shapes );
-    bool exportVRML ( const QString& fileName, const Handle_TopTools_HSequenceOfShape& shapes );
+    bool exportBREP ( const QString& fileName, const Handle(TopTools_HSequenceOfShape)& shapes );
+    bool exportIGES ( const QString& fileName, const Handle(TopTools_HSequenceOfShape)& shapes );
+    bool exportSTEP ( const QString& fileName, const Handle(TopTools_HSequenceOfShape)& shapes );
+    bool exportSTL  ( const QString& fileName, const Handle(TopTools_HSequenceOfShape)& shapes );
+    bool exportVRML ( const QString& fileName, const Handle(TopTools_HSequenceOfShape)& shapes );
 
-    bool checkFacetedBrep( const Handle_TopTools_HSequenceOfShape& );
+    bool checkFacetedBrep( const Handle(TopTools_HSequenceOfShape)& );
 
     // Attributes
     

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -165,10 +165,10 @@ protected: // methods
     virtual void contextMenuEvent  (QContextMenuEvent *event);
 
 private: // members
-    void initializeOCC(const Handle_AIS_InteractiveContext& aContext = NULL);
+    void initializeOCC(const Handle(AIS_InteractiveContext)& aContext);
 
-    Handle_V3d_View                 myView;
-    Handle_V3d_Viewer               myViewer;
+    Handle(V3d_View)                myView;
+    Handle(V3d_Viewer)              myViewer;
 
 #if OCC_VERSION_HEX < 0x070000
     Handle_Visual3d_Layer           myLayer;

--- a/TIGLViewer/src/main.cpp
+++ b/TIGLViewer/src/main.cpp
@@ -147,7 +147,7 @@ int parseArguments(QStringList argList)
         }
         else if (arg.compare("--filename") == 0) {
             if (i+1 >= argList.size()) {
-                cout << "missing filename" << endl;
+                cout << "missing filename" << std::endl;
                 return -1;
             }
             else {
@@ -156,7 +156,7 @@ int parseArguments(QStringList argList)
         }
         else if (arg.compare("--script") == 0) {
             if (i+1 >= argList.size()) {
-                cout << "missing script filename" << endl;
+                cout << "missing script filename" << std::endl;
                 return -1;
             }
             else {
@@ -165,7 +165,7 @@ int parseArguments(QStringList argList)
         }
         else if (arg.compare("--windowtitle") == 0) {
             if (i+1 >= argList.size()) {
-                cout << "missing windowtitle" << endl;
+                cout << "missing windowtitle" << std::endl;
                 PARAMS.windowTitle = "TIGLViewer";
             }
             else {
@@ -174,7 +174,7 @@ int parseArguments(QStringList argList)
         }
         else if (arg.compare("--modelUID") == 0) {
             if (i+1 >= argList.size()) {
-                cout << "missing modelUID" << endl;
+                cout << "missing modelUID" << std::endl;
                 PARAMS.modelUID = "";
             }
             else {
@@ -183,7 +183,7 @@ int parseArguments(QStringList argList)
         }
         else if (arg.compare("--controlFile") == 0) {
             if (i+1 >= argList.size()) {
-                cout << "missing controlFile" << endl;
+                cout << "missing controlFile" << std::endl;
                 PARAMS.controlFile = "";
             }
             else {

--- a/cpacs_gen_input/CustomTypes.txt
+++ b/cpacs_gen_input/CustomTypes.txt
@@ -11,7 +11,7 @@ CPACSRotorHub_type                 TiglRotorHubType
 CPACSAircraftModel                 CCPACSAircraftModel
 CPACSRotorcraftModel               CCPACSRotorcraftModel
 CPACSProfiles                      CCPACSProfiles
-CPACSMaterialDefinition            CCPACSMaterial
+CPACSMaterialDefinition            CCPACSMaterialDefinition
 CPACSFarField                      CCPACSFarField
 CPACSGuideCurves                   CCPACSGuideCurves
 CPACSGuideCurveProfileGeometry     CCPACSGuideCurveProfile

--- a/cpacs_gen_input/ParentPointer.txt
+++ b/cpacs_gen_input/ParentPointer.txt
@@ -13,8 +13,12 @@ CPACSWingRibsDefinition
 CPACSWingRibsDefinitions
 CPACSWingRibsPositioning
 CPACSWingRibExplicitPositioning
+CPACSWingSection
+CPACSWingSections
 CPACSWingSegment
 CPACSWingSegments
+CPACSWingElement
+CPACSWingElements
 CPACSWingShell
 CPACSWingSpar
 CPACSSparCrossSection
@@ -27,8 +31,12 @@ CPACSComponentSegments
 
 CPACSFuselage
 CPACSFuselages
+CPACSFuselageSection
+CPACSFuselageSections
 CPACSFuselageSegment
 CPACSFuselageSegments
+CPACSFuselageElement
+CPACSFuselageElements
 
 CPACSRotorBlades
 CPACSRotor

--- a/src/CCPACSPositionings.cpp
+++ b/src/CCPACSPositionings.cpp
@@ -56,7 +56,7 @@ void CCPACSPositionings::Cleanup()
 }
 
 // Returns the positioning matrix for a given section index
-CTiglTransformation CCPACSPositionings::GetPositioningTransformation(std::string sectionIndex)
+CTiglTransformation CCPACSPositionings::GetPositioningTransformation(const std::string& sectionIndex)
 {
     Update();
     for (std::vector<unique_ptr<CCPACSPositioning> >::const_iterator it = m_positionings.begin(); it != m_positionings.end(); ++it) {
@@ -77,7 +77,7 @@ void UpdateNextPositioning(CCPACSPositioning* currPos, int depth)
         throw CTiglError("Recursive definition of positioning is not allowed");
     }
 
-    if (currPos->GetToSectionUID() == "") {
+        if (currPos->GetToSectionUID().empty()){
         throw CTiglError("illegal definition of positionings");
     }
 
@@ -105,22 +105,22 @@ void CCPACSPositionings::Update()
 
     // diconnect and reset
     for (std::vector<unique_ptr<CCPACSPositioning> >::iterator it = m_positionings.begin(); it != m_positionings.end(); ++it) {
-        CCPACSPositioning* actPos = it->get();
-        actPos->DisconnectDependentPositionings();
-        actPos->SetFromPoint(CTiglPoint(0,0,0));
+        CCPACSPositioning* pos = it->get();
+        pos->DisconnectDependentPositionings();
+        pos->SetFromPoint(CTiglPoint(0,0,0));
     }
 
     // connect positionings, find roots
     std::vector<CCPACSPositioning*> rootNodes;
     for (std::vector<unique_ptr<CCPACSPositioning> >::iterator it = m_positionings.begin(); it != m_positionings.end(); ++it) {
-        CCPACSPositioning* actPos = it->get();
+        CCPACSPositioning* pos = it->get();
         // fromSectionUID element may be present but empty
-        if (actPos->GetFromSectionUID() && !actPos->GetFromSectionUID()->empty()) {
-            const std::string fromUID = *actPos->GetFromSectionUID();
+        if (pos->GetFromSectionUID() && !pos->GetFromSectionUID()->empty()) {
+            const std::string& fromUID = *pos->GetFromSectionUID();
             bool found = false;
             for (std::vector<unique_ptr<CCPACSPositioning> >::iterator it2 = m_positionings.begin(); it2 != m_positionings.end(); ++it2) {
                 if ((*it2)->GetToSectionUID() == fromUID) {
-                    (*it2)->AddDependentPositioning(actPos);
+                    (*it2)->AddDependentPositioning(pos);
                     found = true;
                     break;
                 }
@@ -131,7 +131,7 @@ void CCPACSPositionings::Update()
             }
         }
         else {
-            rootNodes.push_back(actPos);
+            rootNodes.push_back(pos);
         }
     }
 

--- a/src/CCPACSPositionings.h
+++ b/src/CCPACSPositionings.h
@@ -54,7 +54,7 @@ public:
     TIGL_EXPORT void Invalidate();
 
     // Returns the positioning matrix for a given section-uid
-    TIGL_EXPORT CTiglTransformation GetPositioningTransformation(std::string sectionIndex);
+    TIGL_EXPORT CTiglTransformation GetPositioningTransformation(const std::string& sectionIndex);
 
     // Cleanup routine
     TIGL_EXPORT void Cleanup();

--- a/src/CCPACSStringVector.cpp
+++ b/src/CCPACSStringVector.cpp
@@ -8,40 +8,40 @@ namespace tigl
     namespace
     {
         const char sep = ';';
+    }
 
-        std::vector<double> toDoubleVec(const std::string& s)
-        {
-            std::stringstream ss(s);
-            std::vector<double> r;
-            std::string d;
-            while (std::getline(ss, d, sep)) {
-                r.push_back(std::strtod(d.c_str(), NULL));
-            }
-            return r;
+    std::vector<double> stringToDoubleVec(const std::string& s)
+    {
+        std::stringstream ss(s);
+        std::vector<double> r;
+        std::string d;
+        while (std::getline(ss, d, sep)) {
+            r.push_back(std::strtod(d.c_str(), NULL));
         }
+        return r;
+    }
 
-        std::string toString(const std::vector<double>& v)
-        {
-            std::stringstream ss;
-            for (std::vector<double>::const_iterator it = v.begin(); it != v.end(); ++it) {
-                ss << *it;
-                if (it != v.end() - 1) {
-                    ss << sep;
-                }
+    std::string doubleVecToString(const std::vector<double>& v)
+    {
+        std::stringstream ss;
+        for (std::vector<double>::const_iterator it = v.begin(); it != v.end(); ++it) {
+            ss << *it;
+            if (it != v.end() - 1) {
+                ss << sep;
             }
-            return ss.str();
         }
+        return ss.str();
     }
 
     void CCPACSStringVector::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string &xpath)
     {
         generated::CPACSStringVectorBase::ReadCPACS(tixiHandle, xpath);
-        m_vec = toDoubleVec(m_simpleContent);
+        m_vec = stringToDoubleVec(m_simpleContent);
     }
 
     void CCPACSStringVector::WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const
     {
-        const_cast<std::string&>(m_simpleContent) = toString(m_vec); // TODO: this is a terrible hack, but WriteCPACS() has to be const
+        const_cast<std::string&>(m_simpleContent) = doubleVecToString(m_vec); // TODO: this is a terrible hack, but WriteCPACS() has to be const
         generated::CPACSStringVectorBase::WriteCPACS(tixiHandle, xpath);
     }
 

--- a/src/CCPACSStringVector.h
+++ b/src/CCPACSStringVector.h
@@ -5,11 +5,17 @@
 
 namespace tigl
 {
+    std::vector<double> stringToDoubleVec(const std::string& s);
+    std::string doubleVecToString(const std::vector<double>& v);
+
     class CCPACSStringVector : private generated::CPACSStringVectorBase
     {
     public:
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string &xpath) OVERRIDE;
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const OVERRIDE;
+
+        using generated::CPACSStringVectorBase::GetMapType;
+        using generated::CPACSStringVectorBase::SetMapType;
 
         TIGL_EXPORT const std::vector<double>& AsVector() const;
         TIGL_EXPORT std::vector<double>& AsVector();

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -1481,7 +1481,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetProfileName(TiglCPACSConfigurationH
         tigl::CCPACSWing& wing = config.GetWing(wingIndex);
         const tigl::CCPACSWingSection& section = wing.GetSection(sectionIndex);
         const tigl::CCPACSWingSectionElement& element = section.GetSectionElement(elementIndex);
-        std::string profileUID = element.GetProfileUID();
+        std::string profileUID = element.GetAirfoilUID();
         tigl::CCPACSWingProfile& profile = config.GetWingProfile(profileUID);
 
         *profileNamePtr = const_cast<char*>(profile.GetName().c_str());
@@ -5923,7 +5923,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetMaterialUID(TiglCPA
                     return TIGL_INDEX_ERROR;
                 }
 
-                const tigl::CCPACSMaterial* material = list.at(materialIndex-1);
+                const tigl::CCPACSMaterialDefinition* material = list.at(materialIndex-1);
                 if (!material) {
                     return TIGL_ERROR;
                 }
@@ -5998,7 +5998,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetMaterialThickness(T
                     return TIGL_INDEX_ERROR;
                 }
 
-                const tigl::CCPACSMaterial* material = list.at(materialIndex-1);
+                const tigl::CCPACSMaterialDefinition* material = list.at(materialIndex-1);
                 if (!material) {
                     return TIGL_ERROR;
                 }

--- a/src/configuration/CCPACSConfiguration.h
+++ b/src/configuration/CCPACSConfiguration.h
@@ -179,6 +179,7 @@ public:
 
     // Returns the uid manager
     TIGL_EXPORT CTiglUIDManager& GetUIDManager();
+    TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
 
     // Returns the algorithm for fusing the aircraft
     TIGL_EXPORT PTiglFusePlane AircraftFusingAlgo();
@@ -221,8 +222,8 @@ private:
 
 private:
     CTiglUIDManager                        uidManager;           /**< Stores the unique ids of the components. */ // list as first member, has to be created first and destroyed last
-    boost::optional<CCPACSAircraftModel>   aircraftModel;        /**< Root component for the CTiglUIDManager */
-    boost::optional<CCPACSRotorcraftModel> rotorcraftModel;      /**< Root component for the CTiglUIDManager */
+    boost::optional<CCPACSAircraftModel>   aircraftModel;
+    boost::optional<CCPACSRotorcraftModel> rotorcraftModel;
     boost::optional<CCPACSProfiles>        profiles;             /**< Wing airfoils, fuselage profiles, rotor airfoils, guide curve profiles */
     TixiDocumentHandle                     tixiDocumentHandle;   /**< Handle for internal TixiDocument */
     CCPACSHeader                           header;               /**< Configuration header element */

--- a/src/cpacs_other/CCPACSAircraftModel.cpp
+++ b/src/cpacs_other/CCPACSAircraftModel.cpp
@@ -37,6 +37,17 @@ CCPACSAircraftModel::CCPACSAircraftModel(CTiglUIDManager* uidMgr)
 
 void CCPACSAircraftModel::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) {
     generated::CPACSAircraftModel::ReadCPACS(tixiHandle, xpath);
+    if (m_uidMgr) {
+        m_uidMgr->AddGeometricComponent(m_uID, this);
+    }
+}
+
+void CCPACSAircraftModel::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSAircraftModel::SetUID(uid);
 }
 
 std::string CCPACSAircraftModel::GetDefaultedUID() const {

--- a/src/cpacs_other/CCPACSAircraftModel.h
+++ b/src/cpacs_other/CCPACSAircraftModel.h
@@ -42,6 +42,8 @@ public:
 
     TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) OVERRIDE;
 
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
+
     TIGL_EXPORT virtual std::string GetDefaultedUID() const OVERRIDE;
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage

--- a/src/cpacs_other/CCPACSExternalObject.cpp
+++ b/src/cpacs_other/CCPACSExternalObject.cpp
@@ -83,9 +83,16 @@ void CCPACSExternalObject::ReadCPACS(const TixiDocumentHandle& tixiHandle, const
 
     // Register ourself at the unique id manager
     if (m_parent) {
-        CCPACSConfiguration& config = m_parent->GetParent()->GetConfiguration();
-        config.GetUIDManager().AddGeometricComponent(m_uID, this);
+        m_uidMgr->AddGeometricComponent(m_uID, this);
     }
+}
+
+void CCPACSExternalObject::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSGenericGeometricComponent::SetUID(uid);
 }
 
 const std::string& CCPACSExternalObject::GetFilePath() const

--- a/src/cpacs_other/CCPACSExternalObject.h
+++ b/src/cpacs_other/CCPACSExternalObject.h
@@ -31,14 +31,16 @@ class CCPACSExternalObject : public generated::CPACSGenericGeometricComponent, p
 {
 public:
     TIGL_EXPORT CCPACSExternalObject(CCPACSExternalObjects* parent, CTiglUIDManager* uidMgr);
-    
+
     TIGL_EXPORT virtual std::string GetDefaultedUID() const OVERRIDE;
 
     TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& objectXPath) OVERRIDE;
-    
+
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
+
     TIGL_EXPORT const std::string& GetFilePath() const;
     
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const;
+    TIGL_EXPORT virtual TiglGeometricComponentType GetComponentType() const OVERRIDE;
 
 private:
     /// reads in the CAD file

--- a/src/cpacs_other/CCPACSMaterialDefinition.cpp
+++ b/src/cpacs_other/CCPACSMaterialDefinition.cpp
@@ -16,53 +16,27 @@
 * limitations under the License.
 */
 
-#include "CCPACSMaterial.h"
+#include "CCPACSMaterialDefinition.h"
 
 #include "CTiglError.h"
-#include "CTiglLogging.h"
 
 namespace tigl
 {
+CCPACSMaterialDefinition::CCPACSMaterialDefinition()
+    : generated::CPACSMaterialDefinition() {}
 
-CCPACSMaterial::CCPACSMaterial()
-    : isvalid(false) { }
-
-void CCPACSMaterial::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
+bool CCPACSMaterialDefinition::isComposite() const
 {
-    generated::CPACSMaterialDefinition::ReadCPACS(tixiHandle, xpath);
-
     if (m_compositeUID_choice1) {
-        is_composite = true;
+        return true;
     } else if (m_materialUID_choice2) {
-        is_composite = false;
+        return false;
     } else {
-        throw CTiglError("Neither materialUID nor compositeUID specified in " + xpath, TIGL_ERROR);
+        throw CTiglError("Neither materialUID nor compositeUID specified", TIGL_ERROR);
     }
-
-    isvalid = true;
 }
 
-void CCPACSMaterial::Invalidate()
-{
-    isvalid = false;
-}
-
-bool CCPACSMaterial::isComposite() const
-{
-    return is_composite;
-}
-
-void CCPACSMaterial::SetComposite(bool composite)
-{
-    is_composite = composite;
-}
-
-bool CCPACSMaterial::IsValid() const
-{
-    return isvalid;
-}
-
-const std::string& CCPACSMaterial::GetUID() const
+const std::string& CCPACSMaterialDefinition::GetUID() const
 {
     if (isComposite())
         return *GetCompositeUID_choice1();
@@ -70,7 +44,7 @@ const std::string& CCPACSMaterial::GetUID() const
         return *GetMaterialUID_choice2();
 }
 
-void CCPACSMaterial::SetUID(const std::string& uid)
+void CCPACSMaterialDefinition::SetUID(const std::string& uid)
 {
     if (isComposite())
         return SetCompositeUID_choice1(uid);

--- a/src/cpacs_other/CCPACSMaterialDefinition.h
+++ b/src/cpacs_other/CCPACSMaterialDefinition.h
@@ -25,39 +25,19 @@
 #include "tigl_internal.h"
 #include "CTiglPoint.h"
 
-/**
- * The orthropy direction changed to the 2.3.0
- * release from a x,y,t vector to a double,
- * which contains now a rotation angle.
- */
-#define CPACS_VERSION VERSION_HEX_CODE(2,3,0)
-
 namespace tigl
 {
 
-class CCPACSMaterial : public generated::CPACSMaterialDefinition
+class CCPACSMaterialDefinition : public generated::CPACSMaterialDefinition
 {
 public:
-    TIGL_EXPORT CCPACSMaterial();
-    
-    TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& materialXPath) OVERRIDE;
+    TIGL_EXPORT CCPACSMaterialDefinition();
 
-    TIGL_EXPORT void Invalidate();
-    
-    // returns true, if the material could be read from CPACS file
-    TIGL_EXPORT bool IsValid() const;
-    
     TIGL_EXPORT bool isComposite() const;
     
-    TIGL_EXPORT void SetComposite(bool composite);
-
     TIGL_EXPORT const std::string& GetUID() const;
 
     TIGL_EXPORT void SetUID(const std::string& uid);
-
-private:
-    bool isvalid;
-    bool is_composite; // whether the material is a composite
 };
 
 } // namespace tigl

--- a/src/cpacs_other/CCPACSRotorcraftModel.cpp
+++ b/src/cpacs_other/CCPACSRotorcraftModel.cpp
@@ -35,6 +35,14 @@ void CCPACSRotorcraftModel::ReadCPACS(const TixiDocumentHandle& tixiHandle, cons
     }
 }
 
+void CCPACSRotorcraftModel::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSRotorcraftModel::SetUID(uid);
+}
+
 std::string CCPACSRotorcraftModel::GetDefaultedUID() const {
     return generated::CPACSRotorcraftModel::GetUID();
 }

--- a/src/cpacs_other/CCPACSRotorcraftModel.h
+++ b/src/cpacs_other/CCPACSRotorcraftModel.h
@@ -35,6 +35,8 @@ public:
 
     TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) OVERRIDE;
 
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
+
     TIGL_EXPORT virtual std::string GetDefaultedUID() const OVERRIDE;
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage

--- a/src/cpacs_other/CTiglUIDManager.cpp
+++ b/src/cpacs_other/CTiglUIDManager.cpp
@@ -36,6 +36,10 @@ namespace tigl
 CTiglUIDManager::CTiglUIDManager()
     : invalidated(true), rootComponent(NULL) {}
 
+bool CTiglUIDManager::IsUIDRegistered(const std::string & uid) const {
+    return cpacsObjects.find(uid) != cpacsObjects.end();
+}
+
 void CTiglUIDManager::RegisterObject(const std::string& uid, void* object, const std::type_info& typeInfo)
 {
     if (uid.empty()) {
@@ -150,13 +154,21 @@ void CTiglUIDManager::AddGeometricComponent(const std::string& uid, ITiglGeometr
     invalidated = true;
 }
 
-void CTiglUIDManager::RemoveGeometricComponent(const std::string &uid)
+bool CTiglUIDManager::TryRemoveGeometricComponent(const std::string & uid)
 {
     const ShapeContainerType::iterator it = allShapes.find(uid);
     if (it == allShapes.end()) {
-        throw CTiglError("No shape is registered for uid \"" + uid + "\"");
+        return false;
     }
     allShapes.erase(it);
+    return true;
+}
+
+void CTiglUIDManager::RemoveGeometricComponent(const std::string &uid)
+{
+    if (!TryRemoveGeometricComponent(uid)) {
+        throw CTiglError("No shape is registered for uid \"" + uid + "\"");
+    }
 }
 
 // Checks if a UID already exists.

--- a/src/cpacs_other/CTiglUIDManager.h
+++ b/src/cpacs_other/CTiglUIDManager.h
@@ -53,10 +53,12 @@ public:
     // Constructor
     TIGL_EXPORT CTiglUIDManager();
 
+    TIGL_EXPORT bool IsUIDRegistered(const std::string& uid) const;
+
     TIGL_EXPORT void RegisterObject(const std::string& uid, void* object, const std::type_info& typeInfo);
 
     template<typename T>
-    void RegisterObject(const std::string& uid, T& object)
+    TIGL_EXPORT void RegisterObject(const std::string& uid, T& object)
     {
         RegisterObject(uid, &object, typeid(object));
     }
@@ -65,13 +67,13 @@ public:
     TIGL_EXPORT TypedPtr ResolveObject(const std::string& uid, const std::type_info& typeInfo) const;
 
     template<typename T>
-    T& ResolveObject(const std::string& uid) const
+    TIGL_EXPORT T& ResolveObject(const std::string& uid) const
     {
         return *static_cast<T* const>(ResolveObject(uid, typeid(T)).ptr);
     }
 
     template<typename T>
-    std::vector<T*> ResolveObjects() const
+    TIGL_EXPORT std::vector<T*> ResolveObjects() const
     {
         const std::type_info* ti = &typeid(T);
         std::vector<T*> objects;
@@ -89,6 +91,7 @@ public:
     TIGL_EXPORT void AddGeometricComponent(const std::string& uid, ITiglGeometricComponent* componentPtr);
 
     // Removes a component from the UID Manager
+    TIGL_EXPORT bool TryRemoveGeometricComponent(const std::string& uid); // returns false on failure
     TIGL_EXPORT void RemoveGeometricComponent(const std::string& uid);
 
     // Checks if a UID already exists.

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -67,6 +67,9 @@ CCPACSFuselage::CCPACSFuselage(CCPACSFuselages* parent, CTiglUIDManager* uidMgr)
 // Destructor
 CCPACSFuselage::~CCPACSFuselage()
 {
+    // unregister
+    configuration->GetUIDManager().RemoveGeometricComponent(m_uID);
+
     Cleanup();
 }
 
@@ -82,6 +85,7 @@ void CCPACSFuselage::Invalidate()
 void CCPACSFuselage::Cleanup()
 {
     m_name = "";
+    m_transformation.reset();
 
     // Calls ITiglGeometricComponent interface Reset to delete e.g. all childs.
     Reset();
@@ -95,7 +99,17 @@ void CCPACSFuselage::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string&
     Cleanup();
     generated::CPACSFuselage::ReadCPACS(tixiHandle, fuselageXPath);
     // Register ourself at the unique id manager
-    configuration->GetUIDManager().AddGeometricComponent(m_uID, this);
+    if (m_uidMgr) {
+        m_uidMgr->AddGeometricComponent(m_uID, this);
+    }
+}
+
+void CCPACSFuselage::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSFuselage::SetUID(uid);
 }
 
 // Returns the parent configuration

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -61,6 +61,8 @@ public:
     // Read CPACS fuselage elements
     TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& fuselageXPath);
 
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
+
     // Returns the parent configuration
     TIGL_EXPORT CCPACSConfiguration & GetConfiguration() const;
 

--- a/src/fuselage/CCPACSFuselageProfile.h
+++ b/src/fuselage/CCPACSFuselageProfile.h
@@ -25,6 +25,7 @@
 #ifndef CCPACSFUSELAGEPROFILE_H
 #define CCPACSFUSELAGEPROFILE_H
 
+#include "generated/UniquePtr.h"
 #include "generated/CPACSProfileGeometry.h"
 #include "tigl_internal.h"
 #include "tixi.h"
@@ -49,14 +50,11 @@ public:
     // Constructor
     TIGL_EXPORT CCPACSFuselageProfile(CTiglUIDManager* uidMgr);
 
-    // Virtual Destructor
+    // Destructor
     TIGL_EXPORT virtual ~CCPACSFuselageProfile();
 
     // Read CPACS fuselage profile file
-    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
-
-    // Write CPACS fuselage profile file
-    TIGL_EXPORT void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
+    TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) OVERRIDE;
 
     // Returns the name of the fuselage profile
     TIGL_EXPORT const int GetNumPoints() const;
@@ -76,16 +74,10 @@ public:
     // for zeta = 1.0 the last wire point.
     TIGL_EXPORT gp_Pnt GetPoint(double zeta);
 
-    // Returns the profile points as read from TIXI.
-    TIGL_EXPORT std::vector<CTiglPoint*> GetCoordinateContainer();
-
     // Returns the "diameter" line as a wire
     TIGL_EXPORT TopoDS_Wire GetDiameterWire();
 
 protected:
-    // Cleanup routine
-    void Cleanup();
-
     // Update the internal state, i.g. recalculates wire
     void Update();
 
@@ -113,15 +105,13 @@ private:
     bool checkSamePoints(gp_Pnt pointA, gp_Pnt pointB);
 
 private:
-    bool                                mirrorSymmetry; /**< Mirror symmetry with repect to the x-z plane */
-    std::vector<CTiglPoint>             coordinates;    /**< Coordinates of a fuselage profile element */
-    bool                                invalidated;    /**< Flag if element is invalid */
-    TopoDS_Wire                         wireOriginal;   /**< Original fuselage profile wire */
-    TopoDS_Wire                         wireClosed;     /**< Forced closed fuselage profile wire */
-    double                              wireLength;     /**< Length of fuselage profile wire */
-    unique_ptr<ITiglWireAlgorithm> profileWireAlgo;
-    gp_Pnt                              startDiameterPoint;
-    gp_Pnt                              endDiameterPoint;
+    bool                             mirrorSymmetry; /**< Mirror symmetry with repect to the x-z plane */
+    bool                             invalidated;    /**< Flag if element is invalid */
+    TopoDS_Wire                      wireOriginal;   /**< Original fuselage profile wire */
+    TopoDS_Wire                      wireClosed;     /**< Forced closed fuselage profile wire */
+    unique_ptr<ITiglWireAlgorithm>   profileWireAlgo;
+    gp_Pnt                           startDiameterPoint;
+    gp_Pnt                           endDiameterPoint;
     CTiglArcLengthReparameterization reparOriginal;
 
 };

--- a/src/fuselage/CCPACSFuselageProfiles.cpp
+++ b/src/fuselage/CCPACSFuselageProfiles.cpp
@@ -104,5 +104,4 @@ CCPACSFuselageProfile& CCPACSFuselageProfiles::GetProfile(int index) const
     return static_cast<CCPACSFuselageProfile&>(*m_fuselageProfiles[index]);
 }
 
-
 } // end namespace tigl

--- a/src/fuselage/CCPACSFuselageProfiles.h
+++ b/src/fuselage/CCPACSFuselageProfiles.h
@@ -38,7 +38,7 @@ public:
     TIGL_EXPORT CCPACSFuselageProfiles(CTiglUIDManager* uidMgr);
 
     // Read CPACS fuselage profiles
-    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
+    TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) OVERRIDE;
 
     TIGL_EXPORT bool HasProfile(std::string uid) const;
 

--- a/src/fuselage/CCPACSFuselageSection.cpp
+++ b/src/fuselage/CCPACSFuselageSection.cpp
@@ -29,8 +29,8 @@
 
 namespace tigl
 {
-CCPACSFuselageSection::CCPACSFuselageSection(CTiglUIDManager* uidMgr)
-    : generated::CPACSFuselageSection(uidMgr) {}
+CCPACSFuselageSection::CCPACSFuselageSection(CCPACSFuselageSections* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSFuselageSection(parent, uidMgr) {}
 
 // Cleanup routine
 void CCPACSFuselageSection::Cleanup()

--- a/src/fuselage/CCPACSFuselageSection.h
+++ b/src/fuselage/CCPACSFuselageSection.h
@@ -39,7 +39,7 @@ namespace tigl
 class CCPACSFuselageSection : public generated::CPACSFuselageSection
 {
 public:
-    TIGL_EXPORT CCPACSFuselageSection(CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSFuselageSection(CCPACSFuselageSections* parent, CTiglUIDManager* uidMgr);
 
     // Read CPACS section elements
     TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& sectionXPath);

--- a/src/fuselage/CCPACSFuselageSectionElement.cpp
+++ b/src/fuselage/CCPACSFuselageSectionElement.cpp
@@ -24,26 +24,29 @@
 */
 
 #include "CCPACSFuselageSectionElement.h"
-#include "CTiglError.h"
-#include <iostream>
+
+#include "CCPACSFuselageSectionElements.h"
+#include "CCPACSFuselageSections.h"
+#include "CCPACSFuselageSection.h"
+#include "CCPACSFuselage.h"
 
 namespace tigl
 {
 
 // Constructor
-CCPACSFuselageSectionElement::CCPACSFuselageSectionElement(CTiglUIDManager* uidMgr)
-    : generated::CPACSFuselageElement(uidMgr) {}
-
-// Read CPACS section elements
-void CCPACSFuselageSectionElement::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& elementXPath)
-{
-    generated::CPACSFuselageElement::ReadCPACS(tixiHandle, elementXPath);
-}
+CCPACSFuselageSectionElement::CCPACSFuselageSectionElement(CCPACSFuselageSectionElements* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSFuselageElement(parent, uidMgr) {}
 
 // Returns the UID of the referenced fuselage profile
 std::string CCPACSFuselageSectionElement::GetProfileIndex() const
 {
     return m_profileUID;
+}
+
+void CCPACSFuselageSectionElement::SetProfileUID(const std::string& value) {
+    generated::CPACSFuselageElement::SetProfileUID(value);
+    // invalidate fuselage
+    m_parent->GetParent()->GetParent()->GetParent()->Invalidate();
 }
 
 // Gets the section element transformation

--- a/src/fuselage/CCPACSFuselageSectionElement.h
+++ b/src/fuselage/CCPACSFuselageSectionElement.h
@@ -37,13 +37,12 @@ class CCPACSFuselageSectionElement : public generated::CPACSFuselageElement
 {
 public:
     // Constructor
-    TIGL_EXPORT CCPACSFuselageSectionElement(CTiglUIDManager* uidMgr);
-
-    // Read CPACS section element
-    TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& elementXPath);
+    TIGL_EXPORT CCPACSFuselageSectionElement(CCPACSFuselageSectionElements* parent, CTiglUIDManager* uidMgr);
 
     // Returns the UID of the referenced wing profile
     TIGL_EXPORT std::string GetProfileIndex() const;
+
+    TIGL_EXPORT virtual void SetProfileUID(const std::string& value);
 
     // Gets the section element transformation
     TIGL_EXPORT CTiglTransformation GetSectionElementTransformation() const;

--- a/src/fuselage/CCPACSFuselageSectionElements.cpp
+++ b/src/fuselage/CCPACSFuselageSectionElements.cpp
@@ -28,8 +28,8 @@
 
 namespace tigl
 {
-CCPACSFuselageSectionElements::CCPACSFuselageSectionElements(CTiglUIDManager* uidMgr)
-    : generated::CPACSFuselageElements(uidMgr) {}
+CCPACSFuselageSectionElements::CCPACSFuselageSectionElements(CCPACSFuselageSection* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSFuselageElements(parent, uidMgr) {}
 
     // Get element count for this section
 int CCPACSFuselageSectionElements::GetSectionElementCount() const

--- a/src/fuselage/CCPACSFuselageSectionElements.h
+++ b/src/fuselage/CCPACSFuselageSectionElements.h
@@ -39,7 +39,7 @@ namespace tigl
 class CCPACSFuselageSectionElements : public generated::CPACSFuselageElements
 {
 public:
-    TIGL_EXPORT CCPACSFuselageSectionElements(CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSFuselageSectionElements(CCPACSFuselageSection* parent, CTiglUIDManager* uidMgr);
 
     // Get element count for this section
     TIGL_EXPORT int GetSectionElementCount() const;

--- a/src/fuselage/CCPACSFuselageSections.cpp
+++ b/src/fuselage/CCPACSFuselageSections.cpp
@@ -29,8 +29,8 @@
 
 namespace tigl
 {
-CCPACSFuselageSections::CCPACSFuselageSections(CTiglUIDManager* uidMgr)
-    : generated::CPACSFuselageSections(uidMgr) {}
+CCPACSFuselageSections::CCPACSFuselageSections(CCPACSFuselage* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSFuselageSections(parent, uidMgr) {}
 
 int CCPACSFuselageSections::GetSectionCount() const
 {

--- a/src/fuselage/CCPACSFuselageSections.h
+++ b/src/fuselage/CCPACSFuselageSections.h
@@ -39,7 +39,7 @@ class CCPACSFuselageSection;
 class CCPACSFuselageSections : public generated::CPACSFuselageSections
 {
 public:
-    TIGL_EXPORT CCPACSFuselageSections(CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSFuselageSections(CCPACSFuselage* parent, CTiglUIDManager* uidMgr);
 
     // Get section count
     TIGL_EXPORT int GetSectionCount() const;

--- a/src/fuselage/CCPACSFuselageSegment.cpp
+++ b/src/fuselage/CCPACSFuselageSegment.cpp
@@ -146,6 +146,9 @@ CCPACSFuselageSegment::CCPACSFuselageSegment(CCPACSFuselageSegments* parent, CTi
 // Destructor
 CCPACSFuselageSegment::~CCPACSFuselageSegment()
 {
+    // unregister
+    GetFuselage().GetConfiguration().GetUIDManager().RemoveGeometricComponent(m_uID);
+
     Cleanup();
 }
 
@@ -166,15 +169,18 @@ void CCPACSFuselageSegment::Invalidate()
 }
 
 // Read CPACS segment elements
-void CCPACSFuselageSegment::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& segmentXPath)
+void CCPACSFuselageSegment::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& segmentXPath)
 {
     Cleanup();
     generated::CPACSFuselageSegment::ReadCPACS(tixiHandle, segmentXPath);
 
-    GetFuselage().GetConfiguration().GetUIDManager().AddGeometricComponent(m_uID, this);
+    if (m_uidMgr) {
+        m_uidMgr->AddGeometricComponent(m_uID, this);
+    }
 
-    startConnection = CTiglFuselageConnection(m_fromElementUID, this);
-    endConnection = CTiglFuselageConnection(m_toElementUID, this);
+    // trigger creation of connections
+    SetFromElementUID(m_fromElementUID);
+    SetToElementUID(m_toElementUID);
 
     // TODO: continuity does not exist in CPACS spec
 
@@ -201,8 +207,26 @@ void CCPACSFuselageSegment::ReadCPACS(TixiDocumentHandle tixiHandle, const std::
     Invalidate();
 }
 
+void CCPACSFuselageSegment::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSFuselageSegment::SetUID(uid);
+}
+
 std::string CCPACSFuselageSegment::GetDefaultedUID() const {
     return generated::CPACSFuselageSegment::GetUID();
+}
+
+void CCPACSFuselageSegment::SetFromElementUID(const std::string& value) {
+    generated::CPACSFuselageSegment::SetFromElementUID(value);
+    startConnection = CTiglFuselageConnection(m_fromElementUID, this);
+}
+
+void CCPACSFuselageSegment::SetToElementUID(const std::string& value) {
+    generated::CPACSFuselageSegment::SetToElementUID(value);
+    endConnection = CTiglFuselageConnection(m_toElementUID, this);
 }
 
 // Returns the fuselage this segment belongs to
@@ -518,38 +542,42 @@ gp_Pnt CCPACSFuselageSegment::GetPoint(double eta, double zeta)
 
 
 // Returns the start profile points as read from TIXI. The points are already transformed.
-std::vector<CTiglPoint*> CCPACSFuselageSegment::GetRawStartProfilePoints()
+std::vector<CTiglPoint> CCPACSFuselageSegment::GetRawStartProfilePoints()
 {
     CCPACSFuselageProfile& startProfile = startConnection.GetProfile();
-    std::vector<CTiglPoint*> points = startProfile.GetCoordinateContainer();
-    std::vector<CTiglPoint*> pointsTransformed;
-    for (std::vector<tigl::CTiglPoint*>::size_type i = 0; i < points.size(); i++) {
-        gp_Pnt pnt = points[i]->Get_gp_Pnt();
+    if (startProfile.GetPointList_choice1()) {
+        const std::vector<CTiglPoint>& points = startProfile.GetPointList_choice1()->AsVector();
+        std::vector<CTiglPoint> pointsTransformed;
+        for (std::vector<CTiglPoint>::size_type i = 0; i < points.size(); i++) {
+            gp_Pnt pnt = points[i].Get_gp_Pnt();
 
-        pnt = transformProfilePoint(fuselage->GetTransformationMatrix(), startConnection, pnt);
+            pnt = transformProfilePoint(fuselage->GetTransformationMatrix(), startConnection, pnt);
 
-        CTiglPoint *tiglPoint = new CTiglPoint(pnt.X(), pnt.Y(), pnt.Z());
-        pointsTransformed.push_back(tiglPoint);
-    }
-    return pointsTransformed;
+            pointsTransformed.push_back(CTiglPoint(pnt.X(), pnt.Y(), pnt.Z()));
+        }
+        return pointsTransformed;
+    } else
+        return std::vector<CTiglPoint>();
 }
 
 
 // Returns the outer profile points as read from TIXI. The points are already transformed.
-std::vector<CTiglPoint*> CCPACSFuselageSegment::GetRawEndProfilePoints()
+std::vector<CTiglPoint> CCPACSFuselageSegment::GetRawEndProfilePoints()
 {
     CCPACSFuselageProfile& endProfile = endConnection.GetProfile();
-    std::vector<CTiglPoint*> points = endProfile.GetCoordinateContainer();
-    std::vector<CTiglPoint*> pointsTransformed;
-    for (std::vector<tigl::CTiglPoint*>::size_type i = 0; i < points.size(); i++) {
-        gp_Pnt pnt = points[i]->Get_gp_Pnt();
+    if (endProfile.GetPointList_choice1()) {
+        const std::vector<CTiglPoint>& points = endProfile.GetPointList_choice1()->AsVector();
+        std::vector<CTiglPoint> pointsTransformed;
+        for (std::vector<tigl::CTiglPoint>::size_type i = 0; i < points.size(); i++) {
+            gp_Pnt pnt = points[i].Get_gp_Pnt();
 
-        pnt = transformProfilePoint(fuselage->GetTransformationMatrix(), endConnection, pnt);
+            pnt = transformProfilePoint(fuselage->GetTransformationMatrix(), endConnection, pnt);
 
-        CTiglPoint *tiglPoint = new CTiglPoint(pnt.X(), pnt.Y(), pnt.Z());
-        pointsTransformed.push_back(tiglPoint);
-    }
-    return pointsTransformed;
+            pointsTransformed.push_back(CTiglPoint(pnt.X(), pnt.Y(), pnt.Z()));
+        }
+        return pointsTransformed;
+    } else
+        return std::vector<CTiglPoint>();
 }
 
 gp_Pnt CCPACSFuselageSegment::GetPointOnYPlane(double eta, double ypos, int pointIndex)

--- a/src/fuselage/CCPACSFuselageSegment.h
+++ b/src/fuselage/CCPACSFuselageSegment.h
@@ -57,9 +57,14 @@ public:
     TIGL_EXPORT void Invalidate();
 
     // Read CPACS segment elements
-    TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& segmentXPath);
+    TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& segmentXPath) OVERRIDE;
+
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
 
     TIGL_EXPORT virtual std::string GetDefaultedUID() const OVERRIDE;
+
+    TIGL_EXPORT virtual void SetFromElementUID(const std::string& value) OVERRIDE;
+    TIGL_EXPORT virtual void SetToElementUID(const std::string& value) OVERRIDE;
 
     // Returns the fuselage this segment belongs to
     TIGL_EXPORT CCPACSFuselage& GetFuselage() const;
@@ -144,10 +149,10 @@ public:
     TIGL_EXPORT double GetCircumference(const double eta);
 
     // Returns the inner profile points as read from TIXI. The points are already transformed.
-    TIGL_EXPORT std::vector<CTiglPoint*> GetRawStartProfilePoints();
+    TIGL_EXPORT std::vector<CTiglPoint> GetRawStartProfilePoints();
 
     // Returns the outer profile points as read from TIXI. The points are already transformed.
-    TIGL_EXPORT std::vector<CTiglPoint*> GetRawEndProfilePoints();
+    TIGL_EXPORT std::vector<CTiglPoint> GetRawEndProfilePoints();
 
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const { return TIGL_COMPONENT_FUSELSEGMENT | TIGL_COMPONENT_SEGMENT | TIGL_COMPONENT_LOGICAL; }
 

--- a/src/fuselage/CCPACSFuselages.cpp
+++ b/src/fuselage/CCPACSFuselages.cpp
@@ -94,20 +94,4 @@ int CCPACSFuselages::GetFuselageIndex(const std::string& UID) const
     throw CTiglError("Invalid UID in CCPACSFuselages::GetFuselageIndex", TIGL_UID_ERROR);
 }
 
-void CCPACSFuselages::Add(CCPACSFuselage* fuselage)
-{
-    m_fuselages.push_back(unique_ptr<CCPACSFuselage>(fuselage));
-}
-
-void CCPACSFuselages::Remove(CCPACSFuselage* fuselage)
-{
-    for (std::size_t i = 0; i < m_fuselages.size(); i++) {
-        if (m_fuselages[i].get() == fuselage) {
-            m_fuselages.erase(m_fuselages.begin() + i);
-            return;
-        }
-    }
-    throw std::runtime_error("Fuselage not found");
-}
-
 } // end namespace tigl

--- a/src/fuselage/CCPACSFuselages.h
+++ b/src/fuselage/CCPACSFuselages.h
@@ -63,9 +63,6 @@ public:
 
     // Returns the fuselage index for a given UID.
     TIGL_EXPORT int GetFuselageIndex(const std::string& UID) const;
-
-    TIGL_EXPORT void Add(CCPACSFuselage* fuselage);
-    TIGL_EXPORT void Remove(CCPACSFuselage* fuselage);
 };
 
 } // end namespace tigl

--- a/src/fuselage/CTiglFuselageConnection.cpp
+++ b/src/fuselage/CTiglFuselageConnection.cpp
@@ -92,7 +92,7 @@ CCPACSFuselageProfile& CTiglFuselageConnection::GetProfile() const
         for (int j=1; j <= section.GetSectionElementCount(); j++) {
             if (section.GetSectionElement(j).GetUID() == *elementUID ) {
                 CCPACSFuselageSectionElement& element = section.GetSectionElement(j);
-                profileUID = element.GetProfileIndex();
+                profileUID = element.GetProfileUID();
                 found = true;
                 break;
             }

--- a/src/generated/CPACSCap.cpp
+++ b/src/generated/CPACSCap.cpp
@@ -71,12 +71,12 @@ namespace tigl
             m_area = value;
         }
         
-        const CCPACSMaterial& CPACSCap::GetMaterial() const
+        const CCPACSMaterialDefinition& CPACSCap::GetMaterial() const
         {
             return m_material;
         }
         
-        CCPACSMaterial& CPACSCap::GetMaterial()
+        CCPACSMaterialDefinition& CPACSCap::GetMaterial()
         {
             return m_material;
         }

--- a/src/generated/CPACSCap.h
+++ b/src/generated/CPACSCap.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <CCPACSMaterial.h>
+#include <CCPACSMaterialDefinition.h>
 #include <string>
 #include <tixi.h>
 #include <typeinfo>
@@ -47,12 +47,12 @@ namespace tigl
             TIGL_EXPORT virtual const double& GetArea() const;
             TIGL_EXPORT virtual void SetArea(const double& value);
             
-            TIGL_EXPORT virtual const CCPACSMaterial& GetMaterial() const;
-            TIGL_EXPORT virtual CCPACSMaterial& GetMaterial();
+            TIGL_EXPORT virtual const CCPACSMaterialDefinition& GetMaterial() const;
+            TIGL_EXPORT virtual CCPACSMaterialDefinition& GetMaterial();
             
         protected:
-            double         m_area;
-            CCPACSMaterial m_material;
+            double                   m_area;
+            CCPACSMaterialDefinition m_material;
             
         private:
             #ifdef HAVE_CPP11

--- a/src/generated/CPACSFuselage.cpp
+++ b/src/generated/CPACSFuselage.cpp
@@ -30,7 +30,7 @@ namespace tigl
         CPACSFuselage::CPACSFuselage(CCPACSFuselages* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
             m_transformation(m_uidMgr), 
-            m_sections(m_uidMgr), 
+            m_sections(reinterpret_cast<CCPACSFuselage*>(this), m_uidMgr), 
             m_positionings(m_uidMgr), 
             m_segments(reinterpret_cast<CCPACSFuselage*>(this), m_uidMgr)
         {

--- a/src/generated/CPACSFuselageElement.cpp
+++ b/src/generated/CPACSFuselageElement.cpp
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include "CCPACSFuselageSectionElements.h"
 #include "CPACSFuselageElement.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -25,13 +27,22 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSFuselageElement::CPACSFuselageElement(CTiglUIDManager* uidMgr) :
+        CPACSFuselageElement::CPACSFuselageElement(CCPACSFuselageSectionElements* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
-            m_transformation(m_uidMgr) {}
+            m_transformation(m_uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSFuselageElement::~CPACSFuselageElement()
         {
             if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
+        }
+        
+        CCPACSFuselageSectionElements* CPACSFuselageElement::GetParent() const
+        {
+            return m_parent;
         }
         
         CTiglUIDManager& CPACSFuselageElement::GetUIDManager()

--- a/src/generated/CPACSFuselageElement.h
+++ b/src/generated/CPACSFuselageElement.h
@@ -27,6 +27,7 @@
 namespace tigl
 {
     class CTiglUIDManager;
+    class CCPACSFuselageSectionElements;
     
     namespace generated
     {
@@ -37,8 +38,11 @@ namespace tigl
         class CPACSFuselageElement
         {
         public:
-            TIGL_EXPORT CPACSFuselageElement(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSFuselageElement(CCPACSFuselageSectionElements* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSFuselageElement();
+            
+            TIGL_EXPORT CCPACSFuselageSectionElements* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -63,6 +67,8 @@ namespace tigl
             TIGL_EXPORT virtual CCPACSTransformation& GetTransformation();
             
         protected:
+            CCPACSFuselageSectionElements* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::string                  m_uID;

--- a/src/generated/CPACSFuselageElements.cpp
+++ b/src/generated/CPACSFuselageElements.cpp
@@ -15,7 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <CCPACSFuselageSectionElement.h>
+#include "CCPACSFuselageSection.h"
 #include "CPACSFuselageElements.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -26,10 +28,19 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSFuselageElements::CPACSFuselageElements(CTiglUIDManager* uidMgr) :
-            m_uidMgr(uidMgr) {}
+        CPACSFuselageElements::CPACSFuselageElements(CCPACSFuselageSection* parent, CTiglUIDManager* uidMgr) :
+            m_uidMgr(uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSFuselageElements::~CPACSFuselageElements() {}
+        
+        CCPACSFuselageSection* CPACSFuselageElements::GetParent() const
+        {
+            return m_parent;
+        }
         
         CTiglUIDManager& CPACSFuselageElements::GetUIDManager()
         {
@@ -45,7 +56,7 @@ namespace tigl
         {
             // read element element
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/element")) {
-                tixi::TixiReadElements(tixiHandle, xpath + "/element", m_elements, m_uidMgr);
+                tixi::TixiReadElements(tixiHandle, xpath + "/element", m_elements, reinterpret_cast<CCPACSFuselageSectionElements*>(this), m_uidMgr);
             }
             
         }
@@ -69,7 +80,7 @@ namespace tigl
         
         CCPACSFuselageSectionElement& CPACSFuselageElements::AddElement()
         {
-            m_elements.push_back(make_unique<CCPACSFuselageSectionElement>(m_uidMgr));
+            m_elements.push_back(make_unique<CCPACSFuselageSectionElement>(reinterpret_cast<CCPACSFuselageSectionElements*>(this), m_uidMgr));
             return *m_elements.back();
         }
         

--- a/src/generated/CPACSFuselageElements.h
+++ b/src/generated/CPACSFuselageElements.h
@@ -27,6 +27,7 @@ namespace tigl
 {
     class CTiglUIDManager;
     class CCPACSFuselageSectionElement;
+    class CCPACSFuselageSection;
     
     namespace generated
     {
@@ -37,8 +38,11 @@ namespace tigl
         class CPACSFuselageElements
         {
         public:
-            TIGL_EXPORT CPACSFuselageElements(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSFuselageElements(CCPACSFuselageSection* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSFuselageElements();
+            
+            TIGL_EXPORT CCPACSFuselageSection* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -53,6 +57,8 @@ namespace tigl
             TIGL_EXPORT virtual void RemoveElement(CCPACSFuselageSectionElement& ref);
             
         protected:
+            CCPACSFuselageSection* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::vector<unique_ptr<CCPACSFuselageSectionElement> > m_elements;

--- a/src/generated/CPACSFuselageSection.cpp
+++ b/src/generated/CPACSFuselageSection.cpp
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include "CCPACSFuselageSections.h"
 #include "CPACSFuselageSection.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -25,14 +27,23 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSFuselageSection::CPACSFuselageSection(CTiglUIDManager* uidMgr) :
+        CPACSFuselageSection::CPACSFuselageSection(CCPACSFuselageSections* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
             m_transformation(m_uidMgr), 
-            m_elements(m_uidMgr) {}
+            m_elements(reinterpret_cast<CCPACSFuselageSection*>(this), m_uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSFuselageSection::~CPACSFuselageSection()
         {
             if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
+        }
+        
+        CCPACSFuselageSections* CPACSFuselageSection::GetParent() const
+        {
+            return m_parent;
         }
         
         CTiglUIDManager& CPACSFuselageSection::GetUIDManager()

--- a/src/generated/CPACSFuselageSection.h
+++ b/src/generated/CPACSFuselageSection.h
@@ -28,6 +28,7 @@
 namespace tigl
 {
     class CTiglUIDManager;
+    class CCPACSFuselageSections;
     
     namespace generated
     {
@@ -38,8 +39,11 @@ namespace tigl
         class CPACSFuselageSection
         {
         public:
-            TIGL_EXPORT CPACSFuselageSection(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSFuselageSection(CCPACSFuselageSections* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSFuselageSection();
+            
+            TIGL_EXPORT CCPACSFuselageSections* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -64,6 +68,8 @@ namespace tigl
             TIGL_EXPORT virtual CCPACSFuselageSectionElements& GetElements();
             
         protected:
+            CCPACSFuselageSections* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::string                   m_uID;

--- a/src/generated/CPACSFuselageSections.cpp
+++ b/src/generated/CPACSFuselageSections.cpp
@@ -15,7 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <CCPACSFuselageSection.h>
+#include "CCPACSFuselage.h"
 #include "CPACSFuselageSections.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -26,10 +28,19 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSFuselageSections::CPACSFuselageSections(CTiglUIDManager* uidMgr) :
-            m_uidMgr(uidMgr) {}
+        CPACSFuselageSections::CPACSFuselageSections(CCPACSFuselage* parent, CTiglUIDManager* uidMgr) :
+            m_uidMgr(uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSFuselageSections::~CPACSFuselageSections() {}
+        
+        CCPACSFuselage* CPACSFuselageSections::GetParent() const
+        {
+            return m_parent;
+        }
         
         CTiglUIDManager& CPACSFuselageSections::GetUIDManager()
         {
@@ -45,7 +56,7 @@ namespace tigl
         {
             // read element section
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/section")) {
-                tixi::TixiReadElements(tixiHandle, xpath + "/section", m_sections, m_uidMgr);
+                tixi::TixiReadElements(tixiHandle, xpath + "/section", m_sections, reinterpret_cast<CCPACSFuselageSections*>(this), m_uidMgr);
             }
             
         }
@@ -69,7 +80,7 @@ namespace tigl
         
         CCPACSFuselageSection& CPACSFuselageSections::AddSection()
         {
-            m_sections.push_back(make_unique<CCPACSFuselageSection>(m_uidMgr));
+            m_sections.push_back(make_unique<CCPACSFuselageSection>(reinterpret_cast<CCPACSFuselageSections*>(this), m_uidMgr));
             return *m_sections.back();
         }
         

--- a/src/generated/CPACSFuselageSections.h
+++ b/src/generated/CPACSFuselageSections.h
@@ -27,6 +27,7 @@ namespace tigl
 {
     class CTiglUIDManager;
     class CCPACSFuselageSection;
+    class CCPACSFuselage;
     
     namespace generated
     {
@@ -37,8 +38,11 @@ namespace tigl
         class CPACSFuselageSections
         {
         public:
-            TIGL_EXPORT CPACSFuselageSections(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSFuselageSections(CCPACSFuselage* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSFuselageSections();
+            
+            TIGL_EXPORT CCPACSFuselage* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -53,6 +57,8 @@ namespace tigl
             TIGL_EXPORT virtual void RemoveSection(CCPACSFuselageSection& ref);
             
         protected:
+            CCPACSFuselage* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::vector<unique_ptr<CCPACSFuselageSection> > m_sections;

--- a/src/generated/CPACSFuselages.h
+++ b/src/generated/CPACSFuselages.h
@@ -48,13 +48,13 @@ namespace tigl
             TIGL_EXPORT virtual ~CPACSFuselages();
             
             template<typename P>
-            bool IsParent() const
+            TIGL_EXPORT bool IsParent() const
             {
                 return m_parentType != NULL && *m_parentType == typeid(P);
             }
             
             template<typename P>
-            P* GetParent() const
+            TIGL_EXPORT P* GetParent() const
             {
                 #ifdef HAVE_STDIS_SAME
                 static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSFuselages");

--- a/src/generated/CPACSMaterialDefinition.h
+++ b/src/generated/CPACSMaterialDefinition.h
@@ -89,5 +89,5 @@ namespace tigl
         };
     }
     
-    // CPACSMaterialDefinition is customized, use type CCPACSMaterial directly
+    // CPACSMaterialDefinition is customized, use type CCPACSMaterialDefinition directly
 }

--- a/src/generated/CPACSWeb.cpp
+++ b/src/generated/CPACSWeb.cpp
@@ -61,12 +61,12 @@ namespace tigl
             
         }
         
-        const CCPACSMaterial& CPACSWeb::GetMaterial() const
+        const CCPACSMaterialDefinition& CPACSWeb::GetMaterial() const
         {
             return m_material;
         }
         
-        CCPACSMaterial& CPACSWeb::GetMaterial()
+        CCPACSMaterialDefinition& CPACSWeb::GetMaterial()
         {
             return m_material;
         }

--- a/src/generated/CPACSWeb.h
+++ b/src/generated/CPACSWeb.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <CCPACSMaterial.h>
+#include <CCPACSMaterialDefinition.h>
 #include <string>
 #include <tixi.h>
 #include <typeinfo>
@@ -42,15 +42,15 @@ namespace tigl
             TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
-            TIGL_EXPORT virtual const CCPACSMaterial& GetMaterial() const;
-            TIGL_EXPORT virtual CCPACSMaterial& GetMaterial();
+            TIGL_EXPORT virtual const CCPACSMaterialDefinition& GetMaterial() const;
+            TIGL_EXPORT virtual CCPACSMaterialDefinition& GetMaterial();
             
             TIGL_EXPORT virtual const double& GetRelPos() const;
             TIGL_EXPORT virtual void SetRelPos(const double& value);
             
         protected:
-            CCPACSMaterial m_material;
-            double         m_relPos;
+            CCPACSMaterialDefinition m_material;
+            double                   m_relPos;
             
         private:
             #ifdef HAVE_CPP11

--- a/src/generated/CPACSWing.cpp
+++ b/src/generated/CPACSWing.cpp
@@ -31,7 +31,7 @@ namespace tigl
         CPACSWing::CPACSWing(CCPACSRotorBlades* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
             m_transformation(m_uidMgr), 
-            m_sections(m_uidMgr), 
+            m_sections(reinterpret_cast<CCPACSWing*>(this), m_uidMgr), 
             m_segments(reinterpret_cast<CCPACSWing*>(this), m_uidMgr)
         {
             //assert(parent != NULL);
@@ -42,7 +42,7 @@ namespace tigl
         CPACSWing::CPACSWing(CCPACSWings* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
             m_transformation(m_uidMgr), 
-            m_sections(m_uidMgr), 
+            m_sections(reinterpret_cast<CCPACSWing*>(this), m_uidMgr), 
             m_segments(reinterpret_cast<CCPACSWing*>(this), m_uidMgr)
         {
             //assert(parent != NULL);

--- a/src/generated/CPACSWing.h
+++ b/src/generated/CPACSWing.h
@@ -54,13 +54,13 @@ namespace tigl
             TIGL_EXPORT virtual ~CPACSWing();
             
             template<typename P>
-            bool IsParent() const
+            TIGL_EXPORT bool IsParent() const
             {
                 return m_parentType != NULL && *m_parentType == typeid(P);
             }
             
             template<typename P>
-            P* GetParent() const
+            TIGL_EXPORT P* GetParent() const
             {
                 #ifdef HAVE_STDIS_SAME
                 static_assert(std::is_same<P, CCPACSRotorBlades>::value || std::is_same<P, CCPACSWings>::value, "template argument for P is not a parent class of CPACSWing");

--- a/src/generated/CPACSWingElement.cpp
+++ b/src/generated/CPACSWingElement.cpp
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include "CCPACSWingSectionElements.h"
 #include "CPACSWingElement.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -25,13 +27,22 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSWingElement::CPACSWingElement(CTiglUIDManager* uidMgr) :
+        CPACSWingElement::CPACSWingElement(CCPACSWingSectionElements* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
-            m_transformation(m_uidMgr) {}
+            m_transformation(m_uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSWingElement::~CPACSWingElement()
         {
             if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
+        }
+        
+        CCPACSWingSectionElements* CPACSWingElement::GetParent() const
+        {
+            return m_parent;
         }
         
         CTiglUIDManager& CPACSWingElement::GetUIDManager()

--- a/src/generated/CPACSWingElement.h
+++ b/src/generated/CPACSWingElement.h
@@ -27,6 +27,7 @@
 namespace tigl
 {
     class CTiglUIDManager;
+    class CCPACSWingSectionElements;
     
     namespace generated
     {
@@ -37,8 +38,11 @@ namespace tigl
         class CPACSWingElement
         {
         public:
-            TIGL_EXPORT CPACSWingElement(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSWingElement(CCPACSWingSectionElements* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSWingElement();
+            
+            TIGL_EXPORT CCPACSWingSectionElements* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -63,6 +67,8 @@ namespace tigl
             TIGL_EXPORT virtual CCPACSTransformation& GetTransformation();
             
         protected:
+            CCPACSWingSectionElements* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::string                  m_uID;

--- a/src/generated/CPACSWingElements.cpp
+++ b/src/generated/CPACSWingElements.cpp
@@ -15,7 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <CCPACSWingSectionElement.h>
+#include "CCPACSWingSection.h"
 #include "CPACSWingElements.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -26,10 +28,19 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSWingElements::CPACSWingElements(CTiglUIDManager* uidMgr) :
-            m_uidMgr(uidMgr) {}
+        CPACSWingElements::CPACSWingElements(CCPACSWingSection* parent, CTiglUIDManager* uidMgr) :
+            m_uidMgr(uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSWingElements::~CPACSWingElements() {}
+        
+        CCPACSWingSection* CPACSWingElements::GetParent() const
+        {
+            return m_parent;
+        }
         
         CTiglUIDManager& CPACSWingElements::GetUIDManager()
         {
@@ -45,7 +56,7 @@ namespace tigl
         {
             // read element element
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/element")) {
-                tixi::TixiReadElements(tixiHandle, xpath + "/element", m_elements, m_uidMgr);
+                tixi::TixiReadElements(tixiHandle, xpath + "/element", m_elements, reinterpret_cast<CCPACSWingSectionElements*>(this), m_uidMgr);
             }
             
         }
@@ -69,7 +80,7 @@ namespace tigl
         
         CCPACSWingSectionElement& CPACSWingElements::AddElement()
         {
-            m_elements.push_back(make_unique<CCPACSWingSectionElement>(m_uidMgr));
+            m_elements.push_back(make_unique<CCPACSWingSectionElement>(reinterpret_cast<CCPACSWingSectionElements*>(this), m_uidMgr));
             return *m_elements.back();
         }
         

--- a/src/generated/CPACSWingElements.h
+++ b/src/generated/CPACSWingElements.h
@@ -27,6 +27,7 @@ namespace tigl
 {
     class CTiglUIDManager;
     class CCPACSWingSectionElement;
+    class CCPACSWingSection;
     
     namespace generated
     {
@@ -37,8 +38,11 @@ namespace tigl
         class CPACSWingElements
         {
         public:
-            TIGL_EXPORT CPACSWingElements(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSWingElements(CCPACSWingSection* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSWingElements();
+            
+            TIGL_EXPORT CCPACSWingSection* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -53,6 +57,8 @@ namespace tigl
             TIGL_EXPORT virtual void RemoveElement(CCPACSWingSectionElement& ref);
             
         protected:
+            CCPACSWingSection* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::vector<unique_ptr<CCPACSWingSectionElement> > m_elements;

--- a/src/generated/CPACSWingRibCell.cpp
+++ b/src/generated/CPACSWingRibCell.cpp
@@ -201,12 +201,12 @@ namespace tigl
             return m_ribRotation;
         }
         
-        const CCPACSMaterial& CPACSWingRibCell::GetMaterial() const
+        const CCPACSMaterialDefinition& CPACSWingRibCell::GetMaterial() const
         {
             return m_material;
         }
         
-        CCPACSMaterial& CPACSWingRibCell::GetMaterial()
+        CCPACSMaterialDefinition& CPACSWingRibCell::GetMaterial()
         {
             return m_material;
         }

--- a/src/generated/CPACSWingRibCell.h
+++ b/src/generated/CPACSWingRibCell.h
@@ -19,7 +19,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
-#include <CCPACSMaterial.h>
+#include <CCPACSMaterialDefinition.h>
 #include <string>
 #include <tixi.h>
 #include "CPACSCap.h"
@@ -61,8 +61,8 @@ namespace tigl
             TIGL_EXPORT virtual const CPACSPointX& GetRibRotation() const;
             TIGL_EXPORT virtual CPACSPointX& GetRibRotation();
             
-            TIGL_EXPORT virtual const CCPACSMaterial& GetMaterial() const;
-            TIGL_EXPORT virtual CCPACSMaterial& GetMaterial();
+            TIGL_EXPORT virtual const CCPACSMaterialDefinition& GetMaterial() const;
+            TIGL_EXPORT virtual CCPACSMaterialDefinition& GetMaterial();
             
             TIGL_EXPORT virtual const CPACSCap& GetUpperCap() const;
             TIGL_EXPORT virtual CPACSCap& GetUpperCap();
@@ -77,7 +77,7 @@ namespace tigl
             std::string                  m_fromRib;
             std::string                  m_toRib;
             CPACSPointX                  m_ribRotation;
-            CCPACSMaterial               m_material;
+            CCPACSMaterialDefinition     m_material;
             CPACSCap                     m_upperCap;
             CPACSCap                     m_lowerCap;
             

--- a/src/generated/CPACSWingRibCrossSection.cpp
+++ b/src/generated/CPACSWingRibCrossSection.cpp
@@ -155,12 +155,12 @@ namespace tigl
             
         }
         
-        const CCPACSMaterial& CPACSWingRibCrossSection::GetMaterial() const
+        const CCPACSMaterialDefinition& CPACSWingRibCrossSection::GetMaterial() const
         {
             return m_material;
         }
         
-        CCPACSMaterial& CPACSWingRibCrossSection::GetMaterial()
+        CCPACSMaterialDefinition& CPACSWingRibCrossSection::GetMaterial()
         {
             return m_material;
         }

--- a/src/generated/CPACSWingRibCrossSection.h
+++ b/src/generated/CPACSWingRibCrossSection.h
@@ -19,7 +19,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
-#include <CCPACSMaterial.h>
+#include <CCPACSMaterialDefinition.h>
 #include <string>
 #include <tixi.h>
 #include "CPACSCap.h"
@@ -54,8 +54,8 @@ namespace tigl
             TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
-            TIGL_EXPORT virtual const CCPACSMaterial& GetMaterial() const;
-            TIGL_EXPORT virtual CCPACSMaterial& GetMaterial();
+            TIGL_EXPORT virtual const CCPACSMaterialDefinition& GetMaterial() const;
+            TIGL_EXPORT virtual CCPACSMaterialDefinition& GetMaterial();
             
             TIGL_EXPORT virtual const boost::optional<CPACSPointX>& GetRibRotation() const;
             TIGL_EXPORT virtual boost::optional<CPACSPointX>& GetRibRotation();
@@ -86,7 +86,7 @@ namespace tigl
             
             CTiglUIDManager* m_uidMgr;
             
-            CCPACSMaterial                    m_material;
+            CCPACSMaterialDefinition          m_material;
             boost::optional<CPACSPointX>      m_ribRotation;
             boost::optional<CPACSWingRibCell> m_ribCell;
             boost::optional<CPACSCap>         m_upperCap;

--- a/src/generated/CPACSWingSection.cpp
+++ b/src/generated/CPACSWingSection.cpp
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include "CCPACSWingSections.h"
 #include "CPACSWingSection.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -25,14 +27,23 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSWingSection::CPACSWingSection(CTiglUIDManager* uidMgr) :
+        CPACSWingSection::CPACSWingSection(CCPACSWingSections* parent, CTiglUIDManager* uidMgr) :
             m_uidMgr(uidMgr), 
             m_transformation(m_uidMgr), 
-            m_elements(m_uidMgr) {}
+            m_elements(reinterpret_cast<CCPACSWingSection*>(this), m_uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSWingSection::~CPACSWingSection()
         {
             if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
+        }
+        
+        CCPACSWingSections* CPACSWingSection::GetParent() const
+        {
+            return m_parent;
         }
         
         CTiglUIDManager& CPACSWingSection::GetUIDManager()

--- a/src/generated/CPACSWingSection.h
+++ b/src/generated/CPACSWingSection.h
@@ -28,6 +28,7 @@
 namespace tigl
 {
     class CTiglUIDManager;
+    class CCPACSWingSections;
     
     namespace generated
     {
@@ -38,8 +39,11 @@ namespace tigl
         class CPACSWingSection
         {
         public:
-            TIGL_EXPORT CPACSWingSection(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSWingSection(CCPACSWingSections* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSWingSection();
+            
+            TIGL_EXPORT CCPACSWingSections* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -64,6 +68,8 @@ namespace tigl
             TIGL_EXPORT virtual CCPACSWingSectionElements& GetElements();
             
         protected:
+            CCPACSWingSections* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::string                  m_uID;

--- a/src/generated/CPACSWingSections.cpp
+++ b/src/generated/CPACSWingSections.cpp
@@ -15,7 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <CCPACSWingSection.h>
+#include "CCPACSWing.h"
 #include "CPACSWingSections.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -26,10 +28,19 @@ namespace tigl
 {
     namespace generated
     {
-        CPACSWingSections::CPACSWingSections(CTiglUIDManager* uidMgr) :
-            m_uidMgr(uidMgr) {}
+        CPACSWingSections::CPACSWingSections(CCPACSWing* parent, CTiglUIDManager* uidMgr) :
+            m_uidMgr(uidMgr)
+        {
+            //assert(parent != NULL);
+            m_parent = parent;
+        }
         
         CPACSWingSections::~CPACSWingSections() {}
+        
+        CCPACSWing* CPACSWingSections::GetParent() const
+        {
+            return m_parent;
+        }
         
         CTiglUIDManager& CPACSWingSections::GetUIDManager()
         {
@@ -45,7 +56,7 @@ namespace tigl
         {
             // read element section
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/section")) {
-                tixi::TixiReadElements(tixiHandle, xpath + "/section", m_sections, m_uidMgr);
+                tixi::TixiReadElements(tixiHandle, xpath + "/section", m_sections, reinterpret_cast<CCPACSWingSections*>(this), m_uidMgr);
             }
             
         }
@@ -69,7 +80,7 @@ namespace tigl
         
         CCPACSWingSection& CPACSWingSections::AddSection()
         {
-            m_sections.push_back(make_unique<CCPACSWingSection>(m_uidMgr));
+            m_sections.push_back(make_unique<CCPACSWingSection>(reinterpret_cast<CCPACSWingSections*>(this), m_uidMgr));
             return *m_sections.back();
         }
         

--- a/src/generated/CPACSWingSections.h
+++ b/src/generated/CPACSWingSections.h
@@ -27,6 +27,7 @@ namespace tigl
 {
     class CTiglUIDManager;
     class CCPACSWingSection;
+    class CCPACSWing;
     
     namespace generated
     {
@@ -37,8 +38,11 @@ namespace tigl
         class CPACSWingSections
         {
         public:
-            TIGL_EXPORT CPACSWingSections(CTiglUIDManager* uidMgr);
+            TIGL_EXPORT CPACSWingSections(CCPACSWing* parent, CTiglUIDManager* uidMgr);
+            
             TIGL_EXPORT virtual ~CPACSWingSections();
+            
+            TIGL_EXPORT CCPACSWing* GetParent() const;
             
             TIGL_EXPORT CTiglUIDManager& GetUIDManager();
             TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
@@ -53,6 +57,8 @@ namespace tigl
             TIGL_EXPORT virtual void RemoveSection(CCPACSWingSection& ref);
             
         protected:
+            CCPACSWing* m_parent;
+            
             CTiglUIDManager* m_uidMgr;
             
             std::vector<unique_ptr<CCPACSWingSection> > m_sections;

--- a/src/generated/CPACSWingSkin.cpp
+++ b/src/generated/CPACSWingSkin.cpp
@@ -48,12 +48,12 @@ namespace tigl
             
         }
         
-        const CCPACSMaterial& CPACSWingSkin::GetMaterial() const
+        const CCPACSMaterialDefinition& CPACSWingSkin::GetMaterial() const
         {
             return m_material;
         }
         
-        CCPACSMaterial& CPACSWingSkin::GetMaterial()
+        CCPACSMaterialDefinition& CPACSWingSkin::GetMaterial()
         {
             return m_material;
         }

--- a/src/generated/CPACSWingSkin.h
+++ b/src/generated/CPACSWingSkin.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <CCPACSMaterial.h>
+#include <CCPACSMaterialDefinition.h>
 #include <string>
 #include <tixi.h>
 #include <typeinfo>
@@ -42,11 +42,11 @@ namespace tigl
             TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
-            TIGL_EXPORT virtual const CCPACSMaterial& GetMaterial() const;
-            TIGL_EXPORT virtual CCPACSMaterial& GetMaterial();
+            TIGL_EXPORT virtual const CCPACSMaterialDefinition& GetMaterial() const;
+            TIGL_EXPORT virtual CCPACSMaterialDefinition& GetMaterial();
             
         protected:
-            CCPACSMaterial m_material;
+            CCPACSMaterialDefinition m_material;
             
         private:
             #ifdef HAVE_CPP11

--- a/src/generated/CPACSWings.h
+++ b/src/generated/CPACSWings.h
@@ -48,13 +48,13 @@ namespace tigl
             TIGL_EXPORT virtual ~CPACSWings();
             
             template<typename P>
-            bool IsParent() const
+            TIGL_EXPORT bool IsParent() const
             {
                 return m_parentType != NULL && *m_parentType == typeid(P);
             }
             
             template<typename P>
-            P* GetParent() const
+            TIGL_EXPORT P* GetParent() const
             {
                 #ifdef HAVE_STDIS_SAME
                 static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSWings");

--- a/src/geometry/CCPACSGenericSystem.cpp
+++ b/src/geometry/CCPACSGenericSystem.cpp
@@ -57,6 +57,10 @@ const std::string& CCPACSGenericSystem::GetUID() const {
 }
 
 void CCPACSGenericSystem::SetUID(const std::string& uid) {
+    if (configuration) {
+        configuration->GetUIDManager().TryRemoveGeometricComponent(this->uid);
+        configuration->GetUIDManager().AddGeometricComponent(uid, this);
+    }
     this->uid = uid;
 }
 

--- a/src/geometry/CCPACSTransformation.cpp
+++ b/src/geometry/CCPACSTransformation.cpp
@@ -45,16 +45,14 @@ void CCPACSTransformation::reset()
 
 void CCPACSTransformation::setTranslation(const CTiglPoint & translation)
 {
-    setTranslation(translation, m_translation && m_translation->GetRefType() ? *m_translation->GetRefType() : ABS_LOCAL);
+    GetTranslation(CreateIfNotExists).SetAsPoint(translation);
 }
 
 void CCPACSTransformation::setTranslation(const CTiglPoint& translation, ECPACSTranslationType type)
 {
-    if (!m_translation) {
-        m_translation = boost::in_place(m_uidMgr);
-    }
-    m_translation->SetAsPoint(translation);
-    m_translation->SetRefType(type);
+    CCPACSPointAbsRel& t = GetTranslation(CreateIfNotExists);
+    t.SetAsPoint(translation);
+    t.SetRefType(type);
 }
 
 void CCPACSTransformation::setRotation(const CTiglPoint& rotation)

--- a/src/geometry/CTiglPolyData.cpp
+++ b/src/geometry/CTiglPolyData.cpp
@@ -825,8 +825,6 @@ void ObjectImpl::addPointNorm(const CTiglPoint& p, const CTiglPoint& n, long pol
 
 unsigned long ObjectImpl::addPointNorm(const CTiglPoint& p, const CTiglPoint& n) 
 {
-    using namespace std;
-
     //check if point is already in pointlist
     unsigned int index = static_cast<unsigned int>(pointlist.size());
     std::pair<PointMap::iterator,bool> ret;

--- a/src/geometry/CWireToCurve.h
+++ b/src/geometry/CWireToCurve.h
@@ -19,10 +19,10 @@
 #ifndef WIRETOCURVE_H
 #define WIRETOCURVE_H
 
-#include "tigl_internal.h"
-
 #include <TopoDS_Wire.hxx>
 #include <Geom_BSplineCurve.hxx>
+
+#include "tigl_internal.h"
 
 namespace tigl
 {

--- a/src/rotor/CCPACSRotor.cpp
+++ b/src/rotor/CCPACSRotor.cpp
@@ -80,8 +80,18 @@ void CCPACSRotor::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::str
 {
     Cleanup();
     generated::CPACSRotor::ReadCPACS(tixiHandle, rotorXPath);
-    m_parent->GetConfiguration().GetUIDManager().AddGeometricComponent(m_uID, this);
+    if (m_uidMgr) {
+        m_uidMgr->AddGeometricComponent(m_uID, this);
+    }
     Update();
+}
+
+void CCPACSRotor::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSRotor::SetUID(uid);
 }
 
 // Get the Transformation object

--- a/src/rotor/CCPACSRotor.h
+++ b/src/rotor/CCPACSRotor.h
@@ -68,6 +68,8 @@ public:
     // Read CPACS rotor elements
     TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& rotorXPath) OVERRIDE;
 
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
+
     // Sets the Translation object
     TIGL_EXPORT virtual void Translate(CTiglPoint trans) OVERRIDE;
 

--- a/src/rotor/CCPACSRotorProfiles.cpp
+++ b/src/rotor/CCPACSRotorProfiles.cpp
@@ -33,8 +33,8 @@ CCPACSRotorProfiles::CCPACSRotorProfiles(CTiglUIDManager* uidMgr)
 // Invalidates internal state
 void CCPACSRotorProfiles::Invalidate()
 {
-    for (int i = 1; i < GetProfileCount(); i++) {
-        GetProfile(i).Invalidate();
+    for (int i = 0; i < m_rotorAirfoils.size(); i++) {
+        static_cast<CCPACSWingProfile&>(*m_rotorAirfoils[i]).Invalidate();
     }
 }
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -176,6 +176,9 @@ CCPACSWing::CCPACSWing(CCPACSRotorBlades* parent, CTiglUIDManager* uidMgr)
 // Destructor
 CCPACSWing::~CCPACSWing()
 {
+    // unregister
+    configuration->GetUIDManager().RemoveGeometricComponent(GetUID());
+
     Cleanup();
 }
 
@@ -194,7 +197,7 @@ void CCPACSWing::Invalidate()
 void CCPACSWing::Cleanup()
 {
     m_name = "";
-    m_description = "";
+    m_description = boost::none;
     isRotorBlade = false;
     m_transformation.reset();
 
@@ -230,6 +233,14 @@ void CCPACSWing::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& win
     configuration->GetUIDManager().AddGeometricComponent(m_uID, this);
 
     Update();
+}
+
+void CCPACSWing::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSWing::SetUID(uid);
 }
 
 std::string CCPACSWing::GetDefaultedUID() const {
@@ -312,7 +323,7 @@ const CCPACSWingComponentSegment& CCPACSWing::GetComponentSegment(const int inde
 }
 
 // Returns the segment for a given uid
-CCPACSWingComponentSegment& CCPACSWing::GetComponentSegment(std::string uid)
+CCPACSWingComponentSegment& CCPACSWing::GetComponentSegment(const std::string& uid)
 {
     return m_componentSegments->GetComponentSegment(uid);
 }

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -61,6 +61,8 @@ public:
     // Read CPACS wing elements
     TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string & wingXPath);
 
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
+
     TIGL_EXPORT virtual std::string GetDefaultedUID() const OVERRIDE;
 
     // Returns whether this wing is a rotor blade
@@ -90,8 +92,8 @@ public:
 
     // Returns the segment for a given index or uid
     TIGL_EXPORT CCPACSWingComponentSegment& GetComponentSegment(const int index);
-	TIGL_EXPORT const CCPACSWingComponentSegment& GetComponentSegment(const int index) const;
-    TIGL_EXPORT CCPACSWingComponentSegment& GetComponentSegment(std::string uid);
+    TIGL_EXPORT const CCPACSWingComponentSegment& GetComponentSegment(const int index) const;
+    TIGL_EXPORT CCPACSWingComponentSegment& GetComponentSegment(const std::string& uid);
 
     // Gets the wing transformation
     TIGL_EXPORT CTiglTransformation GetWingTransformation();

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -270,12 +270,12 @@ void CCPACSWingCell::SetOuterBorderRib(const std::string& ribDefinitionUID, int 
     m_positioningOuterBorder.SetRib(ribDefinitionUID, ribNumber);
 }
 
-CCPACSMaterial& CCPACSWingCell::GetMaterial()
+CCPACSMaterialDefinition& CCPACSWingCell::GetMaterial()
 {
     return m_skin.GetMaterial();
 }
 
-const CCPACSMaterial& CCPACSWingCell::GetMaterial() const
+const CCPACSMaterialDefinition& CCPACSWingCell::GetMaterial() const
 {
     return m_skin.GetMaterial();
 }

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -35,7 +35,6 @@ namespace tigl
 
 // forward declarations
 class CCPACSWingCells;
-class CCPACSMaterial;
 class CCPACSWingCellPositionChordwise;
 class CCPACSWingCellPositionSpanwise;
 
@@ -75,8 +74,8 @@ public:
     TIGL_EXPORT void SetInnerBorderRib(const std::string& ribDefinitionUID, int ribNumber);
     TIGL_EXPORT void SetOuterBorderRib(const std::string& ribDefinitionUID, int ribNumber);
 
-    TIGL_EXPORT CCPACSMaterial& GetMaterial();
-    TIGL_EXPORT const CCPACSMaterial& GetMaterial() const;
+    TIGL_EXPORT CCPACSMaterialDefinition& GetMaterial();
+    TIGL_EXPORT const CCPACSMaterialDefinition& GetMaterial() const;
 
     TIGL_EXPORT void Update() const;
     

--- a/src/wing/CCPACSWingCellPositionChordwise.h
+++ b/src/wing/CCPACSWingCellPositionChordwise.h
@@ -23,18 +23,14 @@
 
 #include <utility>
 
-#include <TopoDS_Shape.hxx>
-
 #include "generated/CPACSCellPositioningChordwise.h"
-#include "tigl_internal.h"
-
 
 namespace tigl
 {
 // forward declarations
 class CCPACSWingCell;
 
-class CCPACSWingCellPositionChordwise : private generated::CPACSCellPositioningChordwise
+class CCPACSWingCellPositionChordwise : public generated::CPACSCellPositioningChordwise
 {
 public:
     enum InputType
@@ -45,9 +41,6 @@ public:
     };
 
     TIGL_EXPORT CCPACSWingCellPositionChordwise(CCPACSWingCell* parent);
-
-    using generated::CPACSCellPositioningChordwise::ReadCPACS;
-    using generated::CPACSCellPositioningChordwise::WriteCPACS;
 
     TIGL_EXPORT InputType GetInputType() const;
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -118,7 +118,7 @@ namespace
     void SetFaceTraits (PNamedShape loft, unsigned int nSegments) 
     { 
         // designated names of the faces
-        std::vector<std::string> names(3);
+        std::vector<std::string> names(3); // TODO: use std::array
         names[0]="Bottom";
         names[1]="Top";
         names[2]="TrailingEdge";
@@ -158,7 +158,6 @@ namespace
 
 CCPACSWingComponentSegment::CCPACSWingComponentSegment(CCPACSWingComponentSegments* parent, CTiglUIDManager* uidMgr)
     : generated::CPACSComponentSegment(parent, uidMgr)
-    , _uidMgr(uidMgr)
     , CTiglAbstractSegment(parent->GetComponentSegments(), parent->GetParent()->m_symmetry)
     , wing(parent->GetParent())
     , upperShape(make_unique<CTiglShapeGeomComponentAdaptor>(this, m_uidMgr))
@@ -1107,9 +1106,6 @@ MaterialList CCPACSWingComponentSegment::GetMaterials(double eta, double xsi, Ti
         int ncells = shell->GetCellCount();
         for (int i = 1; i <= ncells; ++i){
             CCPACSWingCell& cell = shell->GetCell(i);
-            if (!cell.GetMaterial().IsValid()) {
-                continue;
-            }
 
             if (cell.IsInside(eta,xsi)) {
                 list.push_back(&(cell.GetMaterial()));
@@ -1117,7 +1113,7 @@ MaterialList CCPACSWingComponentSegment::GetMaterials(double eta, double xsi, Ti
         }
 
         // add complete skin, only if no cells are defined
-        if (list.empty() && shell->GetMaterial().IsValid()){
+        if (list.empty()){
             list.push_back(&(shell->GetMaterial()));
         }
         

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -38,7 +38,7 @@
 #include "tigl_internal.h"
 
 #include "generated/UniquePtr.h"
-#include "CCPACSMaterial.h"
+#include "CCPACSMaterialDefinition.h"
 #include "CTiglWingConnection.h"
 #include "CCPACSWingCSStructure.h"
 #include "CCPACSWingShell.h"
@@ -55,8 +55,8 @@ class CCPACSWingSegment;
 class CTiglWingChordface;
 class CTiglShapeGeomComponentAdaptor;
 
-typedef std::vector<const CCPACSMaterial*>    MaterialList;
-typedef std::vector<CCPACSWingSegment*>       SegmentList;
+typedef std::vector<const CCPACSMaterialDefinition*> MaterialList;
+typedef std::vector<CCPACSWingSegment*>              SegmentList;
 
 class CCPACSWingComponentSegment : public generated::CPACSComponentSegment, public CTiglAbstractSegment<CCPACSWingComponentSegment>
 {
@@ -221,8 +221,6 @@ private:
 
 
 private:
-    CTiglUIDManager* _uidMgr;
-
     CCPACSWing*          wing;                 /**< Parent wing                             */
     double               myVolume;             /**< Volume of this segment                  */
     double               mySurfaceArea;        /**< Surface area of this segment            */

--- a/src/wing/CCPACSWingProfile.cpp
+++ b/src/wing/CCPACSWingProfile.cpp
@@ -65,26 +65,15 @@ namespace tigl
 
 // Constructor
 CCPACSWingProfile::CCPACSWingProfile(CTiglUIDManager* uidMgr)
-    : generated::CPACSProfileGeometry(uidMgr), invalidated(true), profileAlgo(NULL)
-{
-    Cleanup();
-}
+    : generated::CPACSProfileGeometry(uidMgr), invalidated(true), isRotorProfile(false) {}
 
-// Destructor
-CCPACSWingProfile::~CCPACSWingProfile()
-{
-    Cleanup();
-}
+
+CCPACSWingProfile::~CCPACSWingProfile() {}
 
 // Cleanup routine
 void CCPACSWingProfile::Cleanup()
 {
     isRotorProfile = false;
-
-    if (profileAlgo) {
-        profileAlgo->Cleanup();
-    }
-
     Invalidate();
 }
 
@@ -97,15 +86,6 @@ void CCPACSWingProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, const st
         isRotorProfile = true;
     }
     generated::CPACSProfileGeometry::ReadCPACS(tixiHandle, xpath);
-    if (m_pointList_choice1) {
-        // in case the wing profile algorithm is a point list, create the additional algorithm instance
-        pointListAlgo.reset(new CTiglWingProfilePointList(*this, *m_pointList_choice1));
-        profileAlgo = &*pointListAlgo;
-    } else if (m_cst2D_choice2) {
-        profileAlgo = &*m_cst2D_choice2;
-    } else {
-        throw CTiglError("no profile algorithm");
-    }
 }
 
 // Returns whether the profile is a rotor profile
@@ -128,7 +108,7 @@ void CCPACSWingProfile::Update()
     }
 
     // build wires
-    profileAlgo->Update();
+    GetProfileAlgo()->Update();
     invalidated = false;
 }
     
@@ -136,61 +116,63 @@ void CCPACSWingProfile::Update()
 TopoDS_Edge CCPACSWingProfile::GetUpperWire()
 {
     Update();
-    return profileAlgo->GetUpperWire();
+    return GetProfileAlgo()->GetUpperWire();
 }
 
 // Returns the wing upper profile wire for opened profile
 TopoDS_Edge CCPACSWingProfile::GetUpperWireOpened()
 {
     Update();
-    return profileAlgo->GetUpperWireOpened();
+    return GetProfileAlgo()->GetUpperWireOpened();
 }
 
 // Returns the wing upper profile wire for closed profile
 TopoDS_Edge CCPACSWingProfile::GetUpperWireClosed()
 {
     Update();
-    return profileAlgo->GetUpperWireClosed();
+    return GetProfileAlgo()->GetUpperWireClosed();
 }
 
 // Returns the wing profile lower wire
 TopoDS_Edge CCPACSWingProfile::GetLowerWire()
 {
     Update();
-    return profileAlgo->GetLowerWire();
+    return GetProfileAlgo()->GetLowerWire();
 }
 
 // Returns the wing lower profile wire for opened profile
 TopoDS_Edge CCPACSWingProfile::GetLowerWireOpened()
 {
     Update();
-    return profileAlgo->GetLowerWireOpened();
+    return GetProfileAlgo()->GetLowerWireOpened();
 }
 
 // Returns the wing lower profile wire for closed profile
 TopoDS_Edge CCPACSWingProfile::GetLowerWireClosed()
 {
     Update();
-    return profileAlgo->GetLowerWireClosed();
+    return GetProfileAlgo()->GetLowerWireClosed();
 }
 
 // Returns the wing profile trailing edge
 TopoDS_Edge CCPACSWingProfile::GetTrailingEdge()
 {
     Update();
-    return profileAlgo->GetTrailingEdge();
+    return GetProfileAlgo()->GetTrailingEdge();
 }
 
 TopoDS_Edge CCPACSWingProfile::GetTrailingEdgeOpened()
 {
     Update();
-    return profileAlgo->GetTrailingEdgeOpened();
+    return GetProfileAlgo()->GetTrailingEdgeOpened();
 }
 
 // Returns the wing profile lower and upper wire fused
 TopoDS_Wire CCPACSWingProfile::GetSplitWire()
 {
     Update();
+    ITiglWingProfileAlgo* profileAlgo = GetProfileAlgo();
+
     // rebuild closed wire
     BRepBuilderAPI_MakeWire closedWireBuilder;
     closedWireBuilder.Add(profileAlgo->GetLowerWire());
@@ -210,6 +192,8 @@ TopoDS_Wire CCPACSWingProfile::GetSplitWire()
 TopoDS_Wire CCPACSWingProfile::GetWire()
 {
     Update();
+    ITiglWingProfileAlgo* profileAlgo = GetProfileAlgo();
+
     // rebuild closed wire
     BRepBuilderAPI_MakeWire closedWireBuilder;
     closedWireBuilder.Add(profileAlgo->GetUpperLowerWire());
@@ -223,6 +207,8 @@ TopoDS_Wire CCPACSWingProfile::GetWire()
 TopoDS_Wire CCPACSWingProfile::GetWireOpened()
 {
     Update();
+	ITiglWingProfileAlgo* profileAlgo = GetProfileAlgo();
+	
     BRepBuilderAPI_MakeWire wireBuilder;
     wireBuilder.Add(profileAlgo->GetUpperWireOpened());
     wireBuilder.Add(profileAlgo->GetLowerWireOpened());
@@ -234,6 +220,8 @@ TopoDS_Wire CCPACSWingProfile::GetWireOpened()
 TopoDS_Wire CCPACSWingProfile::GetWireClosed()
 {
     Update();
+	ITiglWingProfileAlgo* profileAlgo = GetProfileAlgo();
+	
     BRepBuilderAPI_MakeWire wireBuilder;
     wireBuilder.Add(profileAlgo->GetUpperWireClosed());
     wireBuilder.Add(profileAlgo->GetLowerWireClosed());
@@ -245,7 +233,7 @@ TopoDS_Wire CCPACSWingProfile::GetWireClosed()
 gp_Pnt CCPACSWingProfile::GetLEPoint()
 {
     Update();
-    return profileAlgo->GetLEPoint();
+    return GetProfileAlgo()->GetLEPoint();
 }
 
 // Returns the trailing edge point of the wing profile wire. The trailing edge point
@@ -253,7 +241,7 @@ gp_Pnt CCPACSWingProfile::GetLEPoint()
 gp_Pnt CCPACSWingProfile::GetTEPoint()
 {
     Update();
-    return profileAlgo->GetTEPoint();
+    return GetProfileAlgo()->GetTEPoint();
 }
 
 // Returns a point on the chord line between leading and trailing
@@ -413,13 +401,23 @@ Handle(Geom2d_TrimmedCurve) CCPACSWingProfile::GetChordLine()
     return chordLine;
 }
 
-ITiglWingProfileAlgo* CCPACSWingProfile::GetProfileAlgo() {
-    return profileAlgo;
+ITiglWingProfileAlgo* CCPACSWingProfile::GetProfileAlgo()
+{
+    if (m_pointList_choice1) {
+        // in case the wing profile algorithm is a point list, create the additional algorithm instance
+        if (!pointListAlgo)
+            pointListAlgo.reset(new CTiglWingProfilePointList(*this, *m_pointList_choice1));
+        return &*pointListAlgo;
+    } else if (m_cst2D_choice2) {
+        return &*m_cst2D_choice2;
+    } else {
+        throw CTiglError("no profile algorithm");
+    }
 }
 
 const ITiglWingProfileAlgo* CCPACSWingProfile::GetProfileAlgo() const
 {
-    return profileAlgo;
+    return const_cast<CCPACSWingProfile&>(*this).GetProfileAlgo();
 }
 
 bool CCPACSWingProfile::HasBluntTE() const

--- a/src/wing/CCPACSWingProfile.h
+++ b/src/wing/CCPACSWingProfile.h
@@ -50,10 +50,8 @@ class CCPACSWingProfile : public generated::CPACSProfileGeometry
 {
 
 public:
-    // Algo
     TIGL_EXPORT CCPACSWingProfile(CTiglUIDManager* uidMgr);
 
-    // Virtual Destructor
     TIGL_EXPORT virtual ~CCPACSWingProfile();
 
     // Read CPACS wing profile file
@@ -154,13 +152,9 @@ private:
     void operator=(const CCPACSWingProfile& );
 
 private:
-    std::string               name;           /**< CPACS wing profile name */
-    std::string               description;    /**< CPACS wing profile description */
-    std::string               uid;            /**< CPACS wing profile UID */
-    bool                      isRotorProfile; /**< Indicates if this profile is a rotor profile */
-    bool                                        invalidated;    /**< Flag if element is invalid */
-    ITiglWingProfileAlgo*                       profileAlgo; // points to the current profile algo (non-owning)
-    unique_ptr<CTiglWingProfilePointList> pointListAlgo; // is created in case the wing profile alg is a point list, otherwise cst2d constructed in the base class is used
+    bool                                  isRotorProfile; /**< Indicates if this profile is a rotor profile */
+    bool                                  invalidated;    /**< Flag if element is invalid */
+    unique_ptr<CTiglWingProfilePointList> pointListAlgo;  // is created in case the wing profile alg is a point list, otherwise cst2d constructed in the base class is used
 
 }; // class CCPACSWingProfile
 

--- a/src/wing/CCPACSWingProfileCST.cpp
+++ b/src/wing/CCPACSWingProfileCST.cpp
@@ -102,6 +102,11 @@ void CCPACSWingProfileCST::BuildWires()
 }
 
 // Returns sample points
+std::vector<CTiglPoint>& CCPACSWingProfileCST::GetSamplePoints() {
+    static std::vector<CTiglPoint> dummy;
+    return dummy;
+}
+
 const std::vector<CTiglPoint>& CCPACSWingProfileCST::GetSamplePoints() const {
     static std::vector<CTiglPoint> dummy;
     return dummy;

--- a/src/wing/CCPACSWingProfileCST.h
+++ b/src/wing/CCPACSWingProfileCST.h
@@ -44,31 +44,32 @@ public:
     TIGL_EXPORT CCPACSWingProfileCST();
 
     // Destructor
-    TIGL_EXPORT ~CCPACSWingProfileCST();
+    TIGL_EXPORT virtual ~CCPACSWingProfileCST();
 
     // Cleanup routine
     TIGL_EXPORT void Cleanup();
 
     // Update of wire points ...
-    TIGL_EXPORT void Update();
+    TIGL_EXPORT virtual void Update() OVERRIDE;
 
     // Returns the profile points as read from TIXI.
+    TIGL_EXPORT virtual std::vector<CTiglPoint>& GetSamplePoints() OVERRIDE; // TODO: why do we need those anyway, they just return an empty vector?
     TIGL_EXPORT virtual const std::vector<CTiglPoint>& GetSamplePoints() const OVERRIDE; // TODO: why do we need those anyway, they just return an empty vector?
 
     // get upper wing profile wire
-    TIGL_EXPORT const TopoDS_Edge & GetUpperWire() const;
+    TIGL_EXPORT virtual const TopoDS_Edge & GetUpperWire() const OVERRIDE;
 
     // get lower wing profile wire
-    TIGL_EXPORT const TopoDS_Edge & GetLowerWire() const;
+    TIGL_EXPORT virtual const TopoDS_Edge & GetLowerWire() const OVERRIDE;
 
     // get trailing edge
     TIGL_EXPORT const TopoDS_Edge & GetTrailingEdge() const;
 
     // get trailing edge for opened profile
-    TIGL_EXPORT const TopoDS_Edge & GetTrailingEdgeOpened() const;
+    TIGL_EXPORT virtual const TopoDS_Edge & GetTrailingEdgeOpened() const OVERRIDE;
 
     // gets the upper and lower wing profile into on edge
-    TIGL_EXPORT const TopoDS_Edge & GetUpperLowerWire() const;
+    TIGL_EXPORT virtual const TopoDS_Edge & GetUpperLowerWire() const OVERRIDE;
 
     // Getter for upper wire of closed profile
     TIGL_EXPORT const TopoDS_Edge & GetUpperWireClosed() const;
@@ -83,13 +84,13 @@ public:
     TIGL_EXPORT const TopoDS_Edge & GetLowerWireOpened() const;
 
     // get leading edge point();
-    TIGL_EXPORT const gp_Pnt & GetLEPoint() const;
+    TIGL_EXPORT virtual const gp_Pnt & GetLEPoint() const OVERRIDE;
 
     // get trailing edge point();
-    TIGL_EXPORT const gp_Pnt & GetTEPoint() const;
+    TIGL_EXPORT virtual const gp_Pnt & GetTEPoint() const OVERRIDE;
 
     // CST profiles have always sharp trailing edges
-    TIGL_EXPORT bool HasBluntTE() const { return false;}
+    TIGL_EXPORT virtual bool HasBluntTE() const OVERRIDE { return false;}
 
 protected:
     // Builds the wing profile wires.

--- a/src/wing/CCPACSWingProfiles.cpp
+++ b/src/wing/CCPACSWingProfiles.cpp
@@ -43,8 +43,8 @@ CCPACSWingProfiles::CCPACSWingProfiles(CTiglUIDManager* uidMgr)
 // Invalidates internal state
 void CCPACSWingProfiles::Invalidate()
 {
-    for (int i = 1; i < GetProfileCount(); i++) {
-        GetProfile(i).Invalidate();
+    for (int i = 0; i < m_wingAirfoils.size(); i++) {
+        static_cast<CCPACSWingProfile&>(*m_wingAirfoils[i]).Invalidate();
     }
 }
 
@@ -66,22 +66,9 @@ void CCPACSWingProfiles::ImportCPACS(const TixiDocumentHandle& tixiHandle, const
     }
 }
 
-void CCPACSWingProfiles::AddProfile(CCPACSWingProfile* profile)
-{
-    // free memory for existing profiles
-    DeleteProfile(profile->GetUID());
-    m_wingAirfoils.push_back(unique_ptr<CCPACSWingProfile>(profile));
-}
-
-
-void CCPACSWingProfiles::DeleteProfile(std::string uid)
-{
-    for (std::vector<unique_ptr<CCPACSProfileGeometry> >::iterator it = m_wingAirfoils.begin(); it != m_wingAirfoils.end(); ++it) {
-        if ((*it)->GetUID() == uid) {
-            m_wingAirfoils.erase(it);
-            return;
-        }
-    }
+CCPACSWingProfile& CCPACSWingProfiles::AddWingAirfoil() {
+    m_wingAirfoils.push_back(make_unique<CCPACSWingProfile>(m_uidMgr));
+    return static_cast<CCPACSWingProfile&>(*m_wingAirfoils.back());
 }
 
 // Returns the total count of wing profiles in this configuration

--- a/src/wing/CCPACSWingProfiles.h
+++ b/src/wing/CCPACSWingProfiles.h
@@ -47,11 +47,7 @@ public:
     // profiles with same UID are overwritten
     TIGL_EXPORT void ImportCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
 
-    // add a CPACS wing profile to list
-    TIGL_EXPORT void AddProfile(CCPACSWingProfile* profile);
-        
-    // removes a CPACS wing profile from the list
-    TIGL_EXPORT void DeleteProfile( std::string uid );
+    TIGL_EXPORT virtual CCPACSWingProfile& AddWingAirfoil();
 
     // Returns the total count of wing profiles in this configuration
     TIGL_EXPORT int GetProfileCount() const;

--- a/src/wing/CCPACSWingRibCrossSection.cpp
+++ b/src/wing/CCPACSWingRibCrossSection.cpp
@@ -40,6 +40,6 @@ void CCPACSWingRibCrossSection::SetXRotation(double rotation)
     m_ribRotation->SetX(rotation);
 
     // invalidate whole component segment structure, since rib could be referenced anywher
-    GetParent()->GetParent()->Invalidate();
+    GetParent()->GetParent()->GetParent()->Invalidate();
 }
 } // end namespace tigl

--- a/src/wing/CCPACSWingRibRotation.cpp
+++ b/src/wing/CCPACSWingRibRotation.cpp
@@ -28,10 +28,23 @@ CCPACSWingRibRotation::CCPACSWingRibRotation(CCPACSWingRibsPositioning* parent)
     m_z = 90;
 }
 
-void CCPACSWingRibRotation::SetZ(const double & value) {
+void CCPACSWingRibRotation::SetRibRotationReference(const ECPACSRibRotation_ribRotationReference& value)
+{
+    generated::CPACSRibRotation::SetRibRotationReference(value);
+    m_parent->invalidateStructure();
+}
+
+void CCPACSWingRibRotation::SetRibRotationReference(const boost::optional<ECPACSRibRotation_ribRotationReference>& value)
+{
+    generated::CPACSRibRotation::SetRibRotationReference(value);
+    m_parent->invalidateStructure();
+}
+
+void CCPACSWingRibRotation::SetZ(const double & value)
+{
     generated::CPACSRibRotation::SetZ(value);
     // invalidate whole component segment structure since rib may be referenced anywhere
-    m_parent->GetParent()->GetParent()->GetParent()->Invalidate();
+    m_parent->invalidateStructure();
 }
 
 } // end namespace tigl

--- a/src/wing/CCPACSWingRibRotation.h
+++ b/src/wing/CCPACSWingRibRotation.h
@@ -25,7 +25,10 @@ class CCPACSWingRibRotation : public generated::CPACSRibRotation
 public:
     TIGL_EXPORT CCPACSWingRibRotation(CCPACSWingRibsPositioning* parent);
 
-    TIGL_EXPORT void SetZ(const double& value);
+    TIGL_EXPORT virtual void SetRibRotationReference(const ECPACSRibRotation_ribRotationReference& value) OVERRIDE;
+    TIGL_EXPORT virtual void SetRibRotationReference(const boost::optional<ECPACSRibRotation_ribRotationReference>& value) OVERRIDE;
+
+    TIGL_EXPORT virtual void SetZ(const double& value) OVERRIDE;
 };
 
 } // end namespace tigl

--- a/src/wing/CCPACSWingRibsPositioning.cpp
+++ b/src/wing/CCPACSWingRibsPositioning.cpp
@@ -20,14 +20,29 @@
 #include "CTiglError.h"
 #include "CTiglLogging.h"
 
-#include "generated/TixiHelper.h"
-
-
 namespace tigl
 {
 
 CCPACSWingRibsPositioning::CCPACSWingRibsPositioning(CCPACSWingRibsDefinition* parent)
     : generated::CPACSWingRibsPositioning(parent) {}
+
+void CCPACSWingRibsPositioning::SetRibReference(const std::string& value)
+{
+    generated::CPACSWingRibsPositioning::SetRibReference(value);
+    invalidateStructure();
+}
+
+void CCPACSWingRibsPositioning::SetRibStart(const std::string& value)
+{
+    generated::CPACSWingRibsPositioning::SetRibStart(value);
+    invalidateStructure();
+}
+
+void CCPACSWingRibsPositioning::SetRibEnd(const std::string& value)
+{
+    generated::CPACSWingRibsPositioning::SetRibEnd(value);
+    invalidateStructure();
+}
 
 CCPACSWingRibsPositioning::StartDefinitionType CCPACSWingRibsPositioning::GetStartDefinitionType() const
 {
@@ -38,14 +53,6 @@ CCPACSWingRibsPositioning::StartDefinitionType CCPACSWingRibsPositioning::GetSta
     if (m_sparPositionStartUID_choice3)
         return SPARPOSITION_START;
     throw CTiglError("Invalid start definition");
-}
-
-double CCPACSWingRibsPositioning::GetEtaStart() const
-{
-    if (!m_etaStart_choice1) {
-        throw CTiglError("RibsPositioning is not defined via etaStart. Please check StartDefinitionType first before calling CCPACSWingRibsPositioning::GetEtaStart()");
-    }
-    return *m_etaStart_choice1;
 }
 
 void CCPACSWingRibsPositioning::SetEtaStart(double value)
@@ -59,14 +66,6 @@ void CCPACSWingRibsPositioning::SetEtaStart(double value)
     invalidateStructure();
 }
 
-const std::string& CCPACSWingRibsPositioning::GetElementStartUID() const
-{
-    if (!m_elementStartUID_choice2) {
-        throw CTiglError("RibsPositioning is not defined via elementStartUID. Please check StartDefinitionType first before calling CCPACSWingRibsPositioning::GetElementStartUID()");
-    }
-    return *m_elementStartUID_choice2;
-}
-
 void CCPACSWingRibsPositioning::SetElementStartUID(const std::string& uid)
 {
     generated::CPACSWingRibsPositioning::SetElementStartUID_choice2(uid);
@@ -75,14 +74,6 @@ void CCPACSWingRibsPositioning::SetElementStartUID(const std::string& uid)
     m_sparPositionStartUID_choice3 = boost::none;
 
     invalidateStructure();
-}
-
-const std::string& CCPACSWingRibsPositioning::GetSparPositionStartUID() const
-{
-    if (!m_sparPositionStartUID_choice3) {
-        throw CTiglError("RibsPositioning is not defined via sparPositionStartUID. Please check StartDefinitionType first before calling CCPACSWingRibsPositioning::GetSparPositionStartUID()");
-    }
-    return *m_sparPositionStartUID_choice3;
 }
 
 void CCPACSWingRibsPositioning::SetSparPositionStartUID(const std::string& uid)
@@ -106,14 +97,6 @@ CCPACSWingRibsPositioning::EndDefinitionType CCPACSWingRibsPositioning::GetEndDe
     throw CTiglError("Invalid end definition");
 }
 
-double CCPACSWingRibsPositioning::GetEtaEnd() const
-{
-    if (!m_etaEnd_choice1) {
-        throw CTiglError("RibsPositioning is not defined via etaEnd. Please check EndDefinitionType first before calling CCPACSWingRibsPositioning::GetEtaEnd()");
-    }
-    return *m_etaEnd_choice1;
-}
-
 void CCPACSWingRibsPositioning::SetEtaEnd(double value)
 {
     generated::CPACSWingRibsPositioning::SetEtaEnd_choice1(value);
@@ -124,14 +107,6 @@ void CCPACSWingRibsPositioning::SetEtaEnd(double value)
     invalidateStructure();
 }
 
-const std::string& CCPACSWingRibsPositioning::GetElementEndUID() const
-{
-    if (!m_elementEndUID_choice2) {
-        throw CTiglError("RibsPositioning is not defined via elementEndUID. Please check EndDefinitionType first before calling CCPACSWingRibsPositioning::GetElementEndUID()");
-    }
-    return *m_elementEndUID_choice2;
-}
-
 void CCPACSWingRibsPositioning::SetElementEndUID(const std::string& uid)
 {
     generated::CPACSWingRibsPositioning::SetElementEndUID_choice2(uid);
@@ -140,14 +115,6 @@ void CCPACSWingRibsPositioning::SetElementEndUID(const std::string& uid)
     m_sparPositionEndUID_choice3 = boost::none;
 
     invalidateStructure();
-}
-
-const std::string& CCPACSWingRibsPositioning::GetSparPositionEndUID() const
-{
-    if (!m_sparPositionEndUID_choice3) {
-        throw CTiglError("RibsPositioning is not defined via sparPositionEndUID. Please check EndDefinitionType first before calling CCPACSWingRibsPositioning::GetSparPositionEndUID()");
-    }
-    return *m_sparPositionEndUID_choice3;
 }
 
 void CCPACSWingRibsPositioning::SetSparPositionEndUID(const std::string& uid)
@@ -169,14 +136,6 @@ CCPACSWingRibsPositioning::RibCountDefinitionType CCPACSWingRibsPositioning::Get
     throw CTiglError("Invalid rib count definition");
 }
 
-int CCPACSWingRibsPositioning::GetNumberOfRibs() const
-{
-    if (!m_numberOfRibs_choice2) {
-        throw CTiglError("RibsPositioning is not defined via numberOfRibs. Please check RibCountDefinitionType first before calling CCPACSWingRibsPositioning::GetNumberOfRibs()");
-    }
-    return *m_numberOfRibs_choice2;
-}
-
 void CCPACSWingRibsPositioning::SetNumberOfRibs(int numRibs)
 {
     m_numberOfRibs_choice2 = numRibs;
@@ -184,14 +143,6 @@ void CCPACSWingRibsPositioning::SetNumberOfRibs(int numRibs)
     m_spacing_choice1 = boost::none;
 
     invalidateStructure();
-}
-
-double CCPACSWingRibsPositioning::GetSpacing() const
-{
-    if (!m_spacing_choice1) {
-        throw CTiglError("RibsPositioning is not defined via spacing. Please check RibCountDefinitionType first before calling CCPACSWingRibsPositioning::GetSpacing()");
-    }
-    return *m_spacing_choice1;
 }
 
 void CCPACSWingRibsPositioning::SetSpacing(double value)
@@ -206,6 +157,12 @@ void CCPACSWingRibsPositioning::SetSpacing(double value)
 void CCPACSWingRibsPositioning::invalidateStructure()
 {
     GetParent()->GetParent()->GetParent()->Invalidate();
+}
+
+void CCPACSWingRibsPositioning::SetRibCrossingBehaviour(const generated::CPACSRibCrossingBehaviour& value)
+{
+    generated::CPACSWingRibsPositioning::SetRibCrossingBehaviour(value);
+    invalidateStructure();
 }
 
 } // end namespace tigl

--- a/src/wing/CCPACSWingRibsPositioning.h
+++ b/src/wing/CCPACSWingRibsPositioning.h
@@ -50,39 +50,29 @@ public:
 public:
     TIGL_EXPORT CCPACSWingRibsPositioning(CCPACSWingRibsDefinition* parent);
 
+    TIGL_EXPORT virtual void SetRibReference(const std::string& value) OVERRIDE;
+    TIGL_EXPORT virtual void SetRibStart(const std::string& value) OVERRIDE;
+    TIGL_EXPORT virtual void SetRibEnd(const std::string& value) OVERRIDE;
+
     TIGL_EXPORT StartDefinitionType GetStartDefinitionType() const;
-    
-    TIGL_EXPORT double GetEtaStart() const;
     TIGL_EXPORT void SetEtaStart(double);
-
-    TIGL_EXPORT const std::string& GetElementStartUID() const;
     TIGL_EXPORT void SetElementStartUID(const std::string&);
-
-    // NOTE: definition via spar position not conform with CPACS format (v2.3)
-    TIGL_EXPORT const std::string& GetSparPositionStartUID() const;
-    TIGL_EXPORT void SetSparPositionStartUID(const std::string&);
+    TIGL_EXPORT void SetSparPositionStartUID(const std::string&); // NOTE: definition via spar position not conform with CPACS format (v2.3)
 
     TIGL_EXPORT EndDefinitionType GetEndDefinitionType() const;
-
-    TIGL_EXPORT double GetEtaEnd() const;
     TIGL_EXPORT void SetEtaEnd(double);
-
-    TIGL_EXPORT const std::string& GetElementEndUID() const;
     TIGL_EXPORT void SetElementEndUID(const std::string&);
-
-    // NOTE: definition via spar position not conform with CPACS format (v2.3)
-    TIGL_EXPORT const std::string& GetSparPositionEndUID() const;
-    TIGL_EXPORT void SetSparPositionEndUID(const std::string&);
+    TIGL_EXPORT void SetSparPositionEndUID(const std::string&); // NOTE: definition via spar position not conform with CPACS format (v2.3)
 
     TIGL_EXPORT RibCountDefinitionType GetRibCountDefinitionType() const;
-
-    TIGL_EXPORT int GetNumberOfRibs() const;
     TIGL_EXPORT void SetNumberOfRibs(int);
-
-    TIGL_EXPORT double GetSpacing() const;
     TIGL_EXPORT void SetSpacing(double);
 
+    TIGL_EXPORT virtual void SetRibCrossingBehaviour(const generated::CPACSRibCrossingBehaviour& value) OVERRIDE;
+
 private:
+    friend class CCPACSWingRibRotation;
+
     void invalidateStructure();
 };
 

--- a/src/wing/CCPACSWingSection.cpp
+++ b/src/wing/CCPACSWingSection.cpp
@@ -28,8 +28,8 @@
 
 namespace tigl
 {
-CCPACSWingSection::CCPACSWingSection(CTiglUIDManager* uidMgr)
-    : generated::CPACSWingSection(uidMgr) {}
+CCPACSWingSection::CCPACSWingSection(CCPACSWingSections* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSWingSection(parent, uidMgr) {}
 
 // Get profile count for this section
 int CCPACSWingSection::GetSectionElementCount() const

--- a/src/wing/CCPACSWingSection.h
+++ b/src/wing/CCPACSWingSection.h
@@ -39,7 +39,7 @@ namespace tigl
 class CCPACSWingSection : public generated::CPACSWingSection
 {
 public:
-    TIGL_EXPORT CCPACSWingSection(CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSWingSection(CCPACSWingSections* parent, CTiglUIDManager* uidMgr);
 
     // Get element count for this section
     TIGL_EXPORT int GetSectionElementCount() const;

--- a/src/wing/CCPACSWingSectionElement.cpp
+++ b/src/wing/CCPACSWingSectionElement.cpp
@@ -25,15 +25,18 @@
 
 #include "CCPACSWingSectionElement.h"
 
+#include "CCPACSWingSection.h"
+#include "CCPACSWing.h"
+
 namespace tigl
 {
-CCPACSWingSectionElement::CCPACSWingSectionElement(CTiglUIDManager* uidMgr)
-    : generated::CPACSWingElement(uidMgr) {}
-	
-// Returns the uid of the profile of this element
-const std::string& CCPACSWingSectionElement::GetProfileUID() const
-{
-    return m_airfoilUID;
+CCPACSWingSectionElement::CCPACSWingSectionElement(CCPACSWingSectionElements* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSWingElement(parent, uidMgr) {}
+
+void CCPACSWingSectionElement::SetAirfoilUID(const std::string& value) {
+    generated::CPACSWingElement::SetAirfoilUID(value);
+    // invalidate wing as we affect wing segments and component segments
+    m_parent->GetParent()->GetParent()->GetParent()->Invalidate();
 }
 
 // Gets the section element transformation

--- a/src/wing/CCPACSWingSectionElement.h
+++ b/src/wing/CCPACSWingSectionElement.h
@@ -36,10 +36,9 @@ namespace tigl
 class CCPACSWingSectionElement : public generated::CPACSWingElement
 {
 public:
-    TIGL_EXPORT CCPACSWingSectionElement(CTiglUIDManager* uidMgr);
-	
-    // Returns the UID of the profile of this element
-    TIGL_EXPORT const std::string& GetProfileUID() const;
+    TIGL_EXPORT CCPACSWingSectionElement(CCPACSWingSectionElements* parent, CTiglUIDManager* uidMgr);
+
+    TIGL_EXPORT virtual void SetAirfoilUID(const std::string& value) OVERRIDE;
 
     // Gets the section element transformation
     TIGL_EXPORT CTiglTransformation GetSectionElementTransformation() const;

--- a/src/wing/CCPACSWingSectionElements.cpp
+++ b/src/wing/CCPACSWingSectionElements.cpp
@@ -28,8 +28,8 @@
 
 namespace tigl
 {
-CCPACSWingSectionElements::CCPACSWingSectionElements(CTiglUIDManager* uidMgr)
-    : generated::CPACSWingElements(uidMgr) {}
+CCPACSWingSectionElements::CCPACSWingSectionElements(CCPACSWingSection* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSWingElements(parent, uidMgr) {}
 
 // Get element count for this section
 int CCPACSWingSectionElements::GetSectionElementCount() const
@@ -40,7 +40,7 @@ int CCPACSWingSectionElements::GetSectionElementCount() const
 // Get element for a given index
 CCPACSWingSectionElement& CCPACSWingSectionElements::GetSectionElement(int index) const
 {
-	index--;
+    index--;
     if (index < 0 || index >= GetSectionElementCount()) {
         throw CTiglError("Invalid index in CCPACSWingSectionElements::GetSectionElement", TIGL_INDEX_ERROR);
     }

--- a/src/wing/CCPACSWingSectionElements.h
+++ b/src/wing/CCPACSWingSectionElements.h
@@ -39,7 +39,7 @@ namespace tigl
 class CCPACSWingSectionElements : public generated::CPACSWingElements
 {
 public:
-    TIGL_EXPORT CCPACSWingSectionElements(CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSWingSectionElements(CCPACSWingSection* parent, CTiglUIDManager* uidMgr);
 
     // Get element count for this section
     TIGL_EXPORT int GetSectionElementCount() const;

--- a/src/wing/CCPACSWingSections.cpp
+++ b/src/wing/CCPACSWingSections.cpp
@@ -28,8 +28,8 @@
 
 namespace tigl
 {
-CCPACSWingSections::CCPACSWingSections(CTiglUIDManager* uidMgr)
-    : generated::CPACSWingSections(uidMgr) {}
+CCPACSWingSections::CCPACSWingSections(CCPACSWing* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSWingSections(parent, uidMgr) {}
 
 // Get section count
 int CCPACSWingSections::GetSectionCount() const
@@ -46,5 +46,4 @@ CCPACSWingSection& CCPACSWingSections::GetSection(int index) const
     }
     return *m_sections[index];
 }
-
 } // end namespace tigl

--- a/src/wing/CCPACSWingSections.h
+++ b/src/wing/CCPACSWingSections.h
@@ -34,7 +34,7 @@ namespace tigl
 class CCPACSWingSections : public generated::CPACSWingSections
 {
 public:
-    TIGL_EXPORT CCPACSWingSections(CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSWingSections(CCPACSWing* parent, CTiglUIDManager* uidMgr);
 
     // Get section count
     TIGL_EXPORT int GetSectionCount() const;

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -214,6 +214,9 @@ CCPACSWingSegment::CCPACSWingSegment(CCPACSWingSegments* parent, CTiglUIDManager
 // Destructor
 CCPACSWingSegment::~CCPACSWingSegment()
 {
+    // unregister
+    GetWing().GetConfiguration().GetUIDManager().RemoveGeometricComponent(GetUID());
+
     Cleanup();
 }
 
@@ -244,15 +247,18 @@ void CCPACSWingSegment::Update()
 }
 
 // Read CPACS segment elements
-void CCPACSWingSegment::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& segmentXPath)
+void CCPACSWingSegment::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& segmentXPath)
 {
     Cleanup();
     generated::CPACSWingSegment::ReadCPACS(tixiHandle, segmentXPath);
 
-    GetWing().GetConfiguration().GetUIDManager().AddGeometricComponent(m_uID, this);
+    if (m_uidMgr) {
+        m_uidMgr->AddGeometricComponent(m_uID, this);
+    }
 
-    innerConnection = CTiglWingConnection(m_fromElementUID, this);
-    outerConnection = CTiglWingConnection(m_toElementUID, this);
+    // trigger creation of connections
+    SetFromElementUID(m_fromElementUID);
+    SetToElementUID(m_toElementUID);
 
     // check that the profiles are consistent
     if (innerConnection.GetProfile().HasBluntTE() !=
@@ -268,8 +274,26 @@ void CCPACSWingSegment::ReadCPACS(TixiDocumentHandle tixiHandle, const std::stri
     Update();
 }
 
+void CCPACSWingSegment::SetUID(const std::string& uid) {
+    if (m_uidMgr) {
+        m_uidMgr->TryRemoveGeometricComponent(m_uID);
+        m_uidMgr->AddGeometricComponent(uid, this);
+    }
+    generated::CPACSWingSegment::SetUID(uid);
+}
+
 std::string CCPACSWingSegment::GetDefaultedUID() const {
     return generated::CPACSWingSegment::GetUID();
+}
+
+void CCPACSWingSegment::SetFromElementUID(const std::string& value) {
+    generated::CPACSWingSegment::SetFromElementUID(value);
+    innerConnection = CTiglWingConnection(m_fromElementUID, this);
+}
+
+void CCPACSWingSegment::SetToElementUID(const std::string& value) {
+    generated::CPACSWingSegment::SetToElementUID(value);
+    outerConnection = CTiglWingConnection(m_toElementUID, this);
 }
 
 // Returns the wing this segment belongs to

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -63,9 +63,14 @@ public:
     TIGL_EXPORT void Invalidate();
 
     // Read CPACS segment elements
-    TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& segmentXPath);
+    TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& segmentXPath) OVERRIDE;
+
+    TIGL_EXPORT virtual void SetUID(const std::string& uid) OVERRIDE;
 
     TIGL_EXPORT virtual std::string GetDefaultedUID() const OVERRIDE;
+
+    TIGL_EXPORT virtual void SetFromElementUID(const std::string& value) OVERRIDE;
+    TIGL_EXPORT virtual void SetToElementUID(const std::string& value) OVERRIDE;
 
     // Returns the wing this segment belongs to
     TIGL_EXPORT CCPACSWing& GetWing() const;
@@ -246,7 +251,7 @@ private:
     mutable TopTools_SequenceOfShape guideCurveWires;  /**< container for the guide curve wires     */
     CCPACSWing*          wing;                 /**< Parent wing                             */
     double               myVolume;             /**< Volume of this segment                  */
-    
+
     struct SurfaceCache
     {
         bool                 valid;

--- a/src/wing/CCPACSWingShell.cpp
+++ b/src/wing/CCPACSWingShell.cpp
@@ -48,12 +48,12 @@ CCPACSWingCell& CCPACSWingShell::GetCell(int index)
     return const_cast<CCPACSWingCell&>(static_cast<const CCPACSWingShell&>(*this).GetCell(index));
 }
 
-const CCPACSMaterial& CCPACSWingShell::GetMaterial() const
+const CCPACSMaterialDefinition& CCPACSWingShell::GetMaterial() const
 {
     return m_skin.GetMaterial();
 }
 
-CCPACSMaterial& CCPACSWingShell::GetMaterial()
+CCPACSMaterialDefinition& CCPACSWingShell::GetMaterial()
 {
     return m_skin.GetMaterial();
 }

--- a/src/wing/CCPACSWingShell.h
+++ b/src/wing/CCPACSWingShell.h
@@ -22,7 +22,7 @@
 #include "generated/CPACSWingShell.h"
 #include "tigl_internal.h"
 #include "CCPACSWingCells.h"
-#include "CCPACSMaterial.h"
+#include "CCPACSMaterialDefinition.h"
 
 #include "tigl.h"
 
@@ -47,8 +47,8 @@ public:
     TIGL_EXPORT const CCPACSWingCell& GetCell(int index) const;
     TIGL_EXPORT CCPACSWingCell& GetCell(int index);
 
-    TIGL_EXPORT const CCPACSMaterial& GetMaterial() const;
-    TIGL_EXPORT CCPACSMaterial& GetMaterial();
+    TIGL_EXPORT const CCPACSMaterialDefinition& GetMaterial() const;
+    TIGL_EXPORT CCPACSMaterialDefinition& GetMaterial();
 
     TIGL_EXPORT const CCPACSWingCSStructure& GetStructure() const;
     TIGL_EXPORT CCPACSWingCSStructure& GetStructure();

--- a/src/wing/CCPACSWingSparPosition.cpp
+++ b/src/wing/CCPACSWingSparPosition.cpp
@@ -47,7 +47,6 @@ const std::string& CCPACSWingSparPosition::GetElementUID() const
 void CCPACSWingSparPosition::SetElementUID(const std::string& uid)
 {
     m_elementUID_choice2 = uid;
-
     m_eta_choice1 = boost::none;
 
     // invalidate whole component segment structure, since ribs or cells could reference the spar
@@ -65,8 +64,14 @@ double CCPACSWingSparPosition::GetEta() const
 void CCPACSWingSparPosition::SetEta(double value)
 {
     m_eta_choice1 = value;
-   
     m_elementUID_choice2 = boost::none;
+
+    // invalidate whole component segment structure, since ribs or cells could reference the spar
+    GetParent()->GetParent()->GetParent()->Invalidate();
+}
+
+void CCPACSWingSparPosition::SetXsi(const double& value) {
+    generated::CPACSSparPosition::SetXsi(value);
 
     // invalidate whole component segment structure, since ribs or cells could reference the spar
     GetParent()->GetParent()->GetParent()->Invalidate();

--- a/src/wing/CCPACSWingSparPosition.h
+++ b/src/wing/CCPACSWingSparPosition.h
@@ -43,7 +43,9 @@ public:
     TIGL_EXPORT void SetElementUID(const std::string&);
 
     TIGL_EXPORT double GetEta() const;
-    TIGL_EXPORT void SetEta(double);
+    TIGL_EXPORT void SetEta(double value);
+
+    TIGL_EXPORT virtual void SetXsi(const double& value) OVERRIDE;
 };
 
 } // end namespace tigl

--- a/src/wing/CCPACSWings.cpp
+++ b/src/wing/CCPACSWings.cpp
@@ -102,18 +102,4 @@ bool CCPACSWings::HasWing(const std::string & uid) const
     return false;
 }
 
-void CCPACSWings::Add(CCPACSWing* wing)
-{
-    m_wings.push_back(unique_ptr<CCPACSWing>(wing));
-}
-
-void CCPACSWings::Remove(CCPACSWing* wing) {
-    for (std::vector<unique_ptr<CCPACSWing> >::iterator it = m_wings.begin(); it != m_wings.end(); ++it) {
-        if ((*it).get() == wing) {
-            m_wings.erase(it);
-            return;
-        }
-    }
-    throw CTiglError("Wing not found");
-}
 } // end namespace tigl

--- a/src/wing/CCPACSWings.h
+++ b/src/wing/CCPACSWings.h
@@ -56,8 +56,6 @@ public:
     // Returns the wing for a given UID.
     TIGL_EXPORT CCPACSWing& GetWing(const std::string& UID) const;
     
-    TIGL_EXPORT void Add(CCPACSWing* wing);
-    TIGL_EXPORT void Remove(CCPACSWing* wing);
     
     // Returns the wing index for a given UID.
     TIGL_EXPORT int GetWingIndex(const std::string& UID) const;

--- a/src/wing/CTiglWingConnection.cpp
+++ b/src/wing/CTiglWingConnection.cpp
@@ -128,7 +128,7 @@ void CTiglWingConnection::resolve() const
                 m_resolved.sectionUidPtr = &section.GetUID();
                 m_resolved.sectionIndex = i;
                 m_resolved.elementIndex = j;
-                m_resolved.profileUIDPtr = &element.GetProfileUID();
+                m_resolved.profileUIDPtr = &element.GetAirfoilUID();
                 return;
             }
         }

--- a/src/wing/CTiglWingProfilePointList.h
+++ b/src/wing/CTiglWingProfilePointList.h
@@ -50,23 +50,18 @@ namespace tigl
 
 class CCPACSWingProfile;
 
-// TODO(bgruber): rename file
 class CTiglWingProfilePointList : public ITiglWingProfileAlgo
 {
 
 public:
     // Constructor
-    TIGL_EXPORT CTiglWingProfilePointList(const CCPACSWingProfile& profile, const CCPACSPointListXYZ& cpacsPointlist);
+    TIGL_EXPORT CTiglWingProfilePointList(const CCPACSWingProfile& profile, CCPACSPointListXYZ& cpacsPointlist);
 
-    DEPRECATED TIGL_EXPORT static std::string CPACSID();
-
-    // Cleanup routine
-    TIGL_EXPORT virtual void Cleanup() OVERRIDE;
-
-    // Update interna
     TIGL_EXPORT virtual void Update() OVERRIDE;
+    TIGL_EXPORT void OrderPoints();
 
     // Returns the profile points as read from TIXI.
+    TIGL_EXPORT virtual std::vector<CTiglPoint>& GetSamplePoints() OVERRIDE;
     TIGL_EXPORT virtual const std::vector<CTiglPoint>& GetSamplePoints() const OVERRIDE;
 
     // get upper wing profile wire
@@ -137,7 +132,7 @@ private:
     // stores whether the defined profile is closed or has a trailing edge
     bool                      profileIsClosed;
 
-    std::vector<CTiglPoint>             coordinates;    /**< Coordinates of a wing profile element */
+    std::vector<CTiglPoint>&            coordinates;    /**< Coordinates of a wing profile element */
     unique_ptr<ITiglWireAlgorithm> profileWireAlgo;/**< Pointer to wire algorithm (e.g. CTiglInterpolateBsplineWire) */
     const CCPACSWingProfile&            profileRef;     /**< Reference to the wing profile */
 

--- a/src/wing/ITiglWingProfileAlgo.h
+++ b/src/wing/ITiglWingProfileAlgo.h
@@ -40,13 +40,11 @@ namespace tigl
 class ITiglWingProfileAlgo
 {
 public:
-    // Clean up 
-    virtual void Cleanup()  = 0;
-
     virtual void Update()   = 0;
 
     // Returns points on profile.
 
+    virtual std::vector<CTiglPoint>& GetSamplePoints() = 0;
     virtual const std::vector<CTiglPoint>& GetSamplePoints() const = 0;
 
     // get upper wing profile wire

--- a/tests/tiglWingComponentSegment.cpp
+++ b/tests/tiglWingComponentSegment.cpp
@@ -30,7 +30,7 @@
 #include "CCPACSWing.h"
 #include "CCPACSWingComponentSegment.h"
 #include "CCPACSWingSegment.h"
-#include "CCPACSMaterial.h"
+#include "CCPACSMaterialDefinition.h"
 #include "CTiglWingChordface.h"
 
 /******************************************************************************/


### PR DESCRIPTION
* renamed CCPACSMaterial to CCPACSMaterialDefinition to reflect name in CPACS schema
* some simplifications on point list in fuselage profiles
* using Handle() macro in OCC code to allow compiling with OCC 7.1
* added std:: prefix to usage of endl, to avoid ambiguity with Qt's endl
* added some missing invalidations
* made some parameters const T& instead of T
* added some const overloads
* overriding SetUID on CTiglRelativelyPositionedComponents to re-register them when their UIDs change
* added some missing virtual and OVERRIDEs
* added IsUIDRegistered and TryRemoveGeometricComponent to CTiglUIDManager
* using manipulation API where appropriate
* removed unused members in CCPACSWingProfile