### PR TITLE
Improve build speed by concatenating generated source files into one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
 script:
   - '[ "$TRAVIS_OS_NAME" != osx ] || export CMAKE_PREFIX_PATH=`pwd`/../TIXI-3.0.0-Darwin:`pwd`/../oce.0.17.2.macos_static:`pwd`/../Qt5.4_clang64_macOS'
   - '[ "$TRAVIS_OS_NAME" != linux ] || jdk_switcher use oraclejdk8'
-  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTIGL_BUILD_TESTS=ON -DTIGL_OCE_COONS_PATCHED=ON -DTIGL_NIGHTLY=$TIGL_NIGHTLY -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
+  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTIGL_BUILD_TESTS=ON -DTIGL_OCE_COONS_PATCHED=ON -DTIGL_CONCAT_GENERATED_FILES=ON -DTIGL_NIGHTLY=$TIGL_NIGHTLY -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
   - make -j 4
   - make doc
   - make install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,8 +90,8 @@ build_script:
 - ps: |
     md _build -Force | Out-Null
     cd _build
-    Write-Output "Running cmake: -DCMAKE_INSTALL_PREFIX=install -DTIGL_OCE_COONS_PATCHED=ON -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=$BUILD_NIGHTLY -DQT_PATH=c:\Qt\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe -DMATLAB_DIR=c:\matlab-libs-win .."
-    & cmake -G "$generator" -DCMAKE_INSTALL_PREFIX=install -DTIGL_OCE_COONS_PATCHED=ON -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY="$BUILD_NIGHTLY" -DQT_PATH=c:\Qt\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe -DMATLAB_DIR=c:\matlab-libs-win ..
+    Write-Output "Running cmake: -DCMAKE_INSTALL_PREFIX=install -DTIGL_CONCAT_GENERATED_FILES=ON -DTIGL_OCE_COONS_PATCHED=ON -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY=$BUILD_NIGHTLY -DQT_PATH=c:\Qt\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe -DMATLAB_DIR=c:\matlab-libs-win .."
+    & cmake -G "$generator" -DCMAKE_INSTALL_PREFIX=install -DTIGL_CONCAT_GENERATED_FILES=ON -DTIGL_OCE_COONS_PATCHED=ON -DCASROOT=c:\oce\$ocedist -DTIXI_PATH=c:\tixi\$tixidist -DTIGL_BINDINGS_MATLAB=ON -DTIGL_BINDINGS_JAVA=ON -DTIGL_BUILD_TESTS=ON -DTIGL_NIGHTLY="$BUILD_NIGHTLY" -DQT_PATH=c:\Qt\$qtdist -DDOXYGEN_EXECUTABLE=c:/doxygen-win/bin/doxygen.exe -DMATLAB_DIR=c:\matlab-libs-win ..
     if ($LastExitCode -ne 0) {
         throw "Exec: $ErrorMessage"
     }

--- a/cmake/concat_generated.cmake.in
+++ b/cmake/concat_generated.cmake.in
@@ -8,7 +8,12 @@ message("Concatenting all files from src/generated")
 
 file(GLOB GENERATED_SRC "@PROJECT_SOURCE_DIR@/src/generated/*.cpp")
 
-file(REMOVE "@PROJECT_BINARY_DIR@/src/src_generated.cpp")
+string(RANDOM TEMP_STR)
+
+file(REMOVE "@PROJECT_BINARY_DIR@/src/src_generated_${TEMP_STR}.cpp.in")
 foreach(PACKAGE_SQL_FILE ${GENERATED_SRC})
-    cat(${PACKAGE_SQL_FILE} "@PROJECT_BINARY_DIR@/src/src_generated.cpp")
+    cat(${PACKAGE_SQL_FILE} "@PROJECT_BINARY_DIR@/src/src_generated_${TEMP_STR}.cpp.in")
 endforeach()
+
+# Copy the temporary file to the final location
+configure_file("@PROJECT_BINARY_DIR@/src/src_generated_${TEMP_STR}.cpp.in" "@PROJECT_BINARY_DIR@/src/src_generated.cpp" COPYONLY)

--- a/cmake/concat_generated.cmake.in
+++ b/cmake/concat_generated.cmake.in
@@ -1,0 +1,14 @@
+# Building the generated source files takes a lot of time
+# Since they are normally not changed, we concatenate all
+# files into the file src_generated.cpp
+
+include(@PROJECT_SOURCE_DIR@/cmake/tiglmacros.cmake)
+
+message("Concatenting all files from src/generated")
+
+file(GLOB GENERATED_SRC "@PROJECT_SOURCE_DIR@/src/generated/*.cpp")
+
+file(REMOVE "@PROJECT_BINARY_DIR@/src/src_generated.cpp")
+foreach(PACKAGE_SQL_FILE ${GENERATED_SRC})
+    cat(${PACKAGE_SQL_FILE} "@PROJECT_BINARY_DIR@/src/src_generated.cpp")
+endforeach()

--- a/cmake/tiglmacros.cmake
+++ b/cmake/tiglmacros.cmake
@@ -54,3 +54,13 @@ macro(SUBDIRLIST result curdir)
   endforeach()
   set(${result} ${dirlist})
 endmacro()
+
+# Concatenate files
+#
+# Parameters :
+# IN - input file)
+# OUT - output file
+FUNCTION(CAT IN OUT)
+    FILE(READ ${IN} CONTENTS)
+    FILE(APPEND ${OUT} "${CONTENTS}")
+ENDFUNCTION(CAT IN OUT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ source_group(generated FILES ${TIGL_GENERATED_SRC})
 # add all subdirectories to include path
 set(TIGL_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR})
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
-list(REMOVE_ITEM SUBDIRS generated)
 foreach(subdir ${SUBDIRS})
   set(TIGL_INCLUDES ${TIGL_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
 endforeach()
@@ -42,6 +41,34 @@ file(GLOB_RECURSE TIGL_SRC
     "*.cxx"
 )
 set(TIGL_SRC ${TIGL_SRC} ${BOOST_SRC})
+
+option(TIGL_CONCAT_GENERATED_FILES "Concatenate all generated files into one. This should speed up compiliation" OFF)
+if (TIGL_CONCAT_GENERATED_FILES)
+    # Building the generated source files takes a lot of time
+    # Since they are normally not changed, we concatenate all
+    # files into the file src_generated.cpp
+
+    file(GLOB GENERATED_SRC "generated/*.cpp")
+
+    # remove all generated files from the tigl target
+    list(REMOVE_ITEM TIGL_SRC ${GENERATED_SRC})
+
+    configure_file (
+      "${PROJECT_SOURCE_DIR}/cmake/concat_generated.cmake.in"
+       "${PROJECT_BINARY_DIR}/cmake/concat_generated.cmake"
+       @ONLY
+    )
+
+    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/src/src_generated.cpp"
+      DEPENDS ${GENERATED_SRC}
+      COMMAND ${CMAKE_COMMAND} -P
+      ${PROJECT_BINARY_DIR}/cmake/concat_generated.cmake
+    )
+    list(APPEND TIGL_SRC "${PROJECT_BINARY_DIR}/src/src_generated.cpp")
+
+else(TIGL_CONCAT_GENERATED_FILES)
+    list(REMOVE_ITEM SUBDIRS generated)
+endif(TIGL_CONCAT_GENERATED_FILES)
 
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS=1 /wd4355 -DTIGL_INTERNAL_EXPORTS)


### PR DESCRIPTION
This results in a adequate compilation speedup , roughly:

  * 45 min -> 30 min without compiler cache (e.g. in Windows)
  * 13 min -> 9 min with compiler cache (Mac, Linux)