### PR TITLE
Install qjpeg plugin, to be able to make jpeg screenshots

### DIFF
--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -286,6 +286,7 @@ if (WIN32 OR APPLE)
     if(WIN32)
       set(QT_PLUGINS  "qwindows")
     endif()
+    set(QT_PLUGINS "${QT_PLUGINS};qjpeg")
 
     include(DeployQt5)
     INSTALL_QT5_EXECUTABLE(${APPS} "${QT_PLUGINS}" "" "${DIRS}" "" "" viewer)


### PR DESCRIPTION
Whenever I used a downloaded version of TiGL, I could not save JPEG screenshots.

Local builds didn't have this problem. The reason was, that Qt searches the JPEG plugin 
1. In the current working directory
2. In the Qt installation path

Since the Qt installation path is different on the CI server than on my local machine, it could't find the plugin.

This commit fixes the issue by explicitly installing the jpeg plugin with tigl.

Fixes #349