### PR TITLE
Unified api to set configuration of exporters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,9 +30,10 @@ Version 3.0.0
   
     - Changed API:
       - Removed deprectated intersection functions. These include
-       - tiglComponentIntersectionLineCount
-       - tiglComponentIntersectionPoint
-       - tiglComponentIntersectionPoints
+       - ``tiglComponentIntersectionLineCount``
+       - ``tiglComponentIntersectionPoint``
+       - ``tiglComponentIntersectionPoints``
+      - Removed function ``tiglExportVTKSetOptions``. This is now replace by __TODO__
 
     - Fixes:
       - TiGL Viewer: Fixed missing fonts on macOS

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,13 +27,14 @@ Version 3.0.0
       - ``::tiglFuselageGetCenterLineLength`` computes the length of the centerline of the fuselage.
       - ``::tiglCheckPointInside`` checks, whether a point lies inside some object (defined by its uid).
       - ``::tiglExportFuselageBREPByUID`` and ``::tiglExportWingBREPByUID``
+	  - ``::tiglSetExportOptions`` sets exports-specific options
   
     - Changed API:
       - Removed deprectated intersection functions. These include
        - ``tiglComponentIntersectionLineCount``
        - ``tiglComponentIntersectionPoint``
        - ``tiglComponentIntersectionPoints``
-      - Removed function ``tiglExportVTKSetOptions``. This is now replace by __TODO__
+      - Removed function ``tiglExportVTKSetOptions``. This is now replaced by ``::tiglSetExportOptions``
 
     - Fixes:
       - TiGL Viewer: Fixed missing fonts on macOS
@@ -62,7 +63,7 @@ Version 2.2.1
         - Improved calculation time of ``::tiglFuselageGetPoint`` by applying caching. This leads only to a benefit in case of a large number of GetPoint calls (~30) per fuselage segment. This will be even improved in TiGL 3.
 
     - New API functions:
-        - New API function ``::tiglExportVTKSetOptions``. This function can be used e.g to disable
+        - New API function ``tiglExportVTKSetOptions``. This function can be used e.g to disable
           normal vector writing in the VTK export.
 
     - Changed API:

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -1433,7 +1433,7 @@ void TIGLViewerDocument::exportConfigCollada()
         START_COMMAND();
         TIGLViewerSettings& settings = TIGLViewerSettings::Instance();
         double relDeflect = settings.triangulationAccuracy();
-        tigl::ColladaOptions options(relDeflect);
+        tigl::TriangulatedExportOptions options(relDeflect);
 
         tigl::CTiglExportCollada exporter;
         tigl::CCPACSConfiguration& config = GetConfiguration();
@@ -1538,7 +1538,7 @@ void TIGLViewerDocument::exportMeshedConfigVTKNoFuse()
         writeToStatusBar("Writing meshed vtk file");
 
         tigl::CTiglExportVtk exporter;
-        exporter.AddConfiguration(GetConfiguration(), tigl::VtkOptions(settings.getDeflection()));
+        exporter.AddConfiguration(GetConfiguration(), tigl::TriangulatedExportOptions(settings.getDeflection()));
 
         exporter.Write(fileName.toStdString());
         writeToStatusBar("");

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -1433,9 +1433,7 @@ void TIGLViewerDocument::exportConfigCollada()
         START_COMMAND();
         TIGLViewerSettings& settings = TIGLViewerSettings::Instance();
         double relDeflect = settings.triangulationAccuracy();
-        tigl::ExportOptions options;
-        options.deflection = relDeflect;
-        options.includeFarField = false;
+        tigl::ColladaOptions options(relDeflect);
 
         tigl::CTiglExportCollada exporter;
         tigl::CCPACSConfiguration& config = GetConfiguration();
@@ -1539,11 +1537,8 @@ void TIGLViewerDocument::exportMeshedConfigVTKNoFuse()
         START_COMMAND();
         writeToStatusBar("Writing meshed vtk file");
 
-        tigl::ExportOptions options(settings.getDeflection());
-        options.applySymmetries = true;
-        options.includeFarField = false;
         tigl::CTiglExportVtk exporter;
-        exporter.AddConfiguration(GetConfiguration(), options);
+        exporter.AddConfiguration(GetConfiguration(), tigl::VtkOptions(settings.getDeflection()));
 
         exporter.Write(fileName.toStdString());
         writeToStatusBar("");

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -1542,7 +1542,7 @@ void TIGLViewerDocument::exportMeshedConfigVTKNoFuse()
         tigl::ExportOptions options(settings.getDeflection());
         options.applySymmetries = true;
         options.includeFarField = false;
-        tigl::CTiglExportVtk exporter(GetConfiguration(), tigl::SEGMENT_INFO);
+        tigl::CTiglExportVtk exporter;
         exporter.AddConfiguration(GetConfiguration(), options);
 
         exporter.Write(fileName.toStdString());

--- a/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
+++ b/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
@@ -22,9 +22,9 @@
 #include <tigl.h>
 #include "CGlobalExporterConfigs.h"
 
-TIGLViewerVTKExportDialog::TIGLViewerVTKExportDialog(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::TIGLViewerVTKExportDialog)
+TIGLViewerVTKExportDialog::TIGLViewerVTKExportDialog(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::TIGLViewerVTKExportDialog)
 {
     ui->setupUi(this);
 
@@ -59,5 +59,5 @@ TIGLViewerVTKExportDialog::~TIGLViewerVTKExportDialog()
 
 void TIGLViewerVTKExportDialog::onOkayPressed() const
 {
-    tigl::getExportConfig("vtk").Set("NormalsEnabled",  normalsEnabled());
+    tigl::getExportConfig("vtk").Set("WriteNormals", normalsEnabled());
 }

--- a/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
+++ b/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
@@ -59,10 +59,5 @@ TIGLViewerVTKExportDialog::~TIGLViewerVTKExportDialog()
 void TIGLViewerVTKExportDialog::onOkayPressed() const
 {
     bool enabled = normalsEnabled();
-    if (enabled) {
-        tiglExportVTKSetOptions("normals_enabled", "1");
-    }
-    else {
-        tiglExportVTKSetOptions("normals_enabled", "0");
-    }
+    // TODO: set using new api
 }

--- a/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
+++ b/TIGLViewer/src/TIGLViewerVTKExportDialog.cpp
@@ -20,6 +20,7 @@
 #include "ui_TIGLViewerVTKExportDialog.h"
 
 #include <tigl.h>
+#include "CGlobalExporterConfigs.h"
 
 TIGLViewerVTKExportDialog::TIGLViewerVTKExportDialog(QWidget *parent) :
     QDialog(parent),
@@ -58,6 +59,5 @@ TIGLViewerVTKExportDialog::~TIGLViewerVTKExportDialog()
 
 void TIGLViewerVTKExportDialog::onOkayPressed() const
 {
-    bool enabled = normalsEnabled();
-    // TODO: set using new api
+    tigl::getExportConfig("vtk").Set("NormalsEnabled",  normalsEnabled());
 }

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
@@ -146,7 +146,6 @@ public class TiglNativeInterface {
     public static native int tiglExportMeshedFuselageSTL(int cpacsHandle, int fuselageIndex, String filenamePtr, double deflection);
     public static native int tiglExportMeshedFuselageSTLByUID(int cpacsHandle, String fuselageUID, String filenamePtr, double deflection);
     public static native int tiglExportMeshedGeometrySTL(int cpacsHandle, String filenamePtr, double deflection);
-    public static native int tiglExportVTKSetOptions(String key, String value);
     public static native int tiglExportMeshedWingVTKByIndex(int cpacsHandle, int wingIndex, String filenamePtr, double deflection);
     public static native int tiglExportMeshedWingVTKByUID(int cpacsHandle, String wingUID, String filenamePtr, double deflection);
     public static native int tiglExportMeshedFuselageVTKByIndex(int cpacsHandle, int fuselageIndex, String filenamePtr, double deflection);

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -5382,7 +5382,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByIndex(const TiglCPACS
         tigl::CCPACSWing& wing = config.GetWing(wingIndex);
         tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
 
-        exporter->AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        exporter->AddShape(wing.GetLoft(), &config, tigl::TriangulatedExportOptions(deflection));
         if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5607,9 +5607,11 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
+        tigl::ExporterOptions exportOptions = tigl::getExportConfig("vtk");
+        exportOptions.Set("WriteMetaData", false);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk", exportOptions);
 
-        exporter->AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        exporter->AddShape(wing.GetLoft(), &config, tigl::TriangulatedExportOptions(deflection));
         if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -6848,3 +6848,38 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglCheckPointInside(TiglCPACSConfigurationHan
     }
     return TIGL_ERROR;
 }
+
+TiglReturnCode tiglSetExportOptions(const char *exporter_name, const char *option_name, const char *option_value)
+{
+    if (!exporter_name) {
+        LOG(ERROR) << "Argument exporter_name is NULL in tiglSetExportOptions!";
+        return TIGL_NULL_POINTER;
+    }
+
+    if (!option_name) {
+        LOG(ERROR) << "Argument option_name is NULL in tiglSetExportOptions!";
+        return TIGL_NULL_POINTER;
+    }
+
+    if (!option_value) {
+        LOG(ERROR) << "Argument option_value is NULL in tiglSetExportOptions!";
+        return TIGL_NULL_POINTER;
+    }
+
+    try {
+        tigl::ExporterOptions& options = tigl::getExportConfig(exporter_name);
+        options.SetFromString(option_name, option_value);
+        return TIGL_SUCCESS;
+    }
+    catch (const tigl::CTiglError& ex) {
+        LOG(ERROR) << "In tiglSetExportOptions: " << ex.what();
+        return ex.getCode();
+    }
+    catch (std::exception& ex) {
+        LOG(ERROR) << "In tiglSetExportOptions: " << ex.what();
+    }
+    catch (...) {
+        LOG(ERROR) << "Caught an exception in tiglSetExportOptions!";
+    }
+    return TIGL_ERROR;
+}

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -5043,7 +5043,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportIGES(TiglCPACSConfigurationHandle cp
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CTiglExportIges exporter;
-        exporter.AddConfiguration(config);
+        exporter.AddConfiguration(config, tigl::IgesOptions());
         bool ret = exporter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5075,7 +5075,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFusedWingFuselageIGES(TiglCPACSConfi
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CTiglExportIges exporter;
-        exporter.AddFusedConfiguration(config);
+        exporter.AddFusedConfiguration(config, tigl::IgesOptions());
         bool ret = exporter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5176,7 +5176,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingSTL(TiglCPACSConfiguration
         PNamedShape loft = wing.GetLoft();
         
         tigl::CTiglExportStl exporter;
-        exporter.AddShape(loft, deflection);
+        exporter.AddShape(loft, tigl::StlOptions(deflection));
         bool ret = exporter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5219,7 +5219,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingSTLByUID(TiglCPACSConfigur
                 PNamedShape loft = wing.GetLoft();
                 
                 tigl::CTiglExportStl exporter;
-                exporter.AddShape(loft, deflection);
+                exporter.AddShape(loft, tigl::StlOptions(deflection));
                 bool ret = exporter.Write(filenamePtr);
                 return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
             }
@@ -5265,7 +5265,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageSTL(TiglCPACSConfigura
         PNamedShape loft = fuselage.GetLoft();
         
         tigl::CTiglExportStl exporter;
-        exporter.AddShape(loft, deflection);
+        exporter.AddShape(loft, tigl::StlOptions(deflection));
         bool ret = exporter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5310,7 +5310,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageSTLByUID(TiglCPACSConf
                 PNamedShape loft = fuselage.GetLoft();
                 
                 tigl::CTiglExportStl exporter;
-                exporter.AddShape(loft, deflection);
+                exporter.AddShape(loft, tigl::StlOptions(deflection));
                 bool ret = exporter.Write(filenamePtr);
                 return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
             }
@@ -5347,12 +5347,8 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CTiglExportStl exporter;
-        tigl::ExportOptions options;
-        options.deflection = deflection;
-        options.applySymmetries = true;
-        options.includeFarField = false;
 
-        exporter.AddConfiguration(config, options);
+        exporter.AddConfiguration(config, tigl::StlOptions(deflection));
         bool ret = exporter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5366,38 +5362,6 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
     }
     catch (...) {
         LOG(ERROR) << "Caught an exception in tiglExportMeshedGeometrySTL!";
-        return TIGL_ERROR;
-    }
-}
-
-TIGL_COMMON_EXPORT TiglReturnCode tiglExportVTKSetOptions(const char *key, const char *value)
-{
-    if (!key) {
-        LOG(ERROR) << "Error: Null pointer argument for key ";
-        LOG(ERROR) << "in function call to tiglExportVTKSetOptions." << std::endl;
-        return TIGL_NULL_POINTER;
-    }
-
-    if (!value) {
-        LOG(ERROR) << "Error: Null pointer argument for value ";
-        LOG(ERROR) << "in function call to tiglExportVTKSetOptions." << std::endl;
-        return TIGL_NULL_POINTER;
-    }
-
-    try {
-        tigl::CTiglExportVtk::SetOptions(key, value);
-        return TIGL_SUCCESS;
-    }
-    catch (tigl::CTiglError & ex) {
-        LOG(ERROR) << ex.what() << std::endl;
-        return ex.getCode();
-    }
-    catch (std::exception & ex) {
-        LOG(ERROR) << ex.what() << std::endl;
-        return TIGL_ERROR;
-    }
-    catch (...) {
-        LOG(ERROR) << "Caught an unknown exception in tiglExportVTKSetOptions" << std::endl;
         return TIGL_ERROR;
     }
 }
@@ -5422,7 +5386,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByIndex(const TiglCPACS
         tigl::CCPACSWing& wing = config.GetWing(wingIndex);
         tigl::CTiglExportVtk exporter;
 
-        exporter.AddShape(wing.GetLoft(), deflection);
+        exporter.AddShape(wing.GetLoft(), tigl::VtkOptions(deflection));
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5474,7 +5438,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByUID(const TiglCPACSCo
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
         tigl::CTiglExportVtk exporter;
 
-        exporter.AddShape(wing.GetLoft(), &config, deflection);
+        exporter.AddShape(wing.GetLoft(), &config, tigl::VtkOptions(deflection));
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5525,7 +5489,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByIndex(const TiglC
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageIndex);
         tigl::CTiglExportVtk exporter;
-        exporter.AddShape(fuselage.GetLoft(), deflection);
+        exporter.AddShape(fuselage.GetLoft(), tigl::VtkOptions(deflection));
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5567,7 +5531,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByUID(const TiglCPA
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
         tigl::CTiglExportVtk exporter;
-        exporter.AddShape(fuselage.GetLoft(), deflection);
+        exporter.AddShape(fuselage.GetLoft(), tigl::VtkOptions(deflection));
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5603,11 +5567,8 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTK(const TiglCPACSCon
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
 
-        tigl::ExportOptions options(deflection);
-        options.applySymmetries = true;
-        options.includeFarField = false;
         tigl::CTiglExportVtk exporter;
-        exporter.AddFusedConfiguration(config, options);
+        exporter.AddFusedConfiguration(config, tigl::VtkOptions(deflection));
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5652,7 +5613,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
         tigl::CTiglExportVtk exporter;
 
-        exporter.AddShape(wing.GetLoft(), deflection);
+        exporter.AddShape(wing.GetLoft(), tigl::VtkOptions(deflection));
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5702,7 +5663,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFuselageColladaByUID(const TiglCPACS
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
         tigl::CTiglExportCollada colladaWriter;
-        colladaWriter.AddShape(fuselage.GetLoft(), deflection);
+        colladaWriter.AddShape(fuselage.GetLoft(), tigl::ColladaOptions(deflection));
         bool ret = colladaWriter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5738,7 +5699,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportWingColladaByUID(const TiglCPACSConf
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
         tigl::CTiglExportCollada colladaWriter;
-        colladaWriter.AddShape(wing.GetLoft(), deflection);
+        colladaWriter.AddShape(wing.GetLoft(), tigl::ColladaOptions(deflection));
         bool ret = colladaWriter.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5771,9 +5732,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTKSimple(const TiglCP
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CTiglExportVtk exporter;
         // TODO: #367 disable meta data writing
-        tigl::ExportOptions options(deflection);
-        options.applySymmetries = true;
-        options.includeFarField = false;
+        tigl::VtkOptions options(deflection);
         exporter.AddFusedConfiguration(config, options);
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
@@ -5808,7 +5767,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFusedBREP(TiglCPACSConfigurationHand
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CTiglExportBrep exporter;
-        exporter.AddFusedConfiguration(config);
+        exporter.AddFusedConfiguration(config, tigl::BRepOptions());
         bool ret = exporter.Write(filename);
         return ret == true? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5846,7 +5805,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFuselageBREPByUID(TiglCPACSConfigura
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
         tigl::CTiglExportBrep writer;
-        writer.AddShape(fuselage.GetLoft());
+        writer.AddShape(fuselage.GetLoft(), tigl::BRepOptions());
         bool ret = writer.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
@@ -5885,7 +5844,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportWingBREPByUID(TiglCPACSConfiguration
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
         tigl::CTiglExportBrep writer;
-        writer.AddShape(wing.GetLoft());
+        writer.AddShape(wing.GetLoft(), tigl::BRepOptions());
         bool ret = writer.Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -43,12 +43,7 @@
 #include "CCPACSWingSection.h"
 #include "CCPACSWingSegment.h"
 #include "CCPACSWingComponentSegment.h"
-#include "CTiglExportIges.h"
-#include "CTiglExportStep.h"
-#include "CTiglExportStl.h"
-#include "CTiglExportVtk.h"
-#include "CTiglExportCollada.h"
-#include "CTiglExportBrep.h"
+#include "CTiglExporterFactory.h"
 #include "CTiglLogging.h"
 #include "CCPACSFuselageSection.h"
 #include "CCPACSFuselageSectionElement.h"
@@ -58,6 +53,7 @@
 #include "CCPACSRotor.h"
 #include "CCPACSRotorBladeAttachment.h"
 #include "CTiglAttachedRotorBlade.h"
+#include "CGlobalExporterConfigs.h"
 
 #include "CTiglPoint.h"
 
@@ -5042,9 +5038,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportIGES(TiglCPACSConfigurationHandle cp
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportIges exporter;
-        exporter.AddConfiguration(config, tigl::IgesOptions());
-        bool ret = exporter.Write(filenamePtr);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("iges");
+        exporter->AddConfiguration(config);
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5074,9 +5070,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFusedWingFuselageIGES(TiglCPACSConfi
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportIges exporter;
-        exporter.AddFusedConfiguration(config, tigl::IgesOptions());
-        bool ret = exporter.Write(filenamePtr);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("iges");
+        exporter->AddFusedConfiguration(config);
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5105,9 +5101,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportSTEP(TiglCPACSConfigurationHandle cp
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportStep exporter;
-        exporter.AddConfiguration(config);
-        bool ret = exporter.Write(filenamePtr);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("step");
+        exporter->AddConfiguration(config);
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5135,9 +5131,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFusedSTEP(TiglCPACSConfigurationHand
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportStep exporter;
-        exporter.AddFusedConfiguration(config);
-        bool ret = exporter.Write(filenamePtr);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("step");
+        exporter->AddFusedConfiguration(config);
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5175,9 +5171,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingSTL(TiglCPACSConfiguration
         tigl::CCPACSWing& wing = config.GetWing(wingIndex);
         PNamedShape loft = wing.GetLoft();
         
-        tigl::CTiglExportStl exporter;
-        exporter.AddShape(loft, tigl::StlOptions(deflection));
-        bool ret = exporter.Write(filenamePtr);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("stl");
+        exporter->AddShape(loft, tigl::TriangulatedExportOptions(deflection));
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5217,10 +5213,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingSTLByUID(TiglCPACSConfigur
             tigl::CCPACSWing& wing = config.GetWing(iWing);
             if (wing.GetUID() == wingUID) {
                 PNamedShape loft = wing.GetLoft();
-                
-                tigl::CTiglExportStl exporter;
-                exporter.AddShape(loft, tigl::StlOptions(deflection));
-                bool ret = exporter.Write(filenamePtr);
+
+                tigl::PTiglCADExporter exporter = tigl::createExporter("stl");
+                exporter->AddShape(loft, tigl::TriangulatedExportOptions(deflection));
+                bool ret = exporter->Write(filenamePtr);
                 return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
             }
         }
@@ -5263,10 +5259,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageSTL(TiglCPACSConfigura
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageIndex);
         PNamedShape loft = fuselage.GetLoft();
-        
-        tigl::CTiglExportStl exporter;
-        exporter.AddShape(loft, tigl::StlOptions(deflection));
-        bool ret = exporter.Write(filenamePtr);
+
+        tigl::PTiglCADExporter exporter = tigl::createExporter("stl");
+        exporter->AddShape(loft, tigl::TriangulatedExportOptions(deflection));
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5309,9 +5305,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageSTLByUID(TiglCPACSConf
             if (fuselage.GetUID() == fuselageUID) {
                 PNamedShape loft = fuselage.GetLoft();
                 
-                tigl::CTiglExportStl exporter;
-                exporter.AddShape(loft, tigl::StlOptions(deflection));
-                bool ret = exporter.Write(filenamePtr);
+                tigl::PTiglCADExporter exporter = tigl::createExporter("stl");
+                exporter->AddShape(loft, tigl::TriangulatedExportOptions(deflection));
+                bool ret = exporter->Write(filenamePtr);
                 return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
             }
         }
@@ -5346,10 +5342,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportStl exporter;
+        tigl::PTiglCADExporter exporter = tigl::createExporter("stl");
 
-        exporter.AddConfiguration(config, tigl::StlOptions(deflection));
-        bool ret = exporter.Write(filenamePtr);
+        exporter->AddConfiguration(config, tigl::TriangulatedExportOptions(deflection));
+        bool ret = exporter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5384,10 +5380,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByIndex(const TiglCPACS
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingIndex);
-        tigl::CTiglExportVtk exporter;
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
 
-        exporter.AddShape(wing.GetLoft(), tigl::VtkOptions(deflection));
-        if (exporter.Write(filenamePtr)) {
+        exporter->AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5436,10 +5432,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByUID(const TiglCPACSCo
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::CTiglExportVtk exporter;
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
 
-        exporter.AddShape(wing.GetLoft(), &config, tigl::VtkOptions(deflection));
-        if (exporter.Write(filenamePtr)) {
+        exporter->AddShape(wing.GetLoft(), &config, tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5488,9 +5484,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByIndex(const TiglC
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageIndex);
-        tigl::CTiglExportVtk exporter;
-        exporter.AddShape(fuselage.GetLoft(), tigl::VtkOptions(deflection));
-        if (exporter.Write(filenamePtr)) {
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
+        exporter->AddShape(fuselage.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5530,9 +5526,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByUID(const TiglCPA
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
-        tigl::CTiglExportVtk exporter;
-        exporter.AddShape(fuselage.GetLoft(), tigl::VtkOptions(deflection));
-        if (exporter.Write(filenamePtr)) {
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
+        exporter->AddShape(fuselage.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5567,9 +5563,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTK(const TiglCPACSCon
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
 
-        tigl::CTiglExportVtk exporter;
-        exporter.AddFusedConfiguration(config, tigl::VtkOptions(deflection));
-        if (exporter.Write(filenamePtr)) {
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
+        exporter->AddFusedConfiguration(config, tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5611,10 +5607,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::CTiglExportVtk exporter;
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk");
 
-        exporter.AddShape(wing.GetLoft(), tigl::VtkOptions(deflection));
-        if (exporter.Write(filenamePtr)) {
+        exporter->AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5662,9 +5658,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFuselageColladaByUID(const TiglCPACS
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
-        tigl::CTiglExportCollada colladaWriter;
-        colladaWriter.AddShape(fuselage.GetLoft(), tigl::ColladaOptions(deflection));
-        bool ret = colladaWriter.Write(filenamePtr);
+        tigl::PTiglCADExporter colladaWriter = tigl::createExporter("dae");
+        colladaWriter->AddShape(fuselage.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        bool ret = colladaWriter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5698,9 +5694,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportWingColladaByUID(const TiglCPACSConf
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::CTiglExportCollada colladaWriter;
-        colladaWriter.AddShape(wing.GetLoft(), tigl::ColladaOptions(deflection));
-        bool ret = colladaWriter.Write(filenamePtr);
+        tigl::PTiglCADExporter colladaWriter = tigl::createExporter("dae");
+        colladaWriter->AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(deflection));
+        bool ret = colladaWriter->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5730,11 +5726,12 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTKSimple(const TiglCP
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter;
-        // TODO: #367 disable meta data writing
-        tigl::VtkOptions options(deflection);
-        exporter.AddFusedConfiguration(config, options);
-        if (exporter.Write(filenamePtr)) {
+        tigl::ExporterOptions expConfig = tigl::getExportConfig("vtk");
+        expConfig.Set("WriteMetaData", false);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("vtk", expConfig);
+
+        exporter->AddFusedConfiguration(config, tigl::TriangulatedExportOptions(deflection));
+        if (exporter->Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
         else {
@@ -5766,9 +5763,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFusedBREP(TiglCPACSConfigurationHand
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportBrep exporter;
-        exporter.AddFusedConfiguration(config, tigl::BRepOptions());
-        bool ret = exporter.Write(filename);
+        tigl::PTiglCADExporter exporter = tigl::createExporter("brep");
+        exporter->AddFusedConfiguration(config);
+        bool ret = exporter->Write(filename);
         return ret == true? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5804,9 +5801,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportFuselageBREPByUID(TiglCPACSConfigura
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
-        tigl::CTiglExportBrep writer;
-        writer.AddShape(fuselage.GetLoft(), tigl::BRepOptions());
-        bool ret = writer.Write(filenamePtr);
+        tigl::PTiglCADExporter writer = tigl::createExporter("brep");
+        writer->AddShape(fuselage.GetLoft());
+        bool ret = writer->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
@@ -5843,9 +5840,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportWingBREPByUID(TiglCPACSConfiguration
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::CTiglExportBrep writer;
-        writer.AddShape(wing.GetLoft(), tigl::BRepOptions());
-        bool ret = writer.Write(filenamePtr);
+        tigl::PTiglCADExporter writer = tigl::createExporter("brep");
+        writer->AddShape(wing.GetLoft());
+        bool ret = writer->Write(filenamePtr);
         return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -5420,7 +5420,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByIndex(const TiglCPACS
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingIndex);
-        tigl::CTiglExportVtk exporter(config, tigl::SEGMENT_INFO);
+        tigl::CTiglExportVtk exporter;
 
         exporter.AddShape(wing.GetLoft(), deflection);
         if (exporter.Write(filenamePtr)) {
@@ -5472,9 +5472,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKByUID(const TiglCPACSCo
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::CTiglExportVtk exporter(config, tigl::SEGMENT_INFO);
+        tigl::CTiglExportVtk exporter;
 
-        exporter.AddShape(wing.GetLoft(), deflection);
+        exporter.AddShape(wing.GetLoft(), &config, deflection);
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
         }
@@ -5524,7 +5524,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByIndex(const TiglC
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageIndex);
-        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        tigl::CTiglExportVtk exporter;
         exporter.AddShape(fuselage.GetLoft(), deflection);
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
@@ -5566,7 +5566,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedFuselageVTKByUID(const TiglCPA
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSFuselage& fuselage = config.GetFuselage(fuselageUID);
-        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        tigl::CTiglExportVtk exporter;
         exporter.AddShape(fuselage.GetLoft(), deflection);
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
@@ -5606,7 +5606,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTK(const TiglCPACSCon
         tigl::ExportOptions options(deflection);
         options.applySymmetries = true;
         options.includeFarField = false;
-        tigl::CTiglExportVtk exporter(config, tigl::SEGMENT_INFO);
+        tigl::CTiglExportVtk exporter;
         exporter.AddFusedConfiguration(config, options);
         if (exporter.Write(filenamePtr)) {
             return TIGL_SUCCESS;
@@ -5650,7 +5650,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedWingVTKSimpleByUID(const TiglC
         tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        tigl::CTiglExportVtk exporter;
 
         exporter.AddShape(wing.GetLoft(), deflection);
         if (exporter.Write(filenamePtr)) {
@@ -5769,7 +5769,8 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometryVTKSimple(const TiglCP
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        tigl::CTiglExportVtk exporter(config, tigl::NO_INFO);
+        tigl::CTiglExportVtk exporter;
+        // TODO: #367 disable meta data writing
         tigl::ExportOptions options(deflection);
         options.applySymmetries = true;
         options.includeFarField = false;

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -3525,27 +3525,6 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
                                                               const char* filenamePtr,
                                                               double deflection);
 
-
-/**
- * @brief Sets options for the VTK Export
- *
- * **Available Settings**:
- *
- *   - *key*: "normals_enabled" *valid values*: "0 or 1" *default*: "1".
- *
- *       Enables or disables the output of normal vectors.
- *       A Normal vector and a vertex belong to the same logical structure. If there
- *       are two identical vertices but with different normal vectors, the VTK export stores
- *       them as two entries. Thus, a VTK file may have "duplicate" vertices. To disable this
- *       behavior, set "normal_enabled" to "0".
- *
- * @return
- *   - TIGL_SUCCESS if no error occurred
- *   - TIGL_NULL_POINTER if key or value are a null pointer
- *   - TIGL_ERROR if the specified key/value pair is invalid
- */
-TIGL_COMMON_EXPORT TiglReturnCode tiglExportVTKSetOptions(const char* key, const char* value);
-
 /**
 * @brief Exports the boolean fused geometry of a wing (selected by id) meshed to VTK format.
 *

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -3339,6 +3339,38 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetCurveParameter (TiglCPACSConfigurationH
 
 /*@{*/
 
+/**
+* @brief Sets options for the geometry export
+* 
+* Generic options for all exporters:
+*   - ApplySymmetries (Values: "true", "false"): Whether symmetric cpacs objects (e.g. wings) should be written.
+*   - IncludeFarfield (Values: "true", "false"): Whether to include the far field into the export or not.
+*   - ShapeGroupMode  (Values: "WHOLE_SHAPE", "NAMED_COMPOUNDS", "FACES"): Adjust, how shapes are grouped.
+* 
+* Exporter-specific options:
+*  - VTK:
+*    - WriteNormals (Values: "true", "false"): Whether to write normal vectors or not.
+*      To avoid duplicate vertices, normals should be disabled.
+*    - MultiplePieces (Values: "true", "false"): Whether to export the shapes into multiple vtk pieces.
+*    - WriteMetaData (Values: "true", "false"): Whether to add meta data (e.g. wing segments etc...)
+*
+* Example: The IGES export normally does only write half-models. It does not apply symmetries.
+* to change this, just call 
+  @verbatim
+  tiglSetExportOptions("iges", "ApplySymmetries", "true");
+  @endverbatim
+* 
+* @param[in] exporter_name File format of the export. E.g. "vtk", "iges", "step", "collada", "brep" or "stl"
+* @param[in] option_name   Name of the option to be set
+* @param[in] option_value  Value of the options to be set
+*
+* @return 
+*   - TIGL_SUCCESS if no error occurred
+*   - TIGL_NOT_FOUND if the specifid exporter or the option does not exist
+*   - TIGL_NULL_POINTER if exporter_name, option_name or option_value is a null pointer
+*   - TIGL_ERROR if some other error occurred
+*/
+TIGL_COMMON_EXPORT TiglReturnCode tiglSetExportOptions(const char* exporter_name, const char* option_name, const char* option_value);
 
 /**
 * @brief Exports the geometry of a CPACS configuration to IGES format.

--- a/src/common/COptionList.h
+++ b/src/common/COptionList.h
@@ -22,10 +22,10 @@
 #include "tigl_internal.h"
 #include "CTiglError.h"
 #include "typename.h"
+#include "any.h"
 
 #include <map>
 #include <vector>
-#include <boost/any.hpp>
 #include <boost/core/typeinfo.hpp>
 
 namespace tigl
@@ -47,9 +47,9 @@ public:
         }
         else {
             try {
-                return boost::any_cast<T>(it->second);
+                return tigl::any_cast<T>(it->second);
             }
-            catch(const boost::bad_any_cast&) {
+            catch(const CTiglError&) {
                 throw CTiglError("Cannot convert option \"" + it->first +
                                  "\" to " + typeName(typeid(T)) + ". Expecting " + 
                                  boost::core::demangled_name(it->second.type()));
@@ -87,7 +87,18 @@ public:
             it->second = value;
         }
     }
-    
+
+    void SetOption_FromString(const std::string& name, const std::string& value)
+    {
+        OptionsMap::iterator it = m_options.find(name);
+        if (it == m_options.end()) {
+            throw CTiglError("No such option: " + name);
+        }
+        else {
+            it->second.from_string(value);
+        }
+    }
+
     void SetDoubleOption(const std::string& name, double value)
     {
         SetOption(name, value);
@@ -139,7 +150,7 @@ protected:
     }
 
 private:
-    typedef std::map<std::string, boost::any> OptionsMap;
+    typedef std::map<std::string, tigl::any> OptionsMap;
     OptionsMap m_options;
     std::vector<OptionsMap::iterator> m_iters;
 };

--- a/src/common/COptionList.h
+++ b/src/common/COptionList.h
@@ -95,7 +95,7 @@ public:
             throw CTiglError("No such option: " + name);
         }
         else {
-            it->second.from_string(value);
+            tigl::from_string(value, it->second);
         }
     }
 

--- a/src/common/COptionList.h
+++ b/src/common/COptionList.h
@@ -92,7 +92,7 @@ public:
     {
         OptionsMap::iterator it = m_options.find(name);
         if (it == m_options.end()) {
-            throw CTiglError("No such option: " + name);
+            throw CTiglError("No such option: " + name, TIGL_NOT_FOUND);
         }
         else {
             tigl::from_string(value, it->second);

--- a/src/common/COptionList.h
+++ b/src/common/COptionList.h
@@ -39,7 +39,7 @@ public:
     }
 
     template <class T>
-    T GetOption(const std::string& name) const
+    T Get(const std::string& name) const
     {
         OptionsMap::const_iterator it = m_options.find(name);
         if (it == m_options.end()) {
@@ -57,23 +57,23 @@ public:
         }
     }
 
-    double GetDoubleOption(const std::string& name) const
+    double GetDouble(const std::string& name) const
     {
-        return GetOption<double>(name);
+        return Get<double>(name);
     }
 
-    int GetIntOption(const std::string& name) const
+    int GetInt(const std::string& name) const
     {
-        return GetOption<int>(name);
+        return Get<int>(name);
     }
 
-    std::string GetStringOption(const std::string& name) const
+    std::string GetString(const std::string& name) const
     {
-        return GetOption<std::string>(name);
+        return Get<std::string>(name);
     }
 
     template <class T>
-    void SetOption(const std::string& name, const T& value)
+    void Set(const std::string& name, const T& value)
     {
         OptionsMap::iterator it = m_options.find(name);
         if (it == m_options.end()) {
@@ -88,7 +88,7 @@ public:
         }
     }
 
-    void SetOption_FromString(const std::string& name, const std::string& value)
+    void SetFromString(const std::string& name, const std::string& value)
     {
         OptionsMap::iterator it = m_options.find(name);
         if (it == m_options.end()) {
@@ -99,19 +99,19 @@ public:
         }
     }
 
-    void SetDoubleOption(const std::string& name, double value)
+    void SetDouble(const std::string& name, double value)
     {
-        SetOption(name, value);
+        Set(name, value);
     }
 
-    void SetIntOption(const std::string& name, int value)
+    void SetInt(const std::string& name, int value)
     {
-        SetOption(name, value);
+        Set(name, value);
     }
 
-    void SetStringOption(const std::string& name, const std::string& value)
+    void SetString(const std::string& name, const std::string& value)
     {
-        SetOption(name, value);
+        Set(name, value);
     }
 
     size_t GetNOptions() const
@@ -134,9 +134,28 @@ public:
         return m_options.find(name) != m_options.end();
     }
 
+    COptionList Merged(const tigl::COptionList& other) const
+    {
+        COptionList l1(*this);
+
+        for (OptionsMap::const_iterator it = other.m_options.begin();
+             it != other.m_options.end(); ++it) {
+            const std::string& name = it->first;
+            const any& value = it->second;
+            l1.AddOption(name, value);
+        }
+
+        return l1;
+    }
+
 protected:
     template <class T>
     void AddOption(const std::string& name, const T& default_value)
+    {
+        AddOption(name, tigl::any(default_value));
+    }
+    
+    void AddOption(const std::string& name, const any& default_value)
     {
         size_t old_size = m_options.size();
         m_options[name] = default_value;

--- a/src/common/COptionList.h
+++ b/src/common/COptionList.h
@@ -1,0 +1,149 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-03-29 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef COPTIONLIST_H
+#define COPTIONLIST_H
+
+#include "tigl_internal.h"
+#include "CTiglError.h"
+#include "typename.h"
+
+#include <map>
+#include <vector>
+#include <boost/any.hpp>
+#include <boost/core/typeinfo.hpp>
+
+namespace tigl
+{
+
+class COptionList
+{
+public:
+    COptionList()
+    {
+    }
+
+    template <class T>
+    T GetOption(const std::string& name) const
+    {
+        OptionsMap::const_iterator it = m_options.find(name);
+        if (it == m_options.end()) {
+            throw CTiglError("No such option: " + name);
+        }
+        else {
+            try {
+                return boost::any_cast<T>(it->second);
+            }
+            catch(const boost::bad_any_cast&) {
+                throw CTiglError("Cannot convert option \"" + it->first +
+                                 "\" to " + typeName(typeid(T)) + ". Expecting " + 
+                                 boost::core::demangled_name(it->second.type()));
+            }
+        }
+    }
+
+    double GetDoubleOption(const std::string& name) const
+    {
+        return GetOption<double>(name);
+    }
+
+    int GetIntOption(const std::string& name) const
+    {
+        return GetOption<int>(name);
+    }
+
+    std::string GetStringOption(const std::string& name) const
+    {
+        return GetOption<std::string>(name);
+    }
+
+    template <class T>
+    void SetOption(const std::string& name, const T& value)
+    {
+        OptionsMap::iterator it = m_options.find(name);
+        if (it == m_options.end()) {
+            throw CTiglError("No such option: " + name);
+        }
+        else if (it->second.type() != typeid(T)) { // check type
+            throw CTiglError("Wrong type in COptionList::SetOption. Expecting " + 
+                             boost::core::demangled_name(it->second.type()));
+        }
+        else {
+            it->second = value;
+        }
+    }
+    
+    void SetDoubleOption(const std::string& name, double value)
+    {
+        SetOption(name, value);
+    }
+
+    void SetIntOption(const std::string& name, int value)
+    {
+        SetOption(name, value);
+    }
+
+    void SetStringOption(const std::string& name, const std::string& value)
+    {
+        SetOption(name, value);
+    }
+
+    size_t GetNOptions() const
+    {
+        return m_options.size();
+    }
+    
+    std::string GetOptionName(size_t idx)
+    {
+        return m_iters[idx]->first;
+    }
+
+    std::string GetOptionType(size_t idx)
+    {
+        return boost::core::demangled_name(m_iters[idx]->second.type());
+    }
+
+    bool HasOption(const std::string& name) const
+    {
+        return m_options.find(name) != m_options.end();
+    }
+
+protected:
+    template <class T>
+    void AddOption(const std::string& name, const T& default_value)
+    {
+        size_t old_size = m_options.size();
+        m_options[name] = default_value;
+        if (old_size < m_options.size()) {
+            m_iters.clear();
+            for (OptionsMap::iterator it = m_options.begin(); it != m_options.end(); ++it) {
+                m_iters.push_back(it);
+            }
+        }
+        assert(m_iters.size() == m_options.size());
+    }
+
+private:
+    typedef std::map<std::string, boost::any> OptionsMap;
+    OptionsMap m_options;
+    std::vector<OptionsMap::iterator> m_iters;
+};
+
+} // namespace tigl
+
+#endif // COPTIONLIST_H

--- a/src/common/any.h
+++ b/src/common/any.h
@@ -1,0 +1,175 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-04-03 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+#ifndef any_H
+#define any_H
+
+#include "tigl_internal.h"
+#include "CTiglError.h"
+#include <boost/lexical_cast.hpp>
+
+namespace tigl
+{
+
+/**
+ * @brief A class that can hold any other object. Similar to boost::any
+ * but includes also a from_string method
+ */
+class any
+{
+public:
+    /// Creates an empty element
+    any()
+        : pimpl(NULL)
+    {
+    }
+
+    /// Creates an element holding the value t
+    template <class T>
+    any(const T& t)
+        : pimpl(new any_conceptImpl<T>(t))
+    {
+    }
+
+    any(const any& other)
+        : pimpl(other.pimpl->clone())
+    {
+    }
+    
+    any& operator = (const any& other)
+    {
+        any tmp(other);
+
+        // move from tmp
+        this->pimpl = tmp.pimpl;
+        tmp.pimpl = NULL;
+        return *this;
+    }
+
+    /// Tests, whether the element is empty or not
+    bool empty() const
+    {
+        return pimpl == NULL;
+    }
+
+    const std::type_info& type() const
+    {
+        if (empty()) {
+            return typeid(NULL);
+        }
+        else {
+            return pimpl->type();
+        }
+    }
+
+    template <class to_value>
+    to_value const * to_ptr() const
+    {
+        if (typeid(to_value) != type()) {
+            return NULL;
+        }
+        else {
+            return &(static_cast<any_conceptImpl<to_value> *>(pimpl)->value);
+        }
+    }
+
+    any& from_string(const std::string& s)
+    {
+        if (!empty()) {
+            pimpl->from_string(s);
+            return *this;
+        }
+        else {
+            throw CTiglError("Empty any element");
+        }
+    }
+
+    ~any()
+    {
+        if (!pimpl) {
+            delete pimpl;
+        }
+    }
+    
+private:
+    class any_concept
+    {
+    public:
+        virtual any_concept* clone() const  = 0;
+        virtual const std::type_info& type() const = 0;
+        virtual void from_string(const std::string& s) = 0;
+    };
+    
+    template <class T>
+    class any_conceptImpl : public any_concept
+    {
+    public:
+        any_conceptImpl(const T& t)
+            : value(t)
+        {
+        }
+
+        any_concept* clone() const OVERRIDE
+        {
+            return new any_conceptImpl(value);
+        }
+
+        const std::type_info& type() const OVERRIDE
+        {
+            return typeid(value);
+        }
+        
+        void from_string(const std::string& s) OVERRIDE
+        {
+            tigl::from_string(s, value);
+        }
+
+        T value;
+    };
+private:
+    any_concept* pimpl;
+};
+
+template <class T>
+T any_cast(const any& any)
+{
+    T const * ptr = any.to_ptr<T>();
+    if (ptr) {
+        return *ptr;
+    }
+    else {
+        throw tigl::CTiglError("Cannot convert");
+    }
+}
+
+template <class to_value>
+void from_string(const std::string& s, to_value& t)
+{
+    try {
+        t = boost::lexical_cast<to_value>(s);
+    }
+    catch (boost::bad_lexical_cast&) {
+        throw tigl::CTiglError("Cannot convert string to " +
+                               boost::core::demangled_name(typeid(to_value)));
+    }
+}
+
+}
+
+#endif // any_H

--- a/src/common/any.h
+++ b/src/common/any.h
@@ -24,8 +24,6 @@
 #include "CTiglError.h"
 #include "stringtools.h"
 
-#include <boost/lexical_cast.hpp>
-#include <boost/core/demangle.hpp>
 #include <algorithm> // For swap
 
 namespace tigl
@@ -174,31 +172,6 @@ T any_cast(const any& any)
     }
 }
 
-template <class to_value>
-void from_string(const std::string& s, to_value& t) {
-    try {
-        t = boost::lexical_cast<to_value>(s);
-    }
-    catch (boost::bad_lexical_cast&) {
-        throw tigl::CTiglError("Cannot convert string to " +
-                               boost::core::demangle(typeid(to_value).name()));
-    }
-}
-
-template <>
-inline void from_string<bool>(const std::string& s, bool& t) {
-    std::string str = tigl::to_lower(s);
-    if (str == "1" || str == "true" || str == "yes") {
-        t = true;
-    }
-    else if (str == "0" || str == "false" || str == "no") {
-        t = false;
-    }
-    else {
-        throw tigl::CTiglError("Cannot convert string '" + s + "' to bool.");
-    }
-}
-
-}
+} // namespace tigl
 
 #endif // any_H

--- a/src/common/any.h
+++ b/src/common/any.h
@@ -22,7 +22,9 @@
 
 #include "tigl_internal.h"
 #include "CTiglError.h"
+
 #include <boost/lexical_cast.hpp>
+#include <algorithm> // For swap
 
 namespace tigl
 {
@@ -57,8 +59,7 @@ public:
         any tmp(other);
 
         // move from tmp
-        this->pimpl = tmp.pimpl;
-        tmp.pimpl = NULL;
+        std::swap(this->pimpl, tmp.pimpl);
         return *this;
     }
 
@@ -89,16 +90,7 @@ public:
         }
     }
 
-    any& from_string(const std::string& s)
-    {
-        if (!empty()) {
-            pimpl->from_string(s);
-            return *this;
-        }
-        else {
-            throw CTiglError("Empty any element");
-        }
-    }
+    friend void from_string(const std::string& s, any& a);
 
     ~any()
     {
@@ -156,6 +148,16 @@ T any_cast(const any& any)
     }
     else {
         throw tigl::CTiglError("Cannot convert");
+    }
+}
+
+inline void from_string(const std::string& s, any& a)
+{
+    if (!a.empty()) {
+        a.pimpl->from_string(s);
+    }
+    else {
+        throw CTiglError("Empty any element");
     }
 }
 

--- a/src/common/any.h
+++ b/src/common/any.h
@@ -22,6 +22,7 @@
 
 #include "tigl_internal.h"
 #include "CTiglError.h"
+#include "stringtools.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/core/demangle.hpp>
@@ -181,6 +182,20 @@ void from_string(const std::string& s, to_value& t) {
     catch (boost::bad_lexical_cast&) {
         throw tigl::CTiglError("Cannot convert string to " +
                                boost::core::demangle(typeid(to_value).name()));
+    }
+}
+
+template <>
+inline void from_string<bool>(const std::string& s, bool& t) {
+    std::string str = tigl::to_lower(s);
+    if (str == "1" || str == "true" || str == "yes") {
+        t = true;
+    }
+    else if (str == "0" || str == "false" || str == "no") {
+        t = false;
+    }
+    else {
+        throw tigl::CTiglError("Cannot convert string '" + s + "' to bool.");
     }
 }
 

--- a/src/common/any.h
+++ b/src/common/any.h
@@ -48,7 +48,7 @@ public:
     }
 
     any(const any& other)
-        : pimpl(other.pimpl->clone())
+        : pimpl(other.pimpl ? other.pimpl->clone() : NULL)
     {
     }
     
@@ -114,8 +114,9 @@ private:
         virtual any_concept* clone() const  = 0;
         virtual const std::type_info& type() const = 0;
         virtual void from_string(const std::string& s) = 0;
+        virtual ~any_concept(){}
     };
-    
+
     template <class T>
     class any_conceptImpl : public any_concept
     {
@@ -134,7 +135,7 @@ private:
         {
             return typeid(value);
         }
-        
+
         void from_string(const std::string& s) OVERRIDE
         {
             tigl::from_string(s, value);

--- a/src/common/stringtools.h
+++ b/src/common/stringtools.h
@@ -19,10 +19,15 @@
 #ifndef STRINGTOOLS_H
 #define STRINGTOOLS_H
 
+#include "CTiglError.h"
+
 #include <vector>
 #include <string>
 #include <algorithm>
 #include <sstream>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/core/demangle.hpp>
 
 namespace tigl
 {
@@ -52,6 +57,33 @@ inline std::vector<std::string> split_string(const std::string& mystring, char d
         strings.push_back(s);
     }
     return strings;
+}
+
+template <class to_value>
+void from_string(const std::string& s, to_value& t)
+{
+    try {
+        t = boost::lexical_cast<to_value>(s);
+    }
+    catch (boost::bad_lexical_cast&) {
+        throw tigl::CTiglError("Cannot convert string to " +
+                               boost::core::demangle(typeid(to_value).name()));
+    }
+}
+
+template <>
+inline void from_string<bool>(const std::string& s, bool& t)
+{
+    std::string str = tigl::to_lower(s);
+    if (str == "1" || str == "true" || str == "yes") {
+        t = true;
+    }
+    else if (str == "0" || str == "false" || str == "no") {
+        t = false;
+    }
+    else {
+        throw tigl::CTiglError("Cannot convert string '" + s + "' to bool.");
+    }
 }
 
 } // namespace tigl

--- a/src/common/stringtools.h
+++ b/src/common/stringtools.h
@@ -1,0 +1,59 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-04-04 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STRINGTOOLS_H
+#define STRINGTOOLS_H
+
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <sstream>
+
+namespace tigl
+{
+
+inline std::string to_lower(const std::string& str)
+{
+    std::string result = str;
+    std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+
+    return result;
+}
+
+inline std::string to_upper(const std::string& str)
+{
+    std::string result = str;
+    std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+
+    return result;
+}
+
+inline std::vector<std::string> split_string(const std::string& mystring, char delimiter)
+{
+    std::vector<std::string> strings;
+    std::istringstream f(mystring);
+    std::string s;
+    while (std::getline(f, s, delimiter)) {
+        strings.push_back(s);
+    }
+    return strings;
+}
+
+} // namespace tigl
+
+#endif // STRINGTOOLS_H

--- a/src/exports/CCPACSImportExport.h
+++ b/src/exports/CCPACSImportExport.h
@@ -19,7 +19,9 @@
 #ifndef CCPACSIMPORTEXPORT_H
 #define CCPACSIMPORTEXPORT_H
 
-
+#include "stringtools.h"
+#include "CTiglError.h"
+#include <string>
 
 namespace tigl
 {
@@ -30,6 +32,25 @@ enum ShapeGroupMode
     NAMED_COMPOUNDS,       /** Collects all faces with the same origin into compounds. All faces are named correctly */
     FACES                  /** Exports each face as its own group. The group name and the face name are identical    */
 };
+
+template <>
+inline void from_string<ShapeGroupMode>(const std::string &s, ShapeGroupMode &t)
+{
+    std::string value = tigl::to_upper(s);
+    if (value == "WHOLE_SHAPE") {
+        t = WHOLE_SHAPE;
+    }
+    else if (value == "NAMED_COMPOUNDS") {
+        t = NAMED_COMPOUNDS;
+    }
+    else if (value == "FACES") {
+        t = FACES;
+    }
+    else {
+        throw CTiglError("Cannot convert string to ShapeGroupMode");
+    }
+}
+
 
 } // end namespace tigl
 

--- a/src/exports/CGlobalExporterConfigs.cpp
+++ b/src/exports/CGlobalExporterConfigs.cpp
@@ -1,0 +1,64 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-04-04 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "CGlobalExporterConfigs.h"
+#include "stringtools.h"
+
+namespace tigl
+{
+
+CGlobalExporterConfigs &CGlobalExporterConfigs::Instance()
+{
+    static CGlobalExporterConfigs globalConfig;
+    return globalConfig;
+}
+
+void CGlobalExporterConfigs::Add(const std::string &supportedFileTypes, const ExporterOptions &config)
+{
+    m_configs.push_back(config);
+    size_t idx = m_configs.size() - 1;
+    
+    std::vector<std::string> fileTypes = split_string(supportedFileTypes, ';');
+    for (std::vector<std::string>::const_iterator it = fileTypes.begin(); it != fileTypes.end(); ++it) {
+        std::string type = *it;
+        m_index_map[to_lower(type)] = idx;
+    }
+}
+
+const ExporterOptions& CGlobalExporterConfigs::Get(const std::string &fileType) const
+{
+    IndexMap::const_iterator it = m_index_map.find(to_lower(fileType));
+    if (it == m_index_map.end()) {
+        throw CTiglError("No Exporter '" + fileType + "'", TIGL_INDEX_ERROR);
+    }
+    else {
+        size_t idx = it->second;
+        return m_configs[idx];
+    }
+}
+
+ExporterOptions& CGlobalExporterConfigs::Get(const std::string &fileType)
+{
+     return const_cast<ExporterOptions&>(static_cast<const CGlobalExporterConfigs*>(this)->Get(fileType));
+}
+
+CGlobalExporterConfigs::CGlobalExporterConfigs()
+{
+}
+
+} // namespace tigl

--- a/src/exports/CGlobalExporterConfigs.cpp
+++ b/src/exports/CGlobalExporterConfigs.cpp
@@ -44,7 +44,7 @@ const ExporterOptions& CGlobalExporterConfigs::Get(const std::string &fileType) 
 {
     IndexMap::const_iterator it = m_index_map.find(to_lower(fileType));
     if (it == m_index_map.end()) {
-        throw CTiglError("No Exporter '" + fileType + "'", TIGL_INDEX_ERROR);
+        throw CTiglError("No Exporter '" + fileType + "'", TIGL_NOT_FOUND);
     }
     else {
         size_t idx = it->second;

--- a/src/exports/CGlobalExporterConfigs.h
+++ b/src/exports/CGlobalExporterConfigs.h
@@ -47,6 +47,11 @@ private:
     IndexMap m_index_map;
 };
 
+inline ExporterOptions& getExportConfig(const std::string& filetype)
+{
+    return CGlobalExporterConfigs::Instance().Get(filetype);
+}
+
 } // namespace tigl
 
 #endif // CGLOBALEXPORTERCONFIGS_H

--- a/src/exports/CGlobalExporterConfigs.h
+++ b/src/exports/CGlobalExporterConfigs.h
@@ -1,0 +1,52 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-04-04 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef CGLOBALEXPORTERCONFIGS_H
+#define CGLOBALEXPORTERCONFIGS_H
+
+#include "tigl_internal.h"
+#include "CTiglCADExporter.h"
+#include <map>
+#include <string>
+
+namespace tigl
+{
+
+/** Singleton instance holding the configs */
+class CGlobalExporterConfigs
+{
+public:
+    static CGlobalExporterConfigs &Instance();
+
+    void Add(const std::string& supportedFileTypes, const ExporterOptions& config);
+
+    const ExporterOptions& Get(const std::string& fileType) const;
+    ExporterOptions& Get(const std::string& fileType);
+
+private:
+    CGlobalExporterConfigs();
+
+    std::vector<ExporterOptions> m_configs;
+
+    typedef std::map<std::string, size_t> IndexMap;
+    IndexMap m_index_map;
+};
+
+} // namespace tigl
+
+#endif // CGLOBALEXPORTERCONFIGS_H

--- a/src/exports/CTiglCADExporter.cpp
+++ b/src/exports/CTiglCADExporter.cpp
@@ -172,23 +172,4 @@ std::string CTiglCADExporter::SupportedFileType() const
     return SupportedFileTypeImpl();
 }
 
-template <>
-void from_string<ShapeGroupMode>(const std::string &s, ShapeGroupMode &t)
-{
-    std::string value(s);
-    std::transform(value.begin(), value.end(), value.begin(), ::toupper);
-    if (s == "WHOLE_SHAPE") {
-        t = WHOLE_SHAPE;
-    }
-    else if (s == "NAMED_COMPOUNDS") {
-        t = NAMED_COMPOUNDS;
-    }
-    else if (s == "FACES") {
-        t = FACES;
-    }
-    else {
-        throw CTiglError("Cannot convert string to ShapeGroupMode");
-    }
-}
-
 } // namespace tigl

--- a/src/exports/CTiglCADExporter.h
+++ b/src/exports/CTiglCADExporter.h
@@ -67,6 +67,9 @@ public:
     /// Adds a shape
     TIGL_EXPORT void AddShape(PNamedShape shape, ExportOptions options = ExportOptions());
 
+    TIGL_EXPORT void AddShape(PNamedShape shape, const CCPACSConfiguration* config, ExportOptions options = ExportOptions());
+    
+
     ///  Adds the whole non-fused configuration, to the exporter
     TIGL_EXPORT void AddConfiguration(CCPACSConfiguration &config, ExportOptions options = ExportOptions());
 
@@ -83,13 +86,41 @@ public:
 
     TIGL_EXPORT ExportOptions GetOptions(size_t iShape) const;
 
+    TIGL_EXPORT std::string SupportedFileType() const;
+
+protected:
+    /// Can also be NULL!
+    const CCPACSConfiguration* GetConfiguration(size_t iShape) const;
+
 private:
     /// must be overridden by the concrete implementation
     virtual bool WriteImpl(const std::string& filename) const = 0;
+    
+    /// must be overridden. If multiple types supported, separate with a ";"
+    virtual std::string SupportedFileTypeImpl() const = 0;
 
     ListPNamedShape _shapes;
     std::vector<ExportOptions> _options;
+    std::vector<const CCPACSConfiguration*> _configs; //!< TIGL configurations */
 
+};
+
+typedef CSharedPtr<CTiglCADExporter> PTiglCADExporter;
+
+class ICADExporterBuilder
+{
+public:
+   virtual PTiglCADExporter create() const = 0;
+};
+
+template <class T>
+class CCADExporterBuilder : public ICADExporterBuilder
+{
+public:
+   PTiglCADExporter create() const OVERRIDE
+   {
+       return PTiglCADExporter(new T);
+   }
 };
 
 } // namespace tigl

--- a/src/exports/CTiglCADExporter.h
+++ b/src/exports/CTiglCADExporter.h
@@ -115,9 +115,6 @@ public:
     }
 };
 
-template<>
-TIGL_EXPORT void from_string<ShapeGroupMode>(const std::string& s, ShapeGroupMode& t);
-
 /**
  * @brief Abstract base class for CAD exports
  */
@@ -163,7 +160,6 @@ protected:
     const CCPACSConfiguration* GetConfiguration(size_t iShape) const;
 
 private:
-
     /// must be overridden by the concrete implementation
     virtual bool WriteImpl(const std::string& filename) const = 0;
     

--- a/src/exports/CTiglExportBrep.cpp
+++ b/src/exports/CTiglExportBrep.cpp
@@ -51,7 +51,7 @@ namespace tigl
 AUTORUN(CTiglExportBrep)
 {
     static CCADExporterBuilder<CTiglExportBrep> brepExporterBuilder;
-    CTiglExporterFactory::Instance().RegisterExporter(&brepExporterBuilder);
+    CTiglExporterFactory::Instance().RegisterExporter(&brepExporterBuilder, BRepOptions());
     return true;
 }
 

--- a/src/exports/CTiglExportBrep.cpp
+++ b/src/exports/CTiglExportBrep.cpp
@@ -61,6 +61,11 @@ ExporterOptions CTiglExportBrep::GetDefaultOptions() const
     return BRepOptions();
 }
 
+ShapeExportOptions CTiglExportBrep::GetDefaultShapeOptions() const
+{
+    return ShapeExportOptions();
+}
+
 bool CTiglExportBrep::WriteImpl(const std::string& filename) const
 {
     if (filename.empty()) {

--- a/src/exports/CTiglExportBrep.cpp
+++ b/src/exports/CTiglExportBrep.cpp
@@ -56,6 +56,11 @@ AUTORUN(CTiglExportBrep)
 }
 
 
+ExporterOptions CTiglExportBrep::GetDefaultOptions() const
+{
+    return BRepOptions();
+}
+
 bool CTiglExportBrep::WriteImpl(const std::string& filename) const
 {
     if (filename.empty()) {

--- a/src/exports/CTiglExportBrep.cpp
+++ b/src/exports/CTiglExportBrep.cpp
@@ -25,6 +25,8 @@
 #include "CTiglFusePlane.h"
 #include "CCPACSWingSegment.h"
 #include "CCPACSFuselageSegment.h"
+#include "CTiglExporterFactory.h"
+#include "CTiglTypeRegistry.h"
 
 // OCCT includes
 #include <BRep_Builder.hxx>
@@ -45,6 +47,14 @@ namespace
 
 namespace tigl
 {
+
+AUTORUN(CTiglExportBrep)
+{
+    static CCADExporterBuilder<CTiglExportBrep> brepExporterBuilder;
+    CTiglExporterFactory::Instance().RegisterExporter(&brepExporterBuilder);
+    return true;
+}
+
 
 bool CTiglExportBrep::WriteImpl(const std::string& filename) const
 {

--- a/src/exports/CTiglExportBrep.h
+++ b/src/exports/CTiglExportBrep.h
@@ -52,7 +52,8 @@ public:
     // Constructor
     TIGL_EXPORT CTiglExportBrep(const ExporterOptions& opt = DefaultExporterOption())
         : CTiglCADExporter(opt)
-    {}
+    {
+    }
 
     TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
     TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;

--- a/src/exports/CTiglExportBrep.h
+++ b/src/exports/CTiglExportBrep.h
@@ -45,6 +45,11 @@ private:
     // Writes the shapes to BREP. In multiple shapes were added
     // a compound is created.
     TIGL_EXPORT bool WriteImpl(const std::string& filename) const OVERRIDE;
+
+    std::string SupportedFileTypeImpl() const OVERRIDE
+    {
+        return "brep";
+    }
 };
 
 } // namespace tigl

--- a/src/exports/CTiglExportBrep.h
+++ b/src/exports/CTiglExportBrep.h
@@ -50,9 +50,12 @@ class CTiglExportBrep : public CTiglCADExporter
 
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportBrep(){}
+    TIGL_EXPORT CTiglExportBrep(const ExporterOptions& opt = DefaultExporterOption())
+        : CTiglCADExporter(opt)
+    {}
 
     TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
+    TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;
 
 private:
     // Writes the shapes to BREP. In multiple shapes were added

--- a/src/exports/CTiglExportBrep.h
+++ b/src/exports/CTiglExportBrep.h
@@ -34,12 +34,25 @@ namespace tigl
 
 class CCPACSConfiguration;
 
+class BRepOptions : public ExporterOptions
+{
+public:
+    BRepOptions()
+    {
+        Set("ApplySymmetries", false);
+        Set("IncludeFarfield", false);
+        Set("ShapeGroupMode", WHOLE_SHAPE);
+    }
+};
+
 class CTiglExportBrep : public CTiglCADExporter
 {
 
 public:
     // Constructor
     TIGL_EXPORT CTiglExportBrep(){}
+
+    TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
 
 private:
     // Writes the shapes to BREP. In multiple shapes were added

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -59,7 +59,7 @@ namespace tigl
 AUTORUN(CTiglExportCollada)
 {
     static CCADExporterBuilder<CTiglExportCollada> colladaExporterBuilder;
-    CTiglExporterFactory::Instance().RegisterExporter(&colladaExporterBuilder);
+    CTiglExporterFactory::Instance().RegisterExporter(&colladaExporterBuilder, ColladaOptions());
     return true;
 }
 

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -63,13 +63,19 @@ AUTORUN(CTiglExportCollada)
     return true;
 }
 
-CTiglExportCollada::CTiglExportCollada()
+CTiglExportCollada::CTiglExportCollada(const ExporterOptions& opt)
+    : CTiglCADExporter(opt)
 {
 }
 
 ExporterOptions CTiglExportCollada::GetDefaultOptions() const
 {
     return ColladaOptions();
+}
+
+ShapeExportOptions CTiglExportCollada::GetDefaultShapeOptions() const
+{
+    return TriangulatedExportOptions(0.001);
 }
 
 

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -28,6 +28,8 @@ TODO:
 #include "CTiglPolyData.h"
 #include "CTiglTriangularizer.h"
 #include "CCPACSConfiguration.h"
+#include "CTiglExporterFactory.h"
+#include "CTiglTypeRegistry.h"
 
 #include <tixi.h>
 
@@ -53,6 +55,13 @@ namespace
 
 namespace tigl
 {
+
+AUTORUN(CTiglExportCollada)
+{
+    static CCADExporterBuilder<CTiglExportCollada> colladaExporterBuilder;
+    CTiglExporterFactory::Instance().RegisterExporter(&colladaExporterBuilder);
+    return true;
+}
 
 CTiglExportCollada::CTiglExportCollada()
 {

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -67,6 +67,11 @@ CTiglExportCollada::CTiglExportCollada()
 {
 }
 
+ExporterOptions CTiglExportCollada::GetDefaultOptions() const
+{
+    return ColladaOptions();
+}
+
 
 bool writeHeader(TixiDocumentHandle handle)
 {
@@ -297,7 +302,7 @@ bool CTiglExportCollada::WriteImpl(const std::string& filename) const
     for (unsigned int i = 0; i < NShapes(); ++i) {
         // Do the meshing
         PNamedShape pshape = GetShape(i);
-        double deflection = GetOptions(i).deflection;
+        double deflection = GetOptions(i).Get<double>("Deflection");
         CTiglTriangularizer mesher(pshape, deflection);
         
         writeGeometryMesh(handle, mesher.getTriangulation(), std::string(pshape->Name()) + "-geom", geomIndex);

--- a/src/exports/CTiglExportCollada.h
+++ b/src/exports/CTiglExportCollada.h
@@ -31,10 +31,29 @@
 namespace tigl 
 {
 
+class ColladaOptions : public TriangulatedExportOptions
+{
+public:
+    ColladaOptions(double deflection)
+        : TriangulatedExportOptions(deflection)
+    {
+        Set("ApplySymmetries", true);
+        Set("IncludeFarfield", false);
+    }
+
+    ColladaOptions()
+    {
+        Set("ApplySymmetries", true);
+        Set("IncludeFarfield", false);
+    }
+};
+
 class CTiglExportCollada : public CTiglCADExporter
 {
 public:
     TIGL_EXPORT CTiglExportCollada();
+
+    TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
 
 private:
     bool WriteImpl(const std::string& filename) const OVERRIDE;

--- a/src/exports/CTiglExportCollada.h
+++ b/src/exports/CTiglExportCollada.h
@@ -31,16 +31,9 @@
 namespace tigl 
 {
 
-class ColladaOptions : public TriangulatedExportOptions
+class ColladaOptions : public ExporterOptions
 {
 public:
-    ColladaOptions(double deflection)
-        : TriangulatedExportOptions(deflection)
-    {
-        Set("ApplySymmetries", true);
-        Set("IncludeFarfield", false);
-    }
-
     ColladaOptions()
     {
         Set("ApplySymmetries", true);
@@ -51,9 +44,10 @@ public:
 class CTiglExportCollada : public CTiglCADExporter
 {
 public:
-    TIGL_EXPORT CTiglExportCollada();
+    TIGL_EXPORT CTiglExportCollada(const ExporterOptions& opt = DefaultExporterOption());
 
     TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
+    TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;
 
 private:
     bool WriteImpl(const std::string& filename) const OVERRIDE;

--- a/src/exports/CTiglExportCollada.h
+++ b/src/exports/CTiglExportCollada.h
@@ -39,6 +39,11 @@ public:
 private:
     bool WriteImpl(const std::string& filename) const OVERRIDE;
 
+    std::string SupportedFileTypeImpl() const OVERRIDE
+    {
+        return "dae";
+    }
+
     /// Exports a polygon object to a collada file, the true export code
     TiglReturnCode writeToDisc(class CTiglPolyData &polyData, const char * id, const char * filename);
 };

--- a/src/exports/CTiglExportCollada.h
+++ b/src/exports/CTiglExportCollada.h
@@ -60,7 +60,7 @@ private:
 
     std::string SupportedFileTypeImpl() const OVERRIDE
     {
-        return "dae";
+        return "dae;collada";
     }
 
     /// Exports a polygon object to a collada file, the true export code

--- a/src/exports/CTiglExportIges.cpp
+++ b/src/exports/CTiglExportIges.cpp
@@ -250,7 +250,11 @@ AUTORUN(CTiglExportIges)
 // Constructor
 CTiglExportIges::CTiglExportIges()
 {
-    _groupMode = NAMED_COMPOUNDS;
+}
+
+ExporterOptions CTiglExportIges::GetDefaultOptions() const
+{
+    return IgesOptions();
 }
 
 
@@ -295,12 +299,16 @@ bool CTiglExportIges::WriteImpl(const std::string& filename) const
         }
     }
 
+    size_t iShape = 0;
     ListPNamedShape list;
     for (it = shapeScaled.begin(); it != shapeScaled.end(); ++it) {
-        ListPNamedShape templist = GroupFaces(*it, _groupMode);
+        ShapeGroupMode groupMode = GetOptions(iShape).Get<ShapeGroupMode>("ShapeGroupMode");
+
+        ListPNamedShape templist = GroupFaces(*it, groupMode);
         for (ListPNamedShape::iterator it2 = templist.begin(); it2 != templist.end(); ++it2) {
             list.push_back(*it2);
         }
+        iShape++;
     }
 
     SetTranslationParameters();
@@ -317,11 +325,6 @@ bool CTiglExportIges::WriteImpl(const std::string& filename) const
     igesWriter.ComputeModel();
 
     return toBool(igesWriter.Write(const_cast<char*>(filename.c_str())));
-}
-
-void CTiglExportIges::SetGroupMode(ShapeGroupMode mode)
-{
-    _groupMode = mode;
 }
 
 /**

--- a/src/exports/CTiglExportIges.cpp
+++ b/src/exports/CTiglExportIges.cpp
@@ -243,7 +243,7 @@ namespace tigl
 AUTORUN(CTiglExportIges)
 {
     static CCADExporterBuilder<CTiglExportIges> igesExporterBuilder;
-    CTiglExporterFactory::Instance().RegisterExporter(&igesExporterBuilder);
+    CTiglExporterFactory::Instance().RegisterExporter(&igesExporterBuilder, IgesOptions());
     return true;
 }
 

--- a/src/exports/CTiglExportIges.cpp
+++ b/src/exports/CTiglExportIges.cpp
@@ -248,7 +248,8 @@ AUTORUN(CTiglExportIges)
 }
 
 // Constructor
-CTiglExportIges::CTiglExportIges()
+CTiglExportIges::CTiglExportIges(const ExporterOptions& opt)
+    : CTiglCADExporter(opt)
 {
 }
 
@@ -257,6 +258,10 @@ ExporterOptions CTiglExportIges::GetDefaultOptions() const
     return IgesOptions();
 }
 
+ShapeExportOptions CTiglExportIges::GetDefaultShapeOptions() const
+{
+    return IgesShapeOptions();
+}
 
 void CTiglExportIges::SetTranslationParameters() const
 {
@@ -300,15 +305,24 @@ bool CTiglExportIges::WriteImpl(const std::string& filename) const
     }
 
     size_t iShape = 0;
+    size_t iLevel = 0;
     ListPNamedShape list;
+    std::vector<size_t> levels;
     for (it = shapeScaled.begin(); it != shapeScaled.end(); ++it) {
-        ShapeGroupMode groupMode = GetOptions(iShape).Get<ShapeGroupMode>("ShapeGroupMode");
-
+        ShapeGroupMode groupMode = GlobalExportOptions().GroupMode();
         ListPNamedShape templist = GroupFaces(*it, groupMode);
+
+        int level = GetOptions(iShape).Get<int>("Layer");
+        if (level >= 0) {
+            iLevel = static_cast<size_t>(level);
+        }
+
         for (ListPNamedShape::iterator it2 = templist.begin(); it2 != templist.end(); ++it2) {
             list.push_back(*it2);
+            levels.push_back(iLevel);
         }
         iShape++;
+        iLevel++;
     }
 
     SetTranslationParameters();
@@ -316,10 +330,8 @@ bool CTiglExportIges::WriteImpl(const std::string& filename) const
     IGESControl_Writer igesWriter("MM", 1);
     igesWriter.Model()->ApplyStatic();
 
-    int level = 0;
-    for (it = list.begin(); it != list.end(); ++it) {
-        PNamedShape pshape = *it;
-        AddToIges(pshape, igesWriter, level++);
+    for (size_t i = 0; i < list.size(); ++i) {
+        AddToIges(list[i], igesWriter, static_cast<int>(levels[i]));
     }
 
     igesWriter.ComputeModel();

--- a/src/exports/CTiglExportIges.cpp
+++ b/src/exports/CTiglExportIges.cpp
@@ -32,6 +32,8 @@
 #include "CNamedShape.h"
 #include "tiglcommonfunctions.h"
 #include "CTiglFusePlane.h"
+#include "CTiglExporterFactory.h"
+#include "CTiglTypeRegistry.h"
 
 #include "TopoDS_Shape.hxx"
 #include "TopoDS_Edge.hxx"
@@ -237,6 +239,13 @@ namespace
 
 namespace tigl
 {
+
+AUTORUN(CTiglExportIges)
+{
+    static CCADExporterBuilder<CTiglExportIges> igesExporterBuilder;
+    CTiglExporterFactory::Instance().RegisterExporter(&igesExporterBuilder);
+    return true;
+}
 
 // Constructor
 CTiglExportIges::CTiglExportIges()

--- a/src/exports/CTiglExportIges.h
+++ b/src/exports/CTiglExportIges.h
@@ -39,6 +39,33 @@ namespace tigl
 
 class CCPACSConfiguration;
 
+class IgesOptions : public ExporterOptions
+{
+public:
+    IgesOptions()
+    {
+        AddOption("Layer", 0);
+
+        Set("ApplySymmetries", false);
+        Set("IncludeFarfield", true);
+        Set("ShapeGroupMode", NAMED_COMPOUNDS);
+    }
+
+    IgesOptions(int layer)
+    {
+        AddOption("Layer", layer);
+
+        Set("ApplySymmetries", false);
+        Set("IncludeFarfield", true);
+        Set("ShapeGroupMode", NAMED_COMPOUNDS);
+    }
+
+    void SetLayer(int layer)
+    {
+        Set("Layer", layer);
+    }
+};
+
 class CTiglExportIges : public CTiglCADExporter
 {
 
@@ -46,9 +73,7 @@ public:
     // Constructor
     TIGL_EXPORT CTiglExportIges();
 
-    // Sets the type of storing shapes to iges
-    TIGL_EXPORT void SetGroupMode(ShapeGroupMode mode);
-
+    TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
 
 private:
     // Actual implementation of the IGES file writing
@@ -63,7 +88,6 @@ private:
     void operator=(const CTiglExportIges& );
     void AddToIges(PNamedShape shape, IGESControl_Writer& writer, int level = 0) const;
 
-    ShapeGroupMode  _groupMode;    /**< Type specifying how to group faces in the iges file */
     void SetTranslationParameters() const;
 };
 

--- a/src/exports/CTiglExportIges.h
+++ b/src/exports/CTiglExportIges.h
@@ -54,6 +54,11 @@ private:
     // Actual implementation of the IGES file writing
     TIGL_EXPORT bool WriteImpl(const std::string& filename) const OVERRIDE;
 
+    std::string SupportedFileTypeImpl() const OVERRIDE
+    {
+        return "igs;iges";
+    }
+
     // Assignment operator
     void operator=(const CTiglExportIges& );
     void AddToIges(PNamedShape shape, IGESControl_Writer& writer, int level = 0) const;

--- a/src/exports/CTiglExportIges.h
+++ b/src/exports/CTiglExportIges.h
@@ -44,20 +44,23 @@ class IgesOptions : public ExporterOptions
 public:
     IgesOptions()
     {
-        AddOption("Layer", 0);
-
         Set("ApplySymmetries", false);
         Set("IncludeFarfield", true);
         Set("ShapeGroupMode", NAMED_COMPOUNDS);
     }
+};
 
-    IgesOptions(int layer)
+class IgesShapeOptions : public ShapeExportOptions
+{
+public:
+    IgesShapeOptions()
+    {
+        AddOption("Layer", -1);
+    }
+
+    IgesShapeOptions(int layer)
     {
         AddOption("Layer", layer);
-
-        Set("ApplySymmetries", false);
-        Set("IncludeFarfield", true);
-        Set("ShapeGroupMode", NAMED_COMPOUNDS);
     }
 
     void SetLayer(int layer)
@@ -71,9 +74,10 @@ class CTiglExportIges : public CTiglCADExporter
 
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportIges();
+    TIGL_EXPORT CTiglExportIges(const ExporterOptions& = DefaultExporterOption());
 
     TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
+    TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;
 
 private:
     // Actual implementation of the IGES file writing

--- a/src/exports/CTiglExportStep.cpp
+++ b/src/exports/CTiglExportStep.cpp
@@ -30,6 +30,8 @@
 #include "CCPACSWingSegment.h"
 #include "CTiglFusePlane.h"
 #include "tiglcommonfunctions.h"
+#include "CTiglExporterFactory.h"
+#include "CTiglTypeRegistry.h"
 
 #include "TopoDS_Shape.hxx"
 #include "STEPControl_Controller.hxx"
@@ -235,6 +237,13 @@ namespace
 
 namespace tigl 
 {
+
+AUTORUN(CTiglExportStep)
+{
+    static CCADExporterBuilder<CTiglExportStep> stepExporterBuilder;
+    CTiglExporterFactory::Instance().RegisterExporter(&stepExporterBuilder);
+    return true;
+}
 
 // Constructor
 CTiglExportStep::CTiglExportStep()

--- a/src/exports/CTiglExportStep.cpp
+++ b/src/exports/CTiglExportStep.cpp
@@ -248,7 +248,11 @@ AUTORUN(CTiglExportStep)
 // Constructor
 CTiglExportStep::CTiglExportStep()
 {
-    SetGroupMode(NAMED_COMPOUNDS);
+}
+
+ExporterOptions CTiglExportStep::GetDefaultOptions() const
+{
+    return StepOptions();
 }
 
 /**
@@ -311,8 +315,11 @@ bool CTiglExportStep::WriteImpl(const std::string& filename) const
     Interface_Static::SetCVal("write.step.unit", "M");
 
     ListPNamedShape list;
+    size_t iShape = 0;
     for (size_t ishape = 0; ishape < NShapes(); ++ishape) {
-        ListPNamedShape templist = GroupFaces(GetShape(ishape), _groupMode);
+        ShapeGroupMode groupMode = GetOptions(iShape).Get<ShapeGroupMode>("ShapeGroupMode");
+
+        ListPNamedShape templist = GroupFaces(GetShape(ishape), groupMode);
         for (ListPNamedShape::iterator it2 = templist.begin(); it2 != templist.end(); ++it2) {
             list.push_back(*it2);
         }
@@ -326,11 +333,6 @@ bool CTiglExportStep::WriteImpl(const std::string& filename) const
     }
 
     return stepWriter.Write(const_cast<char*>(filename.c_str())) <= IFSelect_RetDone;
-}
-
-void CTiglExportStep::SetGroupMode(ShapeGroupMode mode)
-{
-    _groupMode = mode;
 }
 
 } // end namespace tigl

--- a/src/exports/CTiglExportStep.cpp
+++ b/src/exports/CTiglExportStep.cpp
@@ -241,7 +241,7 @@ namespace tigl
 AUTORUN(CTiglExportStep)
 {
     static CCADExporterBuilder<CTiglExportStep> stepExporterBuilder;
-    CTiglExporterFactory::Instance().RegisterExporter(&stepExporterBuilder);
+    CTiglExporterFactory::Instance().RegisterExporter(&stepExporterBuilder, StepOptions());
     return true;
 }
 

--- a/src/exports/CTiglExportStep.cpp
+++ b/src/exports/CTiglExportStep.cpp
@@ -246,13 +246,19 @@ AUTORUN(CTiglExportStep)
 }
 
 // Constructor
-CTiglExportStep::CTiglExportStep()
+CTiglExportStep::CTiglExportStep(const ExporterOptions& opt)
+    : CTiglCADExporter(opt)
 {
 }
 
 ExporterOptions CTiglExportStep::GetDefaultOptions() const
 {
     return StepOptions();
+}
+
+ShapeExportOptions CTiglExportStep::GetDefaultShapeOptions() const
+{
+    return StepShapeOptions();
 }
 
 /**

--- a/src/exports/CTiglExportStep.h
+++ b/src/exports/CTiglExportStep.h
@@ -53,6 +53,11 @@ private:
     // Writes the step file
     TIGL_EXPORT bool WriteImpl(const std::string& filename) const OVERRIDE;
 
+    std::string SupportedFileTypeImpl() const OVERRIDE
+    {
+        return "step;stp";
+    }
+
     // Assignment operator
     void operator=(const CTiglExportStep& ) { /* Do nothing */ }
 

--- a/src/exports/CTiglExportStep.h
+++ b/src/exports/CTiglExportStep.h
@@ -47,11 +47,12 @@ public:
         Set("IncludeFarfield", true);
         Set("ShapeGroupMode", NAMED_COMPOUNDS);
     }
+};
 
-    ShapeGroupMode GroupMode() const
-    {
-        return Get<ShapeGroupMode>("ShapeGroupMode");
-    }
+class StepShapeOptions : public ShapeExportOptions
+{
+public:
+    StepShapeOptions(){}
 };
 
 class CTiglExportStep : public CTiglCADExporter
@@ -59,10 +60,10 @@ class CTiglExportStep : public CTiglCADExporter
 
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportStep();
+    TIGL_EXPORT CTiglExportStep(const ExporterOptions& opt = DefaultExporterOption());
 
     TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
-
+    TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;
 
 private:
     // Writes the step file

--- a/src/exports/CTiglExportStep.h
+++ b/src/exports/CTiglExportStep.h
@@ -38,6 +38,22 @@ namespace tigl
 
 class CCPACSConfiguration;
 
+class StepOptions : public ExporterOptions
+{
+public:
+    StepOptions()
+    {
+        Set("ApplySymmetries", false);
+        Set("IncludeFarfield", true);
+        Set("ShapeGroupMode", NAMED_COMPOUNDS);
+    }
+
+    ShapeGroupMode GroupMode() const
+    {
+        return Get<ShapeGroupMode>("ShapeGroupMode");
+    }
+};
+
 class CTiglExportStep : public CTiglCADExporter
 {
 
@@ -45,8 +61,7 @@ public:
     // Constructor
     TIGL_EXPORT CTiglExportStep();
 
-    // Sets the type of storing shapes to iges
-    TIGL_EXPORT void SetGroupMode(ShapeGroupMode mode);
+    TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
 
 
 private:
@@ -61,7 +76,6 @@ private:
     // Assignment operator
     void operator=(const CTiglExportStep& ) { /* Do nothing */ }
 
-    ShapeGroupMode                _groupMode;    /**< Type specifying how to group faces in the step file */
     void AddToStep(PNamedShape shape, STEPControl_Writer &writer) const;
 };
 

--- a/src/exports/CTiglExportStl.cpp
+++ b/src/exports/CTiglExportStl.cpp
@@ -56,13 +56,18 @@ CTiglExportStl::CTiglExportStl()
 {
 }
 
+ExporterOptions CTiglExportStl::GetDefaultOptions() const
+{
+    return StlOptions(0.001);
+}
+
 
 bool CTiglExportStl::WriteImpl(const std::string& filename) const
 {
     for (size_t ishape = 0; ishape < NShapes(); ++ishape) {
         PNamedShape shape = GetShape(ishape);
         if (shape) {
-            BRepMesh_IncrementalMesh(shape->Shape(), GetOptions(ishape).deflection);
+            BRepMesh_IncrementalMesh(shape->Shape(), GetOptions(ishape).Get<double>("Deflection"));
         }
     }
 

--- a/src/exports/CTiglExportStl.cpp
+++ b/src/exports/CTiglExportStl.cpp
@@ -25,6 +25,8 @@
 
 #include "CTiglExportStl.h"
 #include "CCPACSConfiguration.h"
+#include "CTiglExporterFactory.h"
+#include "CTiglTypeRegistry.h"
 
 #include "TopoDS_Shape.hxx"
 #include "Standard_CString.hxx"
@@ -41,6 +43,13 @@
 
 namespace tigl 
 {
+
+AUTORUN(CTiglExportStl)
+{
+    static CCADExporterBuilder<CTiglExportStl> stlExporterBuilder;
+    CTiglExporterFactory::Instance().RegisterExporter(&stlExporterBuilder);
+    return true;
+}
 
 // Constructor
 CTiglExportStl::CTiglExportStl()

--- a/src/exports/CTiglExportStl.cpp
+++ b/src/exports/CTiglExportStl.cpp
@@ -47,7 +47,7 @@ namespace tigl
 AUTORUN(CTiglExportStl)
 {
     static CCADExporterBuilder<CTiglExportStl> stlExporterBuilder;
-    CTiglExporterFactory::Instance().RegisterExporter(&stlExporterBuilder);
+    CTiglExporterFactory::Instance().RegisterExporter(&stlExporterBuilder, StlOptions());
     return true;
 }
 

--- a/src/exports/CTiglExportStl.cpp
+++ b/src/exports/CTiglExportStl.cpp
@@ -52,15 +52,20 @@ AUTORUN(CTiglExportStl)
 }
 
 // Constructor
-CTiglExportStl::CTiglExportStl()
+CTiglExportStl::CTiglExportStl(const ExporterOptions& opt)
+    : CTiglCADExporter(opt)
 {
 }
 
 ExporterOptions CTiglExportStl::GetDefaultOptions() const
 {
-    return StlOptions(0.001);
+    return StlOptions();
 }
 
+ShapeExportOptions CTiglExportStl::GetDefaultShapeOptions() const
+{
+    return TriangulatedExportOptions(0.001);
+}
 
 bool CTiglExportStl::WriteImpl(const std::string& filename) const
 {

--- a/src/exports/CTiglExportStl.h
+++ b/src/exports/CTiglExportStl.h
@@ -46,6 +46,11 @@ private:
 
     bool WriteImpl(const std::string& filename) const OVERRIDE;
 
+    std::string SupportedFileTypeImpl() const OVERRIDE
+    {
+        return "stl";
+    }
+
     // Assignment operator
     void operator=(const CTiglExportStl& ) { /* Do nothing */ }
 };

--- a/src/exports/CTiglExportStl.h
+++ b/src/exports/CTiglExportStl.h
@@ -35,12 +35,25 @@
 namespace tigl 
 {
 
+class StlOptions : public TriangulatedExportOptions
+{
+public:
+    StlOptions(double deflection)
+        : TriangulatedExportOptions(deflection)
+    {
+        Set("ApplySymmetries", true);
+        Set("IncludeFarfield", false);
+    }
+};
+
 class CTiglExportStl : public CTiglCADExporter
 {
 
 public:
     // Constructor
     TIGL_EXPORT CTiglExportStl();
+
+    TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
 
 private:
 

--- a/src/exports/CTiglExportStl.h
+++ b/src/exports/CTiglExportStl.h
@@ -35,16 +35,9 @@
 namespace tigl 
 {
 
-class StlOptions : public TriangulatedExportOptions
+class StlOptions : public ExporterOptions
 {
 public:
-    StlOptions(double deflection)
-        : TriangulatedExportOptions(deflection)
-    {
-        Set("ApplySymmetries", true);
-        Set("IncludeFarfield", false);
-    }
-
     StlOptions()
     {
         Set("ApplySymmetries", true);
@@ -57,9 +50,10 @@ class CTiglExportStl : public CTiglCADExporter
 
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportStl();
+    TIGL_EXPORT CTiglExportStl(const ExporterOptions& opt = DefaultExporterOption());
 
     TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
+    TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;
 
 private:
 

--- a/src/exports/CTiglExportStl.h
+++ b/src/exports/CTiglExportStl.h
@@ -44,6 +44,12 @@ public:
         Set("ApplySymmetries", true);
         Set("IncludeFarfield", false);
     }
+
+    StlOptions()
+    {
+        Set("ApplySymmetries", true);
+        Set("IncludeFarfield", false);
+    }
 };
 
 class CTiglExportStl : public CTiglCADExporter

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -128,7 +128,7 @@ bool CTiglExportVtk::WriteImpl(const std::string &filename) const
     size_t nTotalPolys = 0;
 
     bool multiplePieces = GlobalExportOptions().Get<bool>("MultiplePieces");
-    bool normalsEnabled = GlobalExportOptions().Get<bool>("NormalsEnabled");
+    bool normalsEnabled = GlobalExportOptions().Get<bool>("WriteNormals");
 
     ComponentTraingMode myMode = NO_INFO;
     if (GlobalExportOptions().Get<bool>("WriteMetaData")) {

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -64,14 +64,6 @@ namespace
         return options;
     }
 
-    std::string to_lower(const std::string& str)
-    {
-        std::string result = str;
-        std::transform(result.begin(), result.end(), result.begin(), ::tolower);
-
-        return result;
-    }
-    
     void setMinMax(const tigl::CTiglPoint& p, double* oldmin, double* oldmax)
     {
         if (p.x > *oldmax) {
@@ -106,7 +98,7 @@ namespace tigl
 AUTORUN(CTiglExportVtk)
 {
     static CCADExporterBuilder<CTiglExportVtk> vtkExporterBuilder;
-    CTiglExporterFactory::Instance().RegisterExporter(&vtkExporterBuilder);
+    CTiglExporterFactory::Instance().RegisterExporter(&vtkExporterBuilder, VtkOptions());
     return true;
 }
 

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -51,14 +51,6 @@
 
 namespace
 {
-    tigl::CTiglTriangularizerOptions toTrianOptions(bool normalsEnabled)
-    {
-        tigl::CTiglTriangularizerOptions options;
-        options.setNormalsEnabled(normalsEnabled);
-
-        return options;
-    }
-
     void setMinMax(const tigl::CTiglPoint& p, double* oldmin, double* oldmax)
     {
         if (p.x > *oldmax) {
@@ -142,7 +134,7 @@ bool CTiglExportVtk::WriteImpl(const std::string &filename) const
             double deflection = GetOptions(i).Get<double>("Deflection");
 
             const CTiglUIDManager* mgr = GetConfiguration(i) ? &(GetConfiguration(i)->GetUIDManager()) : NULL;
-            CTiglTriangularizer mesher(mgr, pshape, deflection, myMode, toTrianOptions(normalsEnabled));
+            CTiglTriangularizer mesher(mgr, pshape, deflection, myMode, normalsEnabled);
             const CTiglPolyData& polys = mesher.getTriangulation();
             writeVTKPiece(polys.currentObject(), handle, i + 1);
 
@@ -171,9 +163,7 @@ bool CTiglExportVtk::WriteImpl(const std::string &filename) const
         }
 
         PNamedShape groupedShape = CGroupShapes(shapes);
-        CTiglTriangularizerOptions options;
-        options.setNormalsEnabled(normalsEnabled);
-        CTiglTriangularizer mesher(mgr, groupedShape, minDeflection, myMode, options);
+        CTiglTriangularizer mesher(mgr, groupedShape, minDeflection, myMode, normalsEnabled);
         const CTiglPolyData& polys = mesher.getTriangulation();
         writeVTKPiece(polys.currentObject(), handle, 1);
 

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -39,24 +39,14 @@ namespace tigl
 class CTiglPolyData;
 class CTiglPolyObject;
 
-class VtkOptions : public TriangulatedExportOptions
+class VtkOptions : public ExporterOptions
 {
 public:
-    VtkOptions(double deflection)
-        : TriangulatedExportOptions(deflection)
-    {
-        AddOption("NormalsEnabled", true);
-        AddOption("MultiplePieces", false);
-        AddOption("WriteMetaData", true);
-
-        Set("ApplySymmetries", true);
-        Set("IncludeFarfield", false);
-    }
-
     VtkOptions()
     {
         AddOption("NormalsEnabled", true);
         AddOption("MultiplePieces", false);
+        AddOption("WriteMetaData", true);
 
         Set("ApplySymmetries", true);
         Set("IncludeFarfield", false);
@@ -67,7 +57,11 @@ class CTiglExportVtk : public CTiglCADExporter
 {
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportVtk();
+    TIGL_EXPORT CTiglExportVtk(const ExporterOptions& opt = DefaultExporterOption());
+
+    TIGL_EXPORT ExporterOptions GetDefaultOptions() const OVERRIDE;
+    TIGL_EXPORT ShapeExportOptions GetDefaultShapeOptions() const OVERRIDE;
+
 
     // Virtual Destructor
     TIGL_EXPORT virtual ~CTiglExportVtk();
@@ -85,9 +79,6 @@ private:
 
     static void writeVTKPiece(const CTiglPolyObject& co, TixiDocumentHandle& handle, unsigned int iObject); 
     static void writeVTKHeader(TixiDocumentHandle& handle);
-
-    ComponentTraingMode myMode;
-
 };
 
 } // end namespace tigl

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -39,6 +39,30 @@ namespace tigl
 class CTiglPolyData;
 class CTiglPolyObject;
 
+class VtkOptions : public TriangulatedExportOptions
+{
+public:
+    VtkOptions(double deflection)
+        : TriangulatedExportOptions(deflection)
+    {
+        AddOption("NormalsEnabled", true);
+        AddOption("MultiplePieces", false);
+        AddOption("WriteMetaData", true);
+
+        Set("ApplySymmetries", true);
+        Set("IncludeFarfield", false);
+    }
+
+    VtkOptions()
+    {
+        AddOption("NormalsEnabled", true);
+        AddOption("MultiplePieces", false);
+
+        Set("ApplySymmetries", true);
+        Set("IncludeFarfield", false);
+    }
+};
+
 class CTiglExportVtk : public CTiglCADExporter
 {
 public:
@@ -47,12 +71,6 @@ public:
 
     // Virtual Destructor
     TIGL_EXPORT virtual ~CTiglExportVtk();
-
-    TIGL_EXPORT static void SetOptions(const std::string& key, const std::string& value);
-
-    // Options
-    TIGL_EXPORT static bool normalsEnabled;
-    TIGL_EXPORT static bool multiplePieces;
 
     /// Exports a polygonal data representation directly
     TIGL_EXPORT static void WritePolys(const CTiglPolyData& polys, const char * filename);

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -44,7 +44,7 @@ class VtkOptions : public ExporterOptions
 public:
     VtkOptions()
     {
-        AddOption("NormalsEnabled", true);
+        AddOption("WriteNormals", true);
         AddOption("MultiplePieces", false);
         AddOption("WriteMetaData", true);
 

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -80,7 +80,7 @@ private:
 
     std::string SupportedFileTypeImpl() const OVERRIDE
     {
-        return "vtp";
+        return "vtp;vtk";
     }
 
     static void writeVTKPiece(const CTiglPolyObject& co, TixiDocumentHandle& handle, unsigned int iObject); 

--- a/src/exports/CTiglExportVtk.h
+++ b/src/exports/CTiglExportVtk.h
@@ -31,6 +31,7 @@
 #include "CTiglTriangularizer.h"
 
 #include <string>
+#include <map>
 
 namespace tigl 
 {
@@ -42,7 +43,7 @@ class CTiglExportVtk : public CTiglCADExporter
 {
 public:
     // Constructor
-    TIGL_EXPORT CTiglExportVtk(class CCPACSConfiguration & config, ComponentTraingMode mode = NO_INFO);
+    TIGL_EXPORT CTiglExportVtk();
 
     // Virtual Destructor
     TIGL_EXPORT virtual ~CTiglExportVtk();
@@ -52,17 +53,21 @@ public:
     // Options
     TIGL_EXPORT static bool normalsEnabled;
     TIGL_EXPORT static bool multiplePieces;
-    
+
     /// Exports a polygonal data representation directly
     TIGL_EXPORT static void WritePolys(const CTiglPolyData& polys, const char * filename);
 
 private:
     bool WriteImpl(const std::string& filename) const OVERRIDE;
 
+    std::string SupportedFileTypeImpl() const OVERRIDE
+    {
+        return "vtp";
+    }
+
     static void writeVTKPiece(const CTiglPolyObject& co, TixiDocumentHandle& handle, unsigned int iObject); 
     static void writeVTKHeader(TixiDocumentHandle& handle);
-    
-    class CCPACSConfiguration & myConfig;       /**< TIGL configuration object */
+
     ComponentTraingMode myMode;
 
 };

--- a/src/exports/CTiglExporterFactory.cpp
+++ b/src/exports/CTiglExporterFactory.cpp
@@ -1,0 +1,99 @@
+/*
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "CTiglExporterFactory.h"
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+
+namespace
+{
+
+std::vector<std::string> split_string(const std::string& mystring, char delimiter)
+{
+    std::vector<std::string> strings;
+    std::istringstream f(mystring);
+    std::string s;
+    while (std::getline(f, s, delimiter)) {
+        strings.push_back(s);
+    }
+    return strings;
+}
+
+}
+
+namespace tigl
+{
+
+CTiglExporterFactory& CTiglExporterFactory::Instance()
+{
+    static CTiglExporterFactory factory;
+    return factory;
+}
+
+void CTiglExporterFactory::RegisterExporter(ICADExporterBuilder *creator)
+{
+    if (creator) {
+        // build an importer to get supported file type
+        PTiglCADExporter exporter = creator->create();
+        if (exporter) {
+            std::string filetype = exporter->SupportedFileType();
+            std::vector<std::string> fileTypes = split_string(filetype, ';');
+            for (std::vector<std::string>::const_iterator it = fileTypes.begin(); it != fileTypes.end(); ++it) {
+                std::string type = *it;
+                _exporterBuilders[type] = creator;
+            }
+        }
+    }
+}
+
+PTiglCADExporter CTiglExporterFactory::Create(const std::string &filetype) const
+{
+    // make the requested filetype to lowercase
+    std::string fileTypeToLower = filetype;
+    std::transform(fileTypeToLower.begin(), fileTypeToLower.end(), fileTypeToLower.begin(), ::tolower);
+
+    ExporterMap::const_iterator it = _exporterBuilders.find(fileTypeToLower);
+    if (it != _exporterBuilders.end()) {
+        ICADExporterBuilder* creator = it->second;
+        return creator->create();
+    }
+    else {
+        return PTiglCADExporter();
+    }
+}
+
+bool CTiglExporterFactory::ExporterSupported(const std::string &filetype) const
+{
+    // make the requested filetype to lowercase
+    std::string fileTypeToLower = filetype;
+    std::transform(fileTypeToLower.begin(), fileTypeToLower.end(), fileTypeToLower.begin(), ::tolower);
+
+    ExporterMap::const_iterator it = _exporterBuilders.find(fileTypeToLower);
+    if (it != _exporterBuilders.end()) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+CTiglExporterFactory::CTiglExporterFactory()
+{
+}
+
+} // namespace tigl

--- a/src/exports/CTiglExporterFactory.cpp
+++ b/src/exports/CTiglExporterFactory.cpp
@@ -48,15 +48,17 @@ void CTiglExporterFactory::RegisterExporter(ICADExporterBuilder *creator, const 
     }
 }
 
-PTiglCADExporter CTiglExporterFactory::Create(const std::string &filetype) const
+PTiglCADExporter CTiglExporterFactory::Create(const std::string &filetype, const ExporterOptions& theOptions) const
 {
     // make the requested filetype to lowercase
     std::string fileTypeToLower = to_lower(filetype);
 
+    const ExporterOptions& options = theOptions.IsDefault() ? getExportConfig(fileTypeToLower) : theOptions;
+
     ExporterMap::const_iterator it = _exporterBuilders.find(fileTypeToLower);
     if (it != _exporterBuilders.end()) {
         ICADExporterBuilder* creator = it->second;
-        return creator->create();
+        return creator->create(options);
     }
     else {
         return PTiglCADExporter();

--- a/src/exports/CTiglExporterFactory.h
+++ b/src/exports/CTiglExporterFactory.h
@@ -1,0 +1,52 @@
+/*
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef CTIGLEXPORTERFACTORY_H
+#define CTIGLEXPORTERFACTORY_H
+
+#include "tigl_internal.h"
+#include "CTiglCADExporter.h"
+
+#include <map>
+
+namespace tigl
+{
+
+class CTiglExporterFactory
+{
+public:
+    TIGL_EXPORT static CTiglExporterFactory& Instance();
+
+    /// Registers a CAD Exporter at the factory
+    TIGL_EXPORT void RegisterExporter(ICADExporterBuilder* creator);
+
+    /// Creates an exporter for the matching file format
+    /// Returns NULL, if the format is unknown
+    TIGL_EXPORT PTiglCADExporter Create(const std::string& filetype) const;
+
+    /// Returns true, if an exporter was registered for the specified file type
+    TIGL_EXPORT bool ExporterSupported(const std::string& filetype) const;
+
+private:
+    CTiglExporterFactory();
+    
+    typedef std::map<std::string, ICADExporterBuilder*>  ExporterMap;
+    ExporterMap _exporterBuilders;
+};
+
+} // namespace tigl
+
+#endif // CTIGLEXPORTERFACTORY_H

--- a/src/exports/CTiglExporterFactory.h
+++ b/src/exports/CTiglExporterFactory.h
@@ -35,7 +35,7 @@ public:
 
     /// Creates an exporter for the matching file format
     /// Returns NULL, if the format is unknown
-    TIGL_EXPORT PTiglCADExporter Create(const std::string& filetype) const;
+    TIGL_EXPORT PTiglCADExporter Create(const std::string& filetype, const ExporterOptions& options = DefaultExporterOption()) const;
 
     /// Returns true, if an exporter was registered for the specified file type
     TIGL_EXPORT bool ExporterSupported(const std::string& filetype) const;
@@ -46,6 +46,11 @@ private:
     typedef std::map<std::string, ICADExporterBuilder*>  ExporterMap;
     ExporterMap _exporterBuilders;
 };
+
+inline PTiglCADExporter createExporter(const std::string& filetype, const ExporterOptions& options = DefaultExporterOption())
+{
+    return CTiglExporterFactory::Instance().Create(filetype, options);
+}
 
 } // namespace tigl
 

--- a/src/exports/CTiglExporterFactory.h
+++ b/src/exports/CTiglExporterFactory.h
@@ -31,7 +31,7 @@ public:
     TIGL_EXPORT static CTiglExporterFactory& Instance();
 
     /// Registers a CAD Exporter at the factory
-    TIGL_EXPORT void RegisterExporter(ICADExporterBuilder* creator);
+    TIGL_EXPORT void RegisterExporter(ICADExporterBuilder* creator, const ExporterOptions& exporterConfig);
 
     /// Creates an exporter for the matching file format
     /// Returns NULL, if the format is unknown

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -129,7 +129,12 @@ bool CTiglTriangularizer::writeWingMeta(ITiglGeometricComponent& wingComponent, 
 void CTiglTriangularizer::writeFaceMeta(const CTiglUIDManager* uidMgr, const std::string& componentUID,
                                         TopoDS_Face face, unsigned long iPolyLower, unsigned long iPolyUpper)
 {
-    if (!uidMgr || componentUID.empty()) {
+    if (!uidMgr) {
+        return;
+    }
+
+    if (componentUID.empty()) {
+        writeFaceDummyMeta(iPolyLower, iPolyUpper);
         return;
     }
 

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -67,8 +67,8 @@ namespace
 namespace tigl
 {
 
-CTiglTriangularizer::CTiglTriangularizer(PNamedShape pshape, double deflection, const CTiglTriangularizerOptions& options)
-    : m_options(options)
+CTiglTriangularizer::CTiglTriangularizer(PNamedShape pshape, double deflection, bool computeNormals)
+    : m_computeNormals(computeNormals)
 {
     if (!pshape) {
         throw CTiglError("Null pointer shape in CTiglTriangularizer", TIGL_NULL_POINTER);
@@ -77,8 +77,8 @@ CTiglTriangularizer::CTiglTriangularizer(PNamedShape pshape, double deflection, 
     triangularizeComponent(NULL, pshape, deflection, NO_INFO);
 }
 
-CTiglTriangularizer::CTiglTriangularizer(const CTiglUIDManager* uidMgr, PNamedShape shape, double deflection, ComponentTraingMode mode, const CTiglTriangularizerOptions& options)
-    : m_options(options)
+CTiglTriangularizer::CTiglTriangularizer(const CTiglUIDManager* uidMgr, PNamedShape shape, double deflection, ComponentTraingMode mode, bool computeNormals)
+    : m_computeNormals(computeNormals)
 {
     if (!shape) {
         throw CTiglError("Null pointer shape in CTiglTriangularizer", TIGL_NULL_POINTER);
@@ -176,7 +176,7 @@ int CTiglTriangularizer::triangularizeComponent(const CTiglUIDManager* uidMgr, P
     BRepMesh_IncrementalMesh(shape, deflection);
     LOG(INFO) << "Done meshing";
 
-    polys.currentObject().enableNormals(m_options.normalsEnabled());
+    polys.currentObject().enableNormals(m_computeNormals);
 
     TopTools_IndexedMapOfShape faceMap;
     TopExp::MapShapes(shape, TopAbs_FACE, faceMap);
@@ -280,7 +280,7 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
     unsigned long ilower = 0;
     unsigned long iBufferSize = 0;
     
-    if (triangulation->HasUVNodes() && m_options.normalsEnabled()) {
+    if (triangulation->HasUVNodes() && m_computeNormals) {
         // we use the uv nodes to compute normal vectors for each point
         
         BRepGProp_Face prop(face);

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -73,39 +73,16 @@ CTiglTriangularizer::CTiglTriangularizer(PNamedShape pshape, double deflection, 
     if (!pshape) {
         throw CTiglError("Null pointer shape in CTiglTriangularizer", TIGL_NULL_POINTER);
     }
-    
-    const TopoDS_Shape& shape = pshape->Shape();
-    // check if we have already a mesh with given deflection
-    if (!BRepTools::Triangulation (shape, deflection)) {
-        BRepTools::Clean (shape);
-        BRepMesh_IncrementalMesh(shape, deflection);
-    }
-    triangularizeShape(shape);
+
+    triangularizeComponent(NULL, pshape, deflection, NO_INFO);
 }
 
-int CTiglTriangularizer::triangularizeShape(const TopoDS_Shape& shape)
-{
-    TopExp_Explorer shellExplorer;
-    TopExp_Explorer faceExplorer;
-    
-    for (shellExplorer.Init(shape, TopAbs_SHELL); shellExplorer.More(); shellExplorer.Next()) {
-        const TopoDS_Shell shell = TopoDS::Shell(shellExplorer.Current());
-        
-        polys.currentObject().enableNormals(m_options.normalsEnabled());
-
-        for (faceExplorer.Init(shell, TopAbs_FACE); faceExplorer.More(); faceExplorer.Next()) {
-            TopoDS_Face face = TopoDS::Face(faceExplorer.Current());
-            unsigned long nVertices, iPolyLower, iPolyUpper;
-            triangularizeFace(face, nVertices, iPolyLower, iPolyUpper);
-        } // for faces
-    } // for shells
-    
-    return 0;
-}
-
-CTiglTriangularizer::CTiglTriangularizer(const CTiglUIDManager& uidMgr, PNamedShape shape, double deflection, ComponentTraingMode mode, const CTiglTriangularizerOptions& options)
+CTiglTriangularizer::CTiglTriangularizer(const CTiglUIDManager* uidMgr, PNamedShape shape, double deflection, ComponentTraingMode mode, const CTiglTriangularizerOptions& options)
     : m_options(options)
 {
+    if (!shape) {
+        throw CTiglError("Null pointer shape in CTiglTriangularizer", TIGL_NULL_POINTER);
+    }
 
     triangularizeComponent(uidMgr, shape, deflection, mode);
     
@@ -129,7 +106,7 @@ void CTiglTriangularizer::writeFaceDummyMeta(unsigned long iPolyLower, unsigned 
         polys.currentObject().setPolyDataReal(iPoly, "segment_index", 0.);
         polys.currentObject().setPolyDataReal(iPoly, "eta", 0.);
         polys.currentObject().setPolyDataReal(iPoly, "xsi", 0.);
-        
+
         polys.currentObject().setPolyMetadata(iPoly,"\"\" 0 0.0 0.0 0");
     }
 }
@@ -149,13 +126,46 @@ bool CTiglTriangularizer::writeWingMeta(ITiglGeometricComponent& wingComponent, 
     return false;
 }
 
-int CTiglTriangularizer::triangularizeComponent(const CTiglUIDManager& uidMgr, PNamedShape pshape, double deflection, ComponentTraingMode mode)
+void CTiglTriangularizer::writeFaceMeta(const CTiglUIDManager* uidMgr, const std::string& componentUID,
+                                        TopoDS_Face face, unsigned long iPolyLower, unsigned long iPolyUpper)
+{
+    if (!uidMgr || componentUID.empty()) {
+        return;
+    }
+
+    // compute a central point on the face
+    BRepGProp_Face prop(face);
+    Standard_Real umin, umax, vmin, vmax;
+    prop.Bounds(umin, umax, vmin, vmax);
+
+    Standard_Real umean = 0.5*(umin+umax);
+    Standard_Real vmean = 0.5*(vmin+vmax);
+
+    gp_Pnt centralP; gp_Vec n;
+    prop.Normal(umean,vmean,centralP,n);
+
+    try {
+        ITiglGeometricComponent& component = uidMgr->GetGeometricComponent(componentUID);
+        if (writeWingMeta(component, centralP, iPolyLower, iPolyUpper)) {
+            return;
+        }
+        
+        if (writeWingSegmentMeta(component, centralP, iPolyLower, iPolyUpper)) {
+            return;
+        }
+    }
+    catch(CTiglError&) {
+        // uid is not a component. do nothing
+    }
+    writeFaceDummyMeta(iPolyLower, iPolyUpper);
+}
+
+int CTiglTriangularizer::triangularizeComponent(const CTiglUIDManager* uidMgr, PNamedShape pshape, double deflection, ComponentTraingMode mode)
 {
     if (!pshape) {
         return TIGL_NULL_POINTER;
     }
-    
-    
+
     TopoDS_Shape shape = pshape->Shape();
     BRepTools::Clean (shape);
     BRepMesh_IncrementalMesh(shape, deflection);
@@ -167,38 +177,13 @@ int CTiglTriangularizer::triangularizeComponent(const CTiglUIDManager& uidMgr, P
     TopExp::MapShapes(shape, TopAbs_FACE, faceMap);
     for (int iface = 1; iface <= faceMap.Extent(); ++iface) {
         TopoDS_Face face = TopoDS::Face(faceMap(iface));
-        const CFaceTraits& faceTraits = pshape->GetFaceTraits(iface-1);
+        std::string componentUID = pshape->GetFaceTraits(iface-1).ComponentUID();
         unsigned long nVertices, iPolyLower, iPolyUpper;
         triangularizeFace(face, nVertices, iPolyLower, iPolyUpper);
-        
-        // find to which segment the face belongs
-        if (nVertices > 0  &&  mode ==  SEGMENT_INFO) {
-            // compute a central point on the face
-            BRepGProp_Face prop(face);
-            Standard_Real umin, umax, vmin, vmax;
-            prop.Bounds(umin, umax, vmin, vmax);
-            
-            Standard_Real umean = 0.5*(umin+umax);
-            Standard_Real vmean = 0.5*(vmin+vmax);
-            
-            gp_Pnt centralP; gp_Vec n;
-            prop.Normal(umean,vmean,centralP,n);
 
-            try {
-                ITiglGeometricComponent& component = uidMgr.GetGeometricComponent(faceTraits.ComponentUID());
-                if (writeWingMeta(component, centralP, iPolyLower, iPolyUpper)) {
-                    continue;
-                }
-                
-                if (writeWingSegmentMeta(component, centralP, iPolyLower, iPolyUpper)) {
-                    continue;
-                }
-            }
-            catch(CTiglError&) {
-                // uid is not a component. do nothing
-            }
-            writeFaceDummyMeta(iPolyLower, iPolyUpper);
-
+        if (nVertices > 0 && mode ==  SEGMENT_INFO) {
+            // write face metadata
+            writeFaceMeta(uidMgr, componentUID, face, iPolyLower, iPolyUpper);
         }
     }
 
@@ -279,15 +264,14 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
 {
     TopLoc_Location location;
     std::vector<unsigned long> indexBuffer;
-    
+
     const Handle(Poly_Triangulation) triangulation = BRep_Tool::Triangulation(face, location);
     if (triangulation.IsNull()) {
         return 0;
     }
-    
+
     gp_Trsf nodeTransformation = location;
-    
-    
+
     unsigned long ilower = 0;
     unsigned long iBufferSize = 0;
     
@@ -319,15 +303,15 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
         
         const TColgp_Array1OfPnt& nodes = triangulation->Nodes(); // get (face-local) list of nodes
         ilower = nodes.Lower();
-        
+
         iBufferSize = nodes.Upper()-nodes.Lower()+1;
-        indexBuffer.reserve(iBufferSize);        for (int inode = nodes.Lower(); inode <= nodes.Upper(); inode++) {
+        indexBuffer.reserve(iBufferSize);
+        for (int inode = nodes.Lower(); inode <= nodes.Upper(); inode++) {
             const gp_Pnt& p = nodes(inode).Transformed(nodeTransformation);
             indexBuffer.push_back(polys.currentObject().addPointNormal(p.XYZ(), CTiglPoint(1,0,0)));
         }
     }
 
-    
     const Poly_Array1OfTriangle& triangles = triangulation->Triangles();
     iPolyLower = ULONG_MAX;
     iPolyUpper = 0;
@@ -340,16 +324,16 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
         index1 = indexBuffer[occindex1-ilower];
         index2 = indexBuffer[occindex2-ilower];
         index3 = indexBuffer[occindex3-ilower];
-        
+
         unsigned long iPolyIndex = 0;
-        
+
         if (face.Orientation() != TopAbs_REVERSED && face.Orientation() != TopAbs_INTERNAL) {
             iPolyIndex = polys.currentObject().addTriangleByVertexIndex(index1, index2, index3);
         }
         else {
             iPolyIndex = polys.currentObject().addTriangleByVertexIndex(index1, index3, index2);
         }
-        
+
         // In some rare cases, 2 indices are the same
         // which means, that we dont have a true triangle.
         // Ignore this triangle

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -45,34 +45,13 @@ enum ComponentTraingMode
     SEGMENT_INFO
 };
 
-class CTiglTriangularizerOptions {
-public:
-    CTiglTriangularizerOptions()
-        : m_normalsEnabled(true)
-    {
-    }
-
-    bool normalsEnabled() const
-    {
-        return m_normalsEnabled;
-    }
-
-    void setNormalsEnabled(bool enabled)
-    {
-        m_normalsEnabled = enabled;
-    }
-
-private:
-    bool m_normalsEnabled;
-};
-
 class CTiglTriangularizer
 {
 public:
-    TIGL_EXPORT CTiglTriangularizer(PNamedShape shape, double deflection, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+    TIGL_EXPORT CTiglTriangularizer(PNamedShape shape, double deflection, bool computeNormals = true);
 
     TIGL_EXPORT CTiglTriangularizer(const CTiglUIDManager* uidMgr, PNamedShape shape, double deflection,
-                                    ComponentTraingMode mode = NO_INFO, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
+                                    ComponentTraingMode mode = NO_INFO, bool computeNormals = true);
 
     const CTiglPolyData& getTriangulation() const
     {
@@ -88,7 +67,7 @@ private:
     bool writeWingSegmentMeta(ITiglGeometricComponent& segment, gp_Pnt centralP, unsigned long iPolyLower, unsigned long iPolyUpper);
 
     // some options
-    CTiglTriangularizerOptions m_options;
+    bool m_computeNormals;
     CTiglPolyData polys;
     void writeFaceMeta(const CTiglUIDManager* uidMgr, const std::string& componentUID, TopoDS_Face face, unsigned long iPolyLower, unsigned long iPolyUpper);
 };

--- a/src/geometry/CTiglTriangularizer.h
+++ b/src/geometry/CTiglTriangularizer.h
@@ -71,7 +71,7 @@ class CTiglTriangularizer
 public:
     TIGL_EXPORT CTiglTriangularizer(PNamedShape shape, double deflection, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
 
-    TIGL_EXPORT CTiglTriangularizer(const CTiglUIDManager& uidMgr, PNamedShape shape, double deflection,
+    TIGL_EXPORT CTiglTriangularizer(const CTiglUIDManager* uidMgr, PNamedShape shape, double deflection,
                                     ComponentTraingMode mode = NO_INFO, const CTiglTriangularizerOptions& options = CTiglTriangularizerOptions());
 
     const CTiglPolyData& getTriangulation() const
@@ -80,8 +80,7 @@ public:
     }
 
 private:
-    int triangularizeComponent(const CTiglUIDManager& uidMgr, PNamedShape shape, double deflection, ComponentTraingMode = NO_INFO);
-    int triangularizeShape(const TopoDS_Shape&);
+    int triangularizeComponent(const CTiglUIDManager* uidMgr, PNamedShape shape, double deflection, ComponentTraingMode = NO_INFO);
     int triangularizeFace(const TopoDS_Face&, unsigned long& nVertices, unsigned long& iPolyLow, unsigned long& iPolyUp);
 
     void writeFaceDummyMeta(unsigned long iPolyLower, unsigned long iPolyUpper);
@@ -91,6 +90,7 @@ private:
     // some options
     CTiglTriangularizerOptions m_options;
     CTiglPolyData polys;
+    void writeFaceMeta(const CTiglUIDManager* uidMgr, const std::string& componentUID, TopoDS_Face face, unsigned long iPolyLower, unsigned long iPolyUpper);
 };
 
 }

--- a/src/system/CTiglTypeRegistry.cpp
+++ b/src/system/CTiglTypeRegistry.cpp
@@ -27,6 +27,12 @@ namespace tigl
 
 // register all dynamic types to prevent linker optimization
 REGISTER_TYPE(CTiglStepReader)
+REGISTER_TYPE(CTiglExportStep)
+REGISTER_TYPE(CTiglExportIges)
+REGISTER_TYPE(CTiglExportVtk)
+REGISTER_TYPE(CTiglExportCollada)
+REGISTER_TYPE(CTiglExportStl)
+REGISTER_TYPE(CTiglExportBrep)
 
 
 void CTiglTypeRegistry::Init()

--- a/tests/unittests/testGlobalExporterConfigs.cpp
+++ b/tests/unittests/testGlobalExporterConfigs.cpp
@@ -1,0 +1,57 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-04-04 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+#include "test.h"
+
+#include "CGlobalExporterConfigs.h"
+#include "CTiglExportStep.h"
+
+TEST(CGlobalExporterConfigs, CheckExporterAvailable)
+{
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("iges"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("igs"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("vtp"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("brep"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("step"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("stp"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("step"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("dae"));
+
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("vtk"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("collada"));
+
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("STEP"));
+    EXPECT_NO_THROW(tigl::CGlobalExporterConfigs::Instance().Get("IGES"));
+
+    EXPECT_THROW(tigl::CGlobalExporterConfigs::Instance().Get("unknown"), tigl::CTiglError);
+}
+
+TEST(CGlobalExporterConfigs, CheckSameConfig)
+{
+    tigl::ExporterOptions& stepOptions = tigl::CGlobalExporterConfigs::Instance().Get("step");
+    ASSERT_FALSE(stepOptions.Get<bool>("ApplySymmetries"));
+    ASSERT_FALSE(tigl::CGlobalExporterConfigs::Instance().Get("stp").Get<bool>("ApplySymmetries"));
+
+    stepOptions.SetApplySymmetries(true);
+    ASSERT_TRUE(stepOptions.Get<bool>("ApplySymmetries"));
+    ASSERT_TRUE(tigl::CGlobalExporterConfigs::Instance().Get("stp").Get<bool>("ApplySymmetries"));
+
+    // This is a global config, hence we have to reset it!
+    tigl::CGlobalExporterConfigs::Instance().Get("stp") = tigl::StepOptions();
+}

--- a/tests/unittests/testOptionList.cpp
+++ b/tests/unittests/testOptionList.cpp
@@ -20,6 +20,7 @@
 #include "test.h"
 
 #include "COptionList.h"
+#include "any.h"
 
 class MockOptions : public tigl::COptionList
 {
@@ -37,6 +38,14 @@ TEST(OptionList, AddGetSet)
 
     double v1 = options.GetOption<double>("my_double");
     EXPECT_NEAR(0.0, v1, 1e-10);
+
+    options.SetDoubleOption("my_double", 10.);
+    v1 = options.GetOption<double>("my_double");
+    EXPECT_NEAR(10.0, v1, 1e-10);
+
+    options.SetOption_FromString("my_double", "20.");
+    v1 = options.GetOption<double>("my_double");
+    EXPECT_NEAR(20.0, v1, 1e-10);
 
     std::string v2 = options.GetOption<std::string>("my_string");
     EXPECT_STREQ("Hallo", v2.c_str());
@@ -62,6 +71,9 @@ TEST(OptionList, AddGetSet)
 
     // no such option
     EXPECT_THROW(options.GetOption<int>("my_new_double"), tigl::CTiglError);
+
+    // cannot convert "welt" to a double
+    EXPECT_THROW(options.SetOption_FromString("my_doublee", "welt"), tigl::CTiglError);
 }
 
 TEST(OptionList, OptionNames)

--- a/tests/unittests/testOptionList.cpp
+++ b/tests/unittests/testOptionList.cpp
@@ -1,0 +1,86 @@
+/* 
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-03-29 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+#include "test.h"
+
+#include "COptionList.h"
+
+class MockOptions : public tigl::COptionList
+{
+public:
+    MockOptions()
+    {
+        AddOption<double>("my_double", 0.0);
+        AddOption<std::string>("my_string", "Hallo");
+    }
+};
+
+TEST(OptionList, AddGetSet)
+{
+    MockOptions options;
+
+    double v1 = options.GetOption<double>("my_double");
+    EXPECT_NEAR(0.0, v1, 1e-10);
+
+    std::string v2 = options.GetOption<std::string>("my_string");
+    EXPECT_STREQ("Hallo", v2.c_str());
+
+    options.SetOption<std::string>("my_string", "welt");
+    v2 = options.GetOption<std::string>("my_string");
+    EXPECT_STREQ("welt", v2.c_str());
+
+    options.SetStringOption("my_string", "hello world");
+    v2 = options.GetStringOption("my_string");
+    EXPECT_STREQ("hello world", v2.c_str());
+
+    // check failures
+    // connot convert
+    EXPECT_THROW(options.SetOption("my_string", 2.0), tigl::CTiglError);
+
+    // no such option
+    EXPECT_THROW(options.SetOption<std::string>("my_new_string", "welt"),
+                 tigl::CTiglError);
+
+    // cannot convert
+    EXPECT_THROW(options.GetOption<int>("my_double"), tigl::CTiglError);
+
+    // no such option
+    EXPECT_THROW(options.GetOption<int>("my_new_double"), tigl::CTiglError);
+}
+
+TEST(OptionList, OptionNames)
+{
+    MockOptions options;
+    ASSERT_EQ(2, options.GetNOptions());
+
+    EXPECT_STREQ("my_double", options.GetOptionName(0).c_str());
+    EXPECT_STREQ("my_string", options.GetOptionName(1).c_str());
+
+    EXPECT_STREQ("double", options.GetOptionType(0).c_str());
+}
+
+TEST(OptionList, HasOption)
+{
+    MockOptions options;
+
+    EXPECT_TRUE(options.HasOption("my_string"));
+    EXPECT_TRUE(options.HasOption("my_double"));
+
+    EXPECT_FALSE(options.HasOption("my_new_string"));
+}

--- a/tests/unittests/testOptionList.cpp
+++ b/tests/unittests/testOptionList.cpp
@@ -32,48 +32,57 @@ public:
     }
 };
 
+class MockOptionsOther : public tigl::COptionList
+{
+public:
+    MockOptionsOther()
+    {
+        AddOption<int>("my_int", 10);
+    }
+};
+
 TEST(OptionList, AddGetSet)
 {
     MockOptions options;
 
-    double v1 = options.GetOption<double>("my_double");
+    double v1 = options.Get<double>("my_double");
     EXPECT_NEAR(0.0, v1, 1e-10);
 
-    options.SetDoubleOption("my_double", 10.);
-    v1 = options.GetOption<double>("my_double");
+    options.SetDouble("my_double", 10.);
+    v1 = options.Get<double>("my_double");
     EXPECT_NEAR(10.0, v1, 1e-10);
 
-    options.SetOption_FromString("my_double", "20.");
-    v1 = options.GetOption<double>("my_double");
+    options.SetFromString("my_double", "20.");
+    v1 = options.Get<double>("my_double");
     EXPECT_NEAR(20.0, v1, 1e-10);
 
-    std::string v2 = options.GetOption<std::string>("my_string");
+    std::string v2 = options.Get<std::string>("my_string");
     EXPECT_STREQ("Hallo", v2.c_str());
 
-    options.SetOption<std::string>("my_string", "welt");
-    v2 = options.GetOption<std::string>("my_string");
+    options.Set<std::string>("my_string", "welt");
+    v2 = options.Get<std::string>("my_string");
     EXPECT_STREQ("welt", v2.c_str());
 
-    options.SetStringOption("my_string", "hello world");
-    v2 = options.GetStringOption("my_string");
+    options.SetString("my_string", "hello world");
+    v2 = options.GetString("my_string");
     EXPECT_STREQ("hello world", v2.c_str());
 
     // check failures
     // connot convert
-    EXPECT_THROW(options.SetOption("my_string", 2.0), tigl::CTiglError);
+    EXPECT_THROW(options.Set("my_string", 2.0), tigl::CTiglError);
 
     // no such option
-    EXPECT_THROW(options.SetOption<std::string>("my_new_string", "welt"),
+    EXPECT_THROW(options.Set<std::string>("my_new_string", "welt"),
                  tigl::CTiglError);
 
     // cannot convert
-    EXPECT_THROW(options.GetOption<int>("my_double"), tigl::CTiglError);
+    EXPECT_THROW(options.Get<int>("my_double"), tigl::CTiglError);
 
     // no such option
-    EXPECT_THROW(options.GetOption<int>("my_new_double"), tigl::CTiglError);
+    EXPECT_THROW(options.Get<int>("my_new_double"), tigl::CTiglError);
 
     // cannot convert "welt" to a double
-    EXPECT_THROW(options.SetOption_FromString("my_doublee", "welt"), tigl::CTiglError);
+    EXPECT_THROW(options.SetFromString("my_doublee", "welt"), tigl::CTiglError);
 }
 
 TEST(OptionList, OptionNames)
@@ -93,6 +102,25 @@ TEST(OptionList, HasOption)
 
     EXPECT_TRUE(options.HasOption("my_string"));
     EXPECT_TRUE(options.HasOption("my_double"));
+
+    EXPECT_FALSE(options.HasOption("my_new_string"));
+}
+
+TEST(OptionList, Merged)
+{
+    MockOptions first;
+    MockOptionsOther second;
+    tigl::COptionList options = first.Merged(second);
+
+    EXPECT_TRUE(options.HasOption("my_string"));
+    EXPECT_TRUE(options.HasOption("my_double"));
+    EXPECT_TRUE(options.HasOption("my_int"));
+
+    double v1 = options.Get<double>("my_double");
+    EXPECT_NEAR(0.0, v1, 1e-10);
+
+    int v2 = options.Get<int>("my_int");
+    EXPECT_EQ(10, v2);
 
     EXPECT_FALSE(options.HasOption("my_new_string"));
 }

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -33,6 +33,8 @@
 #include "CCPACSConfiguration.h"
 #include "CCPACSWing.h"
 #include "CTiglExporterFactory.h"
+#include "CGlobalExporterConfigs.h"
+#include "CTiglExportIges.h"
 
 
 /******************************************************************************/
@@ -274,6 +276,36 @@ TEST_F(tiglExportSimple, export_generic_stl)
     tigl::TriangulatedExportOptions options(0.01);
     stlExporter->AddConfiguration(config, options);
     bool ret = stlExporter->Write("TestData/export/simpletest_export_generic.stl");
+
+    ASSERT_EQ(true, ret);
+}
+
+TEST_F(tiglExportSimple, export_iges_layers)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+
+    tigl::PTiglCADExporter igesExporter = tigl::createExporter("iges");
+
+    igesExporter->AddShape(config.GetWing(1).GetLoft(), tigl::IgesShapeOptions(111));
+    igesExporter->AddShape(config.GetFuselage(1).GetLoft(), tigl::IgesShapeOptions(222));
+    bool ret = igesExporter->Write("TestData/export/simpletest_export_igeslayer.igs");
+
+    ASSERT_EQ(true, ret);
+}
+
+TEST_F(tiglExportSimple, export_iges_symmetry)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+
+    tigl::ExporterOptions options = tigl::getExportConfig("iges");
+    options.SetApplySymmetries(true);
+    options.SetIncludeFarfield(false);
+    tigl::PTiglCADExporter igesExporter = tigl::createExporter("iges", options);
+
+    igesExporter->AddConfiguration(config);
+    bool ret = igesExporter->Write("TestData/export/simpletest_export_iges_sym.igs");
 
     ASSERT_EQ(true, ret);
 }

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -294,6 +294,31 @@ TEST_F(tiglExportSimple, export_iges_layers)
     ASSERT_EQ(true, ret);
 }
 
+TEST_F(tiglExportSimple, set_export_options_api)
+{
+    EXPECT_EQ(TIGL_NOT_FOUND, tiglSetExportOptions("unknown", "ApplySymmetries", "true"));
+    EXPECT_EQ(TIGL_NOT_FOUND, tiglSetExportOptions("vtk", "unknown", "true"));
+    EXPECT_EQ(TIGL_ERROR, tiglSetExportOptions("vtk", "ApplySymmetries", "unknown"));
+
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "ApplySymmetries", "false"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "ApplySymmetries", "true"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "IncludeFarfield", "true"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "IncludeFarfield", "false"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "WriteNormals", "false"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "WriteNormals", "true"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("vtk", "WriteNormals", "yes"));
+    EXPECT_EQ(TIGL_ERROR, tiglSetExportOptions("vtk", "WriteNormals", "yyeeesss"));
+
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglSetExportOptions(0, "ApplySymmetries", "false"));
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglSetExportOptions("vtk", 0, "false"));
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglSetExportOptions("vtk", "ApplySymmetries", 0));
+
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("brep", "ShapeGroupMode", "NAMED_COMPOUNDS"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("brep", "ShapeGroupMode", "FACES"));
+    EXPECT_EQ(TIGL_SUCCESS, tiglSetExportOptions("brep", "ShapeGroupMode", "WHOLE_SHAPE"));
+    EXPECT_EQ(TIGL_ERROR, tiglSetExportOptions("brep", "ShapeGroupMode", "INVALID"));
+}
+
 TEST_F(tiglExportSimple, export_iges_symmetry)
 {
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -207,7 +207,7 @@ TEST_F(tiglExportSimple, export_wing_collada)
     tigl::CCPACSWing& wing = config.GetWing(1);
 
     tigl::CTiglExportCollada colladaWriter;
-    colladaWriter.AddShape(wing.GetLoft(), tigl::ColladaOptions(0.001));
+    colladaWriter.AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(0.001));
     bool ret = colladaWriter.Write("TestData/export/simpletest_wing.dae");
 
     ASSERT_EQ(true, ret);
@@ -220,7 +220,7 @@ TEST_F(tiglExportSimple, export_wing_vtk_newapi_simple)
     tigl::CCPACSWing& wing = config.GetWing(1);
 
     tigl::CTiglExportVtk vtkWriter;
-    vtkWriter.AddShape(wing.GetLoft(), tigl::VtkOptions(0.001));
+    vtkWriter.AddShape(wing.GetLoft(), tigl::TriangulatedExportOptions(0.001));
     bool ret = vtkWriter.Write("TestData/export/simpletest_wing_simple_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -233,7 +233,7 @@ TEST_F(tiglExportSimple, export_wing_vtk_newapi_meta)
     tigl::CCPACSWing& wing = config.GetWing(1);
 
     tigl::CTiglExportVtk vtkWriter;
-    vtkWriter.AddShape(wing.GetLoft(), &config, tigl::VtkOptions(0.001));
+    vtkWriter.AddShape(wing.GetLoft(), &config, tigl::TriangulatedExportOptions(0.001));
     bool ret = vtkWriter.Write("TestData/export/simpletest_wing_meta_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -245,8 +245,7 @@ TEST_F(tiglExportSimple, export_fusedplane_vtk_newapi_meta)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
     tigl::CTiglExportVtk vtkWriter;
-    tigl::VtkOptions options(0.01);
-    vtkWriter.AddFusedConfiguration(config, options);
+    vtkWriter.AddFusedConfiguration(config, tigl::TriangulatedExportOptions(0.01));
     bool ret = vtkWriter.Write("TestData/export/simpletest_fusedplane_meta_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -258,8 +257,7 @@ TEST_F(tiglExportSimple, export_componentplane_vtk_newapi_meta)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
     tigl::CTiglExportVtk vtkWriter;
-    tigl::VtkOptions options(0.01);
-    vtkWriter.AddConfiguration(config, options);
+    vtkWriter.AddConfiguration(config, tigl::TriangulatedExportOptions(0.01));
     bool ret = vtkWriter.Write("TestData/export/simpletest_nonfusedplane_meta_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -273,7 +271,7 @@ TEST_F(tiglExportSimple, export_generic_stl)
     tigl::CTiglExporterFactory& factory = tigl::CTiglExporterFactory::Instance();
     tigl::PTiglCADExporter stlExporter = factory.Create("stl");
 
-    tigl::VtkOptions options(0.01);
+    tigl::TriangulatedExportOptions options(0.01);
     stlExporter->AddConfiguration(config, options);
     bool ret = stlExporter->Write("TestData/export/simpletest_export_generic.stl");
 

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -160,18 +160,6 @@ TiglCPACSConfigurationHandle tiglExportRectangularWing::tiglRectangularWingHandl
 //    writer.ExportMeshedWingVTK
 //}
 
-TEST_F(tiglExport, vtkOptions)
-{
-    ASSERT_EQ(TIGL_SUCCESS, tiglExportVTKSetOptions("normals_enabled", "0"));
-    ASSERT_EQ(TIGL_SUCCESS, tiglExportVTKSetOptions("normals_enabled", "1"));
-
-    ASSERT_EQ(TIGL_ERROR, tiglExportVTKSetOptions("normals_enabled", "no"));
-    ASSERT_EQ(TIGL_ERROR, tiglExportVTKSetOptions("invalid options", "0"));
-
-    ASSERT_EQ(TIGL_NULL_POINTER, tiglExportVTKSetOptions(NULL, "0"));
-    ASSERT_EQ(TIGL_NULL_POINTER, tiglExportVTKSetOptions("normals_enabled", NULL));
-}
-
 /**
 * Tests tiglWingGetProfileName with invalid CPACS handle.
 */
@@ -219,7 +207,7 @@ TEST_F(tiglExportSimple, export_wing_collada)
     tigl::CCPACSWing& wing = config.GetWing(1);
 
     tigl::CTiglExportCollada colladaWriter;
-    colladaWriter.AddShape(wing.GetLoft(), 0.001);
+    colladaWriter.AddShape(wing.GetLoft(), tigl::ColladaOptions(0.001));
     bool ret = colladaWriter.Write("TestData/export/simpletest_wing.dae");
 
     ASSERT_EQ(true, ret);
@@ -232,7 +220,7 @@ TEST_F(tiglExportSimple, export_wing_vtk_newapi_simple)
     tigl::CCPACSWing& wing = config.GetWing(1);
 
     tigl::CTiglExportVtk vtkWriter;
-    vtkWriter.AddShape(wing.GetLoft(), 0.001);
+    vtkWriter.AddShape(wing.GetLoft(), tigl::VtkOptions(0.001));
     bool ret = vtkWriter.Write("TestData/export/simpletest_wing_simple_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -245,7 +233,7 @@ TEST_F(tiglExportSimple, export_wing_vtk_newapi_meta)
     tigl::CCPACSWing& wing = config.GetWing(1);
 
     tigl::CTiglExportVtk vtkWriter;
-    vtkWriter.AddShape(wing.GetLoft(), &config, 0.001);
+    vtkWriter.AddShape(wing.GetLoft(), &config, tigl::VtkOptions(0.001));
     bool ret = vtkWriter.Write("TestData/export/simpletest_wing_meta_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -257,9 +245,7 @@ TEST_F(tiglExportSimple, export_fusedplane_vtk_newapi_meta)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
     tigl::CTiglExportVtk vtkWriter;
-    tigl::ExportOptions options(0.01);
-    options.includeFarField = false;
-    options.applySymmetries = true;
+    tigl::VtkOptions options(0.01);
     vtkWriter.AddFusedConfiguration(config, options);
     bool ret = vtkWriter.Write("TestData/export/simpletest_fusedplane_meta_newapi.vtp");
 
@@ -272,9 +258,7 @@ TEST_F(tiglExportSimple, export_componentplane_vtk_newapi_meta)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
     tigl::CTiglExportVtk vtkWriter;
-    tigl::ExportOptions options(0.01);
-    options.includeFarField = false;
-    options.applySymmetries = true;
+    tigl::VtkOptions options(0.01);
     vtkWriter.AddConfiguration(config, options);
     bool ret = vtkWriter.Write("TestData/export/simpletest_nonfusedplane_meta_newapi.vtp");
 
@@ -289,9 +273,7 @@ TEST_F(tiglExportSimple, export_generic_stl)
     tigl::CTiglExporterFactory& factory = tigl::CTiglExporterFactory::Instance();
     tigl::PTiglCADExporter stlExporter = factory.Create("stl");
 
-    tigl::ExportOptions options(0.01);
-    options.includeFarField = false;
-    options.applySymmetries = true;
+    tigl::VtkOptions options(0.01);
     stlExporter->AddConfiguration(config, options);
     bool ret = stlExporter->Write("TestData/export/simpletest_export_generic.stl");
 

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -32,6 +32,7 @@
 #include "CCPACSConfigurationManager.h"
 #include "CCPACSConfiguration.h"
 #include "CCPACSWing.h"
+#include "CTiglExporterFactory.h"
 
 
 /******************************************************************************/
@@ -280,6 +281,23 @@ TEST_F(tiglExportSimple, export_componentplane_vtk_newapi_meta)
     ASSERT_EQ(true, ret);
 }
 
+TEST_F(tiglExportSimple, export_generic_stl)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
+
+    tigl::CTiglExporterFactory& factory = tigl::CTiglExporterFactory::Instance();
+    tigl::PTiglCADExporter stlExporter = factory.Create("stl");
+
+    tigl::ExportOptions options(0.01);
+    options.includeFarField = false;
+    options.applySymmetries = true;
+    stlExporter->AddConfiguration(config, options);
+    bool ret = stlExporter->Write("TestData/export/simpletest_export_generic.stl");
+
+    ASSERT_EQ(true, ret);
+}
+
 // check if face names were set correctly in the case with a trailing edge
 TEST_F(tiglExportSimple, check_face_traits)
 {
@@ -297,4 +315,20 @@ TEST_F(tiglExportRectangularWing, check_face_traits)
 {
     ASSERT_EQ(TIGL_SUCCESS, tiglExportIGES(tiglRectangularWingHandle,"TestData/export/rectangular_wing_test.iges"));
     ASSERT_EQ(TIGL_SUCCESS, tiglExportFusedWingFuselageIGES(tiglRectangularWingHandle,"TestData/export/rectangular_wing_test_fused.iges"));
+}
+
+TEST(TiglExportFactory, supportedTypes)
+{
+    tigl::CTiglExporterFactory& factory = tigl::CTiglExporterFactory::Instance();
+
+    ASSERT_TRUE(factory.ExporterSupported("step"));
+    ASSERT_TRUE(factory.ExporterSupported("stp"));
+    ASSERT_TRUE(factory.ExporterSupported("brep"));
+    ASSERT_TRUE(factory.ExporterSupported("igs"));
+    ASSERT_TRUE(factory.ExporterSupported("iges"));
+    ASSERT_TRUE(factory.ExporterSupported("dae"));
+    ASSERT_TRUE(factory.ExporterSupported("vtp"));
+    ASSERT_TRUE(factory.ExporterSupported("stl"));
+
+    ASSERT_FALSE(factory.ExporterSupported("unknown"));
 }

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -230,7 +230,7 @@ TEST_F(tiglExportSimple, export_wing_vtk_newapi_simple)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
     tigl::CCPACSWing& wing = config.GetWing(1);
 
-    tigl::CTiglExportVtk vtkWriter(config);
+    tigl::CTiglExportVtk vtkWriter;
     vtkWriter.AddShape(wing.GetLoft(), 0.001);
     bool ret = vtkWriter.Write("TestData/export/simpletest_wing_simple_newapi.vtp");
 
@@ -243,8 +243,8 @@ TEST_F(tiglExportSimple, export_wing_vtk_newapi_meta)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
     tigl::CCPACSWing& wing = config.GetWing(1);
 
-    tigl::CTiglExportVtk vtkWriter(config, tigl::SEGMENT_INFO);
-    vtkWriter.AddShape(wing.GetLoft(), 0.001);
+    tigl::CTiglExportVtk vtkWriter;
+    vtkWriter.AddShape(wing.GetLoft(), &config, 0.001);
     bool ret = vtkWriter.Write("TestData/export/simpletest_wing_meta_newapi.vtp");
 
     ASSERT_EQ(true, ret);
@@ -255,7 +255,7 @@ TEST_F(tiglExportSimple, export_fusedplane_vtk_newapi_meta)
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
-    tigl::CTiglExportVtk vtkWriter(config, tigl::SEGMENT_INFO);
+    tigl::CTiglExportVtk vtkWriter;
     tigl::ExportOptions options(0.01);
     options.includeFarField = false;
     options.applySymmetries = true;
@@ -270,7 +270,7 @@ TEST_F(tiglExportSimple, export_componentplane_vtk_newapi_meta)
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
-    tigl::CTiglExportVtk vtkWriter(config, tigl::SEGMENT_INFO);
+    tigl::CTiglExportVtk vtkWriter;
     tigl::ExportOptions options(0.01);
     options.includeFarField = false;
     options.applySymmetries = true;

--- a/tests/unittests/tiglFuseAircraft.cpp
+++ b/tests/unittests/tiglFuseAircraft.cpp
@@ -181,7 +181,7 @@ TEST_P(tiglFuseAircraftCPACS, exportFusedAircraftToBrep)
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
     tigl::CTiglExportBrep exporter;
-    exporter.AddFusedConfiguration(config);
+    exporter.AddFusedConfiguration(config, tigl::BRepOptions());
     ASSERT_TRUE(exporter.Write("TestData/export/" + name + "_fused.brep"));
 }
 
@@ -198,7 +198,7 @@ TEST_P(tiglFuseAircraftCPACS, fusedAircraft)
     ASSERT_TRUE(BRepTools::Write(wingLoft->Shape(), ("TestData/export/" + name + "_wing.brep").c_str()));
 
     tigl::CTiglExportIges igesExporterWing;
-    igesExporterWing.AddShape(wingLoft);
+    igesExporterWing.AddShape(wingLoft, tigl::IgesOptions());
     igesExporterWing.Write(("TestData/export/" + name + "_wing.igs").c_str());
 
     tigl::CCPACSFuselage& fuselage = config.GetFuselage(1);
@@ -207,7 +207,7 @@ TEST_P(tiglFuseAircraftCPACS, fusedAircraft)
     ASSERT_TRUE(BRepTools::Write(fuselageLoft->Shape(), ("TestData/export/" + name + "_fuselage.brep").c_str()));
 
     tigl::CTiglExportIges igesExporterFuselage;
-    igesExporterFuselage.AddShape(fuselageLoft);
+    igesExporterFuselage.AddShape(fuselageLoft, tigl::IgesOptions());
     igesExporterFuselage.Write(("TestData/export/" + name + "_fuselage.igs").c_str());
 
     ListPNamedShape fuseTools;

--- a/tests/unittests/tiglFuseAircraft.cpp
+++ b/tests/unittests/tiglFuseAircraft.cpp
@@ -181,7 +181,7 @@ TEST_P(tiglFuseAircraftCPACS, exportFusedAircraftToBrep)
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
     tigl::CTiglExportBrep exporter;
-    exporter.AddFusedConfiguration(config, tigl::BRepOptions());
+    exporter.AddFusedConfiguration(config);
     ASSERT_TRUE(exporter.Write("TestData/export/" + name + "_fused.brep"));
 }
 
@@ -198,7 +198,7 @@ TEST_P(tiglFuseAircraftCPACS, fusedAircraft)
     ASSERT_TRUE(BRepTools::Write(wingLoft->Shape(), ("TestData/export/" + name + "_wing.brep").c_str()));
 
     tigl::CTiglExportIges igesExporterWing;
-    igesExporterWing.AddShape(wingLoft, tigl::IgesOptions());
+    igesExporterWing.AddShape(wingLoft);
     igesExporterWing.Write(("TestData/export/" + name + "_wing.igs").c_str());
 
     tigl::CCPACSFuselage& fuselage = config.GetFuselage(1);
@@ -207,7 +207,7 @@ TEST_P(tiglFuseAircraftCPACS, fusedAircraft)
     ASSERT_TRUE(BRepTools::Write(fuselageLoft->Shape(), ("TestData/export/" + name + "_fuselage.brep").c_str()));
 
     tigl::CTiglExportIges igesExporterFuselage;
-    igesExporterFuselage.AddShape(fuselageLoft, tigl::IgesOptions());
+    igesExporterFuselage.AddShape(fuselageLoft);
     igesExporterFuselage.Write(("TestData/export/" + name + "_fuselage.igs").c_str());
 
     ListPNamedShape fuseTools;

--- a/tests/unittests/tiglPolydata.cpp
+++ b/tests/unittests/tiglPolydata.cpp
@@ -431,7 +431,7 @@ TEST_F(TriangularizeShape, exportVTK_WingSegmentInfo)
 
     clock_t start, stop;
     start = clock();
-    tigl::CTiglTriangularizer mesher(config.GetUIDManager(), wing.GetLoft(), 0.0001, SEGMENT_INFO);
+    tigl::CTiglTriangularizer mesher(&config.GetUIDManager(), wing.GetLoft(), 0.0001, SEGMENT_INFO);
     const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
     stop = clock();
@@ -450,7 +450,7 @@ TEST_F(TriangularizeShape, exportVTK_FullPlane_long)
     algo->SetResultMode(FULL_PLANE);
     PNamedShape shape = algo->FusedPlane();
 
-    tigl::CTiglTriangularizer mesher(config.GetUIDManager(), shape, 0.001, SEGMENT_INFO);
+    tigl::CTiglTriangularizer mesher(&config.GetUIDManager(), shape, 0.001, SEGMENT_INFO);
     const tigl::CTiglPolyData& polys = mesher.getTriangulation();
 
     std::cout << "Number of Polygons/Vertices: " << polys.currentObject().getNPolygons() << "/" << polys.currentObject().getNVertices()<<std::endl;

--- a/thirdparty/boost_1_63_0/boost/any.hpp
+++ b/thirdparty/boost_1_63_0/boost/any.hpp
@@ -1,0 +1,325 @@
+// See http://www.boost.org/libs/any for Documentation.
+
+#ifndef BOOST_ANY_INCLUDED
+#define BOOST_ANY_INCLUDED
+
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+// what:  variant type boost::any
+// who:   contributed by Kevlin Henney,
+//        with features contributed and bugs found by
+//        Antony Polukhin, Ed Brey, Mark Rodgers, 
+//        Peter Dimov, and James Curran
+// when:  July 2001, April 2013 - May 2013
+
+#include <algorithm>
+
+#include "boost/config.hpp"
+#include <boost/type_index.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/type_traits/decay.hpp>
+#include <boost/type_traits/remove_cv.hpp>
+#include <boost/type_traits/add_reference.hpp>
+#include <boost/type_traits/is_reference.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost
+{
+    class any
+    {
+    public: // structors
+
+        any() BOOST_NOEXCEPT
+          : content(0)
+        {
+        }
+
+        template<typename ValueType>
+        any(const ValueType & value)
+          : content(new holder<
+                BOOST_DEDUCED_TYPENAME remove_cv<BOOST_DEDUCED_TYPENAME decay<const ValueType>::type>::type
+            >(value))
+        {
+        }
+
+        any(const any & other)
+          : content(other.content ? other.content->clone() : 0)
+        {
+        }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        // Move constructor
+        any(any&& other) BOOST_NOEXCEPT
+          : content(other.content)
+        {
+            other.content = 0;
+        }
+
+        // Perfect forwarding of ValueType
+        template<typename ValueType>
+        any(ValueType&& value
+            , typename boost::disable_if<boost::is_same<any&, ValueType> >::type* = 0 // disable if value has type `any&`
+            , typename boost::disable_if<boost::is_const<ValueType> >::type* = 0) // disable if value has type `const ValueType&&`
+          : content(new holder< typename decay<ValueType>::type >(static_cast<ValueType&&>(value)))
+        {
+        }
+#endif
+
+        ~any() BOOST_NOEXCEPT
+        {
+            delete content;
+        }
+
+    public: // modifiers
+
+        any & swap(any & rhs) BOOST_NOEXCEPT
+        {
+            std::swap(content, rhs.content);
+            return *this;
+        }
+
+
+#ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template<typename ValueType>
+        any & operator=(const ValueType & rhs)
+        {
+            any(rhs).swap(*this);
+            return *this;
+        }
+
+        any & operator=(any rhs)
+        {
+            any(rhs).swap(*this);
+            return *this;
+        }
+
+#else 
+        any & operator=(const any& rhs)
+        {
+            any(rhs).swap(*this);
+            return *this;
+        }
+
+        // move assignement
+        any & operator=(any&& rhs) BOOST_NOEXCEPT
+        {
+            rhs.swap(*this);
+            any().swap(rhs);
+            return *this;
+        }
+
+        // Perfect forwarding of ValueType
+        template <class ValueType>
+        any & operator=(ValueType&& rhs)
+        {
+            any(static_cast<ValueType&&>(rhs)).swap(*this);
+            return *this;
+        }
+#endif
+
+    public: // queries
+
+        bool empty() const BOOST_NOEXCEPT
+        {
+            return !content;
+        }
+
+        void clear() BOOST_NOEXCEPT
+        {
+            any().swap(*this);
+        }
+
+        const boost::typeindex::type_info& type() const BOOST_NOEXCEPT
+        {
+            return content ? content->type() : boost::typeindex::type_id<void>().type_info();
+        }
+
+#ifndef BOOST_NO_MEMBER_TEMPLATE_FRIENDS
+    private: // types
+#else
+    public: // types (public so any_cast can be non-friend)
+#endif
+
+        class placeholder
+        {
+        public: // structors
+
+            virtual ~placeholder()
+            {
+            }
+
+        public: // queries
+
+            virtual const boost::typeindex::type_info& type() const BOOST_NOEXCEPT = 0;
+
+            virtual placeholder * clone() const = 0;
+
+        };
+
+        template<typename ValueType>
+        class holder : public placeholder
+        {
+        public: // structors
+
+            holder(const ValueType & value)
+              : held(value)
+            {
+            }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+            holder(ValueType&& value)
+              : held(static_cast< ValueType&& >(value))
+            {
+            }
+#endif
+        public: // queries
+
+            virtual const boost::typeindex::type_info& type() const BOOST_NOEXCEPT
+            {
+                return boost::typeindex::type_id<ValueType>().type_info();
+            }
+
+            virtual placeholder * clone() const
+            {
+                return new holder(held);
+            }
+
+        public: // representation
+
+            ValueType held;
+
+        private: // intentionally left unimplemented
+            holder & operator=(const holder &);
+        };
+
+#ifndef BOOST_NO_MEMBER_TEMPLATE_FRIENDS
+
+    private: // representation
+
+        template<typename ValueType>
+        friend ValueType * any_cast(any *) BOOST_NOEXCEPT;
+
+        template<typename ValueType>
+        friend ValueType * unsafe_any_cast(any *) BOOST_NOEXCEPT;
+
+#else
+
+    public: // representation (public so any_cast can be non-friend)
+
+#endif
+
+        placeholder * content;
+
+    };
+ 
+    inline void swap(any & lhs, any & rhs) BOOST_NOEXCEPT
+    {
+        lhs.swap(rhs);
+    }
+
+    class BOOST_SYMBOL_VISIBLE bad_any_cast :
+#ifndef BOOST_NO_RTTI
+        public std::bad_cast
+#else
+        public std::exception
+#endif
+    {
+    public:
+        virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW
+        {
+            return "boost::bad_any_cast: "
+                   "failed conversion using boost::any_cast";
+        }
+    };
+
+    template<typename ValueType>
+    ValueType * any_cast(any * operand) BOOST_NOEXCEPT
+    {
+        return operand && operand->type() == boost::typeindex::type_id<ValueType>()
+            ? &static_cast<any::holder<BOOST_DEDUCED_TYPENAME remove_cv<ValueType>::type> *>(operand->content)->held
+            : 0;
+    }
+
+    template<typename ValueType>
+    inline const ValueType * any_cast(const any * operand) BOOST_NOEXCEPT
+    {
+        return any_cast<ValueType>(const_cast<any *>(operand));
+    }
+
+    template<typename ValueType>
+    ValueType any_cast(any & operand)
+    {
+        typedef BOOST_DEDUCED_TYPENAME remove_reference<ValueType>::type nonref;
+
+
+        nonref * result = any_cast<nonref>(&operand);
+        if(!result)
+            boost::throw_exception(bad_any_cast());
+
+        // Attempt to avoid construction of a temporary object in cases when 
+        // `ValueType` is not a reference. Example:
+        // `static_cast<std::string>(*result);` 
+        // which is equal to `std::string(*result);`
+        typedef BOOST_DEDUCED_TYPENAME boost::mpl::if_<
+            boost::is_reference<ValueType>,
+            ValueType,
+            BOOST_DEDUCED_TYPENAME boost::add_reference<ValueType>::type
+        >::type ref_type;
+
+        return static_cast<ref_type>(*result);
+    }
+
+    template<typename ValueType>
+    inline ValueType any_cast(const any & operand)
+    {
+        typedef BOOST_DEDUCED_TYPENAME remove_reference<ValueType>::type nonref;
+        return any_cast<const nonref &>(const_cast<any &>(operand));
+    }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    template<typename ValueType>
+    inline ValueType any_cast(any&& operand)
+    {
+        BOOST_STATIC_ASSERT_MSG(
+            boost::is_rvalue_reference<ValueType&&>::value /*true if ValueType is rvalue or just a value*/
+            || boost::is_const< typename boost::remove_reference<ValueType>::type >::value,
+            "boost::any_cast shall not be used for getting nonconst references to temporary objects" 
+        );
+        return any_cast<ValueType>(operand);
+    }
+#endif
+
+
+    // Note: The "unsafe" versions of any_cast are not part of the
+    // public interface and may be removed at any time. They are
+    // required where we know what type is stored in the any and can't
+    // use typeid() comparison, e.g., when our types may travel across
+    // different shared libraries.
+    template<typename ValueType>
+    inline ValueType * unsafe_any_cast(any * operand) BOOST_NOEXCEPT
+    {
+        return &static_cast<any::holder<ValueType> *>(operand->content)->held;
+    }
+
+    template<typename ValueType>
+    inline const ValueType * unsafe_any_cast(const any * operand) BOOST_NOEXCEPT
+    {
+        return unsafe_any_cast<ValueType>(const_cast<any *>(operand));
+    }
+}
+
+// Copyright Kevlin Henney, 2000, 2001, 2002. All rights reserved.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#endif


### PR DESCRIPTION
This includes
 - A configuration object, that can accept all kinds of values
 - A configuration object for each exporter that is passed in the constructor
 - A factory that creates exporters
 - A global object that stores the exporter specific configurations
 - A tigl api function tiglSetExportOptions to access the new functionality

This new api also allows shape specific export options, such as deflection or iges level.