### PR TITLE
Workaround for black aircraft issue

### DIFF
--- a/TIGLViewer/shaders/PhongShading-v6.fs
+++ b/TIGLViewer/shaders/PhongShading-v6.fs
@@ -163,6 +163,12 @@ vec4 computeLighting (in vec3 theNormal,
     {
       spotLight (anIndex, theNormal, theView, aPoint);
     }
+    else
+    {
+      // on some hardware, aType is always zero. 
+      // as a workaround, we use the directional light
+      directionalLight (anIndex, theNormal, theView);
+    }
   }
 
   vec4 aMaterialAmbient  = gl_FrontFacing ? occFrontMaterial_Ambient()  : occBackMaterial_Ambient();

--- a/TIGLViewer/shaders/PhongShading-v7.fs
+++ b/TIGLViewer/shaders/PhongShading-v7.fs
@@ -163,6 +163,12 @@ vec4 computeLighting (in vec3 theNormal,
     {
       spotLight (anIndex, theNormal, theView, aPoint);
     }
+    else
+    {
+      // on some hardware, aType is always zero. 
+      // as a workaround, we use the directional light
+      directionalLight (anIndex, theNormal, theView);
+    }
   }
 
   vec4 aMaterialAmbient  = gl_FrontFacing ? occFrontMaterial_Ambient()  : occBackMaterial_Ambient();


### PR DESCRIPTION
On some hardware, aType is always zero - which actually
should not be the case. I don't understand why, but for
the single-lighted TiGL, we can use this workaround.

Fixes #333