### PR TITLE
Wrapped boost optional function arguments

### DIFF
--- a/bindings/python_internal/boost_optional.i
+++ b/bindings/python_internal/boost_optional.i
@@ -48,9 +48,29 @@
   }
 }
 
+%typemap(in) const boost::optional<type>& (boost::optional<type> arg_optional_val, int res=0) {
+  $1 = &arg_optional_val;
+  if ($input != Py_None) {
+    void* ptmp;
+    res = SWIG_ConvertPtr($input, &ptmp, $descriptor(type*),  0 );
+    if (!SWIG_IsOK(res)) {
+      %argument_fail(res, type, $symname, $argnum); 
+    }
+    *$1 = *(reinterpret_cast< type * >(ptmp));
+  }
+}
+
 %enddef
 
-%define WRAP_BOOST_OPTIONAL_BASIC_TYPE(type, PyFun_Convert)
+%typemap(in, noblock=1) boost::optional<std::string> {
+  if($input == Py_None) {
+    $1 = boost::optional<type>();
+  } else {
+    $1 = boost::optional<type>(PyFun_ConvertToNative($input));
+  }
+}
+
+%define WRAP_BOOST_OPTIONAL_BASIC_TYPE(type, PyFun_Convert, PyFun_ConvertToNative)
 %typemap(out, noblock=1) boost::optional<type>&, const boost::optional<type>& {
   if (*$1) {
     $result = PyFun_Convert($1->get());
@@ -68,13 +88,68 @@
     Py_INCREF(Py_None);
   }
 }
+
+%typemap(in, noblock=1) const boost::optional<type>& (boost::optional<type> arg_optional_val) {
+  $1 = &arg_optional_val;
+  if($input != Py_None) {
+    *$1 = PyFun_ConvertToNative($input);
+  }
+}
+
+%typemap(in, noblock=1) boost::optional<type> {
+  if($input == Py_None) {
+    $1 = boost::optional<type>();
+  } else {
+    $1 = boost::optional<type>(PyFun_ConvertToNative($input));
+  }
+}
+
 %enddef
 
-// wrap some standard types
-WRAP_BOOST_OPTIONAL_CLASS(std::string)
+#define PYSTR_FROM_STD_STRING(stdstr) (PyString_FromString((stdstr).c_str()))
 
-WRAP_BOOST_OPTIONAL_BASIC_TYPE(int, PyLong_FromLong)
-WRAP_BOOST_OPTIONAL_BASIC_TYPE(unsigned int, PyLong_FromUnsignedLong)
-WRAP_BOOST_OPTIONAL_BASIC_TYPE(double, PyFloat_FromDouble)
-WRAP_BOOST_OPTIONAL_BASIC_TYPE(float, PyFloat_FromDouble)
+%fragment("boost_optional", "header") {
+
+int as_std_string_val(PyObject *obj, std::string& result) {
+  std::string *ptr = (std::string *)0;
+  int res = SWIG_AsPtr_std_string(obj, &ptr);
+  if (ptr) {
+    result = *ptr;
+    if (SWIG_IsNewObj(res)) {
+      %delete(ptr);
+      res = SWIG_DelNewMask(res);
+    }
+  }
+  return res;
+}
+
+int as_boost_optional_string(PyObject *obj, boost::optional<std::string>& result) {
+  int res = SWIG_OK;
+  if (obj != Py_None) {
+    std::string tmp;
+    res = as_std_string_val(obj, tmp);
+    result = boost::optional<std::string>(tmp);
+  }
+  else {
+    result = boost::optional<std::string>();
+  }
+  return res;
+}
+} // end fragment
+
+// wrap some standard types
+WRAP_BOOST_OPTIONAL_BASIC_TYPE(std::string, PYSTR_FROM_STD_STRING, ___ )
+
+%typemap(in, noblock=1, fragment="boost_optional") const boost::optional<std::string>& (boost::optional<std::string> arg_optional_val) {
+  $1 = &arg_optional_val;
+  int res = as_boost_optional_string($input, arg_optional_val);
+  if (!SWIG_IsOK(res)) {
+    %argument_fail(res, string, $symname, $argnum); 
+  }
+}
+
+WRAP_BOOST_OPTIONAL_BASIC_TYPE(int, PyLong_FromLong, PyLong_AsLong)
+WRAP_BOOST_OPTIONAL_BASIC_TYPE(unsigned int, PyLong_FromUnsignedLong, PyLong_AsUnsignedLong)
+WRAP_BOOST_OPTIONAL_BASIC_TYPE(double, PyFloat_FromDouble, PyFloat_AsDouble)
+WRAP_BOOST_OPTIONAL_BASIC_TYPE(float, PyFloat_FromDouble, PyFloat_AsDouble)
 

--- a/bindings/python_internal/common.i
+++ b/bindings/python_internal/common.i
@@ -46,6 +46,34 @@
 #include<Standard_ErrorHandler.hxx>
 #include<Standard_Failure.hxx>
 #include "tigl.h"
+#include "CTiglError.h"
+
+namespace
+{
+PyObject* tiglError_to_PyExc(const tigl::CTiglError& err) {
+  PyObject* exc_class = PyExc_RuntimeError;
+
+  int code = err.getCode();
+  switch (code) {
+  case TIGL_INDEX_ERROR:
+    exc_class = PyExc_IndexError;
+    break;
+  case TIGL_UID_ERROR:
+    exc_class = PyExc_KeyError;
+    break;
+  case TIGL_MATH_ERROR:
+    exc_class = PyExc_ArithmeticError;
+    break;
+  case TIGL_NULL_POINTER:
+    exc_class = PyExc_ValueError;
+    break;
+  default:
+    exc_class = PyExc_RuntimeError;
+  }
+  return exc_class;
+}
+}
+
 %}
 
 %include doc.i

--- a/bindings/python_internal/core.i
+++ b/bindings/python_internal/core.i
@@ -135,28 +135,7 @@ enum TiglImportExportFormat
         $action
     }
     catch (tigl::CTiglError & err) {
-
-        int code = err.getCode();
-        PyObject* exc_class = PyExc_RuntimeError;
-
-        switch (code) {
-        case TIGL_INDEX_ERROR:
-            exc_class = PyExc_IndexError;
-            break;
-        case TIGL_UID_ERROR:
-            exc_class = PyExc_KeyError;
-            break;
-        case TIGL_MATH_ERROR:
-            exc_class = PyExc_ArithmeticError;
-            break;
-        case TIGL_NULL_POINTER:
-            exc_class = PyExc_ValueError;
-            break;
-        default:
-            exc_class = PyExc_RuntimeError;
-        }
-
-        PyErr_SetString(exc_class, const_cast<char*>(err.what()));
+        PyErr_SetString(tiglError_to_PyExc(err), const_cast<char*>(err.what()));
         SWIG_fail;
     }
     catch(Standard_Failure & err) {


### PR DESCRIPTION
Boost optional types for function args is now wrapped. This makes it now completely transparent.