### PR TITLE
Updated to new version of cpacs_tigl_gen

### DIFF
--- a/src/generated/CPACSFuselageCutOut.cpp
+++ b/src/generated/CPACSFuselageCutOut.cpp
@@ -167,7 +167,7 @@ namespace tigl
             
             // read element cutoutType
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/cutoutType")) {
-                m_cutoutType = stringToCPACSFuselageCutOut_cutout(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/cutoutType"));
+                m_cutoutType = stringToCPACSFuselageCutOut_cutoutType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/cutoutType"));
             }
             else {
                 LOG(ERROR) << "Required element cutoutType is missing at xpath " << xpath;
@@ -265,7 +265,7 @@ namespace tigl
             
             // write element cutoutType
             tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/cutoutType");
-            tixi::TixiSaveElement(tixiHandle, xpath + "/cutoutType", CPACSFuselageCutOut_cutoutToString(m_cutoutType));
+            tixi::TixiSaveElement(tixiHandle, xpath + "/cutoutType", CPACSFuselageCutOut_cutoutTypeToString(m_cutoutType));
             
         }
         
@@ -433,12 +433,12 @@ namespace tigl
             m_filletRadius = value;
         }
         
-        const CPACSFuselageCutOut_cutout& CPACSFuselageCutOut::GetCutoutType() const
+        const CPACSFuselageCutOut_cutoutType& CPACSFuselageCutOut::GetCutoutType() const
         {
             return m_cutoutType;
         }
         
-        void CPACSFuselageCutOut::SetCutoutType(const CPACSFuselageCutOut_cutout& value)
+        void CPACSFuselageCutOut::SetCutoutType(const CPACSFuselageCutOut_cutoutType& value)
         {
             m_cutoutType = value;
         }

--- a/src/generated/CPACSFuselageCutOut.h
+++ b/src/generated/CPACSFuselageCutOut.h
@@ -21,7 +21,7 @@
 #include <boost/utility/in_place_factory.hpp>
 #include <string>
 #include <tixi.h>
-#include "CPACSFuselageCutOut_cutout.h"
+#include "CPACSFuselageCutOut_cutoutType.h"
 #include "CPACSPointXYZ.h"
 #include "CreateIfNotExists.h"
 #include "tigl_internal.h"
@@ -94,8 +94,8 @@ namespace tigl
             TIGL_EXPORT virtual const double& GetFilletRadius() const;
             TIGL_EXPORT virtual void SetFilletRadius(const double& value);
             
-            TIGL_EXPORT virtual const CPACSFuselageCutOut_cutout& GetCutoutType() const;
-            TIGL_EXPORT virtual void SetCutoutType(const CPACSFuselageCutOut_cutout& value);
+            TIGL_EXPORT virtual const CPACSFuselageCutOut_cutoutType& GetCutoutType() const;
+            TIGL_EXPORT virtual void SetCutoutType(const CPACSFuselageCutOut_cutoutType& value);
             
             TIGL_EXPORT virtual CPACSPointXYZ& GetAlignmentVector(CreateIfNotExistsTag);
             TIGL_EXPORT virtual void RemoveAlignmentVector();
@@ -117,7 +117,7 @@ namespace tigl
             boost::optional<double>        m_deltaY1;
             boost::optional<double>        m_deltaZ1;
             double                         m_filletRadius;
-            CPACSFuselageCutOut_cutout     m_cutoutType;
+            CPACSFuselageCutOut_cutoutType m_cutoutType;
             
         private:
             #ifdef HAVE_CPP11

--- a/src/generated/CPACSFuselageCutOut_cutoutType.h
+++ b/src/generated/CPACSFuselageCutOut_cutoutType.h
@@ -31,7 +31,7 @@ namespace tigl
         // CPACSFuselageCutOut
         
         // generated from /xsd:schema/xsd:complexType[369]/xsd:complexContent/xsd:extension/xsd:all/xsd:element[14]/xsd:complexType/xsd:simpleContent
-        enum CPACSFuselageCutOut_cutout
+        enum CPACSFuselageCutOut_cutoutType
         {
             window,
             door,
@@ -41,7 +41,7 @@ namespace tigl
             ramp
         };
         
-        inline std::string CPACSFuselageCutOut_cutoutToString(const CPACSFuselageCutOut_cutout& value)
+        inline std::string CPACSFuselageCutOut_cutoutTypeToString(const CPACSFuselageCutOut_cutoutType& value)
         {
             switch(value) {
             case window: return "window";
@@ -50,10 +50,10 @@ namespace tigl
             case emergencyDoor: return "emergencyDoor";
             case cargoDoor: return "cargoDoor";
             case ramp: return "ramp";
-            default: throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) + "\" for enum type CPACSFuselageCutOut_cutout");
+            default: throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) + "\" for enum type CPACSFuselageCutOut_cutoutType");
             }
         }
-        inline CPACSFuselageCutOut_cutout stringToCPACSFuselageCutOut_cutout(const std::string& value)
+        inline CPACSFuselageCutOut_cutoutType stringToCPACSFuselageCutOut_cutoutType(const std::string& value)
         {
             struct ToLower { std::string operator()(std::string str) { for (std::size_t i = 0; i < str.length(); i++) { str[i] = std::tolower(str[i]); } return str; } } toLower;
             if (toLower(value) == "window") { return window; }
@@ -62,15 +62,15 @@ namespace tigl
             if (toLower(value) == "emergencydoor") { return emergencyDoor; }
             if (toLower(value) == "cargodoor") { return cargoDoor; }
             if (toLower(value) == "ramp") { return ramp; }
-            throw CTiglError("Invalid string value \"" + value + "\" for enum type CPACSFuselageCutOut_cutout");
+            throw CTiglError("Invalid string value \"" + value + "\" for enum type CPACSFuselageCutOut_cutoutType");
         }
     }
     
     // Aliases in tigl namespace
     #ifdef HAVE_CPP11
-    using ECPACSFuselageCutOut_cutout = generated::CPACSFuselageCutOut_cutout;
+    using ECPACSFuselageCutOut_cutoutType = generated::CPACSFuselageCutOut_cutoutType;
     #else
-    typedef generated::CPACSFuselageCutOut_cutout ECPACSFuselageCutOut_cutout;
+    typedef generated::CPACSFuselageCutOut_cutoutType ECPACSFuselageCutOut_cutoutType;
     #endif
     using generated::window;
     using generated::door;

--- a/src/generated/CPACSRibCrossingBehaviour.h
+++ b/src/generated/CPACSRibCrossingBehaviour.h
@@ -30,7 +30,7 @@ namespace tigl
         // This enum is used in:
         // CPACSWingRibsPositioning
         
-        // generated from /xsd:schema/xsd:complexType[744]/xsd:complexContent/xsd:extension/xsd:sequence/xsd:element[4]/xsd:complexType/xsd:simpleContent
+        // generated from /xsd:schema/xsd:complexType[949]/xsd:complexContent/xsd:extension/xsd:sequence/xsd:element[4]/xsd:complexType/xsd:simpleContent
         enum CPACSRibCrossingBehaviour
         {
             cross,

--- a/src/generated/CPACSRotorHub_type.h
+++ b/src/generated/CPACSRotorHub_type.h
@@ -34,7 +34,7 @@ namespace tigl
         enum CPACSRotorHub_type
         {
             semiRigid,
-            CPACSRotorHub_type_rigid,
+            rigid,
             articulated,
             hingeless
         };
@@ -43,7 +43,7 @@ namespace tigl
         {
             switch(value) {
             case semiRigid: return "semiRigid";
-            case CPACSRotorHub_type_rigid: return "rigid";
+            case rigid: return "rigid";
             case articulated: return "articulated";
             case hingeless: return "hingeless";
             default: throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) + "\" for enum type CPACSRotorHub_type");
@@ -53,7 +53,7 @@ namespace tigl
         {
             struct ToLower { std::string operator()(std::string str) { for (std::size_t i = 0; i < str.length(); i++) { str[i] = std::tolower(str[i]); } return str; } } toLower;
             if (toLower(value) == "semirigid") { return semiRigid; }
-            if (toLower(value) == "rigid") { return CPACSRotorHub_type_rigid; }
+            if (toLower(value) == "rigid") { return rigid; }
             if (toLower(value) == "articulated") { return articulated; }
             if (toLower(value) == "hingeless") { return hingeless; }
             throw CTiglError("Invalid string value \"" + value + "\" for enum type CPACSRotorHub_type");

--- a/src/generated/CPACSSymmetry.h
+++ b/src/generated/CPACSSymmetry.h
@@ -35,7 +35,7 @@ namespace tigl
         // CPACSRotor
         // CPACSWing
         
-        // generated from /xsd:schema/xsd:complexType[397]/xsd:complexContent/xsd:extension/xsd:attribute[2]/xsd:simpleType
+        // generated from /xsd:schema/xsd:complexType[631]/xsd:complexContent/xsd:extension/xsd:attribute[2]/xsd:simpleType
         enum CPACSSymmetry
         {
             x_y_plane,


### PR DESCRIPTION
I found a bug in the generator which occured with the new CPACS 3 schema. This results in a few type renamings, which are probably not optimal, but we can fix this at another time.