### PR TITLE
Fuselage stringer preparation

### DIFF
--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -697,18 +697,27 @@ bool IsFileReadable(const std::string& filename)
 #endif
 }
 
-/**
- * @brief Returns the starting point of the wire
- */
-gp_Pnt WireGetFirstPoint(const TopoDS_Wire& w)
+gp_Pnt GetFirstPoint(const TopoDS_Shape& wireOrEdge)
+{
+    if (wireOrEdge.ShapeType() == TopAbs_ShapeEnum::TopAbs_WIRE)
+        return GetFirstPoint(TopoDS::Wire(wireOrEdge));
+    if (wireOrEdge.ShapeType() == TopAbs_ShapeEnum::TopAbs_EDGE)
+        return GetFirstPoint(TopoDS::Edge(wireOrEdge));
+    throw tigl::CTiglError("Shape must be wire or edge");
+}
+
+gp_Pnt GetFirstPoint(const TopoDS_Wire& w)
 {
     TopTools_IndexedMapOfShape wireMap;
-    TopExp::MapShapes(w,TopAbs_EDGE, wireMap);
+    TopExp::MapShapes(w, TopAbs_EDGE, wireMap);
     TopoDS_Edge e = TopoDS::Edge(wireMap(1));
+    return GetFirstPoint(e);
+}
 
+gp_Pnt GetFirstPoint(const TopoDS_Edge& e)
+{
     double u1, u2;
     Handle_Geom_Curve c = BRep_Tool::Curve(e, u1, u2);
-
 
     if (e.Orientation() == TopAbs_REVERSED) {
         return c->Value(u2);
@@ -718,18 +727,27 @@ gp_Pnt WireGetFirstPoint(const TopoDS_Wire& w)
     }
 }
 
-/**
- * @brief Returns the endpoint of the wire
- */
-gp_Pnt WireGetLastPoint(const TopoDS_Wire& w)
+gp_Pnt GetLastPoint(const TopoDS_Shape& wireOrEdge)
+{
+    if (wireOrEdge.ShapeType() == TopAbs_ShapeEnum::TopAbs_WIRE)
+        return GetLastPoint(TopoDS::Wire(wireOrEdge));
+    if (wireOrEdge.ShapeType() == TopAbs_ShapeEnum::TopAbs_EDGE)
+        return GetLastPoint(TopoDS::Edge(wireOrEdge));
+    throw tigl::CTiglError("Shape must be wire or edge");
+}
+
+gp_Pnt GetLastPoint(const TopoDS_Wire& w)
 {
     TopTools_IndexedMapOfShape wireMap;
-    TopExp::MapShapes(w,TopAbs_EDGE, wireMap);
+    TopExp::MapShapes(w, TopAbs_EDGE, wireMap);
     TopoDS_Edge e = TopoDS::Edge(wireMap(wireMap.Extent()));
+    return GetLastPoint(e);
+}
 
+gp_Pnt GetLastPoint(const TopoDS_Edge& e)
+{
     double u1, u2;
     Handle_Geom_Curve c = BRep_Tool::Curve(e, u1, u2);
-
 
     if (e.Orientation() == TopAbs_REVERSED) {
         return c->Value(u1);
@@ -738,6 +756,7 @@ gp_Pnt WireGetLastPoint(const TopoDS_Wire& w)
         return c->Value(u2);
     }
 }
+
 TiglContinuity getEdgeContinuity(const TopoDS_Edge& edge1, const TopoDS_Edge& edge2)
 {
     // **********************************************************************************

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -49,11 +49,15 @@ TIGL_EXPORT Standard_Real GetEdgeLength(const class TopoDS_Edge& edge);
 TIGL_EXPORT gp_Pnt WireGetPoint(const TopoDS_Wire& wire, double alpha);
 TIGL_EXPORT void WireGetPointTangent(const TopoDS_Wire& wire, double alpha, gp_Pnt& point, gp_Vec& normal);
 
-// returns the starting point of the wire
-TIGL_EXPORT gp_Pnt WireGetFirstPoint(const TopoDS_Wire& w);
+// returns the starting point of the wire/edge
+TIGL_EXPORT gp_Pnt GetFirstPoint(const TopoDS_Shape& wireOrEdge);
+TIGL_EXPORT gp_Pnt GetFirstPoint(const TopoDS_Wire& w);
+TIGL_EXPORT gp_Pnt GetFirstPoint(const TopoDS_Edge& e);
 
-// returns the end point of the wire
-TIGL_EXPORT gp_Pnt WireGetLastPoint(const TopoDS_Wire& w);
+// returns the end point of the wire/edge
+TIGL_EXPORT gp_Pnt GetLastPoint(const TopoDS_Shape& wireOrEdge);
+TIGL_EXPORT gp_Pnt GetLastPoint(const TopoDS_Wire& w);
+TIGL_EXPORT gp_Pnt GetLastPoint(const TopoDS_Edge& e);
 
 TIGL_EXPORT gp_Pnt EdgeGetPoint(const TopoDS_Edge& edge, double alpha);
 TIGL_EXPORT void EdgeGetPointTangent(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, gp_Vec& normal);

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -415,10 +415,9 @@ gp_Lin CCPACSFuselage::Intersection(const CCPACSFuselageStringerFramePosition& p
 
 namespace
 {
-    template <typename T> TopoDS_Wire project(TopoDS_Shape wireOrEdge, TopoDS_Shape fuselage, T originOrDir)
+    TopoDS_Wire project(TopoDS_Shape wireOrEdge, BRepProj_Projection& proj)
     {
         BRepBuilderAPI_MakeWire wireBuilder;
-        BRepProj_Projection proj(wireOrEdge, fuselage, originOrDir);
         for (; proj.More(); proj.Next())
             wireBuilder.Add(proj.Current());
 
@@ -452,12 +451,14 @@ namespace
 
 TopoDS_Wire CCPACSFuselage::projectConic(TopoDS_Shape wireOrEdge, gp_Pnt origin)
 {
-    return project(wireOrEdge, GetLoft()->Shape(), origin);
+    BRepProj_Projection proj(wireOrEdge, GetLoft()->Shape(), origin);
+    return project(wireOrEdge, proj);
 }
 
 TopoDS_Wire CCPACSFuselage::projectParallel(TopoDS_Shape wireOrEdge, gp_Dir direction)
 {
-    return project(wireOrEdge, GetLoft()->Shape(), direction);
+    BRepProj_Projection proj(wireOrEdge, GetLoft()->Shape(), direction);
+    return project(wireOrEdge, proj);
 }
 
 void CCPACSFuselage::BuildGuideCurves()

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -29,6 +29,7 @@
 
 #include "CCPACSFuselage.h"
 #include "CCPACSFuselageSegment.h"
+#include "CCPACSFuselageStringerFramePosition.h"
 #include "CCPACSConfiguration.h"
 #include "CCPACSWingSegment.h"
 #include "tiglcommonfunctions.h"
@@ -53,6 +54,11 @@
 #include "CTiglMakeLoft.h"
 #include "TopExp.hxx"
 #include "TopTools_IndexedMapOfShape.hxx"
+#include <TopExp_Explorer.hxx>
+#include <IntCurvesFace_Intersector.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepProj_Projection.hxx>
+#include <TopTools_ListIteratorOfListOfShape.hxx>
 
 namespace tigl
 {
@@ -370,6 +376,88 @@ TopoDS_Compound &CCPACSFuselage::GetGuideCurveWires()
 {
     BuildGuideCurves();
     return guideCurves;
+}
+
+gp_Lin CCPACSFuselage::Intersection(gp_Pnt pRef, double angleRef)
+{
+    const gp_Ax1 xAxe(
+        pRef,
+        gp_Dir(1, 0,
+               0)); // to have a left-handed coordinates system for the intersection computation (see documentation)
+    const gp_Dir ZReference(0, 0, 1);
+    const gp_Dir angleDir = ZReference.Rotated(xAxe, angleRef + M_PI);
+
+    // build a line to position the intersection with the fuselage shape
+    gp_Lin line(pRef, angleDir);
+
+    // get the list of shape from the fuselage shape
+    TopExp_Explorer exp;
+    for (exp.Init(GetLoft()->Shape(), TopAbs_FACE); exp.More(); exp.Next()) {
+        IntCurvesFace_Intersector intersection(TopoDS::Face(exp.Current()), 0.1); // intersection builder
+        intersection.Perform(line, -std::numeric_limits<Standard_Real>::max(), // replace by std::numeric_limits<Standard_Real>::lowest() when C++11 available
+                             std::numeric_limits<Standard_Real>::max());
+        if (intersection.IsDone() && intersection.NbPnt() > 0) {
+            gp_Lin result(intersection.Pnt(1), line.Direction());
+            // return the line with the point on the fuselage as the origin, and the previous line's direction
+            return result;
+        }
+    }
+
+    throw std::logic_error("Error computing intersection line");
+}
+
+gp_Lin CCPACSFuselage::Intersection(const CCPACSFuselageStringerFramePosition& pos)
+{
+    const gp_Pnt pRef        = pos.GetRefPoint();
+    const double angleRefRad = (M_PI / 180.) * pos.GetReferenceAngle();
+    return Intersection(pRef, angleRefRad);
+}
+
+namespace
+{
+    template <typename T> TopoDS_Wire project(TopoDS_Shape wireOrEdge, TopoDS_Shape fuselage, T originOrDir)
+    {
+        BRepBuilderAPI_MakeWire wireBuilder;
+        BRepProj_Projection proj(wireOrEdge, fuselage, originOrDir);
+        for (; proj.More(); proj.Next())
+            wireBuilder.Add(proj.Current());
+
+        TopTools_ListOfShape wireList;
+        BuildWiresFromConnectedEdges(proj.Shape(), wireList);
+
+        if (wireList.Extent() == 0)
+            throw CTiglError("Projection returned no wires");
+        if (wireList.Extent() == 1)
+            return TopoDS::Wire(wireList.First());
+
+        // select the wire which is closest to the wire we projected
+        for (TopTools_ListIteratorOfListOfShape it(wireList); it.More(); it.Next()) {
+            const TopoDS_Wire w                = TopoDS::Wire(it.Value());
+            const gp_Pnt wStart     = GetFirstPoint(w);
+            const gp_Pnt wEnd       = GetLastPoint(w);
+            const gp_Pnt inputStart = GetFirstPoint(wireOrEdge);
+            const gp_Pnt inputEnd   = GetLastPoint(wireOrEdge);
+
+            const double pointEqualEpsilon = 1e-4;
+            if ((wStart.IsEqual(inputStart, pointEqualEpsilon) && wEnd.IsEqual(inputEnd, pointEqualEpsilon)) ||
+                (wEnd.IsEqual(inputStart, pointEqualEpsilon) && wStart.IsEqual(inputEnd, pointEqualEpsilon))) {
+                return w;
+            }
+        }
+
+        // give up
+        throw CTiglError("Failed to project wire/edge onto fuselage");
+    }
+}
+
+TopoDS_Wire CCPACSFuselage::projectConic(TopoDS_Shape wireOrEdge, gp_Pnt origin)
+{
+    return project(wireOrEdge, GetLoft()->Shape(), origin);
+}
+
+TopoDS_Wire CCPACSFuselage::projectParallel(TopoDS_Shape wireOrEdge, gp_Dir direction)
+{
+    return project(wireOrEdge, GetLoft()->Shape(), direction);
 }
 
 void CCPACSFuselage::BuildGuideCurves()

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -42,10 +42,12 @@
 #include "TopoDS_Shape.hxx"
 #include "TopoDS_Compound.hxx"
 #include "BRep_Builder.hxx"
+#include <gp_Lin.hxx>
 
 namespace tigl
 {
 class CCPACSConfiguration;
+class CCPACSFuselageStringerFramePosition;
 
 class CCPACSFuselage : public generated::CPACSFuselage, public CTiglRelativelyPositionedComponent
 {
@@ -114,6 +116,14 @@ public:
 
     // Returns all guide curve wires as a compound
     TIGL_EXPORT TopoDS_Compound& GetGuideCurveWires();
+
+    // create the line intersecting the fuselage for the stringer/frame profile
+    TIGL_EXPORT gp_Lin Intersection(gp_Pnt pRef, double angleRef);
+    TIGL_EXPORT gp_Lin Intersection(const CCPACSFuselageStringerFramePosition& pos);
+
+    // project the edge/wire onto the fuselage loft
+    TIGL_EXPORT TopoDS_Wire projectConic(TopoDS_Shape wireOrEdge, gp_Pnt origin);
+    TIGL_EXPORT TopoDS_Wire projectParallel(TopoDS_Shape wireOrEdge, gp_Dir direction);
 
 protected:
     void BuildGuideCurves();

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -97,8 +97,8 @@ PNamedShape CTiglWingBuilder::BuildShape()
             }
             TopoDS_Wire aeroProfile = wireMaker.Wire();
             lofter.addProfiles(aeroProfile);
-            upperTEPoints.push_back(WireGetLastPoint(aeroProfile));
-            lowerTEPoints.push_back(WireGetFirstPoint(aeroProfile));
+            upperTEPoints.push_back(GetLastPoint(aeroProfile));
+            lowerTEPoints.push_back(GetFirstPoint(aeroProfile));
 
         }
         else {
@@ -123,8 +123,8 @@ PNamedShape CTiglWingBuilder::BuildShape()
         lofter.addProfiles(aeroProfile);
 
         // add the trailing edge points
-        upperTEPoints.push_back(WireGetLastPoint(aeroProfile));
-        lowerTEPoints.push_back(WireGetFirstPoint(aeroProfile));
+        upperTEPoints.push_back(GetLastPoint(aeroProfile));
+        lowerTEPoints.push_back(GetFirstPoint(aeroProfile));
 
     }
     else {


### PR DESCRIPTION
Here is some preparation for the fuselage stringer geometry code:
* renamed WireGetFirstPoint and WireGetLastPoint
* added GetFirstPoint and GetLastPoint for edge and shape
* added methods to project wires/edges onto the fuselage loft
* added methods to compute intersections of lines described by stringer frame positions with the fuselage loft
