### PR TITLE
Fixed opening of files with generic systems

### DIFF
--- a/src/geometry/CCPACSGenericSystem.cpp
+++ b/src/geometry/CCPACSGenericSystem.cpp
@@ -137,11 +137,6 @@ void CCPACSGenericSystem::ReadCPACS(TixiDocumentHandle tixiHandle, const std::st
     // Get Transformation
     transformation.ReadCPACS(tixiHandle, genericSysXPath);
 
-    // Register ourself at the unique id manager
-    if (configuration) {
-        configuration->GetUIDManager().AddGeometricComponent(ptrUID, this);
-    }
-
     // Get symmetry axis attribute
     char* ptrSym = NULL;
     tempString   = "symmetry";

--- a/tests/unittests/tiglACSystems.cpp
+++ b/tests/unittests/tiglACSystems.cpp
@@ -1,0 +1,17 @@
+#include "tigl.h"
+
+#include "test.h"
+
+TEST(TiglACSystems, openFile)
+{
+    const char* filename = "TestData/singleModel_withGenericSystems_cylinder.xml";
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    TixiDocumentHandle tixiHandle = -1;
+
+    ASSERT_EQ(SUCCESS, tixiOpenDocument(filename, &tixiHandle));
+    ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
+
+    ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
+    ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
+}


### PR DESCRIPTION
The code mistakenly tried to registers the generic AC system twice at the UID manager. This is now fixed.

Fixes #351