### PR TITLE
Fixed matrix multiplication and added transformation benchmark

### DIFF
--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -539,8 +539,8 @@ std::ostream& operator<<(std::ostream& os, const CTiglTransformation& t)
 
 CTiglTransformation operator*(const CTiglTransformation & a, const CTiglTransformation & b)
 {
-    CTiglTransformation result = a;
-    result.PreMultiply(b);
+    CTiglTransformation result = b;
+    result.PreMultiply(a);
     return result;
 }
 

--- a/tests/unittests/TestData/transformation-benchmark.xml
+++ b/tests/unittests/TestData/transformation-benchmark.xml
@@ -1,0 +1,605 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>TransformationTest</name>
+    <description>Simple Wing to test the different CPACS transformation modes</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2018-01-11T14:23:25</timestamp>
+    <version>0.1</version>
+    <cpacsVersion>3.0</cpacsVersion>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="TrafoTest">
+        <name>TrafoTest</name>
+        <reference>
+          <area>1</area>
+          <length>1</length>
+          <point>
+            <x>0</x>
+            <y>0</y>
+            <z>0</z>
+          </point>
+        </reference>
+        <wings>
+          <wing uID="Wing0" symmetry="x-z-plane">
+            <name>Wing0</name>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation>
+              <scaling>
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation>
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal">
+                <x>1</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning>
+                <name>Cpacs2Test - Wing Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing_Sec1</toSectionUID>
+              </positioning>
+              <positioning>
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec2</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec2_El1</toElementUID>
+              </segment>
+            </segments>
+          </wing>
+          <wing uID="Wing1" symmetry="x-z-plane">
+            <name>Wing</name>
+            <parentUID>Wing0</parentUID>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation>
+              <scaling>
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation>
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absLocal">
+                <x>0</x>
+                <y>1</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing1_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing1_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing1_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing1_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning>
+                <name>Cpacs2Test - Wing1 Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing1_Sec1</toSectionUID>
+              </positioning>
+              <positioning>
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing1_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing1_Sec2</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing1_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing1_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing1_Sec2_El1</toElementUID>
+              </segment>
+            </segments>
+          </wing>
+          <wing uID="Wing2" symmetry="x-z-plane">
+            <name>Wing</name>
+            <parentUID>Wing1</parentUID>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation>
+              <scaling>
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation>
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absLocal">
+                <x>0.5</x>
+                <y>1</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing2_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>-0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing2_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing2_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>-0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing2_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning>
+                <name>Cpacs2Test - Wing2 Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing2_Sec1</toSectionUID>
+              </positioning>
+              <positioning>
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing2_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing2_Sec2</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing2_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing2_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing2_Sec2_El1</toElementUID>
+              </segment>
+            </segments>
+          </wing>
+          <wing uID="Wing3" symmetry="x-z-plane">
+            <name>Wing</name>
+            <parentUID>Wing2</parentUID>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation>
+              <scaling>
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation>
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal">
+                <x>1.5</x>
+                <y>3</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing3_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>-0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing3_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing3_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation>
+                  <scaling>
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation>
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal">
+                    <x>-0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing3_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation>
+                      <scaling>
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation>
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning>
+                <name>Cpacs2Test - Wing3 Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing3_Sec1</toSectionUID>
+              </positioning>
+              <positioning>
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing3_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing3_Sec2</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing3_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing3_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing3_Sec2_El1</toElementUID>
+              </segment>
+            </segments>
+          </wing>
+        </wings>
+      </model>
+    </aircraft>
+    <profiles>
+      <wingAirfoils>
+        <wingAirfoil uID="NACA0012">
+          <name>NACA0.00.00.12</name>
+          <description>NACA 4 Series Profile</description>
+          <pointList>
+            <x mapType="vector">1.0;0.9875;0.975;0.9625;0.95;0.9375;0.925;0.9125;0.9;0.8875;0.875;0.8625;0.85;0.8375;0.825;0.8125;0.8;0.7875;0.775;0.7625;0.75;0.7375;0.725;0.7125;0.7;0.6875;0.675;0.6625;0.65;0.6375;0.625;0.6125;0.6;0.5875;0.575;0.5625;0.55;0.5375;0.525;0.5125;0.5;0.4875;0.475;0.4625;0.45;0.4375;0.425;0.4125;0.4;0.3875;0.375;0.3625;0.35;0.3375;0.325;0.3125;0.3;0.2875;0.275;0.2625;0.25;0.2375;0.225;0.2125;0.2;0.1875;0.175;0.1625;0.15;0.1375;0.125;0.1125;0.1;0.0875;0.075;0.0625;0.05;0.0375;0.025;0.0125;0.0;0.0125;0.025;0.0375;0.05;0.0625;0.075;0.0875;0.1;0.1125;0.125;0.1375;0.15;0.1625;0.175;0.1875;0.2;0.2125;0.225;0.2375;0.25;0.2625;0.275;0.2875;0.3;0.3125;0.325;0.3375;0.35;0.3625;0.375;0.3875;0.4;0.4125;0.425;0.4375;0.45;0.4625;0.475;0.4875;0.5;0.5125;0.525;0.5375;0.55;0.5625;0.575;0.5875;0.6;0.6125;0.625;0.6375;0.65;0.6625;0.675;0.6875;0.7;0.7125;0.725;0.7375;0.75;0.7625;0.775;0.7875;0.8;0.8125;0.825;0.8375;0.85;0.8625;0.875;0.8875;0.9;0.9125;0.925;0.9375;0.95;0.9625;0.975;0.9875;1.0</x>
+            <y mapType="vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+            <z mapType="vector">-0.00126;-0.0030004180415;-0.00471438572941;-0.00640256842113;-0.00806559133343;-0.00970403933653;-0.0113184567357;-0.0129093470398;-0.0144771727147;-0.0160223549226;-0.0175452732434;-0.0190462653789;-0.0205256268372;-0.0219836105968;-0.0234204267471;-0.024836242105;-0.0262311798047;-0.0276053188583;-0.0289586936852;-0.0302912936071;-0.0316030623052;-0.0328938972373;-0.0341636490097;-0.0354121207001;-0.0366390671268;-0.0378441940595;-0.0390271573644;-0.0401875620783;-0.0413249614032;-0.042438855614;-0.043528690869;-0.0445938579126;-0.0456336906587;-0.04664746464;-0.0476343953088;-0.0485936361694;-0.0495242767241;-0.0504253402064;-0.0512957810767;-0.0521344822472;-0.0529402520006;-0.0537118205596;-0.0544478362583;-0.0551468612564;-0.0558073667285;-0.0564277274483;-0.0570062156697;-0.0575409941929;-0.0580301084765;-0.0584714776309;-0.0588628840933;-0.059201961739;-0.0594861821311;-0.0597128385384;-0.059879027262;-0.0599816256958;-0.060017266394;-0.059982306219;-0.05987278938;-0.0596844028137;-0.059412421875;-0.059051643633;-0.0585963041308;-0.0580399746271;-0.0573754299024;-0.0565944788455;-0.0556877432118;-0.054644363746;-0.0534516022043;-0.0520942903127;-0.0505540468987;-0.0488081315259;-0.0468277042382;-0.0445750655553;-0.0419990347204;-0.0390266537476;-0.0355468568262;-0.0313738751622;-0.0261471986426;-0.0189390266528;0.0;0.0189390266528;0.0261471986426;0.0313738751622;0.0355468568262;0.0390266537476;0.0419990347204;0.0445750655553;0.0468277042382;0.0488081315259;0.0505540468987;0.0520942903127;0.0534516022043;0.054644363746;0.0556877432118;0.0565944788455;0.0573754299024;0.0580399746271;0.0585963041308;0.059051643633;0.059412421875;0.0596844028137;0.05987278938;0.059982306219;0.060017266394;0.0599816256958;0.059879027262;0.0597128385384;0.0594861821311;0.059201961739;0.0588628840933;0.0584714776309;0.0580301084765;0.0575409941929;0.0570062156697;0.0564277274483;0.0558073667285;0.0551468612564;0.0544478362583;0.0537118205596;0.0529402520006;0.0521344822472;0.0512957810767;0.0504253402064;0.0495242767241;0.0485936361694;0.0476343953088;0.04664746464;0.0456336906587;0.0445938579126;0.043528690869;0.042438855614;0.0413249614032;0.0401875620783;0.0390271573644;0.0378441940595;0.0366390671268;0.0354121207001;0.0341636490097;0.0328938972373;0.0316030623052;0.0302912936071;0.0289586936852;0.0276053188583;0.0262311798047;0.024836242105;0.0234204267471;0.0219836105968;0.0205256268372;0.0190462653789;0.0175452732434;0.0160223549226;0.0144771727147;0.0129093470398;0.0113184567357;0.00970403933653;0.00806559133343;0.00640256842113;0.00471438572941;0.0030004180415;0.00126</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+    </profiles>
+  </vehicles>
+</cpacs>

--- a/tests/unittests/tiglMath.cpp
+++ b/tests/unittests/tiglMath.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "CTiglPoint.h"
+#include "CTiglTransformation.h"
 
 #include <math_Matrix.hxx>
 
@@ -305,4 +306,36 @@ TEST(TiglMath, DistancePointFromLine)
     ASSERT_NEAR(0., tigl::distance_point_from_line(tigl::CTiglPoint(0., 0., 0.), x0, dx), 1e-10);
     ASSERT_NEAR(0., tigl::distance_point_from_line(tigl::CTiglPoint(3., 3., 0.), x0, dx), 1e-10);
     ASSERT_NEAR(sqrt(0.5), tigl::distance_point_from_line(tigl::CTiglPoint(1., 0., 0.), x0, dx), 1e-10);
+}
+
+TEST(TiglMath, CTiglTransformation_Multiply)
+{
+    tigl::CTiglTransformation a;
+    tigl::CTiglTransformation b;
+    
+    a.AddTranslation(2., 0., 0);
+    
+    b.AddScaling(0.4, 0.4, 0.4);
+    b.AddTranslation(-0.1, 0.9, -0.3);
+    
+    tigl::CTiglTransformation c = a * b;
+    EXPECT_NEAR(0.4, c.GetValue(0, 0), 1e-10);
+    EXPECT_NEAR(0.0, c.GetValue(0, 1), 1e-10);
+    EXPECT_NEAR(0.0, c.GetValue(0, 2), 1e-10);
+    EXPECT_NEAR(1.9, c.GetValue(0, 3), 1e-10);
+    
+    EXPECT_NEAR(0.0, c.GetValue(1, 0), 1e-10);
+    EXPECT_NEAR(0.4, c.GetValue(1, 1), 1e-10);
+    EXPECT_NEAR(0.0, c.GetValue(1, 2), 1e-10);
+    EXPECT_NEAR(0.9, c.GetValue(1, 3), 1e-10);
+    
+    EXPECT_NEAR(0.0, c.GetValue(2, 0), 1e-10);
+    EXPECT_NEAR(0.0, c.GetValue(2, 1), 1e-10);
+    EXPECT_NEAR(0.4, c.GetValue(2, 2), 1e-10);
+    EXPECT_NEAR(-0.3, c.GetValue(2, 3), 1e-10);
+    
+    EXPECT_NEAR(0.0, c.GetValue(3, 0), 1e-10);
+    EXPECT_NEAR(0.0, c.GetValue(3, 1), 1e-10);
+    EXPECT_NEAR(0.0, c.GetValue(3, 2), 1e-10);
+    EXPECT_NEAR(1.0, c.GetValue(3, 3), 1e-10);
 }

--- a/tests/unittests/tiglTransformationBenchmark.cpp
+++ b/tests/unittests/tiglTransformationBenchmark.cpp
@@ -1,0 +1,90 @@
+/* 
+* Copyright (C) 1018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-01-11 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h" // Brings in the GTest framework
+#include "tigl.h"
+#include <string.h>
+
+
+/******************************************************************************/
+
+/**
+ * @brief This tests checks, whether the cpacs transformation properties (absglobal, abslocal)
+ * are interpreted correctly.
+ */
+class TiglTransformationBenchmark : public ::testing::Test 
+{
+protected:
+    static void SetUpTestCase() 
+    {
+        const char* filename = "TestData/transformation-benchmark.xml";
+        ReturnCode tixiRet;
+        TiglReturnCode tiglRet;
+
+        tiglHandle = -1;
+        tixiHandle = -1;
+
+        tixiRet = tixiOpenDocument(filename, &tixiHandle);
+        ASSERT_TRUE (tixiRet == SUCCESS);
+        tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle);
+        ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+    }
+
+    static void TearDownTestCase() 
+    {
+        ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglHandle) == TIGL_SUCCESS);
+        ASSERT_TRUE(tixiCloseDocument(tixiHandle) == SUCCESS);
+        tiglHandle = -1;
+        tixiHandle = -1;
+    }
+
+    void SetUp() OVERRIDE {}
+    void TearDown() OVERRIDE {}
+
+
+    static TixiDocumentHandle           tixiHandle;
+    static TiglCPACSConfigurationHandle tiglHandle;
+};
+
+TixiDocumentHandle  TiglTransformationBenchmark::tixiHandle = 0;
+TiglCPACSConfigurationHandle  TiglTransformationBenchmark::tiglHandle = 0;
+
+TEST_F(TiglTransformationBenchmark, checkProfilePositions)
+{
+    double px, py, pz;
+
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingGetChordPoint(tiglHandle, 1, 1, 0., 0., &px, &py, &pz));
+    EXPECT_NEAR(1.0, px, 1e-10);
+    EXPECT_NEAR(0.0, py, 1e-10);
+    EXPECT_NEAR(0.0, pz, 1e-10);
+
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingGetChordPoint(tiglHandle, 2, 1, 0., 0., &px, &py, &pz));
+    EXPECT_NEAR(1.0, px, 1e-10);
+    EXPECT_NEAR(1.0, py, 1e-10);
+    EXPECT_NEAR(0.0, pz, 1e-10);
+
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingGetChordPoint(tiglHandle, 3, 1, 0., 0., &px, &py, &pz));
+    EXPECT_NEAR(1.0, px, 1e-10);
+    EXPECT_NEAR(2.0, py, 1e-10);
+    EXPECT_NEAR(0.0, pz, 1e-10);
+
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingGetChordPoint(tiglHandle, 4, 1, 0., 0., &px, &py, &pz));
+    EXPECT_NEAR(1.0, px, 1e-10);
+    EXPECT_NEAR(3.0, py, 1e-10);
+    EXPECT_NEAR(0.0, pz, 1e-10);
+}


### PR DESCRIPTION
Fixed the order of the transformation multiplication operator. This is actually never used (will be used in future), hence the error was not detected before.

We never had a proper test, that checks all different combinations of global and local transformation. To make sure, that all changes w.r.t. to the transformation tree are correct, this test is required.