### PR TITLE
Simplified setters for optional elements in cpacs_gen

### DIFF
--- a/src/generated/CPACSAircraftModel.cpp
+++ b/src/generated/CPACSAircraftModel.cpp
@@ -191,11 +191,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSAircraftModel::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSAircraftModel::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSAircraftModel.h
+++ b/src/generated/CPACSAircraftModel.h
@@ -56,7 +56,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<CCPACSFuselages>& GetFuselages() const;

--- a/src/generated/CPACSCellPositioningChordwise.cpp
+++ b/src/generated/CPACSCellPositioningChordwise.cpp
@@ -137,11 +137,6 @@ namespace tigl
             return m_sparUID_choice1;
         }
         
-        void CPACSCellPositioningChordwise::SetSparUID_choice1(const std::string& value)
-        {
-            m_sparUID_choice1 = value;
-        }
-        
         void CPACSCellPositioningChordwise::SetSparUID_choice1(const boost::optional<std::string>& value)
         {
             m_sparUID_choice1 = value;
@@ -152,11 +147,6 @@ namespace tigl
             return m_xsi1_choice2;
         }
         
-        void CPACSCellPositioningChordwise::SetXsi1_choice2(const double& value)
-        {
-            m_xsi1_choice2 = value;
-        }
-        
         void CPACSCellPositioningChordwise::SetXsi1_choice2(const boost::optional<double>& value)
         {
             m_xsi1_choice2 = value;
@@ -165,11 +155,6 @@ namespace tigl
         const boost::optional<double>& CPACSCellPositioningChordwise::GetXsi2_choice2() const
         {
             return m_xsi2_choice2;
-        }
-        
-        void CPACSCellPositioningChordwise::SetXsi2_choice2(const double& value)
-        {
-            m_xsi2_choice2 = value;
         }
         
         void CPACSCellPositioningChordwise::SetXsi2_choice2(const boost::optional<double>& value)

--- a/src/generated/CPACSCellPositioningChordwise.h
+++ b/src/generated/CPACSCellPositioningChordwise.h
@@ -48,15 +48,12 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetSparUID_choice1() const;
-            TIGL_EXPORT virtual void SetSparUID_choice1(const std::string& value);
             TIGL_EXPORT virtual void SetSparUID_choice1(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetXsi1_choice2() const;
-            TIGL_EXPORT virtual void SetXsi1_choice2(const double& value);
             TIGL_EXPORT virtual void SetXsi1_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetXsi2_choice2() const;
-            TIGL_EXPORT virtual void SetXsi2_choice2(const double& value);
             TIGL_EXPORT virtual void SetXsi2_choice2(const boost::optional<double>& value);
             
         protected:

--- a/src/generated/CPACSCellPositioningSpanwise.cpp
+++ b/src/generated/CPACSCellPositioningSpanwise.cpp
@@ -156,11 +156,6 @@ namespace tigl
             return m_eta1_choice1;
         }
         
-        void CPACSCellPositioningSpanwise::SetEta1_choice1(const double& value)
-        {
-            m_eta1_choice1 = value;
-        }
-        
         void CPACSCellPositioningSpanwise::SetEta1_choice1(const boost::optional<double>& value)
         {
             m_eta1_choice1 = value;
@@ -169,11 +164,6 @@ namespace tigl
         const boost::optional<double>& CPACSCellPositioningSpanwise::GetEta2_choice1() const
         {
             return m_eta2_choice1;
-        }
-        
-        void CPACSCellPositioningSpanwise::SetEta2_choice1(const double& value)
-        {
-            m_eta2_choice1 = value;
         }
         
         void CPACSCellPositioningSpanwise::SetEta2_choice1(const boost::optional<double>& value)
@@ -186,11 +176,6 @@ namespace tigl
             return m_ribNumber_choice2;
         }
         
-        void CPACSCellPositioningSpanwise::SetRibNumber_choice2(const int& value)
-        {
-            m_ribNumber_choice2 = value;
-        }
-        
         void CPACSCellPositioningSpanwise::SetRibNumber_choice2(const boost::optional<int>& value)
         {
             m_ribNumber_choice2 = value;
@@ -199,11 +184,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSCellPositioningSpanwise::GetRibDefinitionUID_choice2() const
         {
             return m_ribDefinitionUID_choice2;
-        }
-        
-        void CPACSCellPositioningSpanwise::SetRibDefinitionUID_choice2(const std::string& value)
-        {
-            m_ribDefinitionUID_choice2 = value;
         }
         
         void CPACSCellPositioningSpanwise::SetRibDefinitionUID_choice2(const boost::optional<std::string>& value)

--- a/src/generated/CPACSCellPositioningSpanwise.h
+++ b/src/generated/CPACSCellPositioningSpanwise.h
@@ -48,19 +48,15 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<double>& GetEta1_choice1() const;
-            TIGL_EXPORT virtual void SetEta1_choice1(const double& value);
             TIGL_EXPORT virtual void SetEta1_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetEta2_choice1() const;
-            TIGL_EXPORT virtual void SetEta2_choice1(const double& value);
             TIGL_EXPORT virtual void SetEta2_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<int>& GetRibNumber_choice2() const;
-            TIGL_EXPORT virtual void SetRibNumber_choice2(const int& value);
             TIGL_EXPORT virtual void SetRibNumber_choice2(const boost::optional<int>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetRibDefinitionUID_choice2() const;
-            TIGL_EXPORT virtual void SetRibDefinitionUID_choice2(const std::string& value);
             TIGL_EXPORT virtual void SetRibDefinitionUID_choice2(const boost::optional<std::string>& value);
             
         protected:

--- a/src/generated/CPACSComponentSegment.cpp
+++ b/src/generated/CPACSComponentSegment.cpp
@@ -190,11 +190,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSComponentSegment::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSComponentSegment::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSComponentSegment.h
+++ b/src/generated/CPACSComponentSegment.h
@@ -58,7 +58,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetFromElementUID() const;

--- a/src/generated/CPACSComposite.cpp
+++ b/src/generated/CPACSComposite.cpp
@@ -152,11 +152,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSComposite::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSComposite::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -165,11 +160,6 @@ namespace tigl
         const boost::optional<double>& CPACSComposite::GetOffset() const
         {
             return m_offset;
-        }
-        
-        void CPACSComposite::SetOffset(const double& value)
-        {
-            m_offset = value;
         }
         
         void CPACSComposite::SetOffset(const boost::optional<double>& value)

--- a/src/generated/CPACSComposite.h
+++ b/src/generated/CPACSComposite.h
@@ -56,11 +56,9 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetOffset() const;
-            TIGL_EXPORT virtual void SetOffset(const double& value);
             TIGL_EXPORT virtual void SetOffset(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const std::vector<unique_ptr<CPACSCompositeLayer> >& GetCompositeLayers() const;

--- a/src/generated/CPACSCompositeLayer.cpp
+++ b/src/generated/CPACSCompositeLayer.cpp
@@ -118,11 +118,6 @@ namespace tigl
             return m_name;
         }
         
-        void CPACSCompositeLayer::SetName(const std::string& value)
-        {
-            m_name = value;
-        }
-        
         void CPACSCompositeLayer::SetName(const boost::optional<std::string>& value)
         {
             m_name = value;
@@ -131,11 +126,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSCompositeLayer::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSCompositeLayer::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSCompositeLayer::SetDescription(const boost::optional<std::string>& value)

--- a/src/generated/CPACSCompositeLayer.h
+++ b/src/generated/CPACSCompositeLayer.h
@@ -41,11 +41,9 @@ namespace tigl
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetName() const;
-            TIGL_EXPORT virtual void SetName(const std::string& value);
             TIGL_EXPORT virtual void SetName(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const double& GetThickness() const;

--- a/src/generated/CPACSCst2D.cpp
+++ b/src/generated/CPACSCst2D.cpp
@@ -214,11 +214,6 @@ namespace tigl
             return m_trailingEdgeThickness;
         }
         
-        void CPACSCst2D::SetTrailingEdgeThickness(const double& value)
-        {
-            m_trailingEdgeThickness = value;
-        }
-        
         void CPACSCst2D::SetTrailingEdgeThickness(const boost::optional<double>& value)
         {
             m_trailingEdgeThickness = value;

--- a/src/generated/CPACSCst2D.h
+++ b/src/generated/CPACSCst2D.h
@@ -63,7 +63,6 @@ namespace tigl
             TIGL_EXPORT virtual CCPACSStringVector& GetLowerB();
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTrailingEdgeThickness() const;
-            TIGL_EXPORT virtual void SetTrailingEdgeThickness(const double& value);
             TIGL_EXPORT virtual void SetTrailingEdgeThickness(const boost::optional<double>& value);
             
         protected:

--- a/src/generated/CPACSFuselage.cpp
+++ b/src/generated/CPACSFuselage.cpp
@@ -242,11 +242,6 @@ namespace tigl
             return m_symmetry;
         }
         
-        void CPACSFuselage::SetSymmetry(const TiglSymmetryAxis& value)
-        {
-            m_symmetry = value;
-        }
-        
         void CPACSFuselage::SetSymmetry(const boost::optional<TiglSymmetryAxis>& value)
         {
             m_symmetry = value;
@@ -267,11 +262,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSFuselage::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSFuselage::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -280,11 +270,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSFuselage::GetParentUID() const
         {
             return m_parentUID;
-        }
-        
-        void CPACSFuselage::SetParentUID(const std::string& value)
-        {
-            m_parentUID = value;
         }
         
         void CPACSFuselage::SetParentUID(const boost::optional<std::string>& value)

--- a/src/generated/CPACSFuselage.h
+++ b/src/generated/CPACSFuselage.h
@@ -60,18 +60,15 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<TiglSymmetryAxis>& GetSymmetry() const;
-            TIGL_EXPORT virtual void SetSymmetry(const TiglSymmetryAxis& value);
             TIGL_EXPORT virtual void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value);
             
             TIGL_EXPORT virtual const std::string& GetName() const;
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetParentUID() const;
-            TIGL_EXPORT virtual void SetParentUID(const std::string& value);
             TIGL_EXPORT virtual void SetParentUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;

--- a/src/generated/CPACSFuselageCutOut.cpp
+++ b/src/generated/CPACSFuselageCutOut.cpp
@@ -288,11 +288,6 @@ namespace tigl
             return m_name;
         }
         
-        void CPACSFuselageCutOut::SetName(const std::string& value)
-        {
-            m_name = value;
-        }
-        
         void CPACSFuselageCutOut::SetName(const boost::optional<std::string>& value)
         {
             m_name = value;
@@ -301,11 +296,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSFuselageCutOut::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSFuselageCutOut::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSFuselageCutOut::SetDescription(const boost::optional<std::string>& value)
@@ -398,11 +388,6 @@ namespace tigl
             return m_deltaY1;
         }
         
-        void CPACSFuselageCutOut::SetDeltaY1(const double& value)
-        {
-            m_deltaY1 = value;
-        }
-        
         void CPACSFuselageCutOut::SetDeltaY1(const boost::optional<double>& value)
         {
             m_deltaY1 = value;
@@ -411,11 +396,6 @@ namespace tigl
         const boost::optional<double>& CPACSFuselageCutOut::GetDeltaZ1() const
         {
             return m_deltaZ1;
-        }
-        
-        void CPACSFuselageCutOut::SetDeltaZ1(const double& value)
-        {
-            m_deltaZ1 = value;
         }
         
         void CPACSFuselageCutOut::SetDeltaZ1(const boost::optional<double>& value)

--- a/src/generated/CPACSFuselageCutOut.h
+++ b/src/generated/CPACSFuselageCutOut.h
@@ -52,11 +52,9 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetName() const;
-            TIGL_EXPORT virtual void SetName(const std::string& value);
             TIGL_EXPORT virtual void SetName(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const double& GetPositionX() const;
@@ -84,11 +82,9 @@ namespace tigl
             TIGL_EXPORT virtual void SetDeltaZ(const double& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetDeltaY1() const;
-            TIGL_EXPORT virtual void SetDeltaY1(const double& value);
             TIGL_EXPORT virtual void SetDeltaY1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetDeltaZ1() const;
-            TIGL_EXPORT virtual void SetDeltaZ1(const double& value);
             TIGL_EXPORT virtual void SetDeltaZ1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const double& GetFilletRadius() const;

--- a/src/generated/CPACSFuselageElement.cpp
+++ b/src/generated/CPACSFuselageElement.cpp
@@ -167,11 +167,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSFuselageElement::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSFuselageElement::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSFuselageElement.h
+++ b/src/generated/CPACSFuselageElement.h
@@ -57,7 +57,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetProfileUID() const;

--- a/src/generated/CPACSFuselageSection.cpp
+++ b/src/generated/CPACSFuselageSection.cpp
@@ -165,11 +165,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSFuselageSection::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSFuselageSection::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSFuselageSection.h
+++ b/src/generated/CPACSFuselageSection.h
@@ -58,7 +58,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;

--- a/src/generated/CPACSFuselageSegment.cpp
+++ b/src/generated/CPACSFuselageSegment.cpp
@@ -190,11 +190,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSFuselageSegment::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSFuselageSegment::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSFuselageSegment.h
+++ b/src/generated/CPACSFuselageSegment.h
@@ -58,7 +58,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetFromElementUID() const;

--- a/src/generated/CPACSGenericGeometricComponent.cpp
+++ b/src/generated/CPACSGenericGeometricComponent.cpp
@@ -186,11 +186,6 @@ namespace tigl
             return m_symmetry;
         }
         
-        void CPACSGenericGeometricComponent::SetSymmetry(const TiglSymmetryAxis& value)
-        {
-            m_symmetry = value;
-        }
-        
         void CPACSGenericGeometricComponent::SetSymmetry(const boost::optional<TiglSymmetryAxis>& value)
         {
             m_symmetry = value;
@@ -211,11 +206,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSGenericGeometricComponent::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSGenericGeometricComponent::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -224,11 +214,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSGenericGeometricComponent::GetParentUID() const
         {
             return m_parentUID;
-        }
-        
-        void CPACSGenericGeometricComponent::SetParentUID(const std::string& value)
-        {
-            m_parentUID = value;
         }
         
         void CPACSGenericGeometricComponent::SetParentUID(const boost::optional<std::string>& value)

--- a/src/generated/CPACSGenericGeometricComponent.h
+++ b/src/generated/CPACSGenericGeometricComponent.h
@@ -56,18 +56,15 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<TiglSymmetryAxis>& GetSymmetry() const;
-            TIGL_EXPORT virtual void SetSymmetry(const TiglSymmetryAxis& value);
             TIGL_EXPORT virtual void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value);
             
             TIGL_EXPORT virtual const std::string& GetName() const;
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetParentUID() const;
-            TIGL_EXPORT virtual void SetParentUID(const std::string& value);
             TIGL_EXPORT virtual void SetParentUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;

--- a/src/generated/CPACSGuideCurve.cpp
+++ b/src/generated/CPACSGuideCurve.cpp
@@ -308,11 +308,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSGuideCurve::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSGuideCurve::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -343,11 +338,6 @@ namespace tigl
             return m_fromGuideCurveUID_choice1;
         }
         
-        void CPACSGuideCurve::SetFromGuideCurveUID_choice1(const std::string& value)
-        {
-            m_fromGuideCurveUID_choice1 = value;
-        }
-        
         void CPACSGuideCurve::SetFromGuideCurveUID_choice1(const boost::optional<std::string>& value)
         {
             m_fromGuideCurveUID_choice1 = value;
@@ -358,11 +348,6 @@ namespace tigl
             return m_continuity_choice1;
         }
         
-        void CPACSGuideCurve::SetContinuity_choice1(const CPACSGuideCurve_continuity& value)
-        {
-            m_continuity_choice1 = value;
-        }
-        
         void CPACSGuideCurve::SetContinuity_choice1(const boost::optional<CPACSGuideCurve_continuity>& value)
         {
             m_continuity_choice1 = value;
@@ -371,11 +356,6 @@ namespace tigl
         const boost::optional<double>& CPACSGuideCurve::GetFromRelativeCircumference_choice2() const
         {
             return m_fromRelativeCircumference_choice2;
-        }
-        
-        void CPACSGuideCurve::SetFromRelativeCircumference_choice2(const double& value)
-        {
-            m_fromRelativeCircumference_choice2 = value;
         }
         
         void CPACSGuideCurve::SetFromRelativeCircumference_choice2(const boost::optional<double>& value)

--- a/src/generated/CPACSGuideCurve.h
+++ b/src/generated/CPACSGuideCurve.h
@@ -57,7 +57,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetGuideCurveProfileUID() const;
@@ -67,15 +66,12 @@ namespace tigl
             TIGL_EXPORT virtual boost::optional<CPACSPointXYZ>& GetRXDirection();
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetFromGuideCurveUID_choice1() const;
-            TIGL_EXPORT virtual void SetFromGuideCurveUID_choice1(const std::string& value);
             TIGL_EXPORT virtual void SetFromGuideCurveUID_choice1(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<CPACSGuideCurve_continuity>& GetContinuity_choice1() const;
-            TIGL_EXPORT virtual void SetContinuity_choice1(const CPACSGuideCurve_continuity& value);
             TIGL_EXPORT virtual void SetContinuity_choice1(const boost::optional<CPACSGuideCurve_continuity>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetFromRelativeCircumference_choice2() const;
-            TIGL_EXPORT virtual void SetFromRelativeCircumference_choice2(const double& value);
             TIGL_EXPORT virtual void SetFromRelativeCircumference_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<CPACSPointXYZ>& GetTangent_choice2() const;

--- a/src/generated/CPACSGuideCurveProfileGeometry.cpp
+++ b/src/generated/CPACSGuideCurveProfileGeometry.cpp
@@ -130,11 +130,6 @@ namespace tigl
             return m_symmetry;
         }
         
-        void CPACSGuideCurveProfileGeometry::SetSymmetry(const TiglSymmetryAxis& value)
-        {
-            m_symmetry = value;
-        }
-        
         void CPACSGuideCurveProfileGeometry::SetSymmetry(const boost::optional<TiglSymmetryAxis>& value)
         {
             m_symmetry = value;
@@ -167,11 +162,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSGuideCurveProfileGeometry::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSGuideCurveProfileGeometry::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSGuideCurveProfileGeometry::SetDescription(const boost::optional<std::string>& value)

--- a/src/generated/CPACSGuideCurveProfileGeometry.h
+++ b/src/generated/CPACSGuideCurveProfileGeometry.h
@@ -48,7 +48,6 @@ namespace tigl
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
             TIGL_EXPORT virtual const boost::optional<TiglSymmetryAxis>& GetSymmetry() const;
-            TIGL_EXPORT virtual void SetSymmetry(const TiglSymmetryAxis& value);
             TIGL_EXPORT virtual void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value);
             
             TIGL_EXPORT virtual const std::string& GetUID() const;
@@ -58,7 +57,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSPointListRelXYZ& GetPointList() const;

--- a/src/generated/CPACSHeader.cpp
+++ b/src/generated/CPACSHeader.cpp
@@ -163,11 +163,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSHeader::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSHeader::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSHeader.h
+++ b/src/generated/CPACSHeader.h
@@ -47,7 +47,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetCreator() const;

--- a/src/generated/CPACSLinkToFile.cpp
+++ b/src/generated/CPACSLinkToFile.cpp
@@ -79,11 +79,6 @@ namespace tigl
             return m_format;
         }
         
-        void CPACSLinkToFile::SetFormat(const CPACSLinkToFileType_format& value)
-        {
-            m_format = value;
-        }
-        
         void CPACSLinkToFile::SetFormat(const boost::optional<CPACSLinkToFileType_format>& value)
         {
             m_format = value;

--- a/src/generated/CPACSLinkToFile.h
+++ b/src/generated/CPACSLinkToFile.h
@@ -45,7 +45,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetBase(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<CPACSLinkToFileType_format>& GetFormat() const;
-            TIGL_EXPORT virtual void SetFormat(const CPACSLinkToFileType_format& value);
             TIGL_EXPORT virtual void SetFormat(const boost::optional<CPACSLinkToFileType_format>& value);
             
         protected:

--- a/src/generated/CPACSMaterial.cpp
+++ b/src/generated/CPACSMaterial.cpp
@@ -859,11 +859,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSMaterial::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSMaterial::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -904,11 +899,6 @@ namespace tigl
             return m_maxStrain;
         }
         
-        void CPACSMaterial::SetMaxStrain(const double& value)
-        {
-            m_maxStrain = value;
-        }
-        
         void CPACSMaterial::SetMaxStrain(const boost::optional<double>& value)
         {
             m_maxStrain = value;
@@ -917,11 +907,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetFatigueFactor() const
         {
             return m_fatigueFactor;
-        }
-        
-        void CPACSMaterial::SetFatigueFactor(const double& value)
-        {
-            m_fatigueFactor = value;
         }
         
         void CPACSMaterial::SetFatigueFactor(const boost::optional<double>& value)
@@ -942,11 +927,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetThermalConductivity() const
         {
             return m_thermalConductivity;
-        }
-        
-        void CPACSMaterial::SetThermalConductivity(const double& value)
-        {
-            m_thermalConductivity = value;
         }
         
         void CPACSMaterial::SetThermalConductivity(const boost::optional<double>& value)
@@ -979,11 +959,6 @@ namespace tigl
             return m_sig11_choice1;
         }
         
-        void CPACSMaterial::SetSig11_choice1(const double& value)
-        {
-            m_sig11_choice1 = value;
-        }
-        
         void CPACSMaterial::SetSig11_choice1(const boost::optional<double>& value)
         {
             m_sig11_choice1 = value;
@@ -992,11 +967,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetTau12_choice1() const
         {
             return m_tau12_choice1;
-        }
-        
-        void CPACSMaterial::SetTau12_choice1(const double& value)
-        {
-            m_tau12_choice1 = value;
         }
         
         void CPACSMaterial::SetTau12_choice1(const boost::optional<double>& value)
@@ -1009,11 +979,6 @@ namespace tigl
             return m_sig11yieldT_choice1;
         }
         
-        void CPACSMaterial::SetSig11yieldT_choice1(const double& value)
-        {
-            m_sig11yieldT_choice1 = value;
-        }
-        
         void CPACSMaterial::SetSig11yieldT_choice1(const boost::optional<double>& value)
         {
             m_sig11yieldT_choice1 = value;
@@ -1022,11 +987,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetSig11yieldC_choice1() const
         {
             return m_sig11yieldC_choice1;
-        }
-        
-        void CPACSMaterial::SetSig11yieldC_choice1(const double& value)
-        {
-            m_sig11yieldC_choice1 = value;
         }
         
         void CPACSMaterial::SetSig11yieldC_choice1(const boost::optional<double>& value)
@@ -1039,11 +999,6 @@ namespace tigl
             return m_k22_choice2;
         }
         
-        void CPACSMaterial::SetK22_choice2(const double& value)
-        {
-            m_k22_choice2 = value;
-        }
-        
         void CPACSMaterial::SetK22_choice2(const boost::optional<double>& value)
         {
             m_k22_choice2 = value;
@@ -1052,11 +1007,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetK23_choice2() const
         {
             return m_k23_choice2;
-        }
-        
-        void CPACSMaterial::SetK23_choice2(const double& value)
-        {
-            m_k23_choice2 = value;
         }
         
         void CPACSMaterial::SetK23_choice2(const boost::optional<double>& value)
@@ -1069,11 +1019,6 @@ namespace tigl
             return m_k66_choice2;
         }
         
-        void CPACSMaterial::SetK66_choice2(const double& value)
-        {
-            m_k66_choice2 = value;
-        }
-        
         void CPACSMaterial::SetK66_choice2(const boost::optional<double>& value)
         {
             m_k66_choice2 = value;
@@ -1082,11 +1027,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetSig11t_choice2() const
         {
             return m_sig11t_choice2;
-        }
-        
-        void CPACSMaterial::SetSig11t_choice2(const double& value)
-        {
-            m_sig11t_choice2 = value;
         }
         
         void CPACSMaterial::SetSig11t_choice2(const boost::optional<double>& value)
@@ -1099,11 +1039,6 @@ namespace tigl
             return m_sig11c_choice2;
         }
         
-        void CPACSMaterial::SetSig11c_choice2(const double& value)
-        {
-            m_sig11c_choice2 = value;
-        }
-        
         void CPACSMaterial::SetSig11c_choice2(const boost::optional<double>& value)
         {
             m_sig11c_choice2 = value;
@@ -1112,11 +1047,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetSig22t_choice2() const
         {
             return m_sig22t_choice2;
-        }
-        
-        void CPACSMaterial::SetSig22t_choice2(const double& value)
-        {
-            m_sig22t_choice2 = value;
         }
         
         void CPACSMaterial::SetSig22t_choice2(const boost::optional<double>& value)
@@ -1129,11 +1059,6 @@ namespace tigl
             return m_sig22c_choice2;
         }
         
-        void CPACSMaterial::SetSig22c_choice2(const double& value)
-        {
-            m_sig22c_choice2 = value;
-        }
-        
         void CPACSMaterial::SetSig22c_choice2(const boost::optional<double>& value)
         {
             m_sig22c_choice2 = value;
@@ -1142,11 +1067,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetTau12_choice2() const
         {
             return m_tau12_choice2;
-        }
-        
-        void CPACSMaterial::SetTau12_choice2(const double& value)
-        {
-            m_tau12_choice2 = value;
         }
         
         void CPACSMaterial::SetTau12_choice2(const boost::optional<double>& value)
@@ -1159,11 +1079,6 @@ namespace tigl
             return m_tau23_choice2;
         }
         
-        void CPACSMaterial::SetTau23_choice2(const double& value)
-        {
-            m_tau23_choice2 = value;
-        }
-        
         void CPACSMaterial::SetTau23_choice2(const boost::optional<double>& value)
         {
             m_tau23_choice2 = value;
@@ -1172,11 +1087,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetK13_choice3() const
         {
             return m_k13_choice3;
-        }
-        
-        void CPACSMaterial::SetK13_choice3(const double& value)
-        {
-            m_k13_choice3 = value;
         }
         
         void CPACSMaterial::SetK13_choice3(const boost::optional<double>& value)
@@ -1189,11 +1099,6 @@ namespace tigl
             return m_k22_choice3;
         }
         
-        void CPACSMaterial::SetK22_choice3(const double& value)
-        {
-            m_k22_choice3 = value;
-        }
-        
         void CPACSMaterial::SetK22_choice3(const boost::optional<double>& value)
         {
             m_k22_choice3 = value;
@@ -1202,11 +1107,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetK23_choice3() const
         {
             return m_k23_choice3;
-        }
-        
-        void CPACSMaterial::SetK23_choice3(const double& value)
-        {
-            m_k23_choice3 = value;
         }
         
         void CPACSMaterial::SetK23_choice3(const boost::optional<double>& value)
@@ -1219,11 +1119,6 @@ namespace tigl
             return m_k33_choice3;
         }
         
-        void CPACSMaterial::SetK33_choice3(const double& value)
-        {
-            m_k33_choice3 = value;
-        }
-        
         void CPACSMaterial::SetK33_choice3(const boost::optional<double>& value)
         {
             m_k33_choice3 = value;
@@ -1232,11 +1127,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetK44_choice3() const
         {
             return m_k44_choice3;
-        }
-        
-        void CPACSMaterial::SetK44_choice3(const double& value)
-        {
-            m_k44_choice3 = value;
         }
         
         void CPACSMaterial::SetK44_choice3(const boost::optional<double>& value)
@@ -1249,11 +1139,6 @@ namespace tigl
             return m_k55_choice3;
         }
         
-        void CPACSMaterial::SetK55_choice3(const double& value)
-        {
-            m_k55_choice3 = value;
-        }
-        
         void CPACSMaterial::SetK55_choice3(const boost::optional<double>& value)
         {
             m_k55_choice3 = value;
@@ -1262,11 +1147,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetK66_choice3() const
         {
             return m_k66_choice3;
-        }
-        
-        void CPACSMaterial::SetK66_choice3(const double& value)
-        {
-            m_k66_choice3 = value;
         }
         
         void CPACSMaterial::SetK66_choice3(const boost::optional<double>& value)
@@ -1279,11 +1159,6 @@ namespace tigl
             return m_sig11t_choice3;
         }
         
-        void CPACSMaterial::SetSig11t_choice3(const double& value)
-        {
-            m_sig11t_choice3 = value;
-        }
-        
         void CPACSMaterial::SetSig11t_choice3(const boost::optional<double>& value)
         {
             m_sig11t_choice3 = value;
@@ -1292,11 +1167,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetSig11c_choice3() const
         {
             return m_sig11c_choice3;
-        }
-        
-        void CPACSMaterial::SetSig11c_choice3(const double& value)
-        {
-            m_sig11c_choice3 = value;
         }
         
         void CPACSMaterial::SetSig11c_choice3(const boost::optional<double>& value)
@@ -1309,11 +1179,6 @@ namespace tigl
             return m_sig22t_choice3;
         }
         
-        void CPACSMaterial::SetSig22t_choice3(const double& value)
-        {
-            m_sig22t_choice3 = value;
-        }
-        
         void CPACSMaterial::SetSig22t_choice3(const boost::optional<double>& value)
         {
             m_sig22t_choice3 = value;
@@ -1322,11 +1187,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetSig22c_choice3() const
         {
             return m_sig22c_choice3;
-        }
-        
-        void CPACSMaterial::SetSig22c_choice3(const double& value)
-        {
-            m_sig22c_choice3 = value;
         }
         
         void CPACSMaterial::SetSig22c_choice3(const boost::optional<double>& value)
@@ -1339,11 +1199,6 @@ namespace tigl
             return m_sig33t_choice3;
         }
         
-        void CPACSMaterial::SetSig33t_choice3(const double& value)
-        {
-            m_sig33t_choice3 = value;
-        }
-        
         void CPACSMaterial::SetSig33t_choice3(const boost::optional<double>& value)
         {
             m_sig33t_choice3 = value;
@@ -1352,11 +1207,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetSig33c_choice3() const
         {
             return m_sig33c_choice3;
-        }
-        
-        void CPACSMaterial::SetSig33c_choice3(const double& value)
-        {
-            m_sig33c_choice3 = value;
         }
         
         void CPACSMaterial::SetSig33c_choice3(const boost::optional<double>& value)
@@ -1369,11 +1219,6 @@ namespace tigl
             return m_tau12_choice3;
         }
         
-        void CPACSMaterial::SetTau12_choice3(const double& value)
-        {
-            m_tau12_choice3 = value;
-        }
-        
         void CPACSMaterial::SetTau12_choice3(const boost::optional<double>& value)
         {
             m_tau12_choice3 = value;
@@ -1384,11 +1229,6 @@ namespace tigl
             return m_tau13_choice3;
         }
         
-        void CPACSMaterial::SetTau13_choice3(const double& value)
-        {
-            m_tau13_choice3 = value;
-        }
-        
         void CPACSMaterial::SetTau13_choice3(const boost::optional<double>& value)
         {
             m_tau13_choice3 = value;
@@ -1397,11 +1237,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterial::GetTau23_choice3() const
         {
             return m_tau23_choice3;
-        }
-        
-        void CPACSMaterial::SetTau23_choice3(const double& value)
-        {
-            m_tau23_choice3 = value;
         }
         
         void CPACSMaterial::SetTau23_choice3(const boost::optional<double>& value)

--- a/src/generated/CPACSMaterial.h
+++ b/src/generated/CPACSMaterial.h
@@ -61,7 +61,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const double& GetRho() const;
@@ -74,18 +73,15 @@ namespace tigl
             TIGL_EXPORT virtual void SetK12(const double& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetMaxStrain() const;
-            TIGL_EXPORT virtual void SetMaxStrain(const double& value);
             TIGL_EXPORT virtual void SetMaxStrain(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetFatigueFactor() const;
-            TIGL_EXPORT virtual void SetFatigueFactor(const double& value);
             TIGL_EXPORT virtual void SetFatigueFactor(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const std::vector<unique_ptr<CPACSPostFailure> >& GetPostFailures() const;
             TIGL_EXPORT virtual std::vector<unique_ptr<CPACSPostFailure> >& GetPostFailures();
             
             TIGL_EXPORT virtual const boost::optional<double>& GetThermalConductivity() const;
-            TIGL_EXPORT virtual void SetThermalConductivity(const double& value);
             TIGL_EXPORT virtual void SetThermalConductivity(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<CPACSSpecificHeatMap>& GetSpecificHeatMap() const;
@@ -95,119 +91,90 @@ namespace tigl
             TIGL_EXPORT virtual boost::optional<CPACSEmissivityMap>& GetEmissivityMap();
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11_choice1() const;
-            TIGL_EXPORT virtual void SetSig11_choice1(const double& value);
             TIGL_EXPORT virtual void SetSig11_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTau12_choice1() const;
-            TIGL_EXPORT virtual void SetTau12_choice1(const double& value);
             TIGL_EXPORT virtual void SetTau12_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11yieldT_choice1() const;
-            TIGL_EXPORT virtual void SetSig11yieldT_choice1(const double& value);
             TIGL_EXPORT virtual void SetSig11yieldT_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11yieldC_choice1() const;
-            TIGL_EXPORT virtual void SetSig11yieldC_choice1(const double& value);
             TIGL_EXPORT virtual void SetSig11yieldC_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK22_choice2() const;
-            TIGL_EXPORT virtual void SetK22_choice2(const double& value);
             TIGL_EXPORT virtual void SetK22_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK23_choice2() const;
-            TIGL_EXPORT virtual void SetK23_choice2(const double& value);
             TIGL_EXPORT virtual void SetK23_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK66_choice2() const;
-            TIGL_EXPORT virtual void SetK66_choice2(const double& value);
             TIGL_EXPORT virtual void SetK66_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11t_choice2() const;
-            TIGL_EXPORT virtual void SetSig11t_choice2(const double& value);
             TIGL_EXPORT virtual void SetSig11t_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11c_choice2() const;
-            TIGL_EXPORT virtual void SetSig11c_choice2(const double& value);
             TIGL_EXPORT virtual void SetSig11c_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig22t_choice2() const;
-            TIGL_EXPORT virtual void SetSig22t_choice2(const double& value);
             TIGL_EXPORT virtual void SetSig22t_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig22c_choice2() const;
-            TIGL_EXPORT virtual void SetSig22c_choice2(const double& value);
             TIGL_EXPORT virtual void SetSig22c_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTau12_choice2() const;
-            TIGL_EXPORT virtual void SetTau12_choice2(const double& value);
             TIGL_EXPORT virtual void SetTau12_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTau23_choice2() const;
-            TIGL_EXPORT virtual void SetTau23_choice2(const double& value);
             TIGL_EXPORT virtual void SetTau23_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK13_choice3() const;
-            TIGL_EXPORT virtual void SetK13_choice3(const double& value);
             TIGL_EXPORT virtual void SetK13_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK22_choice3() const;
-            TIGL_EXPORT virtual void SetK22_choice3(const double& value);
             TIGL_EXPORT virtual void SetK22_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK23_choice3() const;
-            TIGL_EXPORT virtual void SetK23_choice3(const double& value);
             TIGL_EXPORT virtual void SetK23_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK33_choice3() const;
-            TIGL_EXPORT virtual void SetK33_choice3(const double& value);
             TIGL_EXPORT virtual void SetK33_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK44_choice3() const;
-            TIGL_EXPORT virtual void SetK44_choice3(const double& value);
             TIGL_EXPORT virtual void SetK44_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK55_choice3() const;
-            TIGL_EXPORT virtual void SetK55_choice3(const double& value);
             TIGL_EXPORT virtual void SetK55_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetK66_choice3() const;
-            TIGL_EXPORT virtual void SetK66_choice3(const double& value);
             TIGL_EXPORT virtual void SetK66_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11t_choice3() const;
-            TIGL_EXPORT virtual void SetSig11t_choice3(const double& value);
             TIGL_EXPORT virtual void SetSig11t_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig11c_choice3() const;
-            TIGL_EXPORT virtual void SetSig11c_choice3(const double& value);
             TIGL_EXPORT virtual void SetSig11c_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig22t_choice3() const;
-            TIGL_EXPORT virtual void SetSig22t_choice3(const double& value);
             TIGL_EXPORT virtual void SetSig22t_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig22c_choice3() const;
-            TIGL_EXPORT virtual void SetSig22c_choice3(const double& value);
             TIGL_EXPORT virtual void SetSig22c_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig33t_choice3() const;
-            TIGL_EXPORT virtual void SetSig33t_choice3(const double& value);
             TIGL_EXPORT virtual void SetSig33t_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSig33c_choice3() const;
-            TIGL_EXPORT virtual void SetSig33c_choice3(const double& value);
             TIGL_EXPORT virtual void SetSig33c_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTau12_choice3() const;
-            TIGL_EXPORT virtual void SetTau12_choice3(const double& value);
             TIGL_EXPORT virtual void SetTau12_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTau13_choice3() const;
-            TIGL_EXPORT virtual void SetTau13_choice3(const double& value);
             TIGL_EXPORT virtual void SetTau13_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetTau23_choice3() const;
-            TIGL_EXPORT virtual void SetTau23_choice3(const double& value);
             TIGL_EXPORT virtual void SetTau23_choice3(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual CPACSPostFailure& AddPostFailure();

--- a/src/generated/CPACSMaterialDefinition.cpp
+++ b/src/generated/CPACSMaterialDefinition.cpp
@@ -167,11 +167,6 @@ namespace tigl
             return m_compositeUID_choice1;
         }
         
-        void CPACSMaterialDefinition::SetCompositeUID_choice1(const std::string& value)
-        {
-            m_compositeUID_choice1 = value;
-        }
-        
         void CPACSMaterialDefinition::SetCompositeUID_choice1(const boost::optional<std::string>& value)
         {
             m_compositeUID_choice1 = value;
@@ -180,11 +175,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterialDefinition::GetOrthotropyDirection_choice1() const
         {
             return m_orthotropyDirection_choice1;
-        }
-        
-        void CPACSMaterialDefinition::SetOrthotropyDirection_choice1(const double& value)
-        {
-            m_orthotropyDirection_choice1 = value;
         }
         
         void CPACSMaterialDefinition::SetOrthotropyDirection_choice1(const boost::optional<double>& value)
@@ -197,11 +187,6 @@ namespace tigl
             return m_thicknessScaling_choice1;
         }
         
-        void CPACSMaterialDefinition::SetThicknessScaling_choice1(const double& value)
-        {
-            m_thicknessScaling_choice1 = value;
-        }
-        
         void CPACSMaterialDefinition::SetThicknessScaling_choice1(const boost::optional<double>& value)
         {
             m_thicknessScaling_choice1 = value;
@@ -212,11 +197,6 @@ namespace tigl
             return m_materialUID_choice2;
         }
         
-        void CPACSMaterialDefinition::SetMaterialUID_choice2(const std::string& value)
-        {
-            m_materialUID_choice2 = value;
-        }
-        
         void CPACSMaterialDefinition::SetMaterialUID_choice2(const boost::optional<std::string>& value)
         {
             m_materialUID_choice2 = value;
@@ -225,11 +205,6 @@ namespace tigl
         const boost::optional<double>& CPACSMaterialDefinition::GetThickness_choice2() const
         {
             return m_thickness_choice2;
-        }
-        
-        void CPACSMaterialDefinition::SetThickness_choice2(const double& value)
-        {
-            m_thickness_choice2 = value;
         }
         
         void CPACSMaterialDefinition::SetThickness_choice2(const boost::optional<double>& value)

--- a/src/generated/CPACSMaterialDefinition.h
+++ b/src/generated/CPACSMaterialDefinition.h
@@ -49,23 +49,18 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetCompositeUID_choice1() const;
-            TIGL_EXPORT virtual void SetCompositeUID_choice1(const std::string& value);
             TIGL_EXPORT virtual void SetCompositeUID_choice1(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetOrthotropyDirection_choice1() const;
-            TIGL_EXPORT virtual void SetOrthotropyDirection_choice1(const double& value);
             TIGL_EXPORT virtual void SetOrthotropyDirection_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetThicknessScaling_choice1() const;
-            TIGL_EXPORT virtual void SetThicknessScaling_choice1(const double& value);
             TIGL_EXPORT virtual void SetThicknessScaling_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetMaterialUID_choice2() const;
-            TIGL_EXPORT virtual void SetMaterialUID_choice2(const std::string& value);
             TIGL_EXPORT virtual void SetMaterialUID_choice2(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetThickness_choice2() const;
-            TIGL_EXPORT virtual void SetThickness_choice2(const double& value);
             TIGL_EXPORT virtual void SetThickness_choice2(const boost::optional<double>& value);
             
         protected:

--- a/src/generated/CPACSPoint.cpp
+++ b/src/generated/CPACSPoint.cpp
@@ -130,11 +130,6 @@ namespace tigl
             return m_x;
         }
         
-        void CPACSPoint::SetX(const double& value)
-        {
-            m_x = value;
-        }
-        
         void CPACSPoint::SetX(const boost::optional<double>& value)
         {
             m_x = value;
@@ -145,11 +140,6 @@ namespace tigl
             return m_y;
         }
         
-        void CPACSPoint::SetY(const double& value)
-        {
-            m_y = value;
-        }
-        
         void CPACSPoint::SetY(const boost::optional<double>& value)
         {
             m_y = value;
@@ -158,11 +148,6 @@ namespace tigl
         const boost::optional<double>& CPACSPoint::GetZ() const
         {
             return m_z;
-        }
-        
-        void CPACSPoint::SetZ(const double& value)
-        {
-            m_z = value;
         }
         
         void CPACSPoint::SetZ(const boost::optional<double>& value)

--- a/src/generated/CPACSPoint.h
+++ b/src/generated/CPACSPoint.h
@@ -49,15 +49,12 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetX() const;
-            TIGL_EXPORT virtual void SetX(const double& value);
             TIGL_EXPORT virtual void SetX(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetY() const;
-            TIGL_EXPORT virtual void SetY(const double& value);
             TIGL_EXPORT virtual void SetY(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetZ() const;
-            TIGL_EXPORT virtual void SetZ(const double& value);
             TIGL_EXPORT virtual void SetZ(const boost::optional<double>& value);
             
         protected:

--- a/src/generated/CPACSPointAbsRel.cpp
+++ b/src/generated/CPACSPointAbsRel.cpp
@@ -144,11 +144,6 @@ namespace tigl
             return m_refType;
         }
         
-        void CPACSPointAbsRel::SetRefType(const ECPACSTranslationType& value)
-        {
-            m_refType = value;
-        }
-        
         void CPACSPointAbsRel::SetRefType(const boost::optional<ECPACSTranslationType>& value)
         {
             m_refType = value;
@@ -157,11 +152,6 @@ namespace tigl
         const boost::optional<double>& CPACSPointAbsRel::GetX() const
         {
             return m_x;
-        }
-        
-        void CPACSPointAbsRel::SetX(const double& value)
-        {
-            m_x = value;
         }
         
         void CPACSPointAbsRel::SetX(const boost::optional<double>& value)
@@ -174,11 +164,6 @@ namespace tigl
             return m_y;
         }
         
-        void CPACSPointAbsRel::SetY(const double& value)
-        {
-            m_y = value;
-        }
-        
         void CPACSPointAbsRel::SetY(const boost::optional<double>& value)
         {
             m_y = value;
@@ -187,11 +172,6 @@ namespace tigl
         const boost::optional<double>& CPACSPointAbsRel::GetZ() const
         {
             return m_z;
-        }
-        
-        void CPACSPointAbsRel::SetZ(const double& value)
-        {
-            m_z = value;
         }
         
         void CPACSPointAbsRel::SetZ(const boost::optional<double>& value)

--- a/src/generated/CPACSPointAbsRel.h
+++ b/src/generated/CPACSPointAbsRel.h
@@ -50,19 +50,15 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<ECPACSTranslationType>& GetRefType() const;
-            TIGL_EXPORT virtual void SetRefType(const ECPACSTranslationType& value);
             TIGL_EXPORT virtual void SetRefType(const boost::optional<ECPACSTranslationType>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetX() const;
-            TIGL_EXPORT virtual void SetX(const double& value);
             TIGL_EXPORT virtual void SetX(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetY() const;
-            TIGL_EXPORT virtual void SetY(const double& value);
             TIGL_EXPORT virtual void SetY(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetZ() const;
-            TIGL_EXPORT virtual void SetZ(const double& value);
             TIGL_EXPORT virtual void SetZ(const boost::optional<double>& value);
             
         protected:

--- a/src/generated/CPACSPositioning.cpp
+++ b/src/generated/CPACSPositioning.cpp
@@ -200,11 +200,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSPositioning::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSPositioning::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -243,11 +238,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSPositioning::GetFromSectionUID() const
         {
             return m_fromSectionUID;
-        }
-        
-        void CPACSPositioning::SetFromSectionUID(const std::string& value)
-        {
-            m_fromSectionUID = value;
         }
         
         void CPACSPositioning::SetFromSectionUID(const boost::optional<std::string>& value)

--- a/src/generated/CPACSPositioning.h
+++ b/src/generated/CPACSPositioning.h
@@ -52,7 +52,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const double& GetLength() const;
@@ -65,7 +64,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetDihedralAngle(const double& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetFromSectionUID() const;
-            TIGL_EXPORT virtual void SetFromSectionUID(const std::string& value);
             TIGL_EXPORT virtual void SetFromSectionUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetToSectionUID() const;

--- a/src/generated/CPACSPostFailure.cpp
+++ b/src/generated/CPACSPostFailure.cpp
@@ -247,11 +247,6 @@ namespace tigl
             return m_name;
         }
         
-        void CPACSPostFailure::SetName(const std::string& value)
-        {
-            m_name = value;
-        }
-        
         void CPACSPostFailure::SetName(const boost::optional<std::string>& value)
         {
             m_name = value;
@@ -260,11 +255,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSPostFailure::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSPostFailure::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSPostFailure::SetDescription(const boost::optional<std::string>& value)
@@ -277,11 +267,6 @@ namespace tigl
             return m_materialLaw;
         }
         
-        void CPACSPostFailure::SetMaterialLaw(const std::string& value)
-        {
-            m_materialLaw = value;
-        }
-        
         void CPACSPostFailure::SetMaterialLaw(const boost::optional<std::string>& value)
         {
             m_materialLaw = value;
@@ -290,11 +275,6 @@ namespace tigl
         const boost::optional<double>& CPACSPostFailure::GetPlasticEliminationStrain_choice1() const
         {
             return m_plasticEliminationStrain_choice1;
-        }
-        
-        void CPACSPostFailure::SetPlasticEliminationStrain_choice1(const double& value)
-        {
-            m_plasticEliminationStrain_choice1 = value;
         }
         
         void CPACSPostFailure::SetPlasticEliminationStrain_choice1(const boost::optional<double>& value)
@@ -317,11 +297,6 @@ namespace tigl
             return m_initialEquivalentShearStrain_choice2;
         }
         
-        void CPACSPostFailure::SetInitialEquivalentShearStrain_choice2(const double& value)
-        {
-            m_initialEquivalentShearStrain_choice2 = value;
-        }
-        
         void CPACSPostFailure::SetInitialEquivalentShearStrain_choice2(const boost::optional<double>& value)
         {
             m_initialEquivalentShearStrain_choice2 = value;
@@ -330,11 +305,6 @@ namespace tigl
         const boost::optional<double>& CPACSPostFailure::GetIntermediateEquivalentShearStrain_choice2() const
         {
             return m_intermediateEquivalentShearStrain_choice2;
-        }
-        
-        void CPACSPostFailure::SetIntermediateEquivalentShearStrain_choice2(const double& value)
-        {
-            m_intermediateEquivalentShearStrain_choice2 = value;
         }
         
         void CPACSPostFailure::SetIntermediateEquivalentShearStrain_choice2(const boost::optional<double>& value)
@@ -347,11 +317,6 @@ namespace tigl
             return m_ultimateEquivalentShearStrain_choice2;
         }
         
-        void CPACSPostFailure::SetUltimateEquivalentShearStrain_choice2(const double& value)
-        {
-            m_ultimateEquivalentShearStrain_choice2 = value;
-        }
-        
         void CPACSPostFailure::SetUltimateEquivalentShearStrain_choice2(const boost::optional<double>& value)
         {
             m_ultimateEquivalentShearStrain_choice2 = value;
@@ -362,11 +327,6 @@ namespace tigl
             return m_intermediateDamage_choice2;
         }
         
-        void CPACSPostFailure::SetIntermediateDamage_choice2(const double& value)
-        {
-            m_intermediateDamage_choice2 = value;
-        }
-        
         void CPACSPostFailure::SetIntermediateDamage_choice2(const boost::optional<double>& value)
         {
             m_intermediateDamage_choice2 = value;
@@ -375,11 +335,6 @@ namespace tigl
         const boost::optional<double>& CPACSPostFailure::GetUltimateDamage_choice2() const
         {
             return m_ultimateDamage_choice2;
-        }
-        
-        void CPACSPostFailure::SetUltimateDamage_choice2(const double& value)
-        {
-            m_ultimateDamage_choice2 = value;
         }
         
         void CPACSPostFailure::SetUltimateDamage_choice2(const boost::optional<double>& value)

--- a/src/generated/CPACSPostFailure.h
+++ b/src/generated/CPACSPostFailure.h
@@ -47,42 +47,33 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetName() const;
-            TIGL_EXPORT virtual void SetName(const std::string& value);
             TIGL_EXPORT virtual void SetName(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetMaterialLaw() const;
-            TIGL_EXPORT virtual void SetMaterialLaw(const std::string& value);
             TIGL_EXPORT virtual void SetMaterialLaw(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetPlasticEliminationStrain_choice1() const;
-            TIGL_EXPORT virtual void SetPlasticEliminationStrain_choice1(const double& value);
             TIGL_EXPORT virtual void SetPlasticEliminationStrain_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const std::vector<unique_ptr<CPACSPlasticityCurvePoint> >& GetPlasticityCurvePoints_choice1() const;
             TIGL_EXPORT virtual std::vector<unique_ptr<CPACSPlasticityCurvePoint> >& GetPlasticityCurvePoints_choice1();
             
             TIGL_EXPORT virtual const boost::optional<double>& GetInitialEquivalentShearStrain_choice2() const;
-            TIGL_EXPORT virtual void SetInitialEquivalentShearStrain_choice2(const double& value);
             TIGL_EXPORT virtual void SetInitialEquivalentShearStrain_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetIntermediateEquivalentShearStrain_choice2() const;
-            TIGL_EXPORT virtual void SetIntermediateEquivalentShearStrain_choice2(const double& value);
             TIGL_EXPORT virtual void SetIntermediateEquivalentShearStrain_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetUltimateEquivalentShearStrain_choice2() const;
-            TIGL_EXPORT virtual void SetUltimateEquivalentShearStrain_choice2(const double& value);
             TIGL_EXPORT virtual void SetUltimateEquivalentShearStrain_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetIntermediateDamage_choice2() const;
-            TIGL_EXPORT virtual void SetIntermediateDamage_choice2(const double& value);
             TIGL_EXPORT virtual void SetIntermediateDamage_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetUltimateDamage_choice2() const;
-            TIGL_EXPORT virtual void SetUltimateDamage_choice2(const double& value);
             TIGL_EXPORT virtual void SetUltimateDamage_choice2(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual CPACSPlasticityCurvePoint& AddPlasticityCurvePoint_choice1();

--- a/src/generated/CPACSProfileGeometry.cpp
+++ b/src/generated/CPACSProfileGeometry.cpp
@@ -193,11 +193,6 @@ namespace tigl
             return m_symmetry;
         }
         
-        void CPACSProfileGeometry::SetSymmetry(const TiglSymmetryAxis& value)
-        {
-            m_symmetry = value;
-        }
-        
         void CPACSProfileGeometry::SetSymmetry(const boost::optional<TiglSymmetryAxis>& value)
         {
             m_symmetry = value;
@@ -230,11 +225,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSProfileGeometry::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSProfileGeometry::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSProfileGeometry::SetDescription(const boost::optional<std::string>& value)

--- a/src/generated/CPACSProfileGeometry.h
+++ b/src/generated/CPACSProfileGeometry.h
@@ -56,7 +56,6 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<TiglSymmetryAxis>& GetSymmetry() const;
-            TIGL_EXPORT virtual void SetSymmetry(const TiglSymmetryAxis& value);
             TIGL_EXPORT virtual void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value);
             
             TIGL_EXPORT virtual const std::string& GetUID() const;
@@ -66,7 +65,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<CCPACSPointListXYZ>& GetPointList_choice1() const;

--- a/src/generated/CPACSRibRotation.cpp
+++ b/src/generated/CPACSRibRotation.cpp
@@ -80,11 +80,6 @@ namespace tigl
             return m_ribRotationReference;
         }
         
-        void CPACSRibRotation::SetRibRotationReference(const CPACSRibRotation_ribRotationReference& value)
-        {
-            m_ribRotationReference = value;
-        }
-        
         void CPACSRibRotation::SetRibRotationReference(const boost::optional<CPACSRibRotation_ribRotationReference>& value)
         {
             m_ribRotationReference = value;

--- a/src/generated/CPACSRibRotation.h
+++ b/src/generated/CPACSRibRotation.h
@@ -47,7 +47,6 @@ namespace tigl
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
             TIGL_EXPORT virtual const boost::optional<CPACSRibRotation_ribRotationReference>& GetRibRotationReference() const;
-            TIGL_EXPORT virtual void SetRibRotationReference(const CPACSRibRotation_ribRotationReference& value);
             TIGL_EXPORT virtual void SetRibRotationReference(const boost::optional<CPACSRibRotation_ribRotationReference>& value);
             
             TIGL_EXPORT virtual const double& GetZ() const;

--- a/src/generated/CPACSRotor.cpp
+++ b/src/generated/CPACSRotor.cpp
@@ -217,11 +217,6 @@ namespace tigl
             return m_symmetry;
         }
         
-        void CPACSRotor::SetSymmetry(const TiglSymmetryAxis& value)
-        {
-            m_symmetry = value;
-        }
-        
         void CPACSRotor::SetSymmetry(const boost::optional<TiglSymmetryAxis>& value)
         {
             m_symmetry = value;
@@ -242,11 +237,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSRotor::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSRotor::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -255,11 +245,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSRotor::GetParentUID() const
         {
             return m_parentUID;
-        }
-        
-        void CPACSRotor::SetParentUID(const std::string& value)
-        {
-            m_parentUID = value;
         }
         
         void CPACSRotor::SetParentUID(const boost::optional<std::string>& value)
@@ -272,11 +257,6 @@ namespace tigl
             return m_type;
         }
         
-        void CPACSRotor::SetType(const CPACSRotor_type& value)
-        {
-            m_type = value;
-        }
-        
         void CPACSRotor::SetType(const boost::optional<CPACSRotor_type>& value)
         {
             m_type = value;
@@ -285,11 +265,6 @@ namespace tigl
         const boost::optional<double>& CPACSRotor::GetNominalRotationsPerMinute() const
         {
             return m_nominalRotationsPerMinute;
-        }
-        
-        void CPACSRotor::SetNominalRotationsPerMinute(const double& value)
-        {
-            m_nominalRotationsPerMinute = value;
         }
         
         void CPACSRotor::SetNominalRotationsPerMinute(const boost::optional<double>& value)

--- a/src/generated/CPACSRotor.h
+++ b/src/generated/CPACSRotor.h
@@ -57,26 +57,21 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<TiglSymmetryAxis>& GetSymmetry() const;
-            TIGL_EXPORT virtual void SetSymmetry(const TiglSymmetryAxis& value);
             TIGL_EXPORT virtual void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value);
             
             TIGL_EXPORT virtual const std::string& GetName() const;
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetParentUID() const;
-            TIGL_EXPORT virtual void SetParentUID(const std::string& value);
             TIGL_EXPORT virtual void SetParentUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<CPACSRotor_type>& GetType() const;
-            TIGL_EXPORT virtual void SetType(const CPACSRotor_type& value);
             TIGL_EXPORT virtual void SetType(const boost::optional<CPACSRotor_type>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetNominalRotationsPerMinute() const;
-            TIGL_EXPORT virtual void SetNominalRotationsPerMinute(const double& value);
             TIGL_EXPORT virtual void SetNominalRotationsPerMinute(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;

--- a/src/generated/CPACSRotorBladeAttachment.cpp
+++ b/src/generated/CPACSRotorBladeAttachment.cpp
@@ -237,11 +237,6 @@ namespace tigl
             return m_name;
         }
         
-        void CPACSRotorBladeAttachment::SetName(const std::string& value)
-        {
-            m_name = value;
-        }
-        
         void CPACSRotorBladeAttachment::SetName(const boost::optional<std::string>& value)
         {
             m_name = value;
@@ -250,11 +245,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSRotorBladeAttachment::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSRotorBladeAttachment::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSRotorBladeAttachment::SetDescription(const boost::optional<std::string>& value)
@@ -295,11 +285,6 @@ namespace tigl
         const boost::optional<int>& CPACSRotorBladeAttachment::GetNumberOfBlades_choice2() const
         {
             return m_numberOfBlades_choice2;
-        }
-        
-        void CPACSRotorBladeAttachment::SetNumberOfBlades_choice2(const int& value)
-        {
-            m_numberOfBlades_choice2 = value;
         }
         
         void CPACSRotorBladeAttachment::SetNumberOfBlades_choice2(const boost::optional<int>& value)

--- a/src/generated/CPACSRotorBladeAttachment.h
+++ b/src/generated/CPACSRotorBladeAttachment.h
@@ -58,11 +58,9 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetName() const;
-            TIGL_EXPORT virtual void SetName(const std::string& value);
             TIGL_EXPORT virtual void SetName(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<CCPACSRotorHinges>& GetHinges() const;
@@ -75,7 +73,6 @@ namespace tigl
             TIGL_EXPORT virtual boost::optional<CCPACSStringVector>& GetAzimuthAngles_choice1();
             
             TIGL_EXPORT virtual const boost::optional<int>& GetNumberOfBlades_choice2() const;
-            TIGL_EXPORT virtual void SetNumberOfBlades_choice2(const int& value);
             TIGL_EXPORT virtual void SetNumberOfBlades_choice2(const boost::optional<int>& value);
             
             TIGL_EXPORT virtual CCPACSRotorHinges& GetHinges(CreateIfNotExistsTag);

--- a/src/generated/CPACSRotorHub.cpp
+++ b/src/generated/CPACSRotorHub.cpp
@@ -160,11 +160,6 @@ namespace tigl
             return m_name;
         }
         
-        void CPACSRotorHub::SetName(const std::string& value)
-        {
-            m_name = value;
-        }
-        
         void CPACSRotorHub::SetName(const boost::optional<std::string>& value)
         {
             m_name = value;
@@ -175,11 +170,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSRotorHub::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSRotorHub::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -188,11 +178,6 @@ namespace tigl
         const boost::optional<TiglRotorHubType>& CPACSRotorHub::GetType() const
         {
             return m_type;
-        }
-        
-        void CPACSRotorHub::SetType(const TiglRotorHubType& value)
-        {
-            m_type = value;
         }
         
         void CPACSRotorHub::SetType(const boost::optional<TiglRotorHubType>& value)

--- a/src/generated/CPACSRotorHub.h
+++ b/src/generated/CPACSRotorHub.h
@@ -55,15 +55,12 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetName() const;
-            TIGL_EXPORT virtual void SetName(const std::string& value);
             TIGL_EXPORT virtual void SetName(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<TiglRotorHubType>& GetType() const;
-            TIGL_EXPORT virtual void SetType(const TiglRotorHubType& value);
             TIGL_EXPORT virtual void SetType(const boost::optional<TiglRotorHubType>& value);
             
             TIGL_EXPORT virtual const CCPACSRotorBladeAttachments& GetRotorBladeAttachments() const;

--- a/src/generated/CPACSRotorHubHinge.cpp
+++ b/src/generated/CPACSRotorHubHinge.cpp
@@ -217,11 +217,6 @@ namespace tigl
             return m_name;
         }
         
-        void CPACSRotorHubHinge::SetName(const std::string& value)
-        {
-            m_name = value;
-        }
-        
         void CPACSRotorHubHinge::SetName(const boost::optional<std::string>& value)
         {
             m_name = value;
@@ -230,11 +225,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSRotorHubHinge::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSRotorHubHinge::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSRotorHubHinge::SetDescription(const boost::optional<std::string>& value)
@@ -267,11 +257,6 @@ namespace tigl
             return m_neutralPosition;
         }
         
-        void CPACSRotorHubHinge::SetNeutralPosition(const double& value)
-        {
-            m_neutralPosition = value;
-        }
-        
         void CPACSRotorHubHinge::SetNeutralPosition(const boost::optional<double>& value)
         {
             m_neutralPosition = value;
@@ -280,11 +265,6 @@ namespace tigl
         const boost::optional<double>& CPACSRotorHubHinge::GetStaticStiffness() const
         {
             return m_staticStiffness;
-        }
-        
-        void CPACSRotorHubHinge::SetStaticStiffness(const double& value)
-        {
-            m_staticStiffness = value;
         }
         
         void CPACSRotorHubHinge::SetStaticStiffness(const boost::optional<double>& value)
@@ -297,11 +277,6 @@ namespace tigl
             return m_dynamicStiffness;
         }
         
-        void CPACSRotorHubHinge::SetDynamicStiffness(const double& value)
-        {
-            m_dynamicStiffness = value;
-        }
-        
         void CPACSRotorHubHinge::SetDynamicStiffness(const boost::optional<double>& value)
         {
             m_dynamicStiffness = value;
@@ -310,11 +285,6 @@ namespace tigl
         const boost::optional<double>& CPACSRotorHubHinge::GetDamping() const
         {
             return m_damping;
-        }
-        
-        void CPACSRotorHubHinge::SetDamping(const double& value)
-        {
-            m_damping = value;
         }
         
         void CPACSRotorHubHinge::SetDamping(const boost::optional<double>& value)

--- a/src/generated/CPACSRotorHubHinge.h
+++ b/src/generated/CPACSRotorHubHinge.h
@@ -55,11 +55,9 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetName() const;
-            TIGL_EXPORT virtual void SetName(const std::string& value);
             TIGL_EXPORT virtual void SetName(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;
@@ -69,19 +67,15 @@ namespace tigl
             TIGL_EXPORT virtual void SetType(const CPACSRotorHubHinge_type& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetNeutralPosition() const;
-            TIGL_EXPORT virtual void SetNeutralPosition(const double& value);
             TIGL_EXPORT virtual void SetNeutralPosition(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetStaticStiffness() const;
-            TIGL_EXPORT virtual void SetStaticStiffness(const double& value);
             TIGL_EXPORT virtual void SetStaticStiffness(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetDynamicStiffness() const;
-            TIGL_EXPORT virtual void SetDynamicStiffness(const double& value);
             TIGL_EXPORT virtual void SetDynamicStiffness(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetDamping() const;
-            TIGL_EXPORT virtual void SetDamping(const double& value);
             TIGL_EXPORT virtual void SetDamping(const boost::optional<double>& value);
             
         protected:

--- a/src/generated/CPACSRotorcraftModel.cpp
+++ b/src/generated/CPACSRotorcraftModel.cpp
@@ -212,11 +212,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSRotorcraftModel::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSRotorcraftModel::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSRotorcraftModel.h
+++ b/src/generated/CPACSRotorcraftModel.h
@@ -57,7 +57,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<CCPACSFuselages>& GetFuselages() const;

--- a/src/generated/CPACSSparPosition.cpp
+++ b/src/generated/CPACSSparPosition.cpp
@@ -164,15 +164,6 @@ namespace tigl
             return m_uID;
         }
         
-        void CPACSSparPosition::SetUID(const std::string& value)
-        {
-            if (m_uidMgr) {
-                if (m_uID) m_uidMgr->TryUnregisterObject(*m_uID);
-                m_uidMgr->RegisterObject(value, *this);
-            }
-            m_uID = value;
-        }
-        
         void CPACSSparPosition::SetUID(const boost::optional<std::string>& value)
         {
             if (m_uidMgr) {
@@ -197,11 +188,6 @@ namespace tigl
             return m_eta_choice1;
         }
         
-        void CPACSSparPosition::SetEta_choice1(const double& value)
-        {
-            m_eta_choice1 = value;
-        }
-        
         void CPACSSparPosition::SetEta_choice1(const boost::optional<double>& value)
         {
             m_eta_choice1 = value;
@@ -210,11 +196,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSSparPosition::GetElementUID_choice2() const
         {
             return m_elementUID_choice2;
-        }
-        
-        void CPACSSparPosition::SetElementUID_choice2(const std::string& value)
-        {
-            m_elementUID_choice2 = value;
         }
         
         void CPACSSparPosition::SetElementUID_choice2(const boost::optional<std::string>& value)

--- a/src/generated/CPACSSparPosition.h
+++ b/src/generated/CPACSSparPosition.h
@@ -52,18 +52,15 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetUID() const;
-            TIGL_EXPORT virtual void SetUID(const std::string& value);
             TIGL_EXPORT virtual void SetUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const double& GetXsi() const;
             TIGL_EXPORT virtual void SetXsi(const double& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetEta_choice1() const;
-            TIGL_EXPORT virtual void SetEta_choice1(const double& value);
             TIGL_EXPORT virtual void SetEta_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetElementUID_choice2() const;
-            TIGL_EXPORT virtual void SetElementUID_choice2(const std::string& value);
             TIGL_EXPORT virtual void SetElementUID_choice2(const boost::optional<std::string>& value);
             
         protected:

--- a/src/generated/CPACSSparSegment.cpp
+++ b/src/generated/CPACSSparSegment.cpp
@@ -140,15 +140,6 @@ namespace tigl
             return m_uID;
         }
         
-        void CPACSSparSegment::SetUID(const std::string& value)
-        {
-            if (m_uidMgr) {
-                if (m_uID) m_uidMgr->TryUnregisterObject(*m_uID);
-                m_uidMgr->RegisterObject(value, *this);
-            }
-            m_uID = value;
-        }
-        
         void CPACSSparSegment::SetUID(const boost::optional<std::string>& value)
         {
             if (m_uidMgr) {

--- a/src/generated/CPACSSparSegment.h
+++ b/src/generated/CPACSSparSegment.h
@@ -52,7 +52,6 @@ namespace tigl
             TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetUID() const;
-            TIGL_EXPORT virtual void SetUID(const std::string& value);
             TIGL_EXPORT virtual void SetUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetName() const;

--- a/src/generated/CPACSStringVectorBase.cpp
+++ b/src/generated/CPACSStringVectorBase.cpp
@@ -198,11 +198,6 @@ namespace tigl
             return m_mu;
         }
         
-        void CPACSStringVectorBase::SetMu(const std::string& value)
-        {
-            m_mu = value;
-        }
-        
         void CPACSStringVectorBase::SetMu(const boost::optional<std::string>& value)
         {
             m_mu = value;
@@ -211,11 +206,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSStringVectorBase::GetDelta() const
         {
             return m_delta;
-        }
-        
-        void CPACSStringVectorBase::SetDelta(const std::string& value)
-        {
-            m_delta = value;
         }
         
         void CPACSStringVectorBase::SetDelta(const boost::optional<std::string>& value)
@@ -228,11 +218,6 @@ namespace tigl
             return m_a;
         }
         
-        void CPACSStringVectorBase::SetA(const std::string& value)
-        {
-            m_a = value;
-        }
-        
         void CPACSStringVectorBase::SetA(const boost::optional<std::string>& value)
         {
             m_a = value;
@@ -241,11 +226,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSStringVectorBase::GetB() const
         {
             return m_b;
-        }
-        
-        void CPACSStringVectorBase::SetB(const std::string& value)
-        {
-            m_b = value;
         }
         
         void CPACSStringVectorBase::SetB(const boost::optional<std::string>& value)
@@ -258,11 +238,6 @@ namespace tigl
             return m_c;
         }
         
-        void CPACSStringVectorBase::SetC(const std::string& value)
-        {
-            m_c = value;
-        }
-        
         void CPACSStringVectorBase::SetC(const boost::optional<std::string>& value)
         {
             m_c = value;
@@ -273,11 +248,6 @@ namespace tigl
             return m_v;
         }
         
-        void CPACSStringVectorBase::SetV(const std::string& value)
-        {
-            m_v = value;
-        }
-        
         void CPACSStringVectorBase::SetV(const boost::optional<std::string>& value)
         {
             m_v = value;
@@ -286,11 +256,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSStringVectorBase::GetW() const
         {
             return m_w;
-        }
-        
-        void CPACSStringVectorBase::SetW(const std::string& value)
-        {
-            m_w = value;
         }
         
         void CPACSStringVectorBase::SetW(const boost::optional<std::string>& value)

--- a/src/generated/CPACSStringVectorBase.h
+++ b/src/generated/CPACSStringVectorBase.h
@@ -51,31 +51,24 @@ namespace tigl
             TIGL_EXPORT virtual void SetMapType(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetMu() const;
-            TIGL_EXPORT virtual void SetMu(const std::string& value);
             TIGL_EXPORT virtual void SetMu(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDelta() const;
-            TIGL_EXPORT virtual void SetDelta(const std::string& value);
             TIGL_EXPORT virtual void SetDelta(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetA() const;
-            TIGL_EXPORT virtual void SetA(const std::string& value);
             TIGL_EXPORT virtual void SetA(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetB() const;
-            TIGL_EXPORT virtual void SetB(const std::string& value);
             TIGL_EXPORT virtual void SetB(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetC() const;
-            TIGL_EXPORT virtual void SetC(const std::string& value);
             TIGL_EXPORT virtual void SetC(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetV() const;
-            TIGL_EXPORT virtual void SetV(const std::string& value);
             TIGL_EXPORT virtual void SetV(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetW() const;
-            TIGL_EXPORT virtual void SetW(const std::string& value);
             TIGL_EXPORT virtual void SetW(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetSimpleContent() const;

--- a/src/generated/CPACSWing.cpp
+++ b/src/generated/CPACSWing.cpp
@@ -250,11 +250,6 @@ namespace tigl
             return m_symmetry;
         }
         
-        void CPACSWing::SetSymmetry(const TiglSymmetryAxis& value)
-        {
-            m_symmetry = value;
-        }
-        
         void CPACSWing::SetSymmetry(const boost::optional<TiglSymmetryAxis>& value)
         {
             m_symmetry = value;
@@ -275,11 +270,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSWing::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSWing::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;
@@ -288,11 +278,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSWing::GetParentUID() const
         {
             return m_parentUID;
-        }
-        
-        void CPACSWing::SetParentUID(const std::string& value)
-        {
-            m_parentUID = value;
         }
         
         void CPACSWing::SetParentUID(const boost::optional<std::string>& value)

--- a/src/generated/CPACSWing.h
+++ b/src/generated/CPACSWing.h
@@ -81,18 +81,15 @@ namespace tigl
             TIGL_EXPORT virtual void SetUID(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<TiglSymmetryAxis>& GetSymmetry() const;
-            TIGL_EXPORT virtual void SetSymmetry(const TiglSymmetryAxis& value);
             TIGL_EXPORT virtual void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value);
             
             TIGL_EXPORT virtual const std::string& GetName() const;
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetParentUID() const;
-            TIGL_EXPORT virtual void SetParentUID(const std::string& value);
             TIGL_EXPORT virtual void SetParentUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;

--- a/src/generated/CPACSWingElement.cpp
+++ b/src/generated/CPACSWingElement.cpp
@@ -167,11 +167,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSWingElement::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSWingElement::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSWingElement.h
+++ b/src/generated/CPACSWingElement.h
@@ -57,7 +57,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetAirfoilUID() const;

--- a/src/generated/CPACSWingRibsDefinition.cpp
+++ b/src/generated/CPACSWingRibsDefinition.cpp
@@ -206,15 +206,6 @@ namespace tigl
             return m_uID;
         }
         
-        void CPACSWingRibsDefinition::SetUID(const std::string& value)
-        {
-            if (m_uidMgr) {
-                if (m_uID) m_uidMgr->TryUnregisterObject(*m_uID);
-                m_uidMgr->RegisterObject(value, *this);
-            }
-            m_uID = value;
-        }
-        
         void CPACSWingRibsDefinition::SetUID(const boost::optional<std::string>& value)
         {
             if (m_uidMgr) {
@@ -237,11 +228,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSWingRibsDefinition::GetDescription() const
         {
             return m_description;
-        }
-        
-        void CPACSWingRibsDefinition::SetDescription(const std::string& value)
-        {
-            m_description = value;
         }
         
         void CPACSWingRibsDefinition::SetDescription(const boost::optional<std::string>& value)

--- a/src/generated/CPACSWingRibsDefinition.h
+++ b/src/generated/CPACSWingRibsDefinition.h
@@ -56,14 +56,12 @@ namespace tigl
             TIGL_EXPORT bool ValidateChoices() const;
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetUID() const;
-            TIGL_EXPORT virtual void SetUID(const std::string& value);
             TIGL_EXPORT virtual void SetUID(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetName() const;
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSWingRibCrossSection& GetRibCrossSection() const;

--- a/src/generated/CPACSWingRibsPositioning.cpp
+++ b/src/generated/CPACSWingRibsPositioning.cpp
@@ -415,11 +415,6 @@ namespace tigl
             return m_etaStart_choice1;
         }
         
-        void CPACSWingRibsPositioning::SetEtaStart_choice1(const double& value)
-        {
-            m_etaStart_choice1 = value;
-        }
-        
         void CPACSWingRibsPositioning::SetEtaStart_choice1(const boost::optional<double>& value)
         {
             m_etaStart_choice1 = value;
@@ -428,11 +423,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSWingRibsPositioning::GetElementStartUID_choice2() const
         {
             return m_elementStartUID_choice2;
-        }
-        
-        void CPACSWingRibsPositioning::SetElementStartUID_choice2(const std::string& value)
-        {
-            m_elementStartUID_choice2 = value;
         }
         
         void CPACSWingRibsPositioning::SetElementStartUID_choice2(const boost::optional<std::string>& value)
@@ -445,11 +435,6 @@ namespace tigl
             return m_sparPositionStartUID_choice3;
         }
         
-        void CPACSWingRibsPositioning::SetSparPositionStartUID_choice3(const std::string& value)
-        {
-            m_sparPositionStartUID_choice3 = value;
-        }
-        
         void CPACSWingRibsPositioning::SetSparPositionStartUID_choice3(const boost::optional<std::string>& value)
         {
             m_sparPositionStartUID_choice3 = value;
@@ -458,11 +443,6 @@ namespace tigl
         const boost::optional<double>& CPACSWingRibsPositioning::GetEtaEnd_choice1() const
         {
             return m_etaEnd_choice1;
-        }
-        
-        void CPACSWingRibsPositioning::SetEtaEnd_choice1(const double& value)
-        {
-            m_etaEnd_choice1 = value;
         }
         
         void CPACSWingRibsPositioning::SetEtaEnd_choice1(const boost::optional<double>& value)
@@ -475,11 +455,6 @@ namespace tigl
             return m_elementEndUID_choice2;
         }
         
-        void CPACSWingRibsPositioning::SetElementEndUID_choice2(const std::string& value)
-        {
-            m_elementEndUID_choice2 = value;
-        }
-        
         void CPACSWingRibsPositioning::SetElementEndUID_choice2(const boost::optional<std::string>& value)
         {
             m_elementEndUID_choice2 = value;
@@ -488,11 +463,6 @@ namespace tigl
         const boost::optional<std::string>& CPACSWingRibsPositioning::GetSparPositionEndUID_choice3() const
         {
             return m_sparPositionEndUID_choice3;
-        }
-        
-        void CPACSWingRibsPositioning::SetSparPositionEndUID_choice3(const std::string& value)
-        {
-            m_sparPositionEndUID_choice3 = value;
         }
         
         void CPACSWingRibsPositioning::SetSparPositionEndUID_choice3(const boost::optional<std::string>& value)
@@ -505,11 +475,6 @@ namespace tigl
             return m_spacing_choice1;
         }
         
-        void CPACSWingRibsPositioning::SetSpacing_choice1(const double& value)
-        {
-            m_spacing_choice1 = value;
-        }
-        
         void CPACSWingRibsPositioning::SetSpacing_choice1(const boost::optional<double>& value)
         {
             m_spacing_choice1 = value;
@@ -518,11 +483,6 @@ namespace tigl
         const boost::optional<int>& CPACSWingRibsPositioning::GetNumberOfRibs_choice2() const
         {
             return m_numberOfRibs_choice2;
-        }
-        
-        void CPACSWingRibsPositioning::SetNumberOfRibs_choice2(const int& value)
-        {
-            m_numberOfRibs_choice2 = value;
         }
         
         void CPACSWingRibsPositioning::SetNumberOfRibs_choice2(const boost::optional<int>& value)

--- a/src/generated/CPACSWingRibsPositioning.h
+++ b/src/generated/CPACSWingRibsPositioning.h
@@ -65,35 +65,27 @@ namespace tigl
             TIGL_EXPORT virtual CCPACSWingRibRotation& GetRibRotation();
             
             TIGL_EXPORT virtual const boost::optional<double>& GetEtaStart_choice1() const;
-            TIGL_EXPORT virtual void SetEtaStart_choice1(const double& value);
             TIGL_EXPORT virtual void SetEtaStart_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetElementStartUID_choice2() const;
-            TIGL_EXPORT virtual void SetElementStartUID_choice2(const std::string& value);
             TIGL_EXPORT virtual void SetElementStartUID_choice2(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetSparPositionStartUID_choice3() const;
-            TIGL_EXPORT virtual void SetSparPositionStartUID_choice3(const std::string& value);
             TIGL_EXPORT virtual void SetSparPositionStartUID_choice3(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetEtaEnd_choice1() const;
-            TIGL_EXPORT virtual void SetEtaEnd_choice1(const double& value);
             TIGL_EXPORT virtual void SetEtaEnd_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetElementEndUID_choice2() const;
-            TIGL_EXPORT virtual void SetElementEndUID_choice2(const std::string& value);
             TIGL_EXPORT virtual void SetElementEndUID_choice2(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetSparPositionEndUID_choice3() const;
-            TIGL_EXPORT virtual void SetSparPositionEndUID_choice3(const std::string& value);
             TIGL_EXPORT virtual void SetSparPositionEndUID_choice3(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const boost::optional<double>& GetSpacing_choice1() const;
-            TIGL_EXPORT virtual void SetSpacing_choice1(const double& value);
             TIGL_EXPORT virtual void SetSpacing_choice1(const boost::optional<double>& value);
             
             TIGL_EXPORT virtual const boost::optional<int>& GetNumberOfRibs_choice2() const;
-            TIGL_EXPORT virtual void SetNumberOfRibs_choice2(const int& value);
             TIGL_EXPORT virtual void SetNumberOfRibs_choice2(const boost::optional<int>& value);
             
         protected:

--- a/src/generated/CPACSWingSection.cpp
+++ b/src/generated/CPACSWingSection.cpp
@@ -165,11 +165,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSWingSection::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSWingSection::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSWingSection.h
+++ b/src/generated/CPACSWingSection.h
@@ -58,7 +58,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const CCPACSTransformation& GetTransformation() const;

--- a/src/generated/CPACSWingSegment.cpp
+++ b/src/generated/CPACSWingSegment.cpp
@@ -190,11 +190,6 @@ namespace tigl
             return m_description;
         }
         
-        void CPACSWingSegment::SetDescription(const std::string& value)
-        {
-            m_description = value;
-        }
-        
         void CPACSWingSegment::SetDescription(const boost::optional<std::string>& value)
         {
             m_description = value;

--- a/src/generated/CPACSWingSegment.h
+++ b/src/generated/CPACSWingSegment.h
@@ -58,7 +58,6 @@ namespace tigl
             TIGL_EXPORT virtual void SetName(const std::string& value);
             
             TIGL_EXPORT virtual const boost::optional<std::string>& GetDescription() const;
-            TIGL_EXPORT virtual void SetDescription(const std::string& value);
             TIGL_EXPORT virtual void SetDescription(const boost::optional<std::string>& value);
             
             TIGL_EXPORT virtual const std::string& GetFromElementUID() const;

--- a/src/wing/CCPACSWingRibRotation.cpp
+++ b/src/wing/CCPACSWingRibRotation.cpp
@@ -28,12 +28,6 @@ CCPACSWingRibRotation::CCPACSWingRibRotation(CCPACSWingRibsPositioning* parent)
     m_z = 90;
 }
 
-void CCPACSWingRibRotation::SetRibRotationReference(const ECPACSRibRotation_ribRotationReference& value)
-{
-    generated::CPACSRibRotation::SetRibRotationReference(value);
-    m_parent->invalidateStructure();
-}
-
 void CCPACSWingRibRotation::SetRibRotationReference(const boost::optional<ECPACSRibRotation_ribRotationReference>& value)
 {
     generated::CPACSRibRotation::SetRibRotationReference(value);

--- a/src/wing/CCPACSWingRibRotation.h
+++ b/src/wing/CCPACSWingRibRotation.h
@@ -25,7 +25,6 @@ class CCPACSWingRibRotation : public generated::CPACSRibRotation
 public:
     TIGL_EXPORT CCPACSWingRibRotation(CCPACSWingRibsPositioning* parent);
 
-    TIGL_EXPORT void SetRibRotationReference(const ECPACSRibRotation_ribRotationReference& value) OVERRIDE;
     TIGL_EXPORT void SetRibRotationReference(const boost::optional<ECPACSRibRotation_ribRotationReference>& value) OVERRIDE;
 
     TIGL_EXPORT void SetZ(const double& value) OVERRIDE;


### PR DESCRIPTION
Updated to newest version of cpacs_tigl_gen, which dropped const T& setters for elements of type optional<T>.

I had a discussion with a colleague about this, and this change incurs a potential performance loss for setters of boost::optional<std::string> as 1 more copy is performed when calling the setter. However, a lot of overloads are eliminated by this change, which makes overriding them easier and shortens the general API.