### PR TITLE
Changed VTK exporter API to match CTiglCadExporter Interface

### DIFF
--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -1542,7 +1542,7 @@ void TIGLViewerDocument::exportMeshedConfigVTKNoFuse()
         tigl::ExportOptions options(settings.getDeflection());
         options.applySymmetries = true;
         options.includeFarField = false;
-        tigl::CTiglExportVtk exporter(GetConfiguration(), tigl::NO_INFO);
+        tigl::CTiglExportVtk exporter(GetConfiguration(), tigl::SEGMENT_INFO);
         exporter.AddConfiguration(GetConfiguration(), options);
 
         exporter.Write(fileName.toStdString());

--- a/TIGLViewer/src/TIGLViewerDocument.h
+++ b/TIGLViewer/src/TIGLViewerDocument.h
@@ -115,7 +115,6 @@ public slots:
     void exportMeshedWingVTK();
     void exportMeshedWingVTKsimple();
     void exportMeshedFuselageVTK();
-    void exportMeshedFuselageVTKsimple();
     void exportMeshedConfigVTK();
     void exportMeshedConfigVTKNoFuse();
     void exportWingCollada();

--- a/TIGLViewer/src/TIGLViewerWindow.cpp
+++ b/TIGLViewer/src/TIGLViewerWindow.cpp
@@ -624,7 +624,6 @@ void TIGLViewerWindow::connectConfiguration()
     connect(tiglExportMeshedFuselageVTK, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportMeshedFuselageVTK()));
     connect(tiglExportMeshedConfigVTK, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportMeshedConfigVTK()));
     connect(tiglExportMeshedConfigVTKNoFuse, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportMeshedConfigVTKNoFuse()));
-    connect(tiglExportMeshedFuselageVTKsimple, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportMeshedFuselageVTKsimple()));
     connect(tiglExportWingColladaAction, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportWingCollada()));
     connect(tiglExportFuselageColladaAction, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportFuselageCollada()));
     connect(tiglExportConfigurationColladaAction, SIGNAL(triggered()), cpacsConfiguration, SLOT(exportConfigCollada()));

--- a/TIGLViewer/src/TIGLViewerWindow.ui
+++ b/TIGLViewer/src/TIGLViewerWindow.ui
@@ -101,7 +101,6 @@
       <addaction name="tiglExportMeshedWingVTK"/>
       <addaction name="tiglExportMeshedWingVTKsimple"/>
       <addaction name="tiglExportMeshedFuselageVTK"/>
-      <addaction name="tiglExportMeshedFuselageVTKsimple"/>
       <addaction name="tiglExportMeshedConfigVTKNoFuse"/>
       <addaction name="tiglExportMeshedConfigVTK"/>
      </widget>

--- a/bindings/java/src/de/dlr/sc/tigl3/CpacsConfiguration.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/CpacsConfiguration.java
@@ -2151,26 +2151,6 @@ public class CpacsConfiguration implements AutoCloseable {
     /**
      * 
      * Exports a CPACS fuselage geometry in VTK format to a local file.
-     * Uses simple and fast method to export quick results!
-     * 
-     * @param fuselageUID - The UID of the fuselage to export.
-     * @param fileName - The filename to save with.
-     * @param deflection - The deflection of the meshing.
-     * @throws TiglException 
-     */
-    public void exportMeshedFuselageVTKSimple(final String fuselageUID, final String fileName, final double deflection) throws TiglException {
-        checkTiglConfiguration();
-
-        // export to the file
-        errorCode = TiglNativeInterface.tiglExportMeshedFuselageVTKSimpleByUID(cpacsHandle, fuselageUID, fileName, deflection); 
-        throwIfError("tiglExportMeshedFuselageVTKSimpleByUID", errorCode);
-    }    
-
-    /**
-     * 
-     * Exports a CPACS fuselage geometry in VTK format to a local file.
-     * This method adds metadata to the VTK file and is a bit slower than
-     * exportMeshedFuselageVTKSimple.
      * 
      * @param fuselageUID - The UID of the fuselage to export.
      * @param fileName - The filename to save with.
@@ -2182,7 +2162,7 @@ public class CpacsConfiguration implements AutoCloseable {
 
         // export to the file
         errorCode = TiglNativeInterface.tiglExportMeshedFuselageVTKByUID(cpacsHandle, fuselageUID, fileName, deflection); 
-        throwIfError("tiglExportMeshedFuselageVTKSimpleByUID", errorCode);
+        throwIfError("tiglExportMeshedFuselageVTKByUID", errorCode);
     }
     
     /**

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
@@ -17,7 +17,7 @@
 */
 
 /* 
-* This file is automatically created from tigl.h on 2017-07-02.
+* This file is automatically created from tigl.h on 2018-02-27.
 * If you experience any bugs please contact the authors
 */
 
@@ -78,6 +78,9 @@ public class TiglNativeInterface {
     public static native int tiglWingComponentSegmentGetSegmentUID(int cpacsHandle, String componentSegmentUID, int segmentIndex, PointerByReference segmentUID);
     public static native int tiglGetFuselageCount(int cpacsHandle, IntByReference fuselageCountPtr);
     public static native int tiglFuselageGetSegmentCount(int cpacsHandle, int fuselageIndex, IntByReference segmentCountPtr);
+    public static native int tiglFuselageGetSectionCenter(int cpacsHandle, String fuselageSegmentUID, double eta, DoubleByReference pointX, DoubleByReference pointY, DoubleByReference pointZ);
+    public static native int tiglFuselageGetCrossSectionArea(int cpacsHandle, String fuselageSegmentUID, double eta, DoubleByReference area);
+    public static native int tiglFuselageGetCenterLineLength(int cpacsHandle, String fuselageUID, DoubleByReference length);
     public static native int tiglFuselageGetPoint(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double zeta, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglFuselageGetPointAngle(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double alpha, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglFuselageGetPointAngleTranslated(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double alpha, double y_cs, double z_cs, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
@@ -127,8 +130,13 @@ public class TiglNativeInterface {
     public static native int tiglRotorBladeGetLocalTwistAngle(int cpacsHandle, int rotorIndex, int rotorBladeIndex, int segmentIndex, double eta, DoubleByReference twistAnglePtr);
     public static native int tiglIntersectComponents(int cpacsHandle, String componentUidOne, String componentUidTwo, PointerByReference intersectionID);
     public static native int tiglIntersectWithPlane(int cpacsHandle, String componentUid, double px, double py, double pz, double nx, double ny, double nz, PointerByReference intersectionID);
+    public static native int tiglIntersectWithPlaneSegment(int cpacsHandle, String componentUid, double p1x, double p1y, double p1z, double p2x, double p2y, double p2z, double wx, double wy, double wz, PointerByReference intersectionID);
+    public static native int tiglGetCurveIntersection(int cpacsHandle, String curvesID1, int curve1Idx, String curvesID2, int curve2Idx, double tolerance, PointerByReference intersectionID);
     public static native int tiglIntersectGetLineCount(int cpacsHandle, String intersectionID, IntByReference lineCount);
+    public static native int tiglGetCurveIntersectionCount(int cpacsHandle, String intersectionID, IntByReference pointCount);
     public static native int tiglIntersectGetPoint(int cpacsHandle, String intersectionID, int lineIdx, double eta, DoubleByReference pointX, DoubleByReference pointY, DoubleByReference pointZ);
+    public static native int tiglGetCurveIntersectionPoint(int cpacsHandle, String intersectionID, int pointIdx, DoubleByReference pointX, DoubleByReference pointY, DoubleByReference pointZ);
+    public static native int tiglGetCurveParameter(int cpacsHandle, String curveID, int curveIdx, double pointX, double pointY, double pointZ, DoubleByReference eta);
     public static native int tiglExportIGES(int cpacsHandle, String filenamePtr);
     public static native int tiglExportFusedWingFuselageIGES(int cpacsHandle, String filenamePtr);
     public static native int tiglExportSTEP(int cpacsHandle, String filenamePtr);
@@ -145,11 +153,12 @@ public class TiglNativeInterface {
     public static native int tiglExportMeshedFuselageVTKByUID(int cpacsHandle, String fuselageUID, String filenamePtr, double deflection);
     public static native int tiglExportMeshedGeometryVTK(int cpacsHandle, String filenamePtr, double deflection);
     public static native int tiglExportMeshedWingVTKSimpleByUID(int cpacsHandle, String wingUID, String filenamePtr, double deflection);
-    public static native int tiglExportMeshedFuselageVTKSimpleByUID(int cpacsHandle, String fuselageUID, String filenamePtr, double deflection);
     public static native int tiglExportMeshedGeometryVTKSimple(int cpacsHandle, String filenamePtr, double deflection);
     public static native int tiglExportFuselageColladaByUID(int cpacsHandle, String fuselageUID, String filename, double deflection);
     public static native int tiglExportWingColladaByUID(int cpacsHandle, String wingUID, String filename, double deflection);
     public static native int tiglExportFusedBREP(int cpacsHandle, String filename);
+    public static native int tiglExportFuselageBREPByUID(int cpacsHandle, String fuselageUID, String filename);
+    public static native int tiglExportWingBREPByUID(int cpacsHandle, String wingUID, String filename);
     public static native int tiglWingComponentSegmentGetMaterialCount(int cpacsHandle, String compSegmentUID, int structureType, double eta, double xsi, IntByReference materialCount);
     public static native int tiglWingComponentSegmentGetMaterialUID(int cpacsHandle, String compSegmentUID, int structureType, double eta, double xsi, int materialIndex, PointerByReference uid);
     public static native int tiglWingComponentSegmentGetMaterialThickness(int cpacsHandle, String compSegmentUID, int structureType, double eta, double xsi, int materialIndex, DoubleByReference thickness);

--- a/bindings/python_internal/exports.i
+++ b/bindings/python_internal/exports.i
@@ -48,6 +48,7 @@
 %include "CTiglExportBrep.h"
 %include "CTiglExportStep.h"
 %include "CTiglExportIges.h"
+%include "CTiglTriangularizer.h"
 %include "CTiglExportStl.h"
 %include "CTiglExportVtk.h"
 %include "CTiglExportCollada.h"

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -5419,10 +5419,16 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByIndex(const TiglCPACS
     try {
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedWingVTKByIndex(wingIndex, filename, deflection);
-        return TIGL_SUCCESS;
+        tigl::CCPACSWing& wing = config.GetWing(wingIndex);
+        tigl::CTiglExportVtk exporter(config, tigl::SEGMENT_INFO);
+
+        exporter.AddShape(wing.GetLoft(), deflection);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     // all exceptions from the standard library 
     catch (tigl::CTiglError & ex) {
@@ -5465,10 +5471,16 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByUID(const TiglCPACSCo
     try {
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedWingVTKByUID(wingUID, filename, deflection);
-        return TIGL_SUCCESS;
+        tigl::CCPACSWing& wing = config.GetWing(wingUID);
+        tigl::CTiglExportVtk exporter(config, tigl::SEGMENT_INFO);
+
+        exporter.AddShape(wing.GetLoft(), deflection);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     // all exceptions from the standard library
     catch (tigl::CTiglError & ex) {
@@ -5511,10 +5523,15 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByIndex(const TiglC
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedFuselageVTKByIndex(fuselageIndex, filename, deflection);
-        return TIGL_SUCCESS;
+        tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageIndex);
+        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        exporter.AddShape(fuselage.GetLoft(), deflection);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();
@@ -5548,10 +5565,15 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByUID(const TiglCPA
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedFuselageVTKByUID(fuselageUID, filename, deflection);
-        return TIGL_SUCCESS;
+        tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
+        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        exporter.AddShape(fuselage.GetLoft(), deflection);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();
@@ -5580,10 +5602,18 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTK(const TiglCPACSCon
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedGeometryVTK(filename, deflection);
-        return TIGL_SUCCESS;
+
+        tigl::ExportOptions options(deflection);
+        options.applySymmetries = true;
+        options.includeFarField = false;
+        tigl::CTiglExportVtk exporter(config, tigl::SEGMENT_INFO);
+        exporter.AddFusedConfiguration(config, options);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();
@@ -5619,10 +5649,16 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
     try {
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedWingVTKSimpleByUID(wingUID, filename, deflection);
-        return TIGL_SUCCESS;
+        tigl::CCPACSWing& wing = config.GetWing(wingUID);
+        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+
+        exporter.AddShape(wing.GetLoft(), deflection);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     // all exceptions from the standard library
     catch (tigl::CTiglError & ex) {
@@ -5647,43 +5683,6 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
     }
 }
 
-
-
-TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKSimpleByUID(const TiglCPACSConfigurationHandle cpacsHandle, const char* fuselageUID,
-                                                                         const char* filenamePtr, double deflection)
-{
-    if (filenamePtr == 0) {
-        LOG(ERROR) << "Null pointer argument for filenamePtr\n"
-                   << "in function call to tiglExportMeshedFuselageVTKSimpleByUID.";
-        return TIGL_NULL_POINTER;
-    }
-    if (fuselageUID == 0) {
-        LOG(ERROR) << "Null pointer argument for fuselageIndex\n"
-                   << "in function call to tiglExportMeshedFuselageVTKSimpleByUID.";
-        return TIGL_INDEX_ERROR;
-    }
-
-    try {
-        tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
-        tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedFuselageVTKSimpleByUID(fuselageUID, filename, deflection);
-        return TIGL_SUCCESS;
-    }
-    catch (const tigl::CTiglError& ex) {
-        LOG(ERROR) << ex.what();
-        return ex.getCode();
-    }
-    catch (std::exception& ex) {
-        LOG(ERROR) << ex.what();
-        return TIGL_ERROR;
-    }
-    catch (...) {
-        LOG(ERROR) << "Caught an exception in tiglExportMeshedFuselageVTKSimpleByUID!";
-        return TIGL_ERROR;
-    }
-}
 
 TIGL_COMMON_EXPORT TiglReturnCode tiglExportFuselageColladaByUID(const TiglCPACSConfigurationHandle cpacsHandle, const char* fuselageUID, const char* filenamePtr, double deflection) 
 {
@@ -5770,10 +5769,17 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTKSimple(const TiglCP
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config);
-        std::string filename = filenamePtr;
-        exporter.ExportMeshedGeometryVTKSimple(filename, deflection);
-        return TIGL_SUCCESS;
+        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        tigl::ExportOptions options(deflection);
+        options.applySymmetries = true;
+        options.includeFarField = false;
+        exporter.AddFusedConfiguration(config, options);
+        if (exporter.Write(filenamePtr)) {
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_WRITE_FAILED;
+        }
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -3685,36 +3685,6 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
 
 
 
-
-
-/**
-* @brief Exports the boolean fused geometry of a fuselage (selected by uid) meshed to VTK format.
-*
-* This function does only a very simple, but also very fast meshing on the fuselage and exports them to
-* a VTK file. No additional CPACS relevant information are computed.
-*
-*
-* @param[in]  cpacsHandle   Handle for the CPACS configuration
-* @param[in]  fuselageUID   UID of the Fuselage to export
-* @param[in]  filenamePtr   Pointer to an VTK export file name (*.vtp = polygonal XML_VTK)
-* @param[in]  deflection    Maximum deflection of the triangulation from the real surface
-*
-* @return
-*   - TIGL_SUCCESS if no error occurred
-*   - TIGL_NOT_FOUND if no configuration was found for the given handle
-*   - TIGL_NULL_POINTER if filenamePtr is a null pointer
-*   - TIGL_INDEX_ERROR if fuselageUID does not exists
-*   - TIGL_ERROR if some other error occurred
-*/
-TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKSimpleByUID(const TiglCPACSConfigurationHandle cpacsHandle, 
-                                                                         const char* fuselageUID,
-                                                                         const char* filenamePtr, 
-                                                                         double deflection);
-
-
-
-
-
 /**
 * @brief Exports the boolean fused geometry of the whole configuration meshed to VTK format.
 *

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -131,7 +131,7 @@ bool writeMeshArray(TixiDocumentHandle handle, std::string meshPath, int sourceI
     return true;
 }
 
-bool writeGeometryMesh(TixiDocumentHandle handle, CTiglPolyData& polyData, std::string col_id, int& geometryIndex)
+bool writeGeometryMesh(TixiDocumentHandle handle, const CTiglPolyData& polyData, std::string col_id, int& geometryIndex)
 {
     // create vertex, normal and triangle strings
     std::stringstream stream_verts;
@@ -140,7 +140,7 @@ bool writeGeometryMesh(TixiDocumentHandle handle, CTiglPolyData& polyData, std::
     unsigned long count_pos =0, count_norm =0, count_vert =0; // count Points, Normals, Verticies for COLLADA-schema arrays
 
     for (unsigned int i = 1; i <= polyData.getNObjects(); ++i) {
-        CTiglPolyObject& obj = polyData.switchObject(i);
+        const CTiglPolyObject& obj = polyData.getObject(i);
 
         unsigned long nvert = obj.getNVertices();
         for (unsigned long jvert = 0; jvert < nvert; ++jvert) {
@@ -289,9 +289,9 @@ bool CTiglExportCollada::WriteImpl(const std::string& filename) const
         // Do the meshing
         PNamedShape pshape = GetShape(i);
         double deflection = GetOptions(i).deflection;
-        CTiglTriangularizer polyData(pshape->Shape(), deflection);
+        CTiglTriangularizer mesher(pshape->Shape(), deflection);
         
-        writeGeometryMesh(handle, polyData, std::string(pshape->Name()) + "-geom", geomIndex);
+        writeGeometryMesh(handle, mesher.getTriangulation(), std::string(pshape->Name()) + "-geom", geomIndex);
     }
     
     // write the scene and link object to geometry

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -289,7 +289,7 @@ bool CTiglExportCollada::WriteImpl(const std::string& filename) const
         // Do the meshing
         PNamedShape pshape = GetShape(i);
         double deflection = GetOptions(i).deflection;
-        CTiglTriangularizer mesher(pshape->Shape(), deflection);
+        CTiglTriangularizer mesher(pshape, deflection);
         
         writeGeometryMesh(handle, mesher.getTriangulation(), std::string(pshape->Name()) + "-geom", geomIndex);
     }

--- a/src/exports/CTiglExportStep.cpp
+++ b/src/exports/CTiglExportStep.cpp
@@ -103,7 +103,7 @@ namespace
         }
         Handle(StepBasic_Product) product = prodDef->Formation()->OfProduct();
         
-        Handle(TCollection_HAsciiString) str = new TCollection_HAsciiString(shape->Name());
+        Handle(TCollection_HAsciiString) str = new TCollection_HAsciiString(shape->Name().c_str());
         product->SetId ( str );
         product->SetName ( str );
     }
@@ -256,7 +256,7 @@ void CTiglExportStep::AddToStep(PNamedShape shape, STEPControl_Writer& writer) c
     Handle(Transfer_FinderProcess) FP = writer.WS()->TransferWriter()->FinderProcess();
 
     TopTools_IndexedMapOfShape faceMap;
-    TopExp::MapShapes(shape->Shape(),   TopAbs_FACE, faceMap);
+    TopExp::MapShapes(shape->Shape(), TopAbs_FACE, faceMap);
     // any faces?
     if (faceMap.Extent() > 0) {
         int ret = writer.Transfer(shape->Shape(), STEP_WRITEMODE);

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -121,7 +121,7 @@ void CTiglExportVtk::ExportMeshedWingVTKByUID(const std::string& wingUID, const 
 {
     tigl::CCPACSWing& wing = myConfig.GetWing(wingUID);
     CTiglTriangularizer wingTrian(wing, deflection, SEGMENT_INFO, getOptions(*this));
-    writeVTK(wingTrian, filename.c_str());
+    writeVTK(wingTrian.getTriangulation(), filename.c_str());
 }
 
 
@@ -139,7 +139,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
     CTiglRelativelyPositionedComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
     CTiglTriangularizer trian(shape, deflection, getOptions(*this));
-    writeVTK(trian, filename.c_str());
+    writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
 
@@ -147,7 +147,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
 void CTiglExportVtk::ExportMeshedGeometryVTK(const std::string& filename, const double deflection)
 {
     tigl::CTiglTriangularizer trian(myConfig, true, deflection, SEGMENT_INFO, getOptions(*this));
-    writeVTK(trian, filename.c_str());
+    writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
 /************* Simple ones *************************/
@@ -157,7 +157,7 @@ void CTiglExportVtk::ExportMeshedWingVTKSimpleByUID(const std::string& wingUID, 
     CCPACSWing & component = dynamic_cast<CCPACSWing&>(myConfig.GetWing(wingUID));
     TopoDS_Shape& loft = component.GetLoftWithLeadingEdge();
     CTiglTriangularizer loftTrian(loft, deflection, getOptions(*this));
-    writeVTK(loftTrian, filename.c_str());
+    writeVTK(loftTrian.getTriangulation(), filename.c_str());
 }
 
 /************* Simple ones *************************/
@@ -174,7 +174,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByUID(const std::string& fusel
     CTiglRelativelyPositionedComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
     CTiglTriangularizer loftTrian(shape, deflection, getOptions(*this));
-    writeVTK(loftTrian, filename.c_str());
+    writeVTK(loftTrian.getTriangulation(), filename.c_str());
 }
 
 // Exports a by UID selected fuselage, boolean fused and meshed, as VTK file
@@ -189,14 +189,14 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByIndex(const int fuselageInde
 void CTiglExportVtk::ExportMeshedGeometryVTKSimple(const std::string& filename, const double deflection)
 {
     tigl::CTiglTriangularizer trian(myConfig, true, deflection, NO_INFO, getOptions(*this));
-    writeVTK(trian, filename.c_str());
+    writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
 // Exports a whole geometry, not fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTKNoFuse(const std::string& filename, const double deflection)
 {
     tigl::CTiglTriangularizer trian(myConfig, false, deflection, NO_INFO, getOptions(*this));
-    writeVTK(trian, filename.c_str());
+    writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
 void CTiglExportVtk::SetOptions(const std::string &key, const std::string &value)

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -44,6 +44,7 @@
 
 #include "CTiglPolyData.h"
 #include "CTiglTriangularizer.h"
+#include "CTiglPolyData.h"
 
 namespace
 {
@@ -61,6 +62,33 @@ namespace
         std::transform(result.begin(), result.end(), result.begin(), ::tolower);
 
         return result;
+    }
+    
+    void setMinMax(const tigl::CTiglPoint& p, double* oldmin, double* oldmax)
+    {
+        if (p.x > *oldmax) {
+            *oldmax = p.x;
+        }
+    
+        if (p.y > *oldmax) {
+            *oldmax = p.y;
+        }
+    
+        if (p.z > *oldmax) {
+            *oldmax = p.z;
+        }
+    
+        if (p.x < *oldmin) {
+            *oldmin = p.x;
+        }
+    
+        if (p.y < *oldmin) {
+            *oldmin = p.y;
+        }
+    
+        if (p.z < *oldmin) {
+            *oldmin = p.z;
+        }
     }
 }
 
@@ -93,7 +121,7 @@ void CTiglExportVtk::ExportMeshedWingVTKByUID(const std::string& wingUID, const 
 {
     tigl::CCPACSWing& wing = myConfig.GetWing(wingUID);
     CTiglTriangularizer wingTrian(wing, deflection, SEGMENT_INFO, getOptions(*this));
-    wingTrian.writeVTK(filename.c_str());
+    writeVTK(wingTrian, filename.c_str());
 }
 
 
@@ -111,7 +139,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
     CTiglRelativelyPositionedComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
     CTiglTriangularizer trian(shape, deflection, getOptions(*this));
-    trian.writeVTK(filename.c_str());
+    writeVTK(trian, filename.c_str());
 }
 
 
@@ -119,7 +147,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
 void CTiglExportVtk::ExportMeshedGeometryVTK(const std::string& filename, const double deflection)
 {
     tigl::CTiglTriangularizer trian(myConfig, true, deflection, SEGMENT_INFO, getOptions(*this));
-    trian.writeVTK(filename.c_str());
+    writeVTK(trian, filename.c_str());
 }
 
 /************* Simple ones *************************/
@@ -129,7 +157,7 @@ void CTiglExportVtk::ExportMeshedWingVTKSimpleByUID(const std::string& wingUID, 
     CCPACSWing & component = dynamic_cast<CCPACSWing&>(myConfig.GetWing(wingUID));
     TopoDS_Shape& loft = component.GetLoftWithLeadingEdge();
     CTiglTriangularizer loftTrian(loft, deflection, getOptions(*this));
-    loftTrian.writeVTK(filename.c_str());
+    writeVTK(loftTrian, filename.c_str());
 }
 
 /************* Simple ones *************************/
@@ -146,7 +174,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByUID(const std::string& fusel
     CTiglRelativelyPositionedComponent & component = myConfig.GetFuselage(fuselageUID);
     const TopoDS_Shape& shape = component.GetLoft()->Shape();
     CTiglTriangularizer loftTrian(shape, deflection, getOptions(*this));
-    loftTrian.writeVTK(filename.c_str());
+    writeVTK(loftTrian, filename.c_str());
 }
 
 // Exports a by UID selected fuselage, boolean fused and meshed, as VTK file
@@ -161,14 +189,14 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByIndex(const int fuselageInde
 void CTiglExportVtk::ExportMeshedGeometryVTKSimple(const std::string& filename, const double deflection)
 {
     tigl::CTiglTriangularizer trian(myConfig, true, deflection, NO_INFO, getOptions(*this));
-    trian.writeVTK(filename.c_str());
+    writeVTK(trian, filename.c_str());
 }
 
 // Exports a whole geometry, not fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTKNoFuse(const std::string& filename, const double deflection)
 {
     tigl::CTiglTriangularizer trian(myConfig, false, deflection, NO_INFO, getOptions(*this));
-    trian.writeVTK(filename.c_str());
+    writeVTK(trian, filename.c_str());
 }
 
 void CTiglExportVtk::SetOptions(const std::string &key, const std::string &value)
@@ -187,6 +215,199 @@ void CTiglExportVtk::SetOptions(const std::string &key, const std::string &value
 
     else {
         throw CTiglError("Invalid key in vtk export: " + key);
+    }
+}
+
+void CTiglExportVtk::writeVTK(const CTiglPolyData& polys, const char *filename)
+{
+    TixiDocumentHandle handle;
+    createVTK(polys, handle);
+    if (tixiSaveDocument(handle, filename)!= SUCCESS) {
+        throw CTiglError("Error saving vtk file!");
+    }
+    LOG(INFO) << "VTK Export succeeded with " << polys.getTotalPolygonCount()
+              << " polygons and " << polys.getTotalVertexCount() << " vertices." << std::endl;
+}
+
+void CTiglExportVtk::createVTK(const CTiglPolyData& polys, TixiDocumentHandle& handle)
+{
+    tixiCreateDocument("VTKFile", &handle);
+    tixiAddTextAttribute(handle, "/VTKFile", "type", "PolyData");
+    tixiAddTextAttribute(handle, "/VTKFile", "version", "0.1");
+    tixiAddTextAttribute(handle, "/VTKFile", "byte_order", "LittleEndian");
+    tixiAddTextAttribute(handle, "/VTKFile", "compressor", "vtkZLibDataCompressor");
+
+    std::stringstream stream;
+    stream << "tigl " << tiglGetVersion();
+    tixiCreateElement(handle, "/VTKFile","MetaData");
+    tixiAddTextAttribute(handle, "/VTKFile/MetaData", "creator", stream.str().c_str());
+    
+    tixiCreateElement(handle, "/VTKFile", "PolyData");
+
+    for (unsigned int iobj = 1; iobj <= polys.getNObjects(); ++iobj ) {
+        writeVTKPiece(polys, handle, iobj);
+    }
+}
+
+// writes the polygon data of a surface (in vtk they call it piece)
+void CTiglExportVtk::writeVTKPiece(const CTiglPolyData& polys, TixiDocumentHandle& handle, unsigned int iObject)
+{
+    const CTiglPolyObject& co = polys.getObject(iObject);
+
+    if (co.getNPolygons() == 0) {
+        return;
+    }
+
+    // count number of vertices - this is not necessarily the number of points
+    int nvert = 0;
+    for (unsigned int i = 0; i < co.getNPolygons(); ++i) {
+        nvert += co.getNPointsOfPolygon(i);
+    }
+
+    if (nvert <= 0) {
+        return;
+    }
+
+    // surface specific stuff
+    tixiCreateElement(handle, "/VTKFile/PolyData","Piece");
+
+    const std::string piecepath = "/VTKFile/PolyData/Piece[" + std_to_string(iObject) + "]";
+
+    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfPoints", co.getNVertices(), "%d");
+    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfVerts",  0, "%d");
+    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfLines",  0, "%d");
+    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfStrips", 0, "%d");
+    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfPolys",  co.getNPolygons(), "%d");
+
+    tixiCreateElement(handle, piecepath.c_str(), "Points");
+
+    //points
+    {
+        unsigned int nPoints = co.getNVertices();
+        std::stringstream stream1;
+        stream1 << std::endl <<   "         ";
+        double min_coord = DBL_MAX, max_coord = DBL_MIN;
+        for (unsigned int i = 0; i < nPoints; ++i) {
+            const CTiglPoint& p = co.getVertexPoint(i);
+            setMinMax(p, &min_coord, &max_coord);
+            stream1 << "    " << std::setprecision(10) << p.x << " " << p.y << " " << p.z << std::endl;
+            stream1 << "         ";
+        }
+        std::string tmpPath = piecepath + "/Points";
+        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream1.str().c_str());
+        tmpPath += "/DataArray";
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "type", "Float64");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "Points");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "NumberOfComponents", "3");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "format", "ascii");
+        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMin", min_coord ,"%f");
+        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMax", max_coord ,"%f");
+    }
+
+    //normals
+    if (co.hasNormals()) {
+        tixiCreateElement(handle, piecepath.c_str(), "PointData");
+        std::string tmpPath = piecepath + "/PointData";
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "Normals", "surf_normals");
+
+        std::stringstream stream;
+        double min_coord = DBL_MAX, max_coord = DBL_MIN;
+        stream << endl  << "        ";
+        for (unsigned int i=0; i < co.getNVertices(); ++i) {
+             const CTiglPoint& n = co.getVertexNormal(i);
+             setMinMax(n, &min_coord, &max_coord);
+             stream << "    " << n.x << " " << n.y << " "  << n.z << endl;
+             stream <<  "        ";
+        }
+
+        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream.str().c_str());
+        tmpPath += "/DataArray";
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "type", "Float64");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "surf_normals");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "NumberOfComponents", "3");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "format", "ascii");
+        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMin", min_coord ,"%f");
+        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMax", max_coord ,"%f");
+    }
+
+    //polygons
+    {
+        tixiCreateElement(handle, piecepath.c_str(), "Polys");
+        std::stringstream stream2;
+        stream2 << std::endl <<   "        ";
+        for (unsigned int iPoly = 0; iPoly < co.getNPolygons(); ++iPoly) {
+            stream2 <<     "    ";
+            for (unsigned int jPoint = 0; jPoint < co.getNPointsOfPolygon(iPoly); ++jPoint ) {
+                stream2 << co.getVertexIndexOfPolygon(jPoint, iPoly) << " ";
+            }
+            stream2  << std::endl <<  "        ";;
+        }
+
+        std::string tmpPath = piecepath + "/Polys";
+        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream2.str().c_str());
+        tmpPath += "/DataArray";
+        tixiAddTextAttribute(handle,tmpPath.c_str(), "type", "Int32");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "connectivity");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "format", "ascii");
+        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMin", 0 ,"%d");
+        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMax", co.getNVertices()-1,"%d");
+    }
+
+    //offset
+    {
+        unsigned int next = 0;
+        std::stringstream stream3;
+        for (unsigned int i = 0; i < co.getNPolygons(); i ++) {
+            if ((i % 10 == 0) && (i != (co.getNPolygons() - 1))) {
+                stream3 << endl << "            ";
+            }
+            next += co.getNPointsOfPolygon(i);
+            stream3 << " " << next;
+        }
+        stream3 << endl << "        ";
+        std::string tmpPath = piecepath + "/Polys";
+        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream3.str().c_str());
+        tmpPath += "/DataArray[2]";
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "type", "Int32");
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "offsets");
+        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMin", co.getNPointsOfPolygon(0) ,"%d");
+        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMax", nvert,"%d");
+    }
+    
+    // write cell data
+    if (co.getNumberOfPolyRealData() > 0) {
+        tixiCreateElement(handle, piecepath.c_str(), "CellData");
+        const std::string tmpPath = piecepath + "/CellData";
+        
+        for (unsigned int iData = 0; iData < co.getNumberOfPolyRealData(); ++iData) {
+            const char * dataField = co.getPolyDataFieldName(iData);
+            std::stringstream stream;
+            for (unsigned long jPoly = 0; jPoly < co.getNPolygons(); ++jPoly) {
+                stream << co.getPolyDataReal(jPoly, dataField) << " ";
+            }
+            tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream.str().c_str());
+            const std::string path = tmpPath + "/DataArray[" + std_to_string(iData + 1) + "]";
+            tixiAddTextAttribute(handle, path.c_str(), "type", "Float64");
+            tixiAddTextAttribute(handle, path.c_str(), "Name", dataField);
+            tixiAddTextAttribute(handle, path.c_str(), "NumberOfComponents", "1");
+            tixiAddTextAttribute(handle, path.c_str(), "format", "ascii");
+            tixiAddDoubleAttribute(handle, path.c_str(), "RangeMin", 0. ,"%f");
+            tixiAddDoubleAttribute(handle, path.c_str(), "RangeMax", 1. ,"%f");
+        }
+    }
+
+    // write metadata
+    if (co.hasMetadata()) {
+        std::stringstream stream4;
+        stream4 << endl  << "        ";
+        for (unsigned int i = 0; i < co.getNPolygons(); i ++) {
+            stream4 << "    " << co.getPolyMetadata(i) << endl;
+            stream4 << "        ";
+        }
+        std::string tmpPath = piecepath + "/Polys";
+        tixiAddTextElement(handle, tmpPath.c_str(), "MetaData", stream4.str().c_str());
+        tmpPath += "/MetaData";
+        tixiAddTextAttribute(handle, tmpPath.c_str(), "elements", co.getMetadataElements() );
     }
 }
 

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -120,7 +120,7 @@ void CTiglExportVtk::ExportMeshedWingVTKByIndex(const int wingIndex, const std::
 void CTiglExportVtk::ExportMeshedWingVTKByUID(const std::string& wingUID, const std::string& filename, const double deflection)
 {
     tigl::CCPACSWing& wing = myConfig.GetWing(wingUID);
-    CTiglTriangularizer wingTrian(wing, deflection, SEGMENT_INFO, getOptions(*this));
+    CTiglTriangularizer wingTrian(myConfig.GetUIDManager(), wing.GetLoft(), deflection, SEGMENT_INFO, getOptions(*this));
     writeVTK(wingTrian.getTriangulation(), filename.c_str());
 }
 
@@ -137,8 +137,7 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByIndex(const int fuselageIndex, con
 void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID, const std::string& filename, const double deflection)
 {
     CTiglRelativelyPositionedComponent & component = myConfig.GetFuselage(fuselageUID);
-    const TopoDS_Shape& shape = component.GetLoft()->Shape();
-    CTiglTriangularizer trian(shape, deflection, getOptions(*this));
+    CTiglTriangularizer trian(component.GetLoft(), deflection, getOptions(*this));
     writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
@@ -146,7 +145,8 @@ void CTiglExportVtk::ExportMeshedFuselageVTKByUID(const std::string& fuselageUID
 // Exports a whole geometry, boolean fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTK(const std::string& filename, const double deflection)
 {
-    tigl::CTiglTriangularizer trian(myConfig, true, deflection, SEGMENT_INFO, getOptions(*this));
+    // TODO: 122 enable fusing
+    tigl::CTiglTriangularizer trian(myConfig, deflection, SEGMENT_INFO, getOptions(*this));
     writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
@@ -155,8 +155,7 @@ void CTiglExportVtk::ExportMeshedGeometryVTK(const std::string& filename, const 
 void CTiglExportVtk::ExportMeshedWingVTKSimpleByUID(const std::string& wingUID, const std::string& filename, const double deflection)
 {
     CCPACSWing & component = dynamic_cast<CCPACSWing&>(myConfig.GetWing(wingUID));
-    TopoDS_Shape& loft = component.GetLoftWithLeadingEdge();
-    CTiglTriangularizer loftTrian(loft, deflection, getOptions(*this));
+    CTiglTriangularizer loftTrian(component.GetLoft(), deflection, getOptions(*this));
     writeVTK(loftTrian.getTriangulation(), filename.c_str());
 }
 
@@ -172,8 +171,7 @@ void CTiglExportVtk::ExportMeshedWingVTKSimpleByIndex(const int wingIndex, const
 void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByUID(const std::string& fuselageUID, const std::string& filename, const double deflection)
 {
     CTiglRelativelyPositionedComponent & component = myConfig.GetFuselage(fuselageUID);
-    const TopoDS_Shape& shape = component.GetLoft()->Shape();
-    CTiglTriangularizer loftTrian(shape, deflection, getOptions(*this));
+    CTiglTriangularizer loftTrian(component.GetLoft(), deflection, getOptions(*this));
     writeVTK(loftTrian.getTriangulation(), filename.c_str());
 }
 
@@ -188,14 +186,16 @@ void CTiglExportVtk::ExportMeshedFuselageVTKSimpleByIndex(const int fuselageInde
 // Exports a whole geometry, boolean fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTKSimple(const std::string& filename, const double deflection)
 {
-    tigl::CTiglTriangularizer trian(myConfig, true, deflection, NO_INFO, getOptions(*this));
+    // TODO: 122 fuse
+    tigl::CTiglTriangularizer trian(myConfig, deflection, NO_INFO, getOptions(*this));
     writeVTK(trian.getTriangulation(), filename.c_str());
 }
 
 // Exports a whole geometry, not fused and meshed, as VTK file
 void CTiglExportVtk::ExportMeshedGeometryVTKNoFuse(const std::string& filename, const double deflection)
 {
-    tigl::CTiglTriangularizer trian(myConfig, false, deflection, NO_INFO, getOptions(*this));
+    // TODO: 122 don't fuse
+    tigl::CTiglTriangularizer trian(myConfig, deflection, NO_INFO, getOptions(*this));
     writeVTK(trian.getTriangulation(), filename.c_str());
 }
 

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -38,12 +38,6 @@ namespace tigl
 class CTiglPolyData;
 class CTiglPolyObject;
 
-enum VTK_EXPORT_MODE
-    {
-    TIGL_VTK_SIMPLE = 0,
-    TIGL_VTK_COMPLEX  = 1
-    };
-
 class CTiglExportVtk : public CTiglCADExporter
 {
 public:
@@ -53,54 +47,19 @@ public:
     // Virtual Destructor
     TIGL_EXPORT virtual ~CTiglExportVtk();
 
-    // Exports a by index selected wing, boolean fused and meshed, as VTK file
-    TIGL_EXPORT void ExportMeshedWingVTKByIndex(const int wingIndex, const std::string& filename, const double deflection = 0.1);
-
-    // Exports a by UID selected wing, boolean fused and meshed, as VTK file
-    TIGL_EXPORT void ExportMeshedWingVTKByUID(const std::string& wingUID, const std::string& filename, const double deflection = 0.1);
-
-    // Exports a by index selected fuselage, boolean fused and meshed, as VTK file
-    TIGL_EXPORT void ExportMeshedFuselageVTKByIndex(const int fuselageIndex, const std::string& filename, const double deflection = 0.1);
-
-    // Exports a by UID selected fuselage, boolean fused and meshed, as VTK file
-    TIGL_EXPORT void ExportMeshedFuselageVTKByUID(const std::string& fuselageUID, const std::string& filename, const double deflection = 0.1);
-
-    // Exports a whole geometry, boolean fused and meshed, as VTK file
-    TIGL_EXPORT void ExportMeshedGeometryVTK(const std::string& filename, const double deflection = 0.1);
-
-
-    // Simple exports without cpacs information
-    // Exports a by UID selected wing, meshed, as VTK file
-    // No additional information are computed.
-    TIGL_EXPORT void ExportMeshedWingVTKSimpleByUID(const std::string& wingUID, const std::string& filename, const double deflection = 0.1);
-    
-    TIGL_EXPORT void ExportMeshedWingVTKSimpleByIndex(const int wingIndex, const std::string& filename, const double deflection = 0.1);
-
-    // Exports a by UID selected fuselage, boolean fused and meshed, as VTK file.
-    // No additional information are computed.
-    TIGL_EXPORT void ExportMeshedFuselageVTKSimpleByUID(const std::string& fuselageUID, const std::string& filename, const double deflection = 0.1);
-    
-    TIGL_EXPORT void ExportMeshedFuselageVTKSimpleByIndex(const int fuselageIndex, const std::string& filename, const double deflection = 0.1);
-
-    // Exports a whole geometry, boolean fused and meshed, as VTK file
-    // No additional information are computed.
-    TIGL_EXPORT void ExportMeshedGeometryVTKSimple(const std::string& filename, const double deflection = 0.1);
-
-    TIGL_EXPORT void ExportMeshedGeometryVTKNoFuse(const std::string& filename, const double deflection = 0.1);
-
     TIGL_EXPORT static void SetOptions(const std::string& key, const std::string& value);
 
     // Options
     TIGL_EXPORT static bool normalsEnabled;
     
-    TIGL_EXPORT static void writeVTK(const CTiglPolyData& polys, const char * filename);
+    /// Exports a polygonal data representation directly
+    TIGL_EXPORT static void WritePolys(const CTiglPolyData& polys, const char * filename);
 
 private:
     bool WriteImpl(const std::string& filename) const OVERRIDE;
 
     static void writeVTKPiece(const CTiglPolyObject& co, TixiDocumentHandle& handle, unsigned int iObject); 
-    static void createVTK(const CTiglPolyData& polys, TixiDocumentHandle& handle);
-    static void createVTKHeader(TixiDocumentHandle& handle);
+    static void writeVTKHeader(TixiDocumentHandle& handle);
     
     class CCPACSConfiguration & myConfig;       /**< TIGL configuration object */
     ComponentTraingMode myMode;

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -33,6 +33,8 @@
 namespace tigl 
 {
 
+class CTiglPolyData;
+
 enum VTK_EXPORT_MODE
     {
     TIGL_VTK_SIMPLE = 0,
@@ -85,11 +87,15 @@ public:
 
     TIGL_EXPORT static void SetOptions(const std::string& key, const std::string& value);
 
-
     // Options
     TIGL_EXPORT static bool normalsEnabled;
+    
+    TIGL_EXPORT static void writeVTK(const CTiglPolyData& polys, const char * filename);
 
 private:
+    static void writeVTKPiece(const CTiglPolyData& polys, TixiDocumentHandle& handle, unsigned int iObject); 
+    static void createVTK(const CTiglPolyData& polys, TixiDocumentHandle& handle);
+
     class CCPACSConfiguration & myConfig;       /**< TIGL configuration object */
 
 };

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -27,6 +27,8 @@
 #define CTIGLEXPORTVTK_H
 
 #include "tigl_internal.h"
+#include "CTiglCADExporter.h"
+#include "CTiglTriangularizer.h"
 
 #include <string>
 
@@ -34,6 +36,7 @@ namespace tigl
 {
 
 class CTiglPolyData;
+class CTiglPolyObject;
 
 enum VTK_EXPORT_MODE
     {
@@ -41,11 +44,11 @@ enum VTK_EXPORT_MODE
     TIGL_VTK_COMPLEX  = 1
     };
 
-class CTiglExportVtk
+class CTiglExportVtk : public CTiglCADExporter
 {
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportVtk(class CCPACSConfiguration & config);
+    TIGL_EXPORT CTiglExportVtk(class CCPACSConfiguration & config, ComponentTraingMode mode = NO_INFO);
 
     // Virtual Destructor
     TIGL_EXPORT virtual ~CTiglExportVtk();
@@ -93,10 +96,14 @@ public:
     TIGL_EXPORT static void writeVTK(const CTiglPolyData& polys, const char * filename);
 
 private:
-    static void writeVTKPiece(const CTiglPolyData& polys, TixiDocumentHandle& handle, unsigned int iObject); 
-    static void createVTK(const CTiglPolyData& polys, TixiDocumentHandle& handle);
+    bool WriteImpl(const std::string& filename) const OVERRIDE;
 
+    static void writeVTKPiece(const CTiglPolyObject& co, TixiDocumentHandle& handle, unsigned int iObject); 
+    static void createVTK(const CTiglPolyData& polys, TixiDocumentHandle& handle);
+    static void createVTKHeader(TixiDocumentHandle& handle);
+    
     class CCPACSConfiguration & myConfig;       /**< TIGL configuration object */
+    ComponentTraingMode myMode;
 
 };
 

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -51,6 +51,7 @@ public:
 
     // Options
     TIGL_EXPORT static bool normalsEnabled;
+    TIGL_EXPORT static bool multiplePieces;
     
     /// Exports a polygonal data representation directly
     TIGL_EXPORT static void WritePolys(const CTiglPolyData& polys, const char * filename);

--- a/src/geometry/CNamedShape.cpp
+++ b/src/geometry/CNamedShape.cpp
@@ -153,6 +153,16 @@ void CFaceTraits::SetName(const std::string& name)
     _faceName = name;
 }
 
+void CFaceTraits::SetComponentUID(const std::string &uid)
+{
+    _componentUID = uid;
+}
+
+std::string CFaceTraits::ComponentUID() const
+{
+    return _componentUID;
+}
+
 std::string CFaceTraits::Name() const
 {
     return _faceName.c_str();

--- a/src/geometry/CNamedShape.cpp
+++ b/src/geometry/CNamedShape.cpp
@@ -29,14 +29,14 @@ CNamedShape::CNamedShape()
     Clear();
 }
 
-CNamedShape::CNamedShape(const TopoDS_Shape &shape, const char *shapeName)
+CNamedShape::CNamedShape(const TopoDS_Shape &shape, const std::string& shapeName)
     : _myshape(shape), _myname(shapeName)
 {
     SetShortName(shapeName);
     InitFaceTraits();
 }
 
-CNamedShape::CNamedShape(const TopoDS_Shape &shape, const char *shapeName, const char *shapeShortName)
+CNamedShape::CNamedShape(const TopoDS_Shape &shape, const std::string &shapeName, const std::string &shapeShortName)
     : _myshape(shape), _myname(shapeName), _myshortName(shapeShortName)
 {
     InitFaceTraits();
@@ -78,14 +78,14 @@ const TopoDS_Shape& CNamedShape::Shape() const
     return _myshape;
 }
 
-const char* CNamedShape::Name() const
+std::string CNamedShape::Name() const
 {
-    return _myname.c_str();
+    return _myname;
 }
 
-const char* CNamedShape::ShortName()  const
+std::string CNamedShape::ShortName()  const
 {
-    return _myshortName.c_str();
+    return _myshortName;
 }
 
 unsigned int CNamedShape::GetFaceCount() const
@@ -100,13 +100,13 @@ void CNamedShape::SetShape(const TopoDS_Shape& shape)
     _myshape = shape;
 }
 
-void CNamedShape::SetName(const char * name)
+void CNamedShape::SetName(const std::string& name)
 {
     _myname = name;
 }
 
 
-void CNamedShape::SetShortName(const char* name)
+void CNamedShape::SetShortName(const std::string& name)
 {
     std::string sname = name;
     if (sname.size() > 8) {
@@ -148,12 +148,12 @@ CFaceTraits::CFaceTraits()
     : _origin(), _indexInOrigin(0), _faceName("")
 {}
 
-void CFaceTraits::SetName(const char* name)
+void CFaceTraits::SetName(const std::string& name)
 {
     _faceName = name;
 }
 
-const char* CFaceTraits::Name() const
+std::string CFaceTraits::Name() const
 {
     return _faceName.c_str();
 }

--- a/src/geometry/CNamedShape.h
+++ b/src/geometry/CNamedShape.h
@@ -52,13 +52,16 @@ public:
     // origin is the other shape and iface is the face index in the original shape
     TIGL_EXPORT void SetDerivedFromShape(PNamedShape origin, unsigned int iface);
     
-    TIGL_EXPORT const char* Name() const;
-    TIGL_EXPORT void SetName(const char* );
+    TIGL_EXPORT std::string Name() const;
+    TIGL_EXPORT void SetName(const std::string&);
+    
+    //TIGL_EXPORT SetComponentUID(const std::string& uid);
     
 private:
     PNamedShape  _origin;        /** Pointer to the original shape where this face was created */
     unsigned int _indexInOrigin; /** Index of face in original shape */
     std::string   _faceName;     /** Name of the face */
+    std::string _componentUID;   /** UID of the TiGL component the face belongs to */
 };
 
 /**
@@ -69,8 +72,8 @@ class CNamedShape
 {
 public:
     TIGL_EXPORT CNamedShape();
-    TIGL_EXPORT CNamedShape(const TopoDS_Shape& shape, const char* shapeName);
-    TIGL_EXPORT CNamedShape(const TopoDS_Shape& shape, const char* shapeName, const char* shapeShortName);
+    TIGL_EXPORT CNamedShape(const TopoDS_Shape& shape, const std::string& shapeName);
+    TIGL_EXPORT CNamedShape(const TopoDS_Shape& shape, const std::string &shapeName, const std::string &shapeShortName);
     TIGL_EXPORT CNamedShape(const CNamedShape&);
     TIGL_EXPORT CNamedShape &operator= (const CNamedShape&);
     TIGL_EXPORT ~CNamedShape();
@@ -82,8 +85,8 @@ public:
 
     // getters
     TIGL_EXPORT const TopoDS_Shape& Shape() const;
-    TIGL_EXPORT const char*         Name()  const;
-    TIGL_EXPORT const char*         ShortName() const;
+    TIGL_EXPORT std::string Name()  const;
+    TIGL_EXPORT std::string ShortName() const;
 
     TIGL_EXPORT unsigned int GetFaceCount() const;
     TIGL_EXPORT const CFaceTraits& GetFaceTraits(int iFace) const;
@@ -91,8 +94,8 @@ public:
     
     // setters
     TIGL_EXPORT void SetShape(const TopoDS_Shape&);
-    TIGL_EXPORT void SetName(const char*);
-    TIGL_EXPORT void SetShortName(const char*);
+    TIGL_EXPORT void SetName(const std::string&);
+    TIGL_EXPORT void SetShortName(const std::string &);
     TIGL_EXPORT void SetFaceTraits(int iFace, const CFaceTraits& traits);
 
 protected:

--- a/src/geometry/CNamedShape.h
+++ b/src/geometry/CNamedShape.h
@@ -55,7 +55,8 @@ public:
     TIGL_EXPORT std::string Name() const;
     TIGL_EXPORT void SetName(const std::string&);
     
-    //TIGL_EXPORT SetComponentUID(const std::string& uid);
+    TIGL_EXPORT void SetComponentUID(const std::string& uid);
+    TIGL_EXPORT std::string ComponentUID() const;
     
 private:
     PNamedShape  _origin;        /** Pointer to the original shape where this face was created */

--- a/src/geometry/CTiglPolyData.cpp
+++ b/src/geometry/CTiglPolyData.cpp
@@ -303,259 +303,43 @@ CTiglPolyObject& CTiglPolyData::switchObject(unsigned int iObject)
     }
 }
 
-unsigned int CTiglPolyData::getNObjects()
+const CTiglPolyObject& CTiglPolyData::getObject(unsigned int iObject) const
+{
+    if (iObject >= 1 && iObject <= _objects.size()) {
+        return **(_objects.begin() + iObject -1);
+    }
+    else {
+        throw tigl::CTiglError("Invalid surface index in CTiglPolyData::switchObject!", TIGL_INDEX_ERROR);
+    }
+}
+
+unsigned int CTiglPolyData::getNObjects() const
 {
     return static_cast<unsigned int>(_objects.size());
 }
 
-unsigned long CTiglPolyData::getTotalPolygonCount()
+unsigned long CTiglPolyData::getTotalPolygonCount() const
 {
-    std::vector<CTiglPolyObject*>::iterator co = itCurrentObj;
-
     unsigned long nPolys = 0;
 
     for (unsigned int i = 1; i <= getNObjects(); ++i) {
-        CTiglPolyObject& obj = switchObject(i);
+        const CTiglPolyObject& obj = getObject(i);
         nPolys += obj.getNPolygons();
     }
 
-    itCurrentObj = co;
     return nPolys;
 }
 
-unsigned long CTiglPolyData::getTotalVertexCount()
+unsigned long CTiglPolyData::getTotalVertexCount() const
 {
-    std::vector<CTiglPolyObject*>::iterator co = itCurrentObj;
-
     unsigned long nVertices = 0;
 
     for (unsigned int i = 1; i <= getNObjects(); ++i) {
-        CTiglPolyObject& obj = switchObject(i);
+        const CTiglPolyObject& obj = getObject(i);
         nVertices += obj.getNVertices();
     }
 
-    itCurrentObj = co;
     return nVertices;
-}
-
-void CTiglPolyData::writeVTK(const char *filename)
-{
-    TixiDocumentHandle handle;
-    createVTK(handle);
-    if (tixiSaveDocument(handle, filename)!= SUCCESS) {
-        throw CTiglError("Error saving vtk file!");
-    }
-    LOG(INFO) << "VTK Export succeeded with " << getTotalPolygonCount()
-              << " polygons and " << getTotalVertexCount() << " vertices." << std::endl;
-}
-
-void CTiglPolyData::createVTK(TixiDocumentHandle& handle)
-{
-    tixiCreateDocument("VTKFile", &handle);
-    tixiAddTextAttribute(handle, "/VTKFile", "type", "PolyData");
-    tixiAddTextAttribute(handle, "/VTKFile", "version", "0.1");
-    tixiAddTextAttribute(handle, "/VTKFile", "byte_order", "LittleEndian");
-    tixiAddTextAttribute(handle, "/VTKFile", "compressor", "vtkZLibDataCompressor");
-
-    std::stringstream stream;
-    stream << "tigl " << tiglGetVersion();
-    tixiCreateElement(handle, "/VTKFile","MetaData");
-    tixiAddTextAttribute(handle, "/VTKFile/MetaData", "creator", stream.str().c_str());
-    
-    tixiCreateElement(handle, "/VTKFile", "PolyData");
-
-    for (unsigned int iobj = 1; iobj <= getNObjects(); ++iobj ) {
-        writeVTKPiece(handle, iobj);
-    }
-}
-
-void setMinMax(const CTiglPoint& p, double* oldmin, double* oldmax)
-{
-    if (p.x > *oldmax) {
-        *oldmax = p.x;
-    }
-
-    if (p.y > *oldmax) {
-        *oldmax = p.y;
-    }
-
-    if (p.z > *oldmax) {
-        *oldmax = p.z;
-    }
-
-    if (p.x < *oldmin) {
-        *oldmin = p.x;
-    }
-
-    if (p.y < *oldmin) {
-        *oldmin = p.y;
-    }
-
-    if (p.z < *oldmin) {
-        *oldmin = p.z;
-    }
-}
-
-// writes the polygon data of a surface (in vtk they call it piece)
-void CTiglPolyData::writeVTKPiece(TixiDocumentHandle& handle, unsigned int iObject)
-{
-    CTiglPolyObject& co = switchObject(iObject);
-
-    if (co.getNPolygons() == 0) {
-        return;
-    }
-
-    // count number of vertices - this is not necessarily the number of points
-    int nvert = 0;
-    for (unsigned int i = 0; i < co.getNPolygons(); ++i) {
-        nvert += co.getNPointsOfPolygon(i);
-    }
-
-    if (nvert <= 0) {
-        return;
-    }
-
-    // surface specific stuff
-    tixiCreateElement(handle, "/VTKFile/PolyData","Piece");
-
-    const std::string piecepath = "/VTKFile/PolyData/Piece[" + std_to_string(iObject) + "]";
-
-    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfPoints", co.getNVertices(), "%d");
-    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfVerts",  0, "%d");
-    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfLines",  0, "%d");
-    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfStrips", 0, "%d");
-    tixiAddIntegerAttribute(handle, piecepath.c_str(), "NumberOfPolys",  co.getNPolygons(), "%d");
-
-    tixiCreateElement(handle, piecepath.c_str(), "Points");
-
-    //points
-    {
-        unsigned int nPoints = co.getNVertices();
-        std::stringstream stream1;
-        stream1 << std::endl <<   "         ";
-        double min_coord = DBL_MAX, max_coord = DBL_MIN;
-        for (unsigned int i = 0; i < nPoints; ++i) {
-            const CTiglPoint& p = co.getVertexPoint(i);
-            setMinMax(p, &min_coord, &max_coord);
-            stream1 << "    " << std::setprecision(10) << p.x << " " << p.y << " " << p.z << std::endl;
-            stream1 << "         ";
-        }
-        std::string tmpPath = piecepath + "/Points";
-        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream1.str().c_str());
-        tmpPath += "/DataArray";
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "type", "Float64");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "Points");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "NumberOfComponents", "3");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "format", "ascii");
-        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMin", min_coord ,"%f");
-        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMax", max_coord ,"%f");
-    }
-
-    //normals
-    if (co.hasNormals()) {
-        tixiCreateElement(handle, piecepath.c_str(), "PointData");
-        std::string tmpPath = piecepath + "/PointData";
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "Normals", "surf_normals");
-
-        std::stringstream stream;
-        double min_coord = DBL_MAX, max_coord = DBL_MIN;
-        stream << endl  << "        ";
-        for (unsigned int i=0; i < co.getNVertices(); ++i) {
-             const CTiglPoint& n = co.getVertexNormal(i);
-             setMinMax(n, &min_coord, &max_coord);
-             stream << "    " << n.x << " " << n.y << " "  << n.z << endl;
-             stream <<  "        ";
-        }
-
-        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream.str().c_str());
-        tmpPath += "/DataArray";
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "type", "Float64");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "surf_normals");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "NumberOfComponents", "3");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "format", "ascii");
-        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMin", min_coord ,"%f");
-        tixiAddDoubleAttribute(handle, tmpPath.c_str(), "RangeMax", max_coord ,"%f");
-    }
-
-    //polygons
-    {
-        tixiCreateElement(handle, piecepath.c_str(), "Polys");
-        std::stringstream stream2;
-        stream2 << std::endl <<   "        ";
-        for (unsigned int iPoly = 0; iPoly < co.getNPolygons(); ++iPoly) {
-            stream2 <<     "    ";
-            for (unsigned int jPoint = 0; jPoint < co.getNPointsOfPolygon(iPoly); ++jPoint ) {
-                stream2 << co.getVertexIndexOfPolygon(jPoint, iPoly) << " ";
-            }
-            stream2  << std::endl <<  "        ";;
-        }
-
-        std::string tmpPath = piecepath + "/Polys";
-        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream2.str().c_str());
-        tmpPath += "/DataArray";
-        tixiAddTextAttribute(handle,tmpPath.c_str(), "type", "Int32");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "connectivity");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "format", "ascii");
-        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMin", 0 ,"%d");
-        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMax", co.getNVertices()-1,"%d");
-    }
-
-    //offset
-    {
-        unsigned int next = 0;
-        std::stringstream stream3;
-        for (unsigned int i = 0; i < co.getNPolygons(); i ++) {
-            if ((i % 10 == 0) && (i != (co.getNPolygons() - 1))) {
-                stream3 << endl << "            ";
-            }
-            next += co.getNPointsOfPolygon(i);
-            stream3 << " " << next;
-        }
-        stream3 << endl << "        ";
-        std::string tmpPath = piecepath + "/Polys";
-        tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream3.str().c_str());
-        tmpPath += "/DataArray[2]";
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "type", "Int32");
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "Name", "offsets");
-        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMin", co.getNPointsOfPolygon(0) ,"%d");
-        tixiAddIntegerAttribute(handle, tmpPath.c_str(), "RangeMax", nvert,"%d");
-    }
-    
-    // write cell data
-    if (currentObject().getNumberOfPolyRealData() > 0) {
-        tixiCreateElement(handle, piecepath.c_str(), "CellData");
-        const std::string tmpPath = piecepath + "/CellData";
-        
-        for (unsigned int iData = 0; iData < currentObject().getNumberOfPolyRealData(); ++iData) {
-            const char * dataField = currentObject().getPolyDataFieldName(iData);
-            std::stringstream stream;
-            for (unsigned long jPoly = 0; jPoly < currentObject().getNPolygons(); ++jPoly) {
-                stream << currentObject().getPolyDataReal(jPoly, dataField) << " ";
-            }
-            tixiAddTextElement(handle, tmpPath.c_str(), "DataArray", stream.str().c_str());
-            const std::string path = tmpPath + "/DataArray[" + std_to_string(iData + 1) + "]";
-            tixiAddTextAttribute(handle, path.c_str(), "type", "Float64");
-            tixiAddTextAttribute(handle, path.c_str(), "Name", dataField);
-            tixiAddTextAttribute(handle, path.c_str(), "NumberOfComponents", "1");
-            tixiAddTextAttribute(handle, path.c_str(), "format", "ascii");
-            tixiAddDoubleAttribute(handle, path.c_str(), "RangeMin", 0. ,"%f");
-            tixiAddDoubleAttribute(handle, path.c_str(), "RangeMax", 1. ,"%f");
-        }
-    }
-
-    // write metadata
-    if (currentObject().hasMetadata()) {
-        std::stringstream stream4;
-        stream4 << endl  << "        ";
-        for (unsigned int i = 0; i < co.getNPolygons(); i ++) {
-            stream4 << "    " << co.getPolyMetadata(i) << endl;
-            stream4 << "        ";
-        }
-        std::string tmpPath = piecepath + "/Polys";
-        tixiAddTextElement(handle, tmpPath.c_str(), "MetaData", stream4.str().c_str());
-        tmpPath += "/MetaData";
-        tixiAddTextAttribute(handle, tmpPath.c_str(), "elements", currentObject().getMetadataElements() );
-    }
 }
 
 // --------------------------------------------------------------------------//

--- a/src/geometry/CTiglPolyData.cpp
+++ b/src/geometry/CTiglPolyData.cpp
@@ -283,6 +283,11 @@ CTiglPolyObject& CTiglPolyData::currentObject()
     return **itCurrentObj;
 }
 
+const CTiglPolyObject& CTiglPolyData::currentObject() const
+{
+    return **itCurrentObj;
+}
+
 CTiglPolyObject& CTiglPolyData::createNewObject() 
 {
     _objects.push_back(new CTiglPolyObject());

--- a/src/geometry/CTiglPolyData.h
+++ b/src/geometry/CTiglPolyData.h
@@ -149,12 +149,12 @@ public:
     TIGL_EXPORT ~CTiglPolyData();
 
     // returns number of object
-    TIGL_EXPORT unsigned int getNObjects();
+    TIGL_EXPORT unsigned int getNObjects() const;
 
     // returns the total number of polygons, including all objects
-    TIGL_EXPORT unsigned long getTotalPolygonCount();
+    TIGL_EXPORT unsigned long getTotalPolygonCount() const;
     // returns the total number of vertices, including all objects
-    TIGL_EXPORT unsigned long getTotalVertexCount();
+    TIGL_EXPORT unsigned long getTotalVertexCount() const;
 
     // creates a new object, switches current object to the new one
     // we store the polygon data as different object
@@ -165,12 +165,10 @@ public:
 
     // changes the current surface, we count from 1 to getNObjects
     TIGL_EXPORT CTiglPolyObject& switchObject(unsigned int iObject);
-
-    TIGL_EXPORT void writeVTK(const char * filename);
+    
+    TIGL_EXPORT const CTiglPolyObject& getObject(unsigned int iObject) const;
 
 private:
-    void writeVTKPiece(TixiDocumentHandle& handle, unsigned int iObject);
-    void createVTK(TixiDocumentHandle& handle);
 
     std::vector<CTiglPolyObject*> _objects;
     std::vector<CTiglPolyObject*>::iterator itCurrentObj;

--- a/src/geometry/CTiglPolyData.h
+++ b/src/geometry/CTiglPolyData.h
@@ -162,6 +162,7 @@ public:
     TIGL_EXPORT CTiglPolyObject& createNewObject();
 
     TIGL_EXPORT CTiglPolyObject& currentObject();
+    TIGL_EXPORT const CTiglPolyObject& currentObject() const;
 
     // changes the current surface, we count from 1 to getNObjects
     TIGL_EXPORT CTiglPolyObject& switchObject(unsigned int iObject);

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -98,9 +98,6 @@ int CTiglTriangularizer::triangularizeShape(const TopoDS_Shape& shape)
             unsigned long nVertices, iPolyLower, iPolyUpper;
             triangularizeFace(face, nVertices, iPolyLower, iPolyUpper);
         } // for faces
-        if (m_options.useMultipleObjects()) {
-            polys.createNewObject();
-        }
     } // for shells
     
     return 0;
@@ -110,7 +107,6 @@ CTiglTriangularizer::CTiglTriangularizer(const CTiglUIDManager& uidMgr, PNamedSh
     : m_options(options)
 {
 
-    m_options.setMutipleObjectsEnabled(false);
     triangularizeComponent(uidMgr, shape, deflection, mode);
     
 }
@@ -204,9 +200,6 @@ int CTiglTriangularizer::triangularizeComponent(const CTiglUIDManager& uidMgr, P
             writeFaceDummyMeta(iPolyLower, iPolyUpper);
 
         }
-    }
-    if (m_options.useMultipleObjects()) {
-        polys.createNewObject();
     }
 
     return TIGL_SUCCESS;

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -115,17 +115,6 @@ CTiglTriangularizer::CTiglTriangularizer(const CTiglUIDManager& uidMgr, PNamedSh
     
 }
 
-CTiglTriangularizer::CTiglTriangularizer(CCPACSConfiguration &config, double deflection, ComponentTraingMode mode, const CTiglTriangularizerOptions &options)
-    : m_options(options)
-{
-    LOG(INFO) << "Calculating fused plane";
-    PTiglFusePlane fuser = config.AircraftFusingAlgo();
-    fuser->SetResultMode(FULL_PLANE);
-    PNamedShape fusedAirplane = fuser->FusedPlane();
-    
-    triangularizeComponent(config.GetUIDManager(), fusedAirplane, deflection, mode);
-}
-
 bool isValidCoord(double c) 
 {
     double tolerance = 2.e-4;

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -85,10 +85,7 @@ public:
 
     TIGL_EXPORT CTiglTriangularizer(const CTiglUIDManager& uidMgr, PNamedShape shape, double deflection,
                                     ComponentTraingMode mode = NO_INFO, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
-    
-    TIGL_EXPORT CTiglTriangularizer(CCPACSConfiguration& config, double deflection,
-                                    ComponentTraingMode mode = NO_INFO, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
-    
+
     const CTiglPolyData& getTriangulation() const
     {
         return polys;

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -48,14 +48,8 @@ enum ComponentTraingMode
 class CTiglTriangularizerOptions {
 public:
     CTiglTriangularizerOptions()
-        : m_useMultipleObjects(false),
-          m_normalsEnabled(true)
+        : m_normalsEnabled(true)
     {
-    }
-
-    bool useMultipleObjects() const
-    {
-        return m_useMultipleObjects;
     }
 
     bool normalsEnabled() const
@@ -68,13 +62,7 @@ public:
         m_normalsEnabled = enabled;
     }
 
-    void setMutipleObjectsEnabled(bool enabled)
-    {
-        m_useMultipleObjects = enabled;
-    }
-
 private:
-    bool m_useMultipleObjects;
     bool m_normalsEnabled;
 };
 

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -26,6 +26,7 @@
 #include "tigl_internal.h"
 #include "CTiglPolyData.h"
 #include <gp_Pnt.hxx>
+#include "PNamedShape.h"
 
 class TopoDS_Shape;
 class TopoDS_Face;
@@ -35,6 +36,8 @@ namespace tigl
 class CTiglRelativelyPositionedComponent;
 class CCPACSConfiguration;
 class CCPACSWingSegment;
+class CTiglUIDManager;
+class CCPACSWing;
 
 enum ComponentTraingMode 
 {
@@ -78,13 +81,13 @@ private:
 class CTiglTriangularizer
 {
 public:
-    TIGL_EXPORT CTiglTriangularizer(const TopoDS_Shape&, double deflection, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+    TIGL_EXPORT CTiglTriangularizer(PNamedShape shape, double deflection, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
 
-    TIGL_EXPORT CTiglTriangularizer(class CTiglRelativelyPositionedComponent &comp, double deflection,
-                                    ComponentTraingMode mode, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
-
-    TIGL_EXPORT CTiglTriangularizer(class CCPACSConfiguration& config, bool fuseShapes, double deflection, ComponentTraingMode mode,
-                                    const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+    TIGL_EXPORT CTiglTriangularizer(const CTiglUIDManager& uidMgr, PNamedShape shape, double deflection,
+                                    ComponentTraingMode mode = NO_INFO, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+    
+    TIGL_EXPORT CTiglTriangularizer(CCPACSConfiguration& config, double deflection,
+                                    ComponentTraingMode mode = NO_INFO, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
     
     const CTiglPolyData& getTriangulation() const
     {
@@ -92,12 +95,13 @@ public:
     }
 
 private:
-    int triangularizeComponent(CTiglRelativelyPositionedComponent& component, bool includeChilds, const TopoDS_Shape& shape, double deflection, ComponentTraingMode = NO_INFO);
-    int triangularizeComponent(const std::vector<CTiglRelativelyPositionedComponent*>& components, bool includeChilds, const TopoDS_Shape& shape, double deflection, ComponentTraingMode = NO_INFO);
+    int triangularizeComponent(const CTiglUIDManager& uidMgr, PNamedShape shape, double deflection, ComponentTraingMode = NO_INFO);
     int triangularizeShape(const TopoDS_Shape&);
-    void annotateWingSegment(CCPACSWingSegment& segment, gp_Pnt centralP, bool pointOnMirroredShape, unsigned long iPolyLow, unsigned long iPolyUp);
     int triangularizeFace(const TopoDS_Face&, unsigned long& nVertices, unsigned long& iPolyLow, unsigned long& iPolyUp);
-    int computeVTKMetaData(class CCPACSWing&);
+
+    void writeFaceDummyMeta(unsigned long iPolyLower, unsigned long iPolyUpper);
+    bool writeWingMeta(CCPACSWing& wing, gp_Pnt centralP, unsigned long iPolyLower, unsigned long iPolyUpper);
+    void writeWingSegmentMeta(CCPACSWingSegment& segment, gp_Pnt centralP, bool pointOnMirroredShape, unsigned long iPolyLower, unsigned long iPolyUpper);
 
     // some options
     CTiglTriangularizerOptions m_options;

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -37,7 +37,7 @@ class CTiglRelativelyPositionedComponent;
 class CCPACSConfiguration;
 class CCPACSWingSegment;
 class CTiglUIDManager;
-class CCPACSWing;
+class ITiglGeometricComponent;
 
 enum ComponentTraingMode 
 {
@@ -100,8 +100,8 @@ private:
     int triangularizeFace(const TopoDS_Face&, unsigned long& nVertices, unsigned long& iPolyLow, unsigned long& iPolyUp);
 
     void writeFaceDummyMeta(unsigned long iPolyLower, unsigned long iPolyUpper);
-    bool writeWingMeta(CCPACSWing& wing, gp_Pnt centralP, unsigned long iPolyLower, unsigned long iPolyUpper);
-    void writeWingSegmentMeta(CCPACSWingSegment& segment, gp_Pnt centralP, bool pointOnMirroredShape, unsigned long iPolyLower, unsigned long iPolyUpper);
+    bool writeWingMeta(ITiglGeometricComponent& wing, gp_Pnt centralP, unsigned long iPolyLower, unsigned long iPolyUpper);
+    bool writeWingSegmentMeta(ITiglGeometricComponent& segment, gp_Pnt centralP, unsigned long iPolyLower, unsigned long iPolyUpper);
 
     // some options
     CTiglTriangularizerOptions m_options;

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -75,11 +75,9 @@ private:
     bool m_normalsEnabled;
 };
 
-class CTiglTriangularizer : public CTiglPolyData
+class CTiglTriangularizer
 {
 public:
-    TIGL_EXPORT CTiglTriangularizer(const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
-
     TIGL_EXPORT CTiglTriangularizer(const TopoDS_Shape&, double deflection, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
 
     TIGL_EXPORT CTiglTriangularizer(class CTiglRelativelyPositionedComponent &comp, double deflection,
@@ -87,6 +85,11 @@ public:
 
     TIGL_EXPORT CTiglTriangularizer(class CCPACSConfiguration& config, bool fuseShapes, double deflection, ComponentTraingMode mode,
                                     const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+    
+    const CTiglPolyData& getTriangulation() const
+    {
+        return polys;
+    }
 
 private:
     int triangularizeComponent(CTiglRelativelyPositionedComponent& component, bool includeChilds, const TopoDS_Shape& shape, double deflection, ComponentTraingMode = NO_INFO);
@@ -98,6 +101,7 @@ private:
 
     // some options
     CTiglTriangularizerOptions m_options;
+    CTiglPolyData polys;
 };
 
 }

--- a/src/imports/CTiglStepReader.cpp
+++ b/src/imports/CTiglStepReader.cpp
@@ -147,7 +147,7 @@ ListPNamedShape CTiglStepReader::Read(const std::string stepFileName)
         shapeName << "StepImport_" << ishape;
         shapeShortName << "STEP" << ishape;
 
-        PNamedShape pshape(new CNamedShape(aReader.Shape(ishape), shapeName.str().c_str(), shapeShortName.str().c_str()));
+        PNamedShape pshape(new CNamedShape(aReader.Shape(ishape), shapeName.str().c_str(), shapeShortName.str()));
         shapeList.push_back(pshape);
     }
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -816,7 +816,7 @@ PNamedShape CCPACSWingComponentSegment::BuildLoft()
     // Set Names
     std::string loftName = m_uID;
     std::string loftShortName = GetShortShapeName();
-    PNamedShape loft (new CNamedShape(loftShape, loftName.c_str(), loftShortName.c_str()));
+    PNamedShape loft (new CNamedShape(loftShape, loftName.c_str(), loftShortName));
     SetFaceTraits(loft, static_cast<unsigned int>(segments.size()));
     return loft;
 }

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -138,7 +138,7 @@ namespace
     }
 
     // Set the face traits
-    void SetFaceTraits (PNamedShape loft) 
+    void SetFaceTraits (PNamedShape loft, std::string shapeUID) 
     { 
         // designated names of the faces
         std::vector<std::string> names(5);
@@ -150,7 +150,11 @@ namespace
 
         // map of faces
         TopTools_IndexedMapOfShape map;
-        TopExp::MapShapes(loft->Shape(),   TopAbs_FACE, map);
+        TopExp::MapShapes(loft->Shape(), TopAbs_FACE, map);
+        
+        for (int iFace = 0; iFace < map.Extent(); ++iFace) {
+            loft->FaceTraits(iFace).SetComponentUID(shapeUID);
+        }
 
         // check if number of faces is correct (only valid for ruled surfaces lofts)
         if (map.Extent() != 5 && map.Extent() != 4) {
@@ -491,7 +495,7 @@ PNamedShape CCPACSWingSegment::BuildLoft()
     std::string loftName = GetUID();
     std::string loftShortName = GetShortShapeName();
     PNamedShape loft (new CNamedShape(loftShape, loftName.c_str(), loftShortName.c_str()));
-    SetFaceTraits(loft);
+    SetFaceTraits(loft, GetUID());
     return loft;
 }
 

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -212,7 +212,7 @@ PNamedShape CTiglWingBuilder::BuildShape()
     std::string loftName = _wing.GetUID();
     std::string loftShortName = _wing.GetShortShapeName();
     PNamedShape loft(new CNamedShape(solid, loftName.c_str(), loftShortName.c_str()));
-    SetFaceTraits(loft, hasBluntTE);
+    SetFaceTraits(_wing.GetUID(), loft, hasBluntTE);
 
     return loft;
 }
@@ -256,7 +256,7 @@ CTiglWingBuilder::operator PNamedShape()
     return BuildShape();
 }
 // Set the name of each wing face
-void CTiglWingBuilder::SetFaceTraits (PNamedShape loft, bool hasBluntTE)
+void CTiglWingBuilder::SetFaceTraits (const std::string& wingUID, PNamedShape loft, bool hasBluntTE)
 {
     unsigned int nSegments = _wing.GetSegmentCount();
 
@@ -271,6 +271,10 @@ void CTiglWingBuilder::SetFaceTraits (PNamedShape loft, bool hasBluntTE)
 
     unsigned int nFaces = GetNumberOfFaces(loft->Shape());
 
+    for (unsigned int i = 0; i < nFaces; i++) {
+        loft->FaceTraits(i).SetComponentUID(wingUID);
+    }
+    
     // check if number of faces without inside and outside surface (nFaces-2)
     // is a multiple of 2 (without Trailing Edges) or 3 (with Trailing Edges)
     if (!((nFaces-2)/nSegments == 2 || (nFaces-2)/nSegments == 3) || nFaces < 4) {

--- a/src/wing/CTiglWingBuilder.h
+++ b/src/wing/CTiglWingBuilder.h
@@ -36,7 +36,7 @@ public:
     PNamedShape BuildShape();
 
 private:
-    void SetFaceTraits (PNamedShape loft, bool hasBluntTE);
+    void SetFaceTraits (const std::string& uid, PNamedShape loft, bool hasBluntTE);
 
     CCPACSWing& _wing;
 };

--- a/tests/unittests/TestData/simpletest-nacelle.xml
+++ b/tests/unittests/TestData/simpletest-nacelle.xml
@@ -468,7 +468,6 @@
         </wings>
         <genericGeometryComponents>
           <genericGeometryComponent uID="nacelle" symmetry="x-z-plane">
-            <parentUID>Wing</parentUID>
             <name>Nacelle</name>
             <transformation uID="nacelle_transformation1">
               <scaling uID="nacelle_transformation1_scaling1">

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -28,6 +28,7 @@
 
 #include "CTiglTriangularizer.h"
 #include "CTiglExportCollada.h"
+#include "CTiglExportVtk.h"
 #include "CCPACSConfigurationManager.h"
 #include "CCPACSConfiguration.h"
 #include "CCPACSWing.h"
@@ -223,6 +224,61 @@ TEST_F(tiglExportSimple, export_wing_collada)
     ASSERT_EQ(true, ret);
 }
 
+TEST_F(tiglExportSimple, export_wing_vtk_newapi_simple)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+
+    tigl::CTiglExportVtk vtkWriter(config);
+    vtkWriter.AddShape(wing.GetLoft(), 0.001);
+    bool ret = vtkWriter.Write("TestData/export/simpletest_wing_simple_newapi.vtp");
+
+    ASSERT_EQ(true, ret);
+}
+
+TEST_F(tiglExportSimple, export_wing_vtk_newapi_meta)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+
+    tigl::CTiglExportVtk vtkWriter(config, tigl::SEGMENT_INFO);
+    vtkWriter.AddShape(wing.GetLoft(), 0.001);
+    bool ret = vtkWriter.Write("TestData/export/simpletest_wing_meta_newapi.vtp");
+
+    ASSERT_EQ(true, ret);
+}
+
+TEST_F(tiglExportSimple, export_fusedplane_vtk_newapi_meta)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+
+    tigl::CTiglExportVtk vtkWriter(config, tigl::SEGMENT_INFO);
+    tigl::ExportOptions options(0.01);
+    options.includeFarField = false;
+    options.applySymmetries = true;
+    vtkWriter.AddFusedConfiguration(config, options);
+    bool ret = vtkWriter.Write("TestData/export/simpletest_fusedplane_meta_newapi.vtp");
+
+    ASSERT_EQ(true, ret);
+}
+
+TEST_F(tiglExportSimple, export_componentplane_vtk_newapi_meta)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+
+    tigl::CTiglExportVtk vtkWriter(config, tigl::SEGMENT_INFO);
+    tigl::ExportOptions options(0.01);
+    options.includeFarField = false;
+    options.applySymmetries = true;
+    vtkWriter.AddConfiguration(config, options);
+    bool ret = vtkWriter.Write("TestData/export/simpletest_nonfusedplane_meta_newapi.vtp");
+
+    ASSERT_EQ(true, ret);
+}
 
 // check if face names were set correctly in the case with a trailing edge
 TEST_F(tiglExportSimple, check_face_traits)

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -192,7 +192,7 @@ TEST_F(tiglExport, export_meshed_wing_simple_success)
 TEST_F(tiglExport, export_meshed_fuselage_success)
 {
     const char* vtkFuselageFilename = "TestData/export/D150modelID_fuselage1.vtp";
-    ASSERT_TRUE(tiglExportMeshedFuselageVTKSimpleByUID(tiglHandle, "D150_VAMP_FL1", vtkFuselageFilename, 0.03) == TIGL_SUCCESS);
+    ASSERT_TRUE(tiglExportMeshedFuselageVTKByUID(tiglHandle, "D150_VAMP_FL1", vtkFuselageFilename, 0.03) == TIGL_SUCCESS);
 }
 
 TEST_F(tiglExport, export_fuselage_collada_success)

--- a/tests/unittests/tiglExternalComponent.cpp
+++ b/tests/unittests/tiglExternalComponent.cpp
@@ -67,7 +67,7 @@ TEST_F(TiglExternalComponent, getShape)
     
     PNamedShape shape = object.GetLoft();
     ASSERT_TRUE(shape != NULL);
-    ASSERT_STREQ("nacelle", shape->Name());
+    ASSERT_STREQ("nacelle", shape->Name().c_str());
 }
 
 TEST_F(TiglExternalComponent, invalidFiletype)

--- a/tests/unittests/tiglImport.cpp
+++ b/tests/unittests/tiglImport.cpp
@@ -30,7 +30,7 @@ TEST(TiglImport, Step)
     ASSERT_EQ(1, shapes.size());
 
     // test shape names
-    ASSERT_STREQ("Nacelle", shapes[0]->Name());
+    ASSERT_STREQ("Nacelle", shapes[0]->Name().c_str());
 }
 
 TEST(TiglImport, ImporterFactory)

--- a/tests/unittests/tiglPolydata.cpp
+++ b/tests/unittests/tiglPolydata.cpp
@@ -204,7 +204,7 @@ TEST(TiglPolyData, cube_export_vtk_standard)
     co.setPolyDataReal(4,"value",4);
     co.setPolyDataReal(5,"value",5);
     
-    CTiglExportVtk::writeVTK(poly, "vtk_cube_standard.vtp");
+    CTiglExportVtk::WritePolys(poly, "vtk_cube_standard.vtp");
     
     ASSERT_EQ(0, co.getPolyDataReal(0,"value"));
     ASSERT_EQ(1, co.getPolyDataReal(1,"value"));
@@ -301,7 +301,7 @@ TEST(TiglPolyData, cube_export_vtk_withnormals)
 
     co.addPolygon(f6);
 
-    CTiglExportVtk::writeVTK(poly, "vtk_cube+normals.vtp");
+    CTiglExportVtk::WritePolys(poly, "vtk_cube+normals.vtp");
 }
 
 TEST(TiglPolyData, cube_export_vtk_withpieces)
@@ -365,7 +365,7 @@ TEST(TiglPolyData, cube_export_vtk_withpieces)
     f6.addPoint(p1);
     co->addPolygon(f6);
 
-    CTiglExportVtk::writeVTK(poly, "vtk_cube+pieces.vtp");
+    CTiglExportVtk::WritePolys(poly, "vtk_cube+pieces.vtp");
 }
 
 TEST_F(TriangularizeShape, exportVTK_FusedWing)
@@ -378,7 +378,7 @@ TEST_F(TriangularizeShape, exportVTK_FusedWing)
 
     tigl::CTiglTriangularizer t(wing.GetLoft(), 0.001);
     try {
-        CTiglExportVtk::writeVTK(t.getTriangulation(), "exported_fused_wing_simple.vtp");
+        CTiglExportVtk::WritePolys(t.getTriangulation(), "exported_fused_wing_simple.vtp");
     }
     catch (...) {
         exportError = true;
@@ -412,7 +412,7 @@ TEST_F(TriangularizeShape, exportVTK_CompoundWing)
     std::cout << "Number of Polygons/Vertices: " << t.getTriangulation().currentObject().getNPolygons() << "/"
               << t.getTriangulation().currentObject().getNVertices()<<std::endl;
     try {
-        CTiglExportVtk::writeVTK(t.getTriangulation(), "exported_compund_wing_simple.vtp");
+        CTiglExportVtk::WritePolys(t.getTriangulation(), "exported_compund_wing_simple.vtp");
     }
     catch (...) {
         exportError = true;
@@ -437,7 +437,7 @@ TEST_F(TriangularizeShape, exportVTK_WingSegmentInfo)
     stop = clock();
     std::cout << "Triangularization time [ms]: " << (stop-start)/(double)CLOCKS_PER_SEC * 1000. << std::endl;
     std::cout << "Number of Polygons/Vertices: " << polys.currentObject().getNPolygons() << "/" << polys.currentObject().getNVertices()<<std::endl;
-    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(polys, vtkWingFilename));
+    ASSERT_NO_THROW(CTiglExportVtk::WritePolys(polys, vtkWingFilename));
 }
 
 TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
@@ -446,11 +446,13 @@ TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
 
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
-    
-    // TODO: 122 Enable fusing
-    tigl::CTiglTriangularizer mesher(config, 0.001, SEGMENT_INFO);
+    PTiglFusePlane algo = config.AircraftFusingAlgo();
+    algo->SetResultMode(FULL_PLANE);
+    PNamedShape shape = algo->FusedPlane();
+
+    tigl::CTiglTriangularizer mesher(config.GetUIDManager(), shape, 0.001, SEGMENT_INFO);
     const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
     std::cout << "Number of Polygons/Vertices: " << polys.currentObject().getNPolygons() << "/" << polys.currentObject().getNVertices()<<std::endl;
-    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(polys, vtkWingFilename));
+    ASSERT_NO_THROW(CTiglExportVtk::WritePolys(polys, vtkWingFilename));
 }

--- a/tests/unittests/tiglPolydata.cpp
+++ b/tests/unittests/tiglPolydata.cpp
@@ -378,7 +378,7 @@ TEST_F(TriangularizeShape, exportVTK_FusedWing)
 
     tigl::CTiglTriangularizer t(wing.GetLoft()->Shape(), 0.001);
     try {
-        CTiglExportVtk::writeVTK(t, "exported_fused_wing_simple.vtp");
+        CTiglExportVtk::writeVTK(t.getTriangulation(), "exported_fused_wing_simple.vtp");
     }
     catch (...) {
         exportError = true;
@@ -408,9 +408,10 @@ TEST_F(TriangularizeShape, exportVTK_CompoundWing)
     tigl::CTiglTriangularizer t(compound, 0.001);
     stop = clock();
     std::cout << "Triangularization time [ms]: " << (stop-start)/(double)CLOCKS_PER_SEC * 1000. << std::endl;
-    std::cout << "Number of Polygons/Vertices: " << t.currentObject().getNPolygons() << "/" << t.currentObject().getNVertices()<<std::endl;
+    std::cout << "Number of Polygons/Vertices: " << t.getTriangulation().currentObject().getNPolygons() << "/"
+              << t.getTriangulation().currentObject().getNVertices()<<std::endl;
     try {
-        CTiglExportVtk::writeVTK(t, "exported_compund_wing_simple.vtp");
+        CTiglExportVtk::writeVTK(t.getTriangulation(), "exported_compund_wing_simple.vtp");
     }
     catch (...) {
         exportError = true;
@@ -429,12 +430,13 @@ TEST_F(TriangularizeShape, exportVTK_WingSegmentInfo)
 
     clock_t start, stop;
     start = clock();
-    tigl::CTiglTriangularizer trian(wing, 0.0001, SEGMENT_INFO);
+    tigl::CTiglTriangularizer mesher(wing, 0.0001, SEGMENT_INFO);
+    const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
     stop = clock();
     std::cout << "Triangularization time [ms]: " << (stop-start)/(double)CLOCKS_PER_SEC * 1000. << std::endl;
-    std::cout << "Number of Polygons/Vertices: " << trian.currentObject().getNPolygons() << "/" << trian.currentObject().getNVertices()<<std::endl;
-    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(trian, vtkWingFilename));
+    std::cout << "Number of Polygons/Vertices: " << polys.currentObject().getNPolygons() << "/" << polys.currentObject().getNVertices()<<std::endl;
+    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(polys, vtkWingFilename));
 }
 
 TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
@@ -444,8 +446,9 @@ TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
     
-    tigl::CTiglTriangularizer trian(config, true, 0.001, SEGMENT_INFO);
+    tigl::CTiglTriangularizer mesher(config, true, 0.001, SEGMENT_INFO);
+    const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
-    std::cout << "Number of Polygons/Vertices: " << trian.currentObject().getNPolygons() << "/" << trian.currentObject().getNVertices()<<std::endl;
-    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(trian, vtkWingFilename));
+    std::cout << "Number of Polygons/Vertices: " << polys.currentObject().getNPolygons() << "/" << polys.currentObject().getNVertices()<<std::endl;
+    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(polys, vtkWingFilename));
 }

--- a/tests/unittests/tiglPolydata.cpp
+++ b/tests/unittests/tiglPolydata.cpp
@@ -376,7 +376,7 @@ TEST_F(TriangularizeShape, exportVTK_FusedWing)
 
     bool exportError = false;
 
-    tigl::CTiglTriangularizer t(wing.GetLoft()->Shape(), 0.001);
+    tigl::CTiglTriangularizer t(wing.GetLoft(), 0.001);
     try {
         CTiglExportVtk::writeVTK(t.getTriangulation(), "exported_fused_wing_simple.vtp");
     }
@@ -405,7 +405,8 @@ TEST_F(TriangularizeShape, exportVTK_CompoundWing)
 
     clock_t start, stop;
     start = clock();
-    tigl::CTiglTriangularizer t(compound, 0.001);
+    PNamedShape compundNS(new CNamedShape(compound, "WingCompound"));
+    tigl::CTiglTriangularizer t(compundNS, 0.001);
     stop = clock();
     std::cout << "Triangularization time [ms]: " << (stop-start)/(double)CLOCKS_PER_SEC * 1000. << std::endl;
     std::cout << "Number of Polygons/Vertices: " << t.getTriangulation().currentObject().getNPolygons() << "/"
@@ -430,7 +431,7 @@ TEST_F(TriangularizeShape, exportVTK_WingSegmentInfo)
 
     clock_t start, stop;
     start = clock();
-    tigl::CTiglTriangularizer mesher(wing, 0.0001, SEGMENT_INFO);
+    tigl::CTiglTriangularizer mesher(config.GetUIDManager(), wing.GetLoft(), 0.0001, SEGMENT_INFO);
     const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
     stop = clock();
@@ -446,7 +447,8 @@ TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
     
-    tigl::CTiglTriangularizer mesher(config, true, 0.001, SEGMENT_INFO);
+    // TODO: 122 Enable fusing
+    tigl::CTiglTriangularizer mesher(config, 0.001, SEGMENT_INFO);
     const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
     std::cout << "Number of Polygons/Vertices: " << polys.currentObject().getNPolygons() << "/" << polys.currentObject().getNVertices()<<std::endl;

--- a/tests/unittests/tiglPolydata.cpp
+++ b/tests/unittests/tiglPolydata.cpp
@@ -29,6 +29,7 @@
 #include "CCPACSConfiguration.h"
 #include "CCPACSWingSegment.h"
 #include "CTiglTriangularizer.h"
+#include "CTiglExportVtk.h"
 #include "CNamedShape.h"
 
 #include <BRepMesh.hxx>
@@ -203,7 +204,7 @@ TEST(TiglPolyData, cube_export_vtk_standard)
     co.setPolyDataReal(4,"value",4);
     co.setPolyDataReal(5,"value",5);
     
-    poly.writeVTK("vtk_cube_standard.vtp");
+    CTiglExportVtk::writeVTK(poly, "vtk_cube_standard.vtp");
     
     ASSERT_EQ(0, co.getPolyDataReal(0,"value"));
     ASSERT_EQ(1, co.getPolyDataReal(1,"value"));
@@ -300,7 +301,7 @@ TEST(TiglPolyData, cube_export_vtk_withnormals)
 
     co.addPolygon(f6);
 
-    poly.writeVTK("vtk_cube+normals.vtp");
+    CTiglExportVtk::writeVTK(poly, "vtk_cube+normals.vtp");
 }
 
 TEST(TiglPolyData, cube_export_vtk_withpieces)
@@ -364,7 +365,7 @@ TEST(TiglPolyData, cube_export_vtk_withpieces)
     f6.addPoint(p1);
     co->addPolygon(f6);
 
-    poly.writeVTK("vtk_cube+pieces.vtp");
+    CTiglExportVtk::writeVTK(poly, "vtk_cube+pieces.vtp");
 }
 
 TEST_F(TriangularizeShape, exportVTK_FusedWing)
@@ -377,7 +378,7 @@ TEST_F(TriangularizeShape, exportVTK_FusedWing)
 
     tigl::CTiglTriangularizer t(wing.GetLoft()->Shape(), 0.001);
     try {
-        t.writeVTK("exported_fused_wing_simple.vtp");
+        CTiglExportVtk::writeVTK(t, "exported_fused_wing_simple.vtp");
     }
     catch (...) {
         exportError = true;
@@ -409,7 +410,7 @@ TEST_F(TriangularizeShape, exportVTK_CompoundWing)
     std::cout << "Triangularization time [ms]: " << (stop-start)/(double)CLOCKS_PER_SEC * 1000. << std::endl;
     std::cout << "Number of Polygons/Vertices: " << t.currentObject().getNPolygons() << "/" << t.currentObject().getNVertices()<<std::endl;
     try {
-        t.writeVTK("exported_compund_wing_simple.vtp");
+        CTiglExportVtk::writeVTK(t, "exported_compund_wing_simple.vtp");
     }
     catch (...) {
         exportError = true;
@@ -433,7 +434,7 @@ TEST_F(TriangularizeShape, exportVTK_WingSegmentInfo)
     stop = clock();
     std::cout << "Triangularization time [ms]: " << (stop-start)/(double)CLOCKS_PER_SEC * 1000. << std::endl;
     std::cout << "Number of Polygons/Vertices: " << trian.currentObject().getNPolygons() << "/" << trian.currentObject().getNVertices()<<std::endl;
-    ASSERT_NO_THROW(trian.writeVTK(vtkWingFilename));
+    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(trian, vtkWingFilename));
 }
 
 TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
@@ -446,5 +447,5 @@ TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
     tigl::CTiglTriangularizer trian(config, true, 0.001, SEGMENT_INFO);
 
     std::cout << "Number of Polygons/Vertices: " << trian.currentObject().getNPolygons() << "/" << trian.currentObject().getNVertices()<<std::endl;
-    ASSERT_NO_THROW(trian.writeVTK(vtkWingFilename));
+    ASSERT_NO_THROW(CTiglExportVtk::writeVTK(trian, vtkWingFilename));
 }


### PR DESCRIPTION
This required a large refactoring. The most important change is, that each face now stores the UID of the component from which it was generated.

This is required in order to figure out, which component is responsible for adding the metadata.