### PR TITLE
supressing deprecation warning of std::tr1 to allow gtest to compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,11 @@ elseif(COMPILER_SUPPORTS_CXX0X)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()
 
+# supress deprecation warning of std::tr1 to allow gtest to compile
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
+endif()
+
 # check features
 file(READ cmake/cpp11featureTest.cpp src_cpp11_features)
 set(src_shared_ptr "#include <memory>\nint main(){\n std::shared_ptr<int> a(new int)\;\n return 0\;\n}\n")


### PR DESCRIPTION
fixes #341