### PR TITLE
Automatic registration of geometric components

### DIFF
--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -256,15 +256,22 @@ class CCPACSWingRibsPositioning;
 
 namespace tigl
 {
+typedef std::map<const std::string, ITiglGeometricComponent*> ShapeContainerType;
+typedef std::map<const std::string, CTiglRelativelyPositionedComponent*> RelativeComponentContainerType;
+
 class CTiglUIDManager
 {
 public:
     CTiglUIDManager();
-    void AddGeometricComponent(const std::string& uid, ITiglGeometricComponent* componentPtr);
-    void RemoveGeometricComponent(const std::string& uid);
+    bool IsUIDRegistered(const std::string& uid) const;
+    bool TryUnregisterObject(const std::string& uid);
+    void UnregisterObject(const std::string& uid);
     bool HasGeometricComponent(const std::string& uid) const;
     ITiglGeometricComponent& GetGeometricComponent(const std::string& uid) const;
     CTiglRelativelyPositionedComponent* GetParentGeometricComponent(const std::string& uid) const;
+    const RelativeComponentContainerType& GetRootGeometricComponents() const;
+    void SetParentComponents();
+    const ShapeContainerType& GetShapeContainer() const;
     void Clear();
 };
 } // namespace tigl

--- a/src/configuration/CTiglShapeGeomComponentAdaptor.h
+++ b/src/configuration/CTiglShapeGeomComponentAdaptor.h
@@ -54,12 +54,10 @@ public:
     void SetUID(const std::string &uid)
     {
         unregisterShape();
-
-        m_uid = uid;
-
         if (!m_uid.empty() && m_uidMgr) {
-            m_uidMgr->AddGeometricComponent(GetDefaultedUID(), this);
+            m_uidMgr->RegisterObject(m_uid, *this);
         }
+        m_uid = uid;
     }
 
 
@@ -95,7 +93,7 @@ private:
     void unregisterShape()
     {
         if (!m_uid.empty() && m_uidMgr) {
-            m_uidMgr->TryRemoveGeometricComponent(GetDefaultedUID());
+            m_uidMgr->TryUnregisterObject(m_uid);
         }
     }
 

--- a/src/cpacs_other/CCPACSAircraftModel.cpp
+++ b/src/cpacs_other/CCPACSAircraftModel.cpp
@@ -35,21 +35,6 @@ CCPACSAircraftModel::CCPACSAircraftModel(CCPACSConfiguration* config)
 CCPACSAircraftModel::CCPACSAircraftModel(CTiglUIDManager* uidMgr)
     : generated::CPACSAircraftModel(uidMgr), CTiglRelativelyPositionedComponent(NULL, NULL), config(NULL) {}
 
-void CCPACSAircraftModel::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) {
-    generated::CPACSAircraftModel::ReadCPACS(tixiHandle, xpath);
-    if (m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(m_uID, this);
-    }
-}
-
-void CCPACSAircraftModel::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSAircraftModel::SetUID(uid);
-}
-
 std::string CCPACSAircraftModel::GetDefaultedUID() const {
     return generated::CPACSAircraftModel::GetUID();
 }

--- a/src/cpacs_other/CCPACSAircraftModel.h
+++ b/src/cpacs_other/CCPACSAircraftModel.h
@@ -40,10 +40,6 @@ public:
     TIGL_EXPORT CCPACSAircraftModel(CCPACSConfiguration* config = NULL);
     TIGL_EXPORT CCPACSAircraftModel(CTiglUIDManager* config);
 
-    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) OVERRIDE;
-
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage

--- a/src/cpacs_other/CCPACSExternalObject.cpp
+++ b/src/cpacs_other/CCPACSExternalObject.cpp
@@ -83,19 +83,6 @@ void CCPACSExternalObject::ReadCPACS(const TixiDocumentHandle& tixiHandle, const
     if (!IsFileReadable(_filePath)) {
         throw tigl::CTiglError("File " + _filePath + " can not be read!", TIGL_OPEN_FAILED);
     }
-
-    // Register ourself at the unique id manager
-    if (!m_uID.empty() && m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(m_uID, this);
-    }
-}
-
-void CCPACSExternalObject::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSGenericGeometricComponent::SetUID(uid);
 }
 
 const std::string& CCPACSExternalObject::GetFilePath() const

--- a/src/cpacs_other/CCPACSExternalObject.h
+++ b/src/cpacs_other/CCPACSExternalObject.h
@@ -36,8 +36,6 @@ public:
 
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& objectXPath) OVERRIDE;
 
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     TIGL_EXPORT const std::string& GetFilePath() const;
     
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;

--- a/src/cpacs_other/CCPACSRotorcraftModel.cpp
+++ b/src/cpacs_other/CCPACSRotorcraftModel.cpp
@@ -28,21 +28,6 @@ CCPACSRotorcraftModel::CCPACSRotorcraftModel(CCPACSConfiguration* config)
 CCPACSRotorcraftModel::CCPACSRotorcraftModel(CTiglUIDManager* uidMgr)
     : generated::CPACSRotorcraftModel(uidMgr), CTiglRelativelyPositionedComponent(NULL, NULL), config(NULL) {}
 
-void CCPACSRotorcraftModel::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) {
-    generated::CPACSRotorcraftModel::ReadCPACS(tixiHandle, xpath);
-    if (config) {
-        config->GetUIDManager().AddGeometricComponent(m_uID, this);
-    }
-}
-
-void CCPACSRotorcraftModel::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSRotorcraftModel::SetUID(uid);
-}
-
 std::string CCPACSRotorcraftModel::GetDefaultedUID() const {
     return generated::CPACSRotorcraftModel::GetUID();
 }

--- a/src/cpacs_other/CCPACSRotorcraftModel.h
+++ b/src/cpacs_other/CCPACSRotorcraftModel.h
@@ -33,10 +33,6 @@ public:
     TIGL_EXPORT CCPACSRotorcraftModel(CCPACSConfiguration* config = NULL);
     TIGL_EXPORT CCPACSRotorcraftModel(CTiglUIDManager* uidMgr);
 
-    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) OVERRIDE;
-
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage

--- a/src/cpacs_other/CTiglUIDManager.cpp
+++ b/src/cpacs_other/CTiglUIDManager.cpp
@@ -92,6 +92,10 @@ bool CTiglUIDManager::TryUnregisterObject(const std::string& uid)
         return false;
     }
     cpacsObjects.erase(it);
+
+    // also remove the geometric component if it exists
+    TryRemoveGeometricComponent(uid);
+
     return true;
 }
 
@@ -168,13 +172,6 @@ bool CTiglUIDManager::TryRemoveGeometricComponent(const std::string & uid)
     return true;
 }
 
-void CTiglUIDManager::RemoveGeometricComponent(const std::string &uid)
-{
-    if (!TryRemoveGeometricComponent(uid)) {
-        throw CTiglError("No shape is registered for uid \"" + uid + "\"");
-    }
-}
-
 // Checks if a UID already exists.
 bool CTiglUIDManager::HasGeometricComponent(const std::string& uid) const
 {
@@ -213,7 +210,6 @@ CTiglRelativelyPositionedComponent& CTiglUIDManager::GetRelativeComponent(const 
 
     return *it->second;
 }
-
 
 // Clears the uid store
 void CTiglUIDManager::Clear()

--- a/src/cpacs_other/CTiglUIDManager.h
+++ b/src/cpacs_other/CTiglUIDManager.h
@@ -59,12 +59,13 @@ public:
         return IsUIDRegistered(uid, typeid(T));
     }
 
-    TIGL_EXPORT void RegisterObject(const std::string& uid, void* object, const std::type_info& typeInfo);
-
     template<typename T>
     void RegisterObject(const std::string& uid, T& object)
     {
         RegisterObject(uid, &object, typeid(object)); // typeid(T) may yield a base class of object
+        if (ITiglGeometricComponent* p = dynamic_cast<ITiglGeometricComponent*>(&object)) {
+            AddGeometricComponent(uid, p);
+        }
     }
 
     TIGL_EXPORT TypedPtr ResolveObject(const std::string& uid) const;
@@ -91,13 +92,6 @@ public:
     TIGL_EXPORT bool TryUnregisterObject(const std::string& uid); // returns false on failure
     TIGL_EXPORT void UnregisterObject(const std::string& uid); // throws on failure
 
-    // Function to add a UID and a geometric component to the uid store.
-    TIGL_EXPORT void AddGeometricComponent(const std::string& uid, ITiglGeometricComponent* componentPtr);
-
-    // Removes a component from the UID Manager
-    TIGL_EXPORT bool TryRemoveGeometricComponent(const std::string& uid); // returns false on failure
-    TIGL_EXPORT void RemoveGeometricComponent(const std::string& uid);
-
     // Checks if a UID already exists.
     TIGL_EXPORT bool HasGeometricComponent(const std::string& uid) const;
 
@@ -119,7 +113,15 @@ public:
     // Clears the uid store
     TIGL_EXPORT void Clear();
 
-protected:
+private:
+    // Function to add a UID and a geometric component to the uid store.
+    void AddGeometricComponent(const std::string& uid, ITiglGeometricComponent* componentPtr);
+
+    void RegisterObject(const std::string& uid, void* object, const std::type_info& typeInfo);
+
+    // Removes a component from the UID Manager
+    bool TryRemoveGeometricComponent(const std::string& uid); // returns false on failure
+
     // Update internal UID manager data.
     void Update();
 

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -72,9 +72,6 @@ CCPACSFuselage::CCPACSFuselage(CCPACSFuselages* parent, CTiglUIDManager* uidMgr)
 // Destructor
 CCPACSFuselage::~CCPACSFuselage()
 {
-    // unregister
-    configuration->GetUIDManager().TryRemoveGeometricComponent(m_uID);
-
     Cleanup();
 }
 
@@ -109,19 +106,6 @@ void CCPACSFuselage::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::
     generated::CPACSFuselage::ReadCPACS(tixiHandle, fuselageXPath);
 
     ConnectGuideCurveSegments();
-
-    // Register ourself at the unique id manager
-    if (m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(m_uID, this);
-    }
-}
-
-void CCPACSFuselage::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSFuselage::SetUID(uid);
 }
 
 // Returns the parent configuration

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -60,8 +60,6 @@ public:
     // Read CPACS fuselage elements
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& fuselageXPath) OVERRIDE;
 
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     // Returns the parent configuration
     TIGL_EXPORT CCPACSConfiguration & GetConfiguration() const;
 

--- a/src/fuselage/CCPACSFuselageSegment.cpp
+++ b/src/fuselage/CCPACSFuselageSegment.cpp
@@ -148,9 +148,6 @@ CCPACSFuselageSegment::CCPACSFuselageSegment(CCPACSFuselageSegments* parent, CTi
 // Destructor
 CCPACSFuselageSegment::~CCPACSFuselageSegment()
 {
-    // unregister
-    GetFuselage().GetConfiguration().GetUIDManager().TryRemoveGeometricComponent(m_uID);
-
     Cleanup();
 }
 
@@ -175,10 +172,6 @@ void CCPACSFuselageSegment::ReadCPACS(const TixiDocumentHandle& tixiHandle, cons
     Cleanup();
     generated::CPACSFuselageSegment::ReadCPACS(tixiHandle, segmentXPath);
 
-    if (m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(m_uID, this);
-    }
-
     // trigger creation of connections
     SetFromElementUID(m_fromElementUID);
     SetToElementUID(m_toElementUID);
@@ -192,14 +185,6 @@ void CCPACSFuselageSegment::ReadCPACS(const TixiDocumentHandle& tixiHandle, cons
     }
 
     Invalidate();
-}
-
-void CCPACSFuselageSegment::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSFuselageSegment::SetUID(uid);
 }
 
 std::string CCPACSFuselageSegment::GetDefaultedUID() const {

--- a/src/fuselage/CCPACSFuselageSegment.h
+++ b/src/fuselage/CCPACSFuselageSegment.h
@@ -56,8 +56,6 @@ public:
     // Read CPACS segment elements
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& segmentXPath) OVERRIDE;
 
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
     TIGL_EXPORT void SetFromElementUID(const std::string& value) OVERRIDE;

--- a/src/geometry/CCPACSGenericSystem.cpp
+++ b/src/geometry/CCPACSGenericSystem.cpp
@@ -58,8 +58,8 @@ const std::string& CCPACSGenericSystem::GetUID() const {
 
 void CCPACSGenericSystem::SetUID(const std::string& uid) {
     if (configuration) {
-        configuration->GetUIDManager().TryRemoveGeometricComponent(this->uid);
-        configuration->GetUIDManager().AddGeometricComponent(uid, this);
+        configuration->GetUIDManager().TryUnregisterObject(this->uid);
+        configuration->GetUIDManager().RegisterObject(uid, *this);
     }
     this->uid = uid;
 }

--- a/src/geometry/CCPACSGenericSystem.cpp
+++ b/src/geometry/CCPACSGenericSystem.cpp
@@ -116,7 +116,7 @@ void CCPACSGenericSystem::ReadCPACS(TixiDocumentHandle tixiHandle, const std::st
     }
 
     // Get Transformation
-    transformation.ReadCPACS(tixiHandle, genericSysXPath);
+    transformation.ReadCPACS(tixiHandle, genericSysXPath + "/transformation");
 
     // Get symmetry axis attribute
     char* ptrSym = NULL;

--- a/src/rotor/CCPACSRotor.cpp
+++ b/src/rotor/CCPACSRotor.cpp
@@ -80,18 +80,7 @@ void CCPACSRotor::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::str
 {
     Cleanup();
     generated::CPACSRotor::ReadCPACS(tixiHandle, rotorXPath);
-    if (m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(m_uID, this);
-    }
     Update();
-}
-
-void CCPACSRotor::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSRotor::SetUID(uid);
 }
 
 // Get the Transformation object

--- a/src/rotor/CCPACSRotor.h
+++ b/src/rotor/CCPACSRotor.h
@@ -68,8 +68,6 @@ public:
     // Read CPACS rotor elements
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& rotorXPath) OVERRIDE;
 
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     // Returns the Translation
     TIGL_EXPORT CTiglPoint GetTranslation() const OVERRIDE;
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -113,9 +113,6 @@ CCPACSWing::CCPACSWing(CCPACSRotorBlades* parent, CTiglUIDManager* uidMgr)
 // Destructor
 CCPACSWing::~CCPACSWing()
 {
-    // unregister
-    configuration->GetUIDManager().TryRemoveGeometricComponent(GetUID());
-
     Cleanup();
 }
 
@@ -191,18 +188,7 @@ void CCPACSWing::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::stri
 
     ConnectGuideCurveSegments();
 
-    // Register ourself at the unique id manager
-    configuration->GetUIDManager().AddGeometricComponent(m_uID, this);
-
     Update();
-}
-
-void CCPACSWing::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSWing::SetUID(uid);
 }
 
 std::string CCPACSWing::GetDefaultedUID() const {

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -60,8 +60,6 @@ public:
     // Read CPACS wing elements
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& wingXPath) OVERRIDE;
 
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
     // Returns whether this wing is a rotor blade

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -207,10 +207,6 @@ void CCPACSWingComponentSegment::Update()
     chordFace->SetUID(GetDefaultedUID() + "_chordface");
     lowerShape->SetUID(GetDefaultedUID() + "_lower");
     upperShape->SetUID(GetDefaultedUID() + "_upper");
-
-    if (!GetDefaultedUID().empty() && m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(GetDefaultedUID(), this);
-    }
 }
 
 // Read CPACS segment elements

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -200,9 +200,6 @@ CCPACSWingSegment::CCPACSWingSegment(CCPACSWingSegments* parent, CTiglUIDManager
 // Destructor
 CCPACSWingSegment::~CCPACSWingSegment()
 {
-    // unregister
-    GetWing().GetConfiguration().GetUIDManager().TryRemoveGeometricComponent(GetUID());
-
     Cleanup();
 }
 
@@ -232,10 +229,6 @@ void CCPACSWingSegment::ReadCPACS(const TixiDocumentHandle& tixiHandle, const st
     Cleanup();
     generated::CPACSWingSegment::ReadCPACS(tixiHandle, segmentXPath);
 
-    if (m_uidMgr) {
-        m_uidMgr->AddGeometricComponent(m_uID, this);
-    }
-
     // trigger creation of connections
     SetFromElementUID(m_fromElementUID);
     SetToElementUID(m_toElementUID);
@@ -262,14 +255,6 @@ void CCPACSWingSegment::ReadCPACS(const TixiDocumentHandle& tixiHandle, const st
     }
 
     Update();
-}
-
-void CCPACSWingSegment::SetUID(const std::string& uid) {
-    if (m_uidMgr) {
-        m_uidMgr->TryRemoveGeometricComponent(m_uID);
-        m_uidMgr->AddGeometricComponent(uid, this);
-    }
-    generated::CPACSWingSegment::SetUID(uid);
 }
 
 std::string CCPACSWingSegment::GetDefaultedUID() const {

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -63,8 +63,6 @@ public:
     // Read CPACS segment elements
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& segmentXPath) OVERRIDE;
 
-    TIGL_EXPORT void SetUID(const std::string& uid) OVERRIDE;
-
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
     TIGL_EXPORT void SetFromElementUID(const std::string& value) OVERRIDE;

--- a/src/wing/CTiglWingChordface.cpp
+++ b/src/wing/CTiglWingChordface.cpp
@@ -76,7 +76,7 @@ void CTiglWingChordface::SetUID(const std::string &uid)
     _uid = uid;
 
     if (_uidManager) {
-        _uidManager->AddGeometricComponent(GetDefaultedUID(), this);
+        _uidManager->RegisterObject(GetDefaultedUID(), *this);
     }
 }
 
@@ -108,7 +108,7 @@ PNamedShape CTiglWingChordface::BuildLoft()
 void CTiglWingChordface::unregisterShape()
 {
     if (_uidManager) {
-        _uidManager->TryRemoveGeometricComponent(GetDefaultedUID());
+        _uidManager->TryUnregisterObject(GetDefaultedUID());
     }
 }
 


### PR DESCRIPTION
* using RTTI to automatically register geometric components in CTiglUIDManager::RegisterObject
* made no longer publicly needed methods private in CTiglUIDManager
* removed all explicit registration as geometry components