### PR TITLE
Refactoring and minor changes

### DIFF
--- a/src/CCPACSPositionings.cpp
+++ b/src/CCPACSPositionings.cpp
@@ -141,7 +141,7 @@ void CCPACSPositionings::Update()
 }
 
 // Read CPACS positionings element
-void CCPACSPositionings::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& wingXPath)
+void CCPACSPositionings::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& wingXPath)
 {
     Cleanup();
     generated::CPACSPositionings::ReadCPACS(tixiHandle, wingXPath);

--- a/src/CCPACSPositionings.h
+++ b/src/CCPACSPositionings.h
@@ -48,7 +48,7 @@ public:
     TIGL_EXPORT ~CCPACSPositionings() OVERRIDE;
 
     // Read CPACS positionings element
-    TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& wingXPath);
+    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& wingXPath) OVERRIDE;
 
     // Invalidates internal state
     TIGL_EXPORT void Invalidate();

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -497,7 +497,7 @@ int GetComponentHashCode(tigl::ITiglGeometricComponent& component)
 // Creates an Edge from the given Points by B-Spline interpolation
 TopoDS_Edge EdgeSplineFromPoints(const std::vector<gp_Pnt>& points)
 {
-    unsigned int pointCount = points.size();
+    unsigned int pointCount = static_cast<int>(points.size());
     
     Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, pointCount);
     for (unsigned int j = 0; j < pointCount; j++) {

--- a/src/fuselage/CCPACSFrame.cpp
+++ b/src/fuselage/CCPACSFrame.cpp
@@ -182,19 +182,19 @@ void CCPACSFrame::BuildGeometry(bool just1DElements)
 
 void CCPACSFrame::BuildCutGeometry()
 {
+    TopoDS_Shape fuselageLoft = m_parent->GetParent()->GetParent()->GetLoft(FUSELAGE_COORDINATE_SYSTEM)->Shape();
+    Bnd_Box fuselageBox;
+    BRepBndLib::Add(fuselageLoft, fuselageBox);
+    double bbSize = fuselageBox.SquareExtent();
+
     if (m_framePositions.size() == 1)
-        m_cutGeomCache = BRepBuilderAPI_MakeFace(gp_Pln(m_framePositions[0]->GetRefPoint(), gp_Dir(1, 0, 0)));
+        m_cutGeomCache = BRepBuilderAPI_MakeFace(gp_Pln(m_framePositions[0]->GetRefPoint(), gp_Dir(1, 0, 0)), -bbSize, bbSize, -bbSize, bbSize);
     else {
         TopoDS_Compound compound;
         TopoDS_Builder builder;
         builder.MakeCompound(compound);
 
-        TopoDS_Shape fuselageLoft = m_parent->GetParent()->GetParent()->GetLoft()->Shape();
-
-        Bnd_Box fuselageBox;
-        BRepBndLib::Add(fuselageLoft, fuselageBox);
-
-        TopoDS_Shape geometry = GetGeometry(true, TiglCoordinateSystem::FUSELAGE_COORDINATE_SYSTEM);
+        TopoDS_Shape geometry = GetGeometry(true, FUSELAGE_COORDINATE_SYSTEM);
 
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(geometry, TopAbs_EDGE, edgeMap);
@@ -227,7 +227,7 @@ void CCPACSFrame::BuildCutGeometry()
                     if (pntA.IsEqual(pnt2, precision) != 0) {
                         frameOnFace                = true;
                         const gp_Vec vN            = gp_Vec(GeomLProp_SLProps(surf, uv.X(), uv.Y(), 1, 0.01).Normal());
-                        const double cutPlaneDepth = fuselageBox.SquareExtent() * 2.e-7 + 0.125;
+                        const double cutPlaneDepth = bbSize * 2.e-7 + 0.125;
                         normalEdge                 = BRepBuilderAPI_MakeEdge(pntA.Translated(-vN * cutPlaneDepth),
                                                              pntA.Translated(vN * cutPlaneDepth));
                         break;

--- a/src/fuselage/CCPACSFramesAssembly.cpp
+++ b/src/fuselage/CCPACSFramesAssembly.cpp
@@ -16,12 +16,18 @@
 
 #include "CCPACSFramesAssembly.h"
 
+#include "CCPACSFrame.h"
+
 namespace tigl
 {
-
 CCPACSFramesAssembly::CCPACSFramesAssembly(CCPACSFuselageStructure* parent, CTiglUIDManager* uidMgr)
     : generated::CPACSFramesAssembly(parent, uidMgr)
 {
 }
 
+void CCPACSFramesAssembly::Invalidate()
+{
+    for (size_t i = 0; i < m_frames.size(); i++)
+        m_frames[i]->Invalidate();
+}
 } // namespace tigl

--- a/src/fuselage/CCPACSFramesAssembly.h
+++ b/src/fuselage/CCPACSFramesAssembly.h
@@ -24,6 +24,8 @@ class CCPACSFramesAssembly : public generated::CPACSFramesAssembly
 {
 public:
     TIGL_EXPORT CCPACSFramesAssembly(CCPACSFuselageStructure* parent, CTiglUIDManager* uidMgr);
+
+    TIGL_EXPORT void Invalidate();
 };
 
 } // namespace tigl

--- a/src/fuselage/CCPACSFuselageSection.cpp
+++ b/src/fuselage/CCPACSFuselageSection.cpp
@@ -37,7 +37,7 @@ void CCPACSFuselageSection::Cleanup()
 }
 
 // Read CPACS section elements
-void CCPACSFuselageSection::ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& sectionXPath)
+void CCPACSFuselageSection::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& sectionXPath)
 {
     Cleanup();
     generated::CPACSFuselageSection::ReadCPACS(tixiHandle, sectionXPath);

--- a/src/fuselage/CCPACSFuselageSection.h
+++ b/src/fuselage/CCPACSFuselageSection.h
@@ -38,7 +38,7 @@ public:
     TIGL_EXPORT CCPACSFuselageSection(CCPACSFuselageSections* parent, CTiglUIDManager* uidMgr);
 
     // Read CPACS section elements
-    TIGL_EXPORT void ReadCPACS(TixiDocumentHandle tixiHandle, const std::string& sectionXPath);
+    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& sectionXPath) OVERRIDE;
 
     // Get element count for this section
     TIGL_EXPORT int GetSectionElementCount() const;

--- a/src/fuselage/CCPACSFuselageSegment.cpp
+++ b/src/fuselage/CCPACSFuselageSegment.cpp
@@ -81,10 +81,6 @@
 #include "ShapeAnalysis_Surface.hxx"
 #include "BRepLib_FindSurface.hxx"
 
-#ifndef max
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-
 namespace
 {
     gp_Pnt transformProfilePoint(const tigl::CTiglTransformation& fuselTransform, const tigl::CTiglFuselageConnection& connection, const gp_Pnt& pointOnProfile)
@@ -757,7 +753,7 @@ gp_Pnt CCPACSFuselageSegment::GetPointAngle(double eta, double alpha, double y_c
     boundingBox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
     double yw = ymax - ymin;
     double zw = zmax - zmin;
-    double length = 2*max(yw, zw);
+    double length = 2*std::max(yw, zw);
 
     //create a rectangular face
     double angle = alpha/180. * M_PI;

--- a/src/fuselage/CCPACSFuselageSegment.h
+++ b/src/fuselage/CCPACSFuselageSegment.h
@@ -139,7 +139,7 @@ public:
 
     // Gets the volume of this segment
     TIGL_EXPORT double GetVolume();
-        
+
     // Gets the surface area of this segment
     TIGL_EXPORT double GetSurfaceArea();
 

--- a/src/fuselage/CCPACSFuselageStringer.cpp
+++ b/src/fuselage/CCPACSFuselageStringer.cpp
@@ -159,7 +159,6 @@ void CCPACSFuselageStringer::BuildCutGeometry()
         TopTools_IndexedMapOfShape faceMap;
         TopExp::MapShapes(fuselageLoft, TopAbs_FACE, faceMap);
 
-        int aux = faceMap.Extent();
         for (int k = 1; k <= faceMap.Extent(); k++) // check if the pntA is on the surface and then create the normal
         {
             // check if it is there

--- a/src/fuselage/CCPACSFuselageStructure.cpp
+++ b/src/fuselage/CCPACSFuselageStructure.cpp
@@ -25,9 +25,9 @@ CCPACSFuselageStructure::CCPACSFuselageStructure(CCPACSFuselage* parent, CTiglUI
 
 void CCPACSFuselageStructure::Invalidate()
 {
-    //if (m_frames) {
-    //    m_frames->Invalidate();
-    //}
+    if (m_frames) {
+        m_frames->Invalidate();
+    }
     if (m_stringers) {
         m_stringers->Invalidate();
     }

--- a/src/guide_curves/CCPACSGuideCurve.cpp
+++ b/src/guide_curves/CCPACSGuideCurve.cpp
@@ -45,6 +45,16 @@ CCPACSGuideCurve::~CCPACSGuideCurve(void)
     Cleanup();
 }
 
+CCPACSGuideCurve::FromDefinition CCPACSGuideCurve::GetFromDefinition() const {
+    if (!ValidateChoices())
+        throw CTiglError("Choices not valid", TIGL_XML_ERROR);
+    if (m_fromRelativeCircumference_choice2)
+        return FromDefinition::CIRCUMFERENCE;
+    if (m_fromGuideCurveUID_choice1)
+        return FromDefinition::UID;
+    throw CTiglError("Logic error in FromDefinition detection");
+}
+
 // Cleanup routine
 void CCPACSGuideCurve::Cleanup(void)
 {

--- a/src/guide_curves/CCPACSGuideCurve.h
+++ b/src/guide_curves/CCPACSGuideCurve.h
@@ -47,6 +47,12 @@ class IGuideCurveBuilder;
 
 class CCPACSGuideCurve : public generated::CPACSGuideCurve
 {
+public:
+    enum FromDefinition
+    {
+        UID,
+        CIRCUMFERENCE
+    };
 
 private:
     // Typedefs for a container to store the coordinates of a guide curve element.
@@ -58,6 +64,8 @@ public:
 
     // Virtual Destructor
     TIGL_EXPORT ~CCPACSGuideCurve(void) OVERRIDE;
+
+    TIGL_EXPORT FromDefinition GetFromDefinition() const;
 
     TIGL_EXPORT const std::vector<gp_Pnt> GetCurvePoints();
     TIGL_EXPORT const TopoDS_Edge& GetCurve();

--- a/src/logging/CTiglLogging.cpp
+++ b/src/logging/CTiglLogging.cpp
@@ -60,6 +60,7 @@ CTiglLogging::~CTiglLogging()
 {
 #ifdef GLOG_FOUND
     // TODO (bgruber): this is problematic, as the application linking to TIGL may also use glog after TIGL has been shutdown
+    // TODO (bgruber): enabling this also causes an abort() at the end of the application if glog was linked statically by TIGL and the application
     google::ShutdownGoogleLogging();
 #endif
 }
@@ -94,6 +95,7 @@ CTiglLogging& CTiglLogging::Instance()
 void CTiglLogging::initLogger()
 {
 #ifdef GLOG_FOUND
+    // TODO (bgruber): this is problematic, as the application linking to TIGL may also use glog and initialize it itself
     // Initialize Google's logging library.
     google::InitGoogleLogging("TIGL-log");
 #endif

--- a/src/structural_elements/CCPACSPressureBulkhead.cpp
+++ b/src/structural_elements/CCPACSPressureBulkhead.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018 RISC Software GmbH
+* Copyright (c) 2018 Airbus Defence and Space and RISC Software GmbH
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,4 +24,13 @@ CCPACSPressureBulkhead::CCPACSPressureBulkhead(CCPACSPressureBulkheads* parent, 
 {
 }
 
+int CCPACSPressureBulkhead::GetReinforcementNumberVertical() const
+{
+    return m_reinforcementNumberVertical_choice1.value_or(0);
+}
+
+int CCPACSPressureBulkhead::GetReinforcementNumberHorizontal() const
+{
+    return m_reinforcementNumberHorizontal_choice1.value_or(0);
+}
 } // namespace tigl

--- a/src/structural_elements/CCPACSPressureBulkhead.h
+++ b/src/structural_elements/CCPACSPressureBulkhead.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018 RISC Software GmbH
+* Copyright (c) 2018 Airbus Defence and Space and RISC Software GmbH
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ class CCPACSPressureBulkhead : public generated::CPACSPressureBulkhead
 {
 public:
     TIGL_EXPORT CCPACSPressureBulkhead(CCPACSPressureBulkheads* parent, CTiglUIDManager* uidMgr);
+
+    TIGL_EXPORT int GetReinforcementNumberVertical() const;
+    TIGL_EXPORT int GetReinforcementNumberHorizontal() const;
 };
 
 } // namespace tigl

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -78,7 +78,7 @@ public:
     TIGL_EXPORT const CCPACSMaterialDefinition& GetMaterial() const;
 
     TIGL_EXPORT void Update() const;
-    
+
 private:
     std::pair<double, double> computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos, 
                                                        const CCPACSWingCellPositionChordwise& chordwisePos, 

--- a/src/wing/CCPACSWingCellPositionSpanwise.cpp
+++ b/src/wing/CCPACSWingCellPositionSpanwise.cpp
@@ -79,7 +79,7 @@ std::pair<std::string, int> CCPACSWingCellPositionSpanwise::GetRib() const {
     if (GetInputType() != Rib) {
         throw CTiglError("CCPACSWingCellPositionSpanwise::GetRib method called, but position is defined via eta1/eta2!");
     }
-    return std::make_pair(*m_ribDefinitionUID_choice2, *m_ribNumber_choice2);
+    return std::make_pair(m_ribDefinitionUID_choice2.value(), m_ribNumber_choice2.value());
 }
 
 void CCPACSWingCellPositionSpanwise::InvalidateParent()

--- a/src/wing/CCPACSWingCells.h
+++ b/src/wing/CCPACSWingCells.h
@@ -30,12 +30,12 @@ class CCPACSWingCells : public generated::CPACSWingCells
 public:
     // Constructor
     TIGL_EXPORT CCPACSWingCells(CCPACSWingShell* parent, CTiglUIDManager* uidMgr);
-    
+
     TIGL_EXPORT void Invalidate();
 
     // Returns the total count of wing cells for that wing component segment
     TIGL_EXPORT int GetCellCount() const;
-    
+
     // Returns the wing cell for a given index.
     TIGL_EXPORT CCPACSWingCell& GetCell(int index) const;
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -431,8 +431,8 @@ TopoDS_Wire CCPACSWingComponentSegment::GetMidplaneLine(const gp_Pnt& startPoint
     // get minimum and maximum z-value of bounding box
     Bnd_Box bbox;
     BRepBndLib::Add(localLoft, bbox);
-    double zmin, zmax, temp;
-    bbox.Get(temp, temp, zmin, temp, temp, zmax);
+    const double zmin = bbox.CornerMin().Z();
+    const double zmax = bbox.CornerMax().Z();
 
     // build cut face
     gp_Pnt p0 = startPnt;
@@ -567,7 +567,7 @@ SegmentList& CCPACSWingComponentSegment::GetSegmentList() const
 
     return wingSegments;
 }
-    
+
 // Determines, which segments belong to the component segment
 std::vector<int> CCPACSWingComponentSegment::findPath(const std::string& fromUID, const::std::string& toUID, const std::vector<int>& curPath, bool forward) const
 {
@@ -913,21 +913,18 @@ gp_Pnt CCPACSWingComponentSegment::GetPoint(double eta, double xsi, TiglCoordina
     return result;
 }
 
-void CCPACSWingComponentSegment::GetEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const
+void CCPACSWingComponentSegment::GetEtaXsi(const gp_Pnt& globalPoint, double& eta, double& xsi) const
 {
     UpdateChordFace();
 
     // TODO (siggel): check that point is part of component segment
 
-    chordFace->GetEtaXsi(p, eta, xsi);
+    chordFace->GetEtaXsi(globalPoint, eta, xsi);
 }
 
-// TODO (siggel): remove this function as it duplicates GetEtaXsi
-void CCPACSWingComponentSegment::GetMidplaneEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const
+void CCPACSWingComponentSegment::GetEtaXsiLocal(const gp_Pnt& localPoint, double& eta, double& xsi) const
 {
-    gp_Pnt globalPoint = wing->GetTransformationMatrix().Transform(p);
-
-    GetEtaXsi(globalPoint, eta, xsi);
+    return GetEtaXsi(GetWing().GetTransformationMatrix().Transform(localPoint), eta, xsi);
 }
 
 // Getter for eta direction of midplane

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -89,7 +89,8 @@ public:
     TIGL_EXPORT gp_Pnt GetPoint(double eta, double xsi, TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM) const;
 
     // Returns the eta xsi coordinates of a points projected onto the midplane / chordface
-    TIGL_EXPORT void GetEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const;
+    TIGL_EXPORT void GetEtaXsi(const gp_Pnt& globalPoint, double& eta, double& xsi) const;
+    TIGL_EXPORT void GetEtaXsiLocal(const gp_Pnt& localPoint, double& eta, double& xsi) const;
 
     // Getter for leading edge point at the relative position, which must be
     // defined between 0 (inner point on leadinge edge) and 1 (outer point)
@@ -101,11 +102,6 @@ public:
 
     // Getter for section element face
     TIGL_EXPORT TopoDS_Face GetSectionElementFace(const std::string& sectionElementUID) const;
-
-    // Getter for eta and xsi for passed point
-    // Passed point must be in wing coordinate system
-    // TODO (siggel): remove this function as it duplicates GetEtaXsi
-    TIGL_EXPORT void GetMidplaneEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const;
 
     // Getter for eta direction of midplane (no X-component)
     TIGL_EXPORT gp_Vec GetMidplaneEtaDir(double eta) const;

--- a/src/wing/CCPACSWingRibsDefinition.cpp
+++ b/src/wing/CCPACSWingRibsDefinition.cpp
@@ -296,13 +296,14 @@ void CCPACSWingRibsDefinition::BuildAuxGeomRibsPositioning() const
         else if (fabs(ribSetDataCache.value().referenceEtaEnd - currentEta) <= Precision::Confusion() && m_ribsPositioning_choice1->GetEndDefinitionType() == CCPACSWingRibsPositioning::ELEMENT_END) {
             elementUID = *m_ribsPositioning_choice1->GetElementEndUID_choice2();
         }
+
         std::string sparPositionUID = "";
-        if (i == 0 && m_ribsPositioning_choice1->GetStartDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_START) {
-            sparPositionUID = *m_ribsPositioning_choice1->GetSparPositionStartUID_choice3();
+        if (i == 0 && m_ribsPositioning_choice1.value().GetStartDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_START) {
+            sparPositionUID = m_ribsPositioning_choice1.value().GetSparPositionStartUID_choice3().value();
         }
         // NOTE: we have to check the eta difference here (instead of the index) to support spacing definitions
         else if (fabs(ribSetDataCache.value().referenceEtaEnd - currentEta) <= Precision::Confusion() && m_ribsPositioning_choice1->GetEndDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_END) {
-            sparPositionUID = *m_ribsPositioning_choice1->GetSparPositionEndUID_choice3();
+            sparPositionUID = m_ribsPositioning_choice1.value().GetSparPositionEndUID_choice3().value();
         }
 
         // STEP 4: build the rib cut geometry based on the current eta value
@@ -314,9 +315,9 @@ void CCPACSWingRibsDefinition::BuildAuxGeomRibsPositioning() const
 
 CCPACSWingRibsDefinition::CutGeometry CCPACSWingRibsDefinition::BuildRibCutGeometry(double currentEta, const std::string& elementUID, const std::string& sparPositionUID) const
 {
-    std::string ribStart = m_ribsPositioning_choice1->GetRibStart();
-    std::string ribEnd = m_ribsPositioning_choice1->GetRibEnd();
-    std::string ribReference = m_ribsPositioning_choice1->GetRibReference();
+    std::string ribStart = m_ribsPositioning_choice1.value().GetRibStart();
+    std::string ribEnd = m_ribsPositioning_choice1.value().GetRibEnd();
+    std::string ribReference = m_ribsPositioning_choice1.value().GetRibReference();
 
     assert(auxGeomCache);
 
@@ -345,7 +346,7 @@ CCPACSWingRibsDefinition::CutGeometry CCPACSWingRibsDefinition::BuildRibCutGeome
     gp_Pnt referencePnt = GetReferencePoint(getStructure(), ribReference, currentEta);
 
     // STEP 2: compute the up vector for the rib cut face without x rotation
-    gp_Vec upVec = GetUpVectorWithoutXRotation(m_ribsPositioning_choice1->GetRibReference(), currentEta, referencePnt, sparPositionUID, getStructure());
+    gp_Vec upVec = GetUpVectorWithoutXRotation(m_ribsPositioning_choice1.value().GetRibReference(), currentEta, referencePnt, sparPositionUID, getStructure());
 
     // STEP 3: compute direction vector of rib (points from start point to end point)
     gp_Vec ribDir = GetRibDirection(currentEta, referencePnt, upVec);
@@ -371,10 +372,10 @@ void CCPACSWingRibsDefinition::BuildAuxGeomExplicitRibPositioning() const
     const CTiglWingStructureReference& wingStructureReference = getStructure().GetWingStructureReference();
 
     // get values from m_ribExplicitPositioning_choice2
-    std::string startReference = m_ribExplicitPositioning_choice2->GetStartReference();
-    std::string endReference = m_ribExplicitPositioning_choice2->GetEndReference();
-    double startEta = m_ribExplicitPositioning_choice2->GetEtaStart();
-    double endEta = m_ribExplicitPositioning_choice2->GetEtaEnd();
+    std::string startReference = m_ribExplicitPositioning_choice2.value().GetStartReference();
+    std::string endReference = m_ribExplicitPositioning_choice2.value().GetEndReference();
+    double startEta = m_ribExplicitPositioning_choice2.value().GetEtaStart();
+    double endEta = m_ribExplicitPositioning_choice2.value().GetEtaEnd();
 
     auxGeomCache.emplace();
 
@@ -403,7 +404,7 @@ void CCPACSWingRibsDefinition::BuildAuxGeomExplicitRibPositioning() const
     if ((startReference == "leadingEdge" || startReference == "trailingEdge") &&
         (endReference == "leadingEdge" || endReference == "trailingEdge")) {
         double midplaneEta, dummy;
-        wingStructureReference.GetMidplaneEtaXsi(startPnt, midplaneEta, dummy);
+        wingStructureReference.GetEtaXsiLocal(startPnt, midplaneEta, dummy);
         upVecStart = wingStructureReference.GetMidplaneNormal(midplaneEta);
         upVecEnd = upVecStart;
     }
@@ -413,7 +414,7 @@ void CCPACSWingRibsDefinition::BuildAuxGeomExplicitRibPositioning() const
             const CCPACSWingSparSegment& spar = getStructure().GetSparSegment(startReference);
             TopoDS_Shape sparShape = spar.GetSparGeometry(WING_COORDINATE_SYSTEM);
             double midplaneEta, dummy;
-            wingStructureReference.GetMidplaneEtaXsi(startPnt, midplaneEta, dummy);
+            wingStructureReference.GetEtaXsiLocal(startPnt, midplaneEta, dummy);
             gp_Vec midplaneNormal = wingStructureReference.GetMidplaneNormal(midplaneEta);
             gp_Vec xDir(1, 0, 0);
             gp_Vec cutPlaneNormal = midplaneNormal.Crossed(xDir).Normalized();
@@ -439,7 +440,7 @@ void CCPACSWingRibsDefinition::BuildAuxGeomExplicitRibPositioning() const
             const CCPACSWingSparSegment& spar = getStructure().GetSparSegment(endReference);
             TopoDS_Shape sparShape = spar.GetSparGeometry(WING_COORDINATE_SYSTEM);
             double midplaneEta, dummy;
-            wingStructureReference.GetMidplaneEtaXsi(endPnt, midplaneEta, dummy);
+            wingStructureReference.GetEtaXsiLocal(endPnt, midplaneEta, dummy);
             gp_Vec midplaneNormal = wingStructureReference.GetMidplaneNormal(midplaneEta);
             gp_Vec xDir(1, 0, 0);
             gp_Vec cutPlaneNormal = midplaneNormal.Crossed(xDir).Normalized();
@@ -454,7 +455,7 @@ void CCPACSWingRibsDefinition::BuildAuxGeomExplicitRibPositioning() const
         // in case only one up vector could be found, use this for both
         if (upVecStart.SquareMagnitude() == 0 && upVecEnd.SquareMagnitude() == 0) {
             double midplaneEta, dummy;
-            wingStructureReference.GetMidplaneEtaXsi(startPnt, midplaneEta, dummy);
+            wingStructureReference.GetEtaXsiLocal(startPnt, midplaneEta, dummy);
             upVecStart = wingStructureReference.GetMidplaneNormal(midplaneEta);
             upVecEnd = upVecStart;
         }
@@ -506,7 +507,7 @@ void CCPACSWingRibsDefinition::BuildGeometry() const
         // handle case when ribCutFace is identical with target rib face
         if (cutGeometry.isTargetFace) {
             compoundBuilder.Add(compound, cutGeometry.shape);
-            ribGeometryCache->ribFaces.push_back(cutGeometry.shape);
+            ribGeometryCache.value().ribFaces.push_back(cutGeometry.shape);
         }
         else {
             // intersect rib cut face with loft
@@ -545,7 +546,7 @@ void CCPACSWingRibsDefinition::BuildGeometry() const
 
             // add rib face to compound
             compoundBuilder.Add(compound, ribFace);
-            ribGeometryCache->ribFaces.push_back(ribFace);
+            ribGeometryCache.value().ribFaces.push_back(ribFace);
         }
     }
 
@@ -563,7 +564,7 @@ void CCPACSWingRibsDefinition::BuildSplittedRibsGeometry() const
 
     // split the ribs geometry with the spar split geometry
     splittedRibGeomCache.emplace();
-    splittedRibGeomCache->shape = CutShapeWithSpars(ribGeometryCache.value().shape, getStructure());
+    splittedRibGeomCache.value().shape = CutShapeWithSpars(ribGeometryCache.value().shape, getStructure());
 }
 
 void CCPACSWingRibsDefinition::BuildRibCapsGeometry() const
@@ -589,7 +590,7 @@ void CCPACSWingRibsDefinition::BuildRibCapsGeometry() const
         for (explorer.Init(cutResult, TopAbs_EDGE); explorer.More(); explorer.Next()) {
             builder.Add(capEdges, TopoDS::Edge(explorer.Current()));
         }
-        ribCapsCache->upperCapsShape = capEdges;
+        ribCapsCache.value().upperCapsShape = capEdges;
     }
     // build caps shape for lower cap
     if (m_ribCrossSection.GetLowerCap()) {
@@ -602,7 +603,7 @@ void CCPACSWingRibsDefinition::BuildRibCapsGeometry() const
         for (explorer.Init(cutResult, TopAbs_EDGE); explorer.More(); explorer.Next()) {
             builder.Add(capEdges, TopoDS::Edge(explorer.Current()));
         }
-        ribCapsCache->lowerCapsShape = capEdges;
+        ribCapsCache.value().lowerCapsShape = capEdges;
     }
 }
 
@@ -610,7 +611,7 @@ TopoDS_Wire CCPACSWingRibsDefinition::GetReferenceLine() const
 {
     const CTiglWingStructureReference& wingStructureReference = getStructure().GetWingStructureReference();
     TopoDS_Wire referenceLine;
-    std::string ribReference = m_ribsPositioning_choice1->GetRibReference();
+    std::string ribReference = m_ribsPositioning_choice1.value().GetRibReference();
     if (ribReference == "leadingEdge") {
         referenceLine = wingStructureReference.GetLeadingEdgeLine();
     }
@@ -630,14 +631,14 @@ double CCPACSWingRibsDefinition::ComputeReferenceEtaStart() const
     assert(GetRibPositioningType() == RIBS_POSITIONING);
 
     const CTiglWingStructureReference& wingStructureReference = getStructure().GetWingStructureReference();
-    if (m_ribsPositioning_choice1->GetStartDefinitionType() == CCPACSWingRibsPositioning::ETA_START) {
-        return *m_ribsPositioning_choice1->GetEtaStart_choice1();
+    if (m_ribsPositioning_choice1.value().GetStartDefinitionType() == CCPACSWingRibsPositioning::ETA_START) {
+        return m_ribsPositioning_choice1.value().GetEtaStart_choice1().value();
     }
     else if (m_ribsPositioning_choice1->GetStartDefinitionType() == CCPACSWingRibsPositioning::ELEMENT_START) {
-        return ComputeSectionElementEta(*m_ribsPositioning_choice1->GetElementStartUID_choice2());
+        return ComputeSectionElementEta(m_ribsPositioning_choice1.value().GetElementStartUID_choice2().value());
     }
-    else if (m_ribsPositioning_choice1->GetStartDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_START) {
-        return ComputeSparPositionEta(*m_ribsPositioning_choice1->GetSparPositionStartUID_choice3());
+    else if (m_ribsPositioning_choice1.value().GetStartDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_START) {
+        return ComputeSparPositionEta(m_ribsPositioning_choice1.value().GetSparPositionStartUID_choice3().value());
     }
     else {
         throw CTiglError("Unknown StartDefinitionType found for RibsPositioning in CCPACSWingRibsDefinition::GetEtaStart");
@@ -649,14 +650,14 @@ double CCPACSWingRibsDefinition::ComputeReferenceEtaEnd() const
     assert(GetRibPositioningType() == RIBS_POSITIONING);
 
     const CTiglWingStructureReference& wingStructureReference = getStructure().GetWingStructureReference();
-    if (m_ribsPositioning_choice1->GetEndDefinitionType() == CCPACSWingRibsPositioning::ETA_END) {
-        return *m_ribsPositioning_choice1->GetEtaEnd_choice1();
+    if (m_ribsPositioning_choice1.value().GetEndDefinitionType() == CCPACSWingRibsPositioning::ETA_END) {
+        return m_ribsPositioning_choice1.value().GetEtaEnd_choice1().value();
     }
-    else if (m_ribsPositioning_choice1->GetEndDefinitionType() == CCPACSWingRibsPositioning::ELEMENT_END) {
-        return ComputeSectionElementEta(*m_ribsPositioning_choice1->GetElementEndUID_choice2());
+    else if (m_ribsPositioning_choice1.value().GetEndDefinitionType() == CCPACSWingRibsPositioning::ELEMENT_END) {
+        return ComputeSectionElementEta(m_ribsPositioning_choice1.value().GetElementEndUID_choice2().value());
     }
-    else if (m_ribsPositioning_choice1->GetEndDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_END) {
-        return ComputeSparPositionEta(*m_ribsPositioning_choice1->GetSparPositionEndUID_choice3());
+    else if (m_ribsPositioning_choice1.value().GetEndDefinitionType() == CCPACSWingRibsPositioning::SPARPOSITION_END) {
+        return ComputeSparPositionEta(m_ribsPositioning_choice1.value().GetSparPositionEndUID_choice3().value());
     }
     else {
         throw CTiglError("Unknown EndDefinitionType found for RibsPositioning in CCPACSWingRibsDefinition::GetEtaEnd");
@@ -692,7 +693,7 @@ double CCPACSWingRibsDefinition::ComputeSparPositionEta(const std::string& sparP
 
     // NOTE: definition of start/end of rib via spar position not conform with CPACS format (v2.3)
     // ensure that the spar position is part of the spar reference line!!!
-    CheckSparPositionOnReference(sparPositionUID, m_ribsPositioning_choice1->GetRibReference(), getStructure());
+    CheckSparPositionOnReference(sparPositionUID, m_ribsPositioning_choice1.value().GetRibReference(), getStructure());
 
     // get componentSegment required for getting section element face
     const CCPACSWingSpars& spars = *getStructure().GetSpars();
@@ -718,12 +719,12 @@ int CCPACSWingRibsDefinition::ComputeNumberOfRibs(double etaStart, double etaEnd
     int numberOfRibs = 0;
 
     // check whether the number is defined in the ribs positioning
-    if (m_ribsPositioning_choice1->GetRibCountDefinitionType() == CCPACSWingRibsPositioning::NUMBER_OF_RIBS) {
-        numberOfRibs = *m_ribsPositioning_choice1->GetNumberOfRibs_choice2();
+    if (m_ribsPositioning_choice1.value().GetRibCountDefinitionType() == CCPACSWingRibsPositioning::NUMBER_OF_RIBS) {
+        numberOfRibs = *m_ribsPositioning_choice1.value().GetNumberOfRibs_choice2();
     }
-    else if (m_ribsPositioning_choice1->GetRibCountDefinitionType() == CCPACSWingRibsPositioning::SPACING) {
+    else if (m_ribsPositioning_choice1.value().GetRibCountDefinitionType() == CCPACSWingRibsPositioning::SPACING) {
         // otherwise compute the number based on the spacing
-        double spacing = *m_ribsPositioning_choice1->GetSpacing_choice1();
+        double spacing = *m_ribsPositioning_choice1.value().GetSpacing_choice1();
 
         // handle the case when start and end eta are identical
         double deltaEta = fabs(etaEnd - etaStart);
@@ -732,7 +733,7 @@ int CCPACSWingRibsDefinition::ComputeNumberOfRibs(double etaStart, double etaEnd
         }
         else {
             // get the length of the reference line between the two points
-            double length = GetRibReferenceLength(m_ribsPositioning_choice1->GetRibReference(), getStructure()) * fabs(etaEnd - etaStart);
+            double length = GetRibReferenceLength(m_ribsPositioning_choice1.value().GetRibReference(), getStructure()) * fabs(etaEnd - etaStart);
             // finally compute the number of ribs by dividing the length by the spacing
             // NOTE: adding of Precision::Confusion in order to avoid floating point problems
             numberOfRibs = (int)((length + Precision::Confusion()) / spacing) + 1;
@@ -753,8 +754,8 @@ double CCPACSWingRibsDefinition::ComputeEtaOffset(double etaStart, double etaEnd
     double etaOffset;
 
     // check whether number of ribs is defined, or spacing is defined
-    if (m_ribsPositioning_choice1->GetRibCountDefinitionType() == CCPACSWingRibsPositioning::NUMBER_OF_RIBS) {
-        int numberOfRibs = *m_ribsPositioning_choice1->GetNumberOfRibs_choice2();
+    if (m_ribsPositioning_choice1.value().GetRibCountDefinitionType() == CCPACSWingRibsPositioning::NUMBER_OF_RIBS) {
+        int numberOfRibs = *m_ribsPositioning_choice1.value().GetNumberOfRibs_choice2();
         // in case only 1 rib is defined define eta offset as 0
         if (numberOfRibs == 1) {
             etaOffset = 0;
@@ -763,10 +764,10 @@ double CCPACSWingRibsDefinition::ComputeEtaOffset(double etaStart, double etaEnd
             etaOffset = fabs(etaEnd - etaStart) / (numberOfRibs - 1);
         }
     }
-    else if (m_ribsPositioning_choice1->GetRibCountDefinitionType() == CCPACSWingRibsPositioning::SPACING) {
-        double spacing = *m_ribsPositioning_choice1->GetSpacing_choice1();
+    else if (m_ribsPositioning_choice1.value().GetRibCountDefinitionType() == CCPACSWingRibsPositioning::SPACING) {
+        double spacing = *m_ribsPositioning_choice1.value().GetSpacing_choice1();
         // get the length of the rib reference line between the two eta points
-        double referenceLength = GetRibReferenceLength(m_ribsPositioning_choice1->GetRibReference(), getStructure());
+        double referenceLength = GetRibReferenceLength(m_ribsPositioning_choice1.value().GetRibReference(), getStructure());
         etaOffset = spacing / referenceLength;
     }
     else {
@@ -828,16 +829,16 @@ gp_Vec CCPACSWingRibsDefinition::GetRibDirection(double currentEta, const gp_Pnt
     gp_Vec ribDir;
     const CTiglWingStructureReference& wingStructureReference = getStructure().GetWingStructureReference();
 
-    std::string ribReference = m_ribsPositioning_choice1->GetRibReference();
-    double zRotation = m_ribsPositioning_choice1->GetRibRotation().GetZ() * M_PI / 180.0;
+    std::string ribReference = m_ribsPositioning_choice1.value().GetRibReference();
+    double zRotation = m_ribsPositioning_choice1.value().GetRibRotation().GetZ() * M_PI / 180.0;
 
     boost::optional<ECPACSRibRotation_ribRotationReference> ribRotationReference;
-    if (m_ribsPositioning_choice1->GetRibRotation().GetRibRotationReference())
-        ribRotationReference = m_ribsPositioning_choice1->GetRibRotation().GetRibRotationReference();
+    if (m_ribsPositioning_choice1.value().GetRibRotation().GetRibRotationReference())
+        ribRotationReference = m_ribsPositioning_choice1.value().GetRibRotation().GetRibRotationReference();
 
     if (!ribRotationReference) {
         double midplaneEta, dummy;
-        wingStructureReference.GetMidplaneEtaXsi(startPnt, midplaneEta, dummy);
+        wingStructureReference.GetEtaXsiLocal(startPnt, midplaneEta, dummy);
         ribDir = wingStructureReference.GetMidplaneEtaDir(midplaneEta);
     } else if (ribRotationReference == LeadingEdge) {
         ribDir = wingStructureReference.GetLeadingEdgeDirection(startPnt);

--- a/src/wing/CCPACSWingRibsDefinition.h
+++ b/src/wing/CCPACSWingRibsDefinition.h
@@ -103,8 +103,6 @@ private:
         gp_Pnt endPnt;
     };
 
-    void Cleanup();
-
     void UpdateRibSetDataCache() const;
 
     void BuildAuxiliaryGeometry() const;

--- a/src/wing/CCPACSWingRibsPositioning.h
+++ b/src/wing/CCPACSWingRibsPositioning.h
@@ -30,7 +30,7 @@ class CCPACSWingRibsPositioning : public generated::CPACSWingRibsPositioning
 public:
     // NOTE: definition of start/end of rib via spar position not conform with CPACS format (v2.3)
     enum StartDefinitionType
-    { 
+    {
         ELEMENT_START,
         ETA_START,
         SPARPOSITION_START

--- a/src/wing/CCPACSWingShell.cpp
+++ b/src/wing/CCPACSWingShell.cpp
@@ -23,7 +23,7 @@
 #include "CCPACSWingCell.h"
 
 
-namespace tigl 
+namespace tigl
 {
 
 CCPACSWingShell::CCPACSWingShell(CCPACSWingCSStructure* parent, CTiglUIDManager* uidMgr)

--- a/src/wing/CCPACSWingSparSegment.cpp
+++ b/src/wing/CCPACSWingSparSegment.cpp
@@ -139,7 +139,7 @@ void CCPACSWingSparSegment::GetEtaXsi(int positionIndex, double& eta, double& xs
     else if (sparPosition.GetInputType() == CCPACSWingSparPosition::ElementUID) {
         gp_Pnt sparPositionPoint = GetMidplanePoint(sparPositionUID);
         double dummy;
-        sparsNode.GetParent()->GetWingStructureReference().GetMidplaneEtaXsi(sparPositionPoint, eta, dummy);
+        sparsNode.GetParent()->GetWingStructureReference().GetEtaXsiLocal(sparPositionPoint, eta, dummy);
         assert(fabs(dummy - xsi) < 1.E-6);
     }
     else {
@@ -370,7 +370,7 @@ void CCPACSWingSparSegment::BuildGeometry() const
     TopExp_Explorer exp;
     for (exp.Init(sparCutGeometry, TopAbs_FACE); exp.More(); exp.Next()) {
         TopoDS_Face sparCutFace = TopoDS::Face(exp.Current());
-            
+
         // intersect spar cut face with loft
         TopoDS_Shape sparCutEdges = CutShapes(loft, sparCutFace);
 

--- a/src/wing/CTiglWingStructureReference.cpp
+++ b/src/wing/CTiglWingStructureReference.cpp
@@ -129,9 +129,9 @@ TopoDS_Wire CTiglWingStructureReference::GetTrailingEdgeLine() const
     DISPATCH(GetTrailingEdgeLine())
 }
 
-void CTiglWingStructureReference::GetMidplaneEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const
+void CTiglWingStructureReference::GetEtaXsiLocal(const gp_Pnt& p, double& eta, double& xsi) const
 {
-    DISPATCH(GetMidplaneEtaXsi(p, eta, xsi));
+    DISPATCH(GetEtaXsiLocal(p, eta, xsi));
 }
 
 gp_Vec CTiglWingStructureReference::GetMidplaneEtaDir(double eta) const

--- a/src/wing/CTiglWingStructureReference.h
+++ b/src/wing/CTiglWingStructureReference.h
@@ -64,7 +64,7 @@ public:
     TIGL_EXPORT gp_Vec GetTrailingEdgeDirection(const gp_Pnt& point, const std::string& defaultSegmentUID = "") const;
     TIGL_EXPORT TopoDS_Wire GetLeadingEdgeLine() const;
     TIGL_EXPORT TopoDS_Wire GetTrailingEdgeLine() const;
-    TIGL_EXPORT void GetMidplaneEtaXsi(const gp_Pnt& p, double& eta, double& xsi) const;
+    TIGL_EXPORT void GetEtaXsiLocal(const gp_Pnt& p, double& eta, double& xsi) const;
     TIGL_EXPORT gp_Vec GetMidplaneEtaDir(double eta) const;
     TIGL_EXPORT gp_Vec GetMidplaneNormal(double eta) const;
     TIGL_EXPORT TopoDS_Shape GetMidplaneShape() const;

--- a/src/wing/tigletaxsifunctions.cpp
+++ b/src/wing/tigletaxsifunctions.cpp
@@ -85,7 +85,7 @@ double computeSparXsiValue(const CTiglWingStructureReference& wsr, const CCPACSW
         throw CTiglError("Error in computation of spar eta point in tigletaxsifunctions::computeSparXsiValue");
     }
     double newEta, xsi;
-    wsr.GetMidplaneEtaXsi(etaXsiPoint, newEta, xsi);
+    wsr.GetEtaXsiLocal(etaXsiPoint, newEta, xsi);
     return xsi;
 }
 
@@ -96,8 +96,8 @@ double computeRibEtaValue(const CTiglWingStructureReference& wsr, const CCPACSWi
     rib.GetRibMidplanePoints(ribIndex, ribStartPoint, ribEndPoint);
 
     double startEta, startXsi, endEta, endXsi;
-    wsr.GetMidplaneEtaXsi(ribStartPoint, startEta, startXsi);
-    wsr.GetMidplaneEtaXsi(ribEndPoint, endEta, endXsi);
+    wsr.GetEtaXsiLocal(ribStartPoint, startEta, startXsi);
+    wsr.GetEtaXsiLocal(ribEndPoint, endEta, endXsi);
 
     // fix numeric inaccuracy in xsi
     double precision = 1.E-8;
@@ -123,8 +123,8 @@ EtaXsi computeRibSparIntersectionEtaXsi(const CTiglWingStructureReference& wsr, 
     rib.GetRibMidplanePoints(ribIndex, ribStartPoint, ribEndPoint);
 
     EtaXsi ribStart, ribEnd;
-    wsr.GetMidplaneEtaXsi(ribStartPoint, ribStart.eta, ribStart.xsi);
-    wsr.GetMidplaneEtaXsi(ribEndPoint, ribEnd.eta, ribEnd.xsi);
+    wsr.GetEtaXsiLocal(ribStartPoint, ribStart.eta, ribStart.xsi);
+    wsr.GetEtaXsiLocal(ribEndPoint, ribEnd.eta, ribEnd.xsi);
 
     // determine number of spar positions
     int numSparPositions = spar.GetSparPositionUIDs().GetSparPositionUIDCount();

--- a/src/wing/tiglwingribhelperfunctions.cpp
+++ b/src/wing/tiglwingribhelperfunctions.cpp
@@ -145,7 +145,7 @@ gp_Vec GetUpVectorWithoutXRotation(const std::string& ribReference, double curre
 
     // use the midplane normal as up vector
     double midplaneEta, dummy;
-    wingStructureReference.GetMidplaneEtaXsi(startPnt, midplaneEta, dummy);
+    wingStructureReference.GetEtaXsiLocal(startPnt, midplaneEta, dummy);
     gp_Vec upVec = wingStructureReference.GetMidplaneNormal(midplaneEta);
 
     // Bug #408: special handling in case the rib is defined at the spar position or start or end point of a spar


### PR DESCRIPTION
* fixed signatures of ReadCPACS/WriteCPACS
* added CCPACSFramesAssembly::Invalidate
* bounded cut shape of CCPACSFrame
* removed max macro
* removed unneeded whitespace
* removed unused variables
* added CCPACSGuideCurve::GetFromDefinition()
* added TODOs
* added CCPACSPressureBulkhead::GetReinforcementNumberVertical/Horizontal with defaulted values
* replaced explicit optional<T> access by calling value()
* removed deprecated CCPACSWingComponentSegment::GetMidplaneEtaXsi
* removed a method declaration with no definition