### PR TITLE
Allow shaders to be overridden by the user

### DIFF
--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -52,9 +52,18 @@ QString getShaderFile(const QString& filename)
 {
     QString result;
 
-    QFile inFile(":/shaders/" + filename);
+    // First try to open shader file from current dir
+    // If not available, load from resource
+    // This makes it possible, to debug the shader code
+    QFile inFile(filename);
     if (!inFile.open(QFile::ReadOnly | QFile::Text)) {
-        return "";
+        inFile.setFileName(":/shaders/" + filename);
+        if (!inFile.open(QFile::ReadOnly | QFile::Text)) {
+            return "";
+        }
+    }
+    else {
+        LOG(WARNING) << "Loading shader file \"" << filename.toStdString() << "\" from working directory.";
     }
 
     QTextStream stream(&inFile);


### PR DESCRIPTION
This helps to debug the shader code without recompilation of tigl viewer. We can use this to debug the black aircraft problem on some graphics cards. I also experiences this in a VM on Ubuntu 15.04, but cannot reproduce this issue on any other VM. 