### PR TITLE
 Integrated cell geometry code from airbus

### DIFF
--- a/TIGLViewer/scripts/globaldefs.js
+++ b/TIGLViewer/scripts/globaldefs.js
@@ -105,7 +105,7 @@ function drawVector() {
 }
 
 function drawShape(shape) {
-    app.scene.displayShape(shape)
+    app.scene.displayShape(shape, true)
 }
 
 function _getObjectMethods(obj) {

--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -316,7 +316,7 @@ void TIGLViewerContext::setGridOffset (Quantity_Length offset)
 }
 
 // a small helper when we just want to display a shape
-void TIGLViewerContext::displayShape(const TopoDS_Shape& loft, Standard_Boolean updateViewer, Quantity_Color color, double transparency)
+void TIGLViewerContext::displayShape(const TopoDS_Shape& loft, bool updateViewer, Quantity_Color color, double transparency)
 {
     TIGLViewerSettings& settings = TIGLViewerSettings::Instance();
     Handle(AIS_TexturedShape) shape = new AIS_TexturedShape(loft);
@@ -347,7 +347,7 @@ void TIGLViewerContext::displayShape(const TopoDS_Shape& loft, Standard_Boolean 
 }
 
 // a small helper when we just want to display a shape
-void TIGLViewerContext::displayShape(const PNamedShape& pshape, Standard_Boolean updateViewer, Quantity_Color color, double transparency)
+void TIGLViewerContext::displayShape(const PNamedShape& pshape, bool updateViewer, Quantity_Color color, double transparency)
 {
     if (!pshape) {
         return;

--- a/TIGLViewer/src/TIGLViewerContext.h
+++ b/TIGLViewer/src/TIGLViewerContext.h
@@ -81,8 +81,8 @@ public:
     void updateViewer();
 
 public slots:
-    void displayShape(const TopoDS_Shape& loft, Standard_Boolean updateViewer, Quantity_Color color = Quantity_NOC_ShapeCol, double transparency=0.);
-    void displayShape(const PNamedShape& pshape, Standard_Boolean updateViewer, Quantity_Color color= Quantity_NOC_ShapeCol, double transparency=0.);
+    void displayShape(const PNamedShape& pshape, bool updateViewer, Quantity_Color color= Quantity_NOC_ShapeCol, double transparency=0.);
+    void displayShape(const TopoDS_Shape& loft, bool updateViewer, Quantity_Color color = Quantity_NOC_ShapeCol, double transparency=0.);
 
     void drawPoint(double x, double y, double z);
     void drawVector(double x, double y, double z, double dirx, double diry, double dirz);

--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -324,7 +324,10 @@ class CCPACSWingRibsPositioning;
          tigl::CCPACSCrossBeamStrutAssemblyPosition,
          tigl::CCPACSDoorAssemblyPosition,
          tigl::CCPACSLongFloorBeam,
-         tigl::CCPACSPressureBulkheadAssemblyPosition
+         tigl::CCPACSPressureBulkheadAssemblyPosition,
+         tigl::CCPACSWingCell,
+         tigl::CCPACSWingRibsDefinition,
+         tigl::CCPACSWingSparSegment
 );
 
 namespace tigl

--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -190,6 +190,7 @@ class CCPACSWingRibsPositioning;
 %include "CCPACSWingCellPositionSpanwise.h"
 %include "generated/CPACSCellPositioningChordwise.h"
 %include "CCPACSWingCellPositionChordwise.h"
+%include "EtaXsi.h"
 %include "generated/CPACSWingCell.h"
 %include "CCPACSWingCell.h"
 %include "generated/CPACSWingShell.h"

--- a/examples/python_internal/example_wing_cell_geometry.py
+++ b/examples/python_internal/example_wing_cell_geometry.py
@@ -1,0 +1,59 @@
+from __future__ import print_function
+
+from tixi3 import tixi3wrapper
+from tigl3 import tigl3wrapper
+import tigl3.configuration
+from OCC.Quantity import Quantity_NOC_RED, Quantity_NOC_GREEN, Quantity_NOC_BLUE1
+import os
+
+
+def display_wing_cell_geom(configuration):
+    """
+    This is an example how to use the internal tigl/pyocc API
+    to display all wing and fuselage segments
+    """
+
+    from OCC.Display.SimpleGui import init_display
+    display, start_display, add_menu, add_function_to_menu = init_display()
+
+    wing = configuration.get_wing(1)
+    display.DisplayShape(wing.get_loft().shape(), transparency=0.7)
+
+    # display cell geometry
+    cs = wing.get_component_segment(1)
+    structure = cs.get_structure()
+    cell = structure.get_upper_shell().get_cell(1)
+    cell_shape = cell.get_cell_skin_geometry()
+    display.DisplayShape(cell_shape, color=Quantity_NOC_RED, transparency=0.3)
+
+    # display spars and ribs
+    spar = structure.get_spar_segment(1)
+    spar_shape = spar.get_spar_geometry()
+    display.DisplayShape(spar_shape, color=Quantity_NOC_GREEN, update=True)
+
+    # draw ribs
+    for i_rib in range(1, structure.get_ribs_definition_count() + 1):
+        rib = structure.get_ribs_definition(i_rib)
+        rib_shape = rib.get_ribs_geometry()
+        display.DisplayShape(rib_shape, color=Quantity_NOC_BLUE1, update=True)
+
+    display.FitAll()
+
+    start_display()
+
+
+if __name__ == '__main__':
+    tixi_h = tixi3wrapper.Tixi3()
+    tigl_h = tigl3wrapper.Tigl3()
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    tixi_h.open(dir_path + "/../../tests/unittests/TestData/cell_rib_spar_test.xml")
+    tigl_h.open(tixi_h, "")
+
+    # get the configuration manager
+    mgr = tigl3.configuration.CCPACSConfigurationManager_get_instance()
+
+    # get the CPACS configuration, defined by the tigl handle
+    # we need to access the underlying tigl handle (that is used in the C/C++ API)
+    config = mgr.get_configuration(tigl_h._handle.value)
+    display_wing_cell_geom(config)

--- a/examples/python_internal/example_wing_cell_geometry.py
+++ b/examples/python_internal/example_wing_cell_geometry.py
@@ -23,8 +23,8 @@ def display_wing_cell_geom(configuration):
     cs = wing.get_component_segment(1)
     structure = cs.get_structure()
     cell = structure.get_upper_shell().get_cell(1)
-    cell_shape = cell.get_cell_skin_geometry()
-    display.DisplayShape(cell_shape, color=Quantity_NOC_RED, transparency=0.3)
+    cell_shape = cell.get_loft()
+    display.DisplayShape(cell_shape.shape(), color=Quantity_NOC_RED, transparency=0.3)
 
     # display spars and ribs
     spar = structure.get_spar_segment(1)

--- a/examples/python_internal/example_wing_cell_geometry.py
+++ b/examples/python_internal/example_wing_cell_geometry.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from tixi3 import tixi3wrapper
 from tigl3 import tigl3wrapper
 import tigl3.configuration
-from OCC.Quantity import Quantity_NOC_RED, Quantity_NOC_GREEN, Quantity_NOC_BLUE1
+from OCC.Quantity import Quantity_NOC_RED
 import os
 
 
@@ -16,26 +16,15 @@ def display_wing_cell_geom(configuration):
     from OCC.Display.SimpleGui import init_display
     display, start_display, add_menu, add_function_to_menu = init_display()
 
-    wing = configuration.get_wing(1)
+    uid_mgr = configuration.get_uidmanager()
+    wing = uid_mgr.get_geometric_component("Wing")
+    # wing = configuration.get_wing(1)
     display.DisplayShape(wing.get_loft().shape(), transparency=0.7)
 
     # display cell geometry
-    cs = wing.get_component_segment(1)
-    structure = cs.get_structure()
-    cell = structure.get_upper_shell().get_cell(1)
+    cell = uid_mgr.get_geometric_component("Wing_CS_upperShell_Cell1")
     cell_shape = cell.get_loft()
-    display.DisplayShape(cell_shape.shape(), color=Quantity_NOC_RED, transparency=0.3)
-
-    # display spars and ribs
-    spar = structure.get_spar_segment(1)
-    spar_shape = spar.get_spar_geometry()
-    display.DisplayShape(spar_shape, color=Quantity_NOC_GREEN, update=True)
-
-    # draw ribs
-    for i_rib in range(1, structure.get_ribs_definition_count() + 1):
-        rib = structure.get_ribs_definition(i_rib)
-        rib_shape = rib.get_ribs_geometry()
-        display.DisplayShape(rib_shape, color=Quantity_NOC_BLUE1, update=True)
+    display.DisplayShape(cell_shape.shape(), transparency=0.3, color=Quantity_NOC_RED)
 
     display.FitAll()
 

--- a/examples/python_internal/example_wing_cell_geometry.py
+++ b/examples/python_internal/example_wing_cell_geometry.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from tixi3 import tixi3wrapper
 from tigl3 import tigl3wrapper
 import tigl3.configuration
-from OCC.Quantity import Quantity_NOC_RED
 import os
 
 
@@ -15,16 +14,22 @@ def display_wing_cell_geom(configuration):
 
     from OCC.Display.SimpleGui import init_display
     display, start_display, add_menu, add_function_to_menu = init_display()
+    display.Context.SetDeviationCoefficient(0.0001)
 
     uid_mgr = configuration.get_uidmanager()
     wing = uid_mgr.get_geometric_component("Wing")
-    # wing = configuration.get_wing(1)
     display.DisplayShape(wing.get_loft().shape(), transparency=0.7)
 
     # display cell geometry
     cell = uid_mgr.get_geometric_component("Wing_CS_upperShell_Cell1")
-    cell_shape = cell.get_loft()
-    display.DisplayShape(cell_shape.shape(), transparency=0.3, color=Quantity_NOC_RED)
+    display.DisplayShape(cell.get_loft().shape(), transparency=0.3, color="green")
+
+    # display ribs and spar
+    ribs = uid_mgr.get_geometric_component("Wing_CS_RibDef1")
+    display.DisplayShape(ribs.get_loft().shape(),color="blue")
+
+    spar = uid_mgr.get_geometric_component("Wing_CS_spar1")
+    display.DisplayShape(spar.get_loft().shape(),color="blue")
 
     display.FitAll()
 

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -661,10 +661,10 @@ void CCPACSWingCell::BuildSkinGeometry() const
         bool sparTest = false, plainTest = false;
 
         if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-            sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+            sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
         }
         else {
-            plainTest = a1Test.Angle(cutPlaneLE.Axis()) < (90.0 * (M_PI / 180.));
+            plainTest = a1Test.Angle(cutPlaneLE.Axis()) < M_PI_2;
         }
 
         if (plainTest || sparTest) {
@@ -676,10 +676,10 @@ void CCPACSWingCell::BuildSkinGeometry() const
             sparTest  = false;
             plainTest = false;
             if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-                sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+                sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
             }
             else {
-                plainTest = a1Test.Angle(cutPlaneTE.Axis()) < (90.0 * (M_PI / 180.));
+                plainTest = a1Test.Angle(cutPlaneTE.Axis()) < M_PI_2;
             }
 
             if (plainTest || sparTest) {
@@ -687,12 +687,12 @@ void CCPACSWingCell::BuildSkinGeometry() const
                 midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
                 vTest  = gp_Vec(midPnt, pTest);
                 a1Test = gp_Ax1(midPnt, vTest);
-                if (a1Test.Angle(cutPlaneIB.Axis()) < (90.0 * (M_PI / 180.))) {
+                if (a1Test.Angle(cutPlaneIB.Axis()) < M_PI_2) {
                     // create an Ax1 from the outer border plane origin to the midpoint of the current face
                     midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
                     vTest  = gp_Vec(midPnt, pTest);
                     a1Test = gp_Ax1(midPnt, vTest);
-                    if (a1Test.Angle(cutPlaneOB.Axis()) < (90.0 * (M_PI / 180.))) {
+                    if (a1Test.Angle(cutPlaneOB.Axis()) < M_PI_2) {
                         builder.Add(compound, loftFace);
                         notFound = false;
                     }
@@ -761,10 +761,10 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Face f)
     bool sparTest = false, plainTest = false;
 
     if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-        sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+        sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
     }
     else {
-        plainTest = a1Test.Angle(cutPlaneLE.Axis()) < (90.0 * (M_PI / 180.));
+        plainTest = a1Test.Angle(cutPlaneLE.Axis()) < M_PI_2;
     }
 
     if (plainTest || sparTest) {
@@ -776,10 +776,10 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Face f)
         sparTest  = false;
         plainTest = false;
         if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-            sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+            sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
         }
         else {
-            plainTest = a1Test.Angle(cutPlaneTE.Axis()) < (90.0 * (M_PI / 180.));
+            plainTest = a1Test.Angle(cutPlaneTE.Axis()) < M_PI_2;
         }
 
         if (plainTest || sparTest) {
@@ -787,12 +787,12 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Face f)
             midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
             vTest  = gp_Vec(midPnt, pTest);
             a1Test = gp_Ax1(midPnt, vTest);
-            if (a1Test.Angle(cutPlaneIB.Axis()) < (90.0 * (M_PI / 180.))) {
+            if (a1Test.Angle(cutPlaneIB.Axis()) < M_PI_2) {
                 // create an Ax1 from the outer border plane origin to the midpoint of the current face
                 midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
                 vTest  = gp_Vec(midPnt, pTest);
                 a1Test = gp_Ax1(midPnt, vTest);
-                if (a1Test.Angle(cutPlaneOB.Axis()) < (90.0 * (M_PI / 180.))) {
+                if (a1Test.Angle(cutPlaneOB.Axis()) < M_PI_2) {
                     return true;
                 }
             }
@@ -837,10 +837,10 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Edge e)
     bool sparTest = false, plainTest = false;
 
     if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-        sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+        sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
     }
     else {
-        plainTest = a1Test.Angle(cutPlaneLE.Axis()) < (90.0 * (M_PI / 180.));
+        plainTest = a1Test.Angle(cutPlaneLE.Axis()) < M_PI_2;
     }
 
     if (plainTest || sparTest) {
@@ -852,10 +852,10 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Edge e)
         sparTest  = false;
         plainTest = false;
         if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-            sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+            sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
         }
         else {
-            plainTest = a1Test.Angle(cutPlaneTE.Axis()) < (90.0 * (M_PI / 180.));
+            plainTest = a1Test.Angle(cutPlaneTE.Axis()) < M_PI_2;
         }
 
         if (plainTest || sparTest) {
@@ -863,12 +863,12 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Edge e)
             midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
             vTest  = gp_Vec(midPnt, pTest);
             a1Test = gp_Ax1(midPnt, vTest);
-            if (a1Test.Angle(cutPlaneIB.Axis()) < (90.0 * (M_PI / 180.))) {
+            if (a1Test.Angle(cutPlaneIB.Axis()) < M_PI_2) {
                 // create an Ax1 from the outer border plane origin to the midpoint of the current face
                 midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
                 vTest  = gp_Vec(midPnt, pTest);
                 a1Test = gp_Ax1(midPnt, vTest);
-                if (a1Test.Angle(cutPlaneOB.Axis()) < (90.0 * (M_PI / 180.))) {
+                if (a1Test.Angle(cutPlaneOB.Axis()) < M_PI_2) {
                     return true;
                 }
             }

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -56,6 +56,7 @@
 #include "tigletaxsifunctions.h"
 #include "to_string.h"
 #include "tiglcommonfunctions.h"
+#include "CNamedShape.h"
 
 namespace tigl
 {
@@ -876,4 +877,20 @@ bool CCPACSWingCell::IsPartOfCell(TopoDS_Edge e)
 
     return false;
 }
+
+std::string CCPACSWingCell::GetDefaultedUID() const
+{
+    return GetUID();
+}
+
+PNamedShape CCPACSWingCell::GetLoft()
+{
+    return PNamedShape(new CNamedShape(GetCellSkinGeometry(true), GetUID()));
+}
+
+TiglGeometricComponentType CCPACSWingCell::GetComponentType() const
+{
+    return TIGL_COMPONENT_LOGICAL;
+}
+
 } // namespace tigl

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -55,31 +55,31 @@
 #include "CTiglLogging.h"
 #include "tigletaxsifunctions.h"
 #include "to_string.h"
-
+#include "tiglcommonfunctions.h"
 
 namespace tigl
 {
 
 namespace WingCellInternal
 {
-    
+
     // calculates crossproduct (p1-p3)x(p2-p3) (only "z"-value)
     double sign(Point2D p1, Point2D p2, Point2D p3)
     {
-      return (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y);
+        return (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y);
     }
-    
+
     // calculates the area of a triangle
     double area(Point2D p1, Point2D p2, Point2D p3)
     {
         double area = 0.;
-        area += p1.x*(p2.y - p3.y);
-        area += p2.x*(p3.y - p1.y);
-        area += p3.x*(p1.y - p2.y);
-        
-        return fabs(area/2.);
+        area += p1.x * (p2.y - p3.y);
+        area += p2.x * (p3.y - p1.y);
+        area += p3.x * (p1.y - p2.y);
+
+        return fabs(area / 2.);
     }
-    
+
     // checks if point p is in triangle p1-p2-p3
     bool is_in_trian(Point2D p, Point2D p1, Point2D p2, Point2D p3)
     {
@@ -95,34 +95,38 @@ namespace WingCellInternal
 using namespace WingCellInternal;
 
 CCPACSWingCell::CCPACSWingCell(CCPACSWingCells* parentCells, CTiglUIDManager* uidMgr)
-    : generated::CPACSWingCell(parentCells, uidMgr) {
+    : generated::CPACSWingCell(parentCells, uidMgr)
+{
     Reset();
 }
 
-CCPACSWingCell::~CCPACSWingCell() {}
+CCPACSWingCell::~CCPACSWingCell()
+{
+}
 
 void CCPACSWingCell::Invalidate()
 {
-    cache = boost::none;
+    geometryValid = false;
+    cache.valid   = false;
 }
 
 void CCPACSWingCell::Reset()
 {
-    m_uID = "";
-    
-    cache = boost::none;
+    m_uID         = "";
+    geometryValid = false;
+    cache.valid   = false;
 }
 
 bool CCPACSWingCell::IsConvex() const
 {
     Point2D p1, p2, p3, p4;
-    
+
     // calculate for all 4 edges the relative position of eta/xsi
     GetTrailingEdgeInnerPoint(&p1.x, &p1.y);
     GetTrailingEdgeOuterPoint(&p2.x, &p2.y);
-    GetLeadingEdgeOuterPoint (&p3.x, &p3.y);
-    GetLeadingEdgeInnerPoint (&p4.x, &p4.y);
-    
+    GetLeadingEdgeOuterPoint(&p3.x, &p3.y);
+    GetLeadingEdgeInnerPoint(&p4.x, &p4.y);
+
     // trailing edge
     bool s1 = sign(p3, p1, p2) > 0.;
     // outer border
@@ -131,23 +135,24 @@ bool CCPACSWingCell::IsConvex() const
     bool s3 = sign(p1, p3, p4) > 0.;
     // inner border
     bool s4 = sign(p2, p4, p1) > 0.;
-    
+
     return (s1 == s2) && (s2 == s3) && (s3 == s4);
 }
 
 bool CCPACSWingCell::IsInside(double eta, double xsi) const
 {
     Point2D p, p1, p2, p3, p4;
-    p.x = eta; p.y = xsi;
+    p.x = eta;
+    p.y = xsi;
 
     GetTrailingEdgeInnerPoint(&p1.x, &p1.y);
     GetTrailingEdgeOuterPoint(&p2.x, &p2.y);
-    GetLeadingEdgeOuterPoint (&p3.x, &p3.y);
-    GetLeadingEdgeInnerPoint (&p4.x, &p4.y);
-    
+    GetLeadingEdgeOuterPoint(&p3.x, &p3.y);
+    GetLeadingEdgeInnerPoint(&p4.x, &p4.y);
+
     if (IsConvex()) {
         // calculate for all 4 edges the relative position of eta/xsi
-        
+
         // trailing edge
         bool s1 = sign(p, p1, p2) > 0.;
         // outer border
@@ -156,7 +161,7 @@ bool CCPACSWingCell::IsInside(double eta, double xsi) const
         bool s3 = sign(p, p3, p4) > 0.;
         // inner border
         bool s4 = sign(p, p4, p1) > 0.;
-        
+
         // this only works if the quadriangle is convex
         return (s1 == s2) && (s2 == s3) && (s3 == s4);
     }
@@ -166,15 +171,15 @@ bool CCPACSWingCell::IsInside(double eta, double xsi) const
         bool w2 = sign(p1, p2, p3) > 0.;
         bool w3 = sign(p2, p3, p4) > 0.;
         bool w4 = sign(p3, p4, p1) > 0.;
-        
+
         // get main winding, if 3 positive one negative -> 3, else 1
-        int  iwind = (w1 + w2 + w3 + w4);
+        int iwind = (w1 + w2 + w3 + w4);
         if (iwind != 1 && iwind != 3) {
             throw CTiglError("Error in Quadriangle Winding calculation in CCPACSWingCell::IsInside.", TIGL_MATH_ERROR);
         }
-        
+
         bool winding = (iwind == 3);
-        
+
         // determine point with w[i] != winding
         if (w1 != winding || w3 != winding) {
             return is_in_trian(p, p1, p3, p4) || is_in_trian(p, p1, p2, p3);
@@ -188,7 +193,7 @@ bool CCPACSWingCell::IsInside(double eta, double xsi) const
     }
 }
 
-void CCPACSWingCell::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string &cellXPath)
+void CCPACSWingCell::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& cellXPath)
 {
     Reset();
     generated::CPACSWingCell::ReadCPACS(tixiHandle, cellXPath);
@@ -197,65 +202,57 @@ void CCPACSWingCell::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::
 void CCPACSWingCell::GetLeadingEdgeInnerPoint(double* eta, double* xsi) const
 {
     UpdateCache();
-    *eta = cache.value().innerLeadingEdgePoint.eta;
-    *xsi = cache.value().innerLeadingEdgePoint.xsi;
+    *eta = cache.innerLeadingEdgePoint.eta;
+    *xsi = cache.innerLeadingEdgePoint.xsi;
 }
 
 void CCPACSWingCell::GetLeadingEdgeOuterPoint(double* eta, double* xsi) const
 {
     UpdateCache();
-    *eta = cache.value().outerLeadingEdgePoint.eta;
-    *xsi = cache.value().outerLeadingEdgePoint.xsi;
+    *eta = cache.outerLeadingEdgePoint.eta;
+    *xsi = cache.outerLeadingEdgePoint.xsi;
 }
 
 void CCPACSWingCell::GetTrailingEdgeInnerPoint(double* eta, double* xsi) const
 {
     UpdateCache();
-    *eta = cache.value().innerTrailingEdgePoint.eta;
-    *xsi = cache.value().innerTrailingEdgePoint.xsi;
+    *eta = cache.innerTrailingEdgePoint.eta;
+    *xsi = cache.innerTrailingEdgePoint.xsi;
 }
 
 void CCPACSWingCell::GetTrailingEdgeOuterPoint(double* eta, double* xsi) const
 {
     UpdateCache();
-    *eta = cache.value().outerTrailingEdgePoint.eta;
-    *xsi = cache.value().outerTrailingEdgePoint.xsi;
+    *eta = cache.outerTrailingEdgePoint.eta;
+    *xsi = cache.outerTrailingEdgePoint.xsi;
 }
 
-void CCPACSWingCell::SetLeadingEdgeInnerPoint(double eta1, double xsi1)
+void CCPACSWingCell::SetLeadingEdgeInnerPoint(double eta, double xsi)
 {
     UpdateCache();
-    const double eta2 = cache.value().innerTrailingEdgePoint.eta;
-    const double xsi2 = cache.value().outerLeadingEdgePoint.xsi;
-    m_positioningInnerBorder.SetEta(eta1, eta2);
-    m_positioningLeadingEdge.SetXsi(xsi1, xsi2);
+    m_positioningInnerBorder.SetEta(eta, cache.innerTrailingEdgePoint.eta);
+    m_positioningLeadingEdge.SetXsi(xsi, cache.outerLeadingEdgePoint.xsi);
 }
 
-void CCPACSWingCell::SetLeadingEdgeOuterPoint(double eta1, double xsi2)
+void CCPACSWingCell::SetLeadingEdgeOuterPoint(double eta, double xsi)
 {
     UpdateCache();
-    const double eta2 = cache.value().outerTrailingEdgePoint.eta;
-    const double xsi1 = cache.value().innerLeadingEdgePoint.xsi;
-    m_positioningOuterBorder.SetEta(eta1, eta2);
-    m_positioningLeadingEdge.SetXsi(xsi1, xsi2);
+    m_positioningOuterBorder.SetEta(eta, cache.outerTrailingEdgePoint.eta);
+    m_positioningLeadingEdge.SetXsi(cache.innerLeadingEdgePoint.xsi, xsi);
 }
 
-void CCPACSWingCell::SetTrailingEdgeInnerPoint(double eta2, double xsi1)
+void CCPACSWingCell::SetTrailingEdgeInnerPoint(double eta, double xsi)
 {
     UpdateCache();
-    const double eta1 = cache.value().innerLeadingEdgePoint.eta;
-    const double xsi2 = cache.value().outerTrailingEdgePoint.xsi;
-    m_positioningInnerBorder.SetEta(eta1, eta2);
-    m_positioningTrailingEdge.SetXsi(xsi1, xsi2);
+    m_positioningInnerBorder.SetEta(cache.innerLeadingEdgePoint.eta, eta);
+    m_positioningTrailingEdge.SetXsi(xsi, cache.outerTrailingEdgePoint.xsi);
 }
 
-void CCPACSWingCell::SetTrailingEdgeOuterPoint(double eta2, double xsi2)
+void CCPACSWingCell::SetTrailingEdgeOuterPoint(double eta, double xsi)
 {
     UpdateCache();
-    const double eta1 = cache.value().outerLeadingEdgePoint.eta;
-    const double xsi1 = cache.value().innerTrailingEdgePoint.xsi;
-    m_positioningOuterBorder.SetEta(eta1, eta2);
-    m_positioningTrailingEdge.SetXsi(xsi1, xsi2);
+    m_positioningOuterBorder.SetEta(cache.outerLeadingEdgePoint.eta, eta);
+    m_positioningTrailingEdge.SetXsi(cache.innerTrailingEdgePoint.xsi, xsi);
 }
 
 void CCPACSWingCell::SetLeadingEdgeSpar(const std::string& sparUID)
@@ -290,15 +287,14 @@ const CCPACSMaterialDefinition& CCPACSWingCell::GetMaterial() const
 
 void CCPACSWingCell::UpdateCache() const
 {
-    if (!cache) {
+    if (!cache.valid) {
         UpdateEtaXsiValues();
     }
-    assert(cache);
+    assert(cache.valid);
 }
 
-
 std::pair<double, double> CCPACSWingCell::computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos,
-                                                                   const CCPACSWingCellPositionChordwise& chordwisePos, 
+                                                                   const CCPACSWingCellPositionChordwise& chordwisePos,
                                                                    bool inner, bool front) const
 {
     double eta, xsi;
@@ -328,8 +324,8 @@ std::pair<double, double> CCPACSWingCell::computePositioningEtaXsi(const CCPACSW
         }
         // get the spar from the wing structure
         const CCPACSWingCSStructure& structure = m_parent->GetParentElement()->GetStructure();
-        const CCPACSWingSparSegment& spar = structure.GetSparSegment(chordwisePos.GetSparUId());
-        xsi = computeSparXsiValue(structure.GetWingStructureReference(), spar, eta);
+        const CCPACSWingSparSegment& spar      = structure.GetSparSegment(chordwisePos.GetSparUId());
+        xsi                                    = computeSparXsiValue(structure.GetWingStructureReference(), spar, eta);
     }
     else if (spanwisePos.GetInputType() == CCPACSWingCellPositionSpanwise::Rib &&
              chordwisePos.GetInputType() == CCPACSWingCellPositionChordwise::Xsi) {
@@ -337,7 +333,7 @@ std::pair<double, double> CCPACSWingCell::computePositioningEtaXsi(const CCPACSW
         int ribIndex;
         // get the ribs definition from the wing structure reference
         spanwisePos.GetRib(ribUid, ribIndex);
-        const CCPACSWingCSStructure& structure = m_parent->GetParentElement()->GetStructure();
+        const CCPACSWingCSStructure& structure         = m_parent->GetParentElement()->GetStructure();
         const CCPACSWingRibsDefinition& ribsDefinition = structure.GetRibsDefinition(ribUid);
         if (inner) {
             xsi = chordwisePos.GetXsi().first;
@@ -351,8 +347,8 @@ std::pair<double, double> CCPACSWingCell::computePositioningEtaXsi(const CCPACSW
              chordwisePos.GetInputType() == CCPACSWingCellPositionChordwise::Spar) {
         // get the spar from the wing structure reference
         const CCPACSWingCSStructure& structure = m_parent->GetParentElement()->GetStructure();
-        CTiglWingStructureReference wsr = structure.GetWingStructureReference();
-        const CCPACSWingSparSegment& spar = structure.GetSparSegment(chordwisePos.GetSparUId());
+        CTiglWingStructureReference wsr        = structure.GetWingStructureReference();
+        const CCPACSWingSparSegment& spar      = structure.GetSparSegment(chordwisePos.GetSparUId());
         // get the ribs definition from the wing structure reference
         std::string ribUid;
         int ribIndex;
@@ -360,8 +356,8 @@ std::pair<double, double> CCPACSWingCell::computePositioningEtaXsi(const CCPACSW
         const CCPACSWingRibsDefinition& ribsDefinition = structure.GetRibsDefinition(ribUid);
 
         tigl::EtaXsi result = computeRibSparIntersectionEtaXsi(wsr, ribsDefinition, ribIndex, spar);
-        eta = result.eta;
-        xsi = result.xsi;
+        eta                 = result.eta;
+        xsi                 = result.xsi;
     }
 
     return std::make_pair(eta, xsi);
@@ -369,28 +365,515 @@ std::pair<double, double> CCPACSWingCell::computePositioningEtaXsi(const CCPACSW
 
 void CCPACSWingCell::UpdateEtaXsiValues() const
 {
-    cache.emplace();
+    cache.valid = false;
 
-    std::pair<double, double> innerLePoint = computePositioningEtaXsi(m_positioningInnerBorder, m_positioningLeadingEdge, true, true);
-    cache->innerLeadingEdgePoint.eta = innerLePoint.first;
-    cache->innerLeadingEdgePoint.xsi = innerLePoint.second;
+    std::pair<double, double> innerLePoint =
+        computePositioningEtaXsi(m_positioningInnerBorder, m_positioningLeadingEdge, true, true);
+    cache.innerLeadingEdgePoint.eta = innerLePoint.first;
+    cache.innerLeadingEdgePoint.xsi = innerLePoint.second;
 
-    std::pair<double, double> outerLePoint = computePositioningEtaXsi(m_positioningOuterBorder, m_positioningLeadingEdge, false, true);
-    cache->outerLeadingEdgePoint.eta = outerLePoint.first;
-    cache->outerLeadingEdgePoint.xsi = outerLePoint.second;
+    std::pair<double, double> outerLePoint =
+        computePositioningEtaXsi(m_positioningOuterBorder, m_positioningLeadingEdge, false, true);
+    cache.outerLeadingEdgePoint.eta = outerLePoint.first;
+    cache.outerLeadingEdgePoint.xsi = outerLePoint.second;
 
-    std::pair<double, double> innerTePoint = computePositioningEtaXsi(m_positioningInnerBorder, m_positioningTrailingEdge, true, false);
-    cache->innerTrailingEdgePoint.eta = innerTePoint.first;
-    cache->innerTrailingEdgePoint.xsi = innerTePoint.second;
+    std::pair<double, double> innerTePoint =
+        computePositioningEtaXsi(m_positioningInnerBorder, m_positioningTrailingEdge, true, false);
+    cache.innerTrailingEdgePoint.eta = innerTePoint.first;
+    cache.innerTrailingEdgePoint.xsi = innerTePoint.second;
 
-    std::pair<double, double> outerTePoint = computePositioningEtaXsi(m_positioningOuterBorder, m_positioningTrailingEdge, false, false);
-    cache->outerTrailingEdgePoint.eta = outerTePoint.first;
-    cache->outerTrailingEdgePoint.xsi = outerTePoint.second;
+    std::pair<double, double> outerTePoint =
+        computePositioningEtaXsi(m_positioningOuterBorder, m_positioningTrailingEdge, false, false);
+    cache.outerTrailingEdgePoint.eta = outerTePoint.first;
+    cache.outerTrailingEdgePoint.xsi = outerTePoint.second;
+
+    cache.valid = true;
 }
 
 void CCPACSWingCell::Update() const
 {
-    // TODO: update geometry
+    if (geometryValid) {
+        return;
+    }
+
+    BuildSkinGeometry();
+    geometryValid = true;
 }
 
+TopoDS_Shape CCPACSWingCell::GetCellSkinGeometry(bool transform) const
+{
+    Update();
+
+    if (transform) {
+        return m_parent->GetParentElement()
+            ->GetStructure()
+            .GetWingStructureReference()
+            .GetWingComponentSegment()
+            .GetWing()
+            .GetTransformationMatrix()
+            .Transform(cellSkinGeometry);
+    }
+    else {
+        return cellSkinGeometry;
+    }
+}
+
+void CCPACSWingCell::BuildSkinGeometry() const
+{
+    // variable for uv bounds
+    double u_min = 0, u_max = 0, v_min = 0, v_max = 0;
+
+    BRep_Builder builder;
+
+    const CTiglWingStructureReference& wsr = m_parent->GetParentElement()->GetStructure().GetWingStructureReference();
+    gp_Pnt p1                              = wsr.GetLeadingEdgePoint(0);
+    gp_Pnt p2                              = wsr.GetLeadingEdgePoint(1);
+    gp_Vec yRefDir(p1, p2);
+    yRefDir.Normalize();
+
+    // create a reference direction without sweep angle
+    gp_Pnt p2stern = gp_Pnt(p1.X(), p2.Y(), p2.Z());
+    gp_Vec yRefDirStern(p1, p2stern);
+    yRefDirStern.Normalize();
+
+    double sweepAngle = yRefDir.Angle(yRefDirStern);
+
+    if (p2.X() < p1.X()) {
+        sweepAngle = -sweepAngle;
+    }
+
+    gp_Pnt p5 = wsr.GetTrailingEdgePoint(0);
+    gp_Pnt p6 = wsr.GetTrailingEdgePoint(1);
+
+    gp_Vec xRefDir(p1, p5);
+    gp_Vec zRefDir(-yRefDirStern ^ xRefDir);
+    zRefDir.Normalize();
+
+    // Step 8: find the correct part of the loft
+    TopoDS_Shape loftShape;
+    TiglLoftSide side = m_parent->GetParentElement()->GetLoftSide();
+    if (side == UPPER_SIDE) {
+        loftShape = wsr.GetUpperShape();
+    }
+    else {
+        loftShape = wsr.GetLowerShape();
+    }
+
+    // determine diagonal vector of loft bounding box (e.g. used for size of cut faces)
+    Bnd_Box boundingBox;
+    BRepBndLib::Add(wsr.GetUpperShape(), boundingBox);
+    BRepBndLib::Add(wsr.GetLowerShape(), boundingBox);
+    Standard_Real xmin, ymin, zmin, xmax, ymax, zmax;
+    boundingBox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+    gp_Vec diagonal(xmax - xmin, ymax - ymin, zmax - zmin);
+    Standard_Real bboxSize = diagonal.Magnitude();
+
+    if (!cache.valid) {
+        UpdateCache();
+    }
+    assert(cache.valid);
+
+    double LEXsi1, LEXsi2, TEXsi1, TEXsi2;
+    double IBEta1, IBEta2, OBEta1, OBEta2;
+
+    LEXsi1 = cache.innerLeadingEdgePoint.xsi;
+    LEXsi2 = cache.outerLeadingEdgePoint.xsi;
+    TEXsi1 = cache.innerTrailingEdgePoint.xsi;
+    TEXsi2 = cache.outerTrailingEdgePoint.xsi;
+    IBEta1 = cache.innerLeadingEdgePoint.eta;
+    IBEta2 = cache.innerTrailingEdgePoint.eta;
+    OBEta1 = cache.outerLeadingEdgePoint.eta;
+    OBEta2 = cache.outerTrailingEdgePoint.eta;
+
+    pC1 = wsr.GetPoint(IBEta1, LEXsi1, WING_COORDINATE_SYSTEM);
+    pC2 = wsr.GetPoint(OBEta1, LEXsi2, WING_COORDINATE_SYSTEM);
+    pC3 = wsr.GetPoint(IBEta2, TEXsi1, WING_COORDINATE_SYSTEM);
+    pC4 = wsr.GetPoint(OBEta2, TEXsi2, WING_COORDINATE_SYSTEM);
+
+    // project the cornerpoints on the lower or upper surface
+    TopoDS_Shape cutEdge1, cutEdge2, cutEdge3, cutEdge4;
+    // build line along z reference axis for intersection points on loft
+    gp_Vec offset(zRefDir * bboxSize);
+    BRepBuilderAPI_MakeEdge edgeBuilder1(pC1.Translated(-offset), pC1.Translated(offset));
+    cutEdge1 = edgeBuilder1.Edge();
+    BRepBuilderAPI_MakeEdge edgeBuilder2(pC2.Translated(-offset), pC2.Translated(offset));
+    cutEdge2 = edgeBuilder2.Edge();
+    BRepBuilderAPI_MakeEdge edgeBuilder3(pC3.Translated(-offset), pC3.Translated(offset));
+    cutEdge3 = edgeBuilder3.Edge();
+    BRepBuilderAPI_MakeEdge edgeBuilder4(pC4.Translated(-offset), pC4.Translated(offset));
+    cutEdge4 = edgeBuilder4.Edge();
+
+    // find intersection points on loft geometry, use minimum distance for stability
+    BRepExtrema_DistShapeShape ex1(loftShape, cutEdge1, Extrema_ExtFlag_MIN);
+    ex1.Perform();
+    pC1 = ex1.PointOnShape1(1);
+    BRepExtrema_DistShapeShape ex2(loftShape, cutEdge2, Extrema_ExtFlag_MIN);
+    ex2.Perform();
+    pC2 = ex2.PointOnShape1(1);
+    BRepExtrema_DistShapeShape ex3(loftShape, cutEdge3, Extrema_ExtFlag_MIN);
+    ex3.Perform();
+    pC3 = ex3.PointOnShape1(1);
+    BRepExtrema_DistShapeShape ex4(loftShape, cutEdge4, Extrema_ExtFlag_MIN);
+    ex4.Perform();
+    pC4 = ex4.PointOnShape1(1);
+
+    // check the 3d point coordinates
+
+    if (pC1.X() > pC3.X()) {
+        throw CTiglError(
+            "Wrong value for cell input in CCPACSWingShell::BuildStringerGeometry!\nThe X values on the inner border.");
+    }
+    if (pC2.X() > pC4.X()) {
+        throw CTiglError(
+            "Wrong value for cell input in CCPACSWingShell::BuildStringerGeometry!\nThe X values on the outer border.");
+    }
+    if (pC1.Y() > pC2.Y()) {
+        throw CTiglError(
+            "Wrong value for cell input in CCPACSWingShell::BuildStringerGeometry!\nThe Y values on the leading edge.");
+    }
+    if (pC3.Y() > pC4.Y()) {
+        throw CTiglError("Wrong value for cell input in CCPACSWingShell::BuildStringerGeometry!\nThe Y values on the "
+                         "trailing edge.");
+    }
+
+    // combine the cell cutting planes to a compound
+    TopoDS_Compound Planecomp;
+    builder.MakeCompound(Planecomp);
+
+    // build the Leading edge cutting plane
+    gp_Vec vCLE(pC1, pC2);
+    vCLE.Normalize();
+    gp_Pnt midPnt = (pC1.XYZ() + pC2.XYZ()) / 2;
+    gp_Ax3 refAxLE(midPnt, -zRefDir ^ vCLE, vCLE);
+    cutPlaneLE   = gp_Pln(refAxLE);
+    planeShapeLE = BRepBuilderAPI_MakeFace(cutPlaneLE).Face();
+    // build the Trailing edge cutting plane
+    gp_Vec vCTE(pC3, pC4);
+    vCTE.Normalize();
+    midPnt = (pC3.XYZ() + pC4.XYZ()) / 2;
+    gp_Ax3 refAxTE(midPnt, zRefDir ^ vCTE, vCTE);
+    cutPlaneTE   = gp_Pln(refAxTE);
+    planeShapeTE = BRepBuilderAPI_MakeFace(cutPlaneTE).Face();
+
+    // build the inner border cutting plane
+    gp_Vec vCIB(pC1, pC3);
+    vCIB.Normalize();
+    midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
+    gp_Ax3 refAxIB(midPnt, zRefDir ^ vCIB, vCIB);
+    cutPlaneIB   = gp_Pln(refAxIB);
+    planeShapeIB = BRepBuilderAPI_MakeFace(cutPlaneIB).Face();
+
+    // build the Outer border cutting plane
+    gp_Vec vCOB(pC2, pC4);
+    vCOB.Normalize();
+    midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
+    gp_Ax3 refAxOB(midPnt, -zRefDir ^ vCOB, vCOB);
+    cutPlaneOB   = gp_Pln(refAxOB);
+    planeShapeOB = BRepBuilderAPI_MakeFace(cutPlaneOB).Face();
+
+    // If any border is defined by a rib or a spar, the cutting plane is changed
+
+    double u05 = 0.5, u1 = 1., v0 = 0., v1 = 1.;
+
+    if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+        planeShapeLE = GetSparCutGeometry(m_positioningLeadingEdge.GetSparUId());
+        sparShapeLE  = m_parent->GetParentElement()
+                          ->GetStructure()
+                          .GetSpars()
+                          ->GetSparSegments()
+                          .GetSparSegment(m_positioningLeadingEdge.GetSparUId())
+                          .GetSparGeometry(WING_COORDINATE_SYSTEM);
+    }
+
+    if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+        planeShapeTE = GetSparCutGeometry(m_positioningTrailingEdge.GetSparUId());
+        sparShapeTE  = m_parent->GetParentElement()
+                          ->GetStructure()
+                          .GetSpars()
+                          ->GetSparSegments()
+                          .GetSparSegment(m_positioningTrailingEdge.GetSparUId())
+                          .GetSparGeometry(WING_COORDINATE_SYSTEM);
+    }
+
+    if (m_positioningInnerBorder.GetInputType() == CCPACSWingCellPositionSpanwise::InputType::Rib) {
+        planeShapeIB = GetRibCutGeometry(m_positioningInnerBorder.GetRib());
+    }
+    // if the inner border of the cell is the inner border of the Component segment
+    // a cutting plane from the inner border of the WCS is created
+    // this is necessary due to cutting precision
+    else if (IBEta1 == 0. && IBEta2 == 0.) {
+        BRepAdaptor_Surface surf(wsr.GetInnerFace());
+        gp_Pnt p0 = surf.Value(u05, v0);
+        gp_Pnt pU = surf.Value(u05, v1);
+        gp_Pnt pV = surf.Value(u1, v0);
+        gp_Ax3 ax0UV(p0, gp_Vec(p0, pU) ^ gp_Vec(p0, pV), gp_Vec(p0, pU));
+
+        planeShapeIB = BRepBuilderAPI_MakeFace(gp_Pln(ax0UV)).Face();
+    }
+
+    if (m_positioningOuterBorder.GetInputType() == CCPACSWingCellPositionSpanwise::InputType::Rib) {
+        planeShapeOB = GetRibCutGeometry(m_positioningOuterBorder.GetRib());
+    }
+    // if the outer border of the cell is the outer border of the Component segment
+    // a cutting plane from the outer border of the WCS is created
+    // this is necessary due to cutting precision
+    else if (OBEta1 == 1. && OBEta2 == 1.) {
+        BRepAdaptor_Surface surf(wsr.GetOuterFace());
+        gp_Pnt p0 = surf.Value(u05, v0);
+        gp_Pnt pU = surf.Value(u05, v1);
+        gp_Pnt pV = surf.Value(u1, v0);
+        gp_Ax3 ax0UV(p0, gp_Vec(p0, pU) ^ gp_Vec(p0, pV), gp_Vec(p0, pU));
+
+        planeShapeOB = BRepBuilderAPI_MakeFace(gp_Pln(ax0UV)).Face();
+    }
+
+    builder.Add(Planecomp, planeShapeLE);
+    builder.Add(Planecomp, planeShapeTE);
+    builder.Add(Planecomp, planeShapeIB);
+    builder.Add(Planecomp, planeShapeOB);
+
+    // cut the lower or upper loft with the planes
+    TopoDS_Shape result = SplitShape(loftShape, Planecomp);
+    TopTools_IndexedMapOfShape faceMap;
+    TopExp::MapShapes(result, TopAbs_FACE, faceMap);
+
+    TopoDS_Compound compound;
+    builder.MakeCompound(compound);
+
+    bool notFound = true;
+
+    for (int f = 1; f <= faceMap.Extent(); f++) {
+
+        TopoDS_Face loftFace      = TopoDS::Face(faceMap(f));
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(loftFace);
+        BRepTools::UVBounds(loftFace, u_min, u_max, v_min, v_max);
+        gp_Pnt pTest = surf->Value(u_min + ((u_max - u_min) / 2), v_min + ((v_max - v_min) / 2));
+
+        // create each midpoint for the vector basis
+
+        // test if the midplane point is behind the leading edge border plane
+        // create an Ax1 from the Leading edge plane origin to the midpoint of the current face
+        gp_Pnt midPnt = (pC1.XYZ() + pC2.XYZ()) / 2;
+        gp_Vec vTest(midPnt, pTest);
+        gp_Ax1 a1Test(midPnt, vTest);
+
+        bool sparTest = false, plainTest = false;
+
+        if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+            sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+        }
+        else {
+            plainTest = a1Test.Angle(cutPlaneLE.Axis()) < (90.0 * (M_PI / 180.));
+        }
+
+        if (plainTest || sparTest) {
+            // create an Ax1 from the trailing edge plane origin to the midpoint of the current face
+            midPnt = (pC3.XYZ() + pC4.XYZ()) / 2;
+            vTest  = gp_Vec(midPnt, pTest);
+            a1Test = gp_Ax1(midPnt, vTest);
+
+            sparTest  = false;
+            plainTest = false;
+            if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+                sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+            }
+            else {
+                plainTest = a1Test.Angle(cutPlaneTE.Axis()) < (90.0 * (M_PI / 180.));
+            }
+
+            if (plainTest || sparTest) {
+                // create an Ax1 from the inner border plane origin to the midpoint of the current face
+                midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
+                vTest  = gp_Vec(midPnt, pTest);
+                a1Test = gp_Ax1(midPnt, vTest);
+                if (a1Test.Angle(cutPlaneIB.Axis()) < (90.0 * (M_PI / 180.))) {
+                    // create an Ax1 from the outer border plane origin to the midpoint of the current face
+                    midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
+                    vTest  = gp_Vec(midPnt, pTest);
+                    a1Test = gp_Ax1(midPnt, vTest);
+                    if (a1Test.Angle(cutPlaneOB.Axis()) < (90.0 * (M_PI / 180.))) {
+                        builder.Add(compound, loftFace);
+                        notFound = false;
+                    }
+                }
+            }
+        }
+    }
+
+    if (notFound) {
+        throw CTiglError("Can not find a matching edge for cell input CCPACSWingCell::BuildSkinGeometry!");
+    }
+
+    cellSkinGeometry = compound;
+}
+
+TopoDS_Shape CCPACSWingCell::GetSparCutGeometry(const std::string& sparUID) const
+{
+    const CCPACSWingCSStructure& structure   = m_parent->GetParentElement()->GetStructure();
+    const CCPACSWingSparSegment& sparSegment = structure.GetSparSegment(sparUID);
+    return sparSegment.GetSparCutGeometry(WING_COORDINATE_SYSTEM);
+}
+
+TopoDS_Shape CCPACSWingCell::GetRibCutGeometry(std::pair<std::string, int> ribUidAndIndex) const
+{
+    const CCPACSWingCSStructure& structure                   = m_parent->GetParentElement()->GetStructure();
+    const CCPACSWingRibsDefinition& ribsDefinition           = structure.GetRibsDefinition(ribUidAndIndex.first);
+    const CCPACSWingRibsDefinition::CutGeometry& cutGeometry = ribsDefinition.GetRibCutGeometry(ribUidAndIndex.second);
+
+    // obtain plane from rib cut geometry, in case this is already the final face
+    if (cutGeometry.isTargetFace) {
+        BRepAdaptor_Surface surf(cutGeometry.shape);
+        return BRepBuilderAPI_MakeFace(surf.Plane()).Face();
+    }
+    return cutGeometry.shape;
+}
+
+bool CCPACSWingCell::IsPartOfCell(TopoDS_Face f)
+{
+    Update();
+
+    Bnd_Box bBox1, bBox2;
+    BRepBndLib::Add(cellSkinGeometry, bBox1);
+    TopoDS_Face face = TopoDS::Face(m_parent->GetParentElement()
+                                        ->GetStructure()
+                                        .GetWingStructureReference()
+                                        .GetWingComponentSegment()
+                                        .GetWing()
+                                        .GetTransformationMatrix()
+                                        .Inverted()
+                                        .Transform(f));
+    BRepBndLib::Add(face, bBox2);
+
+    if (bBox1.IsOut(bBox2)) {
+        return false;
+    }
+
+    double u_min = 0., u_max = 0., v_min = 0., v_max = 0.;
+    Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
+    BRepTools::UVBounds(face, u_min, u_max, v_min, v_max);
+    gp_Pnt pTest = surf->Value(u_min + ((u_max - u_min) / 2), v_min + ((v_max - v_min) / 2));
+
+    gp_Pnt midPnt = (pC1.XYZ() + pC2.XYZ()) / 2;
+    gp_Vec vTest(midPnt, pTest);
+    gp_Ax1 a1Test(midPnt, vTest);
+
+    bool sparTest = false, plainTest = false;
+
+    if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+        sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+    }
+    else {
+        plainTest = a1Test.Angle(cutPlaneLE.Axis()) < (90.0 * (M_PI / 180.));
+    }
+
+    if (plainTest || sparTest) {
+        // create an Ax1 from the trailing edge plane origin to the midpoint of the current face
+        midPnt = (pC3.XYZ() + pC4.XYZ()) / 2;
+        vTest  = gp_Vec(midPnt, pTest);
+        a1Test = gp_Ax1(midPnt, vTest);
+
+        sparTest  = false;
+        plainTest = false;
+        if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+            sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+        }
+        else {
+            plainTest = a1Test.Angle(cutPlaneTE.Axis()) < (90.0 * (M_PI / 180.));
+        }
+
+        if (plainTest || sparTest) {
+            // create an Ax1 from the inner border plane origin to the midpoint of the current face
+            midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
+            vTest  = gp_Vec(midPnt, pTest);
+            a1Test = gp_Ax1(midPnt, vTest);
+            if (a1Test.Angle(cutPlaneIB.Axis()) < (90.0 * (M_PI / 180.))) {
+                // create an Ax1 from the outer border plane origin to the midpoint of the current face
+                midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
+                vTest  = gp_Vec(midPnt, pTest);
+                a1Test = gp_Ax1(midPnt, vTest);
+                if (a1Test.Angle(cutPlaneOB.Axis()) < (90.0 * (M_PI / 180.))) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+bool CCPACSWingCell::IsPartOfCell(TopoDS_Edge e)
+{
+    Update();
+
+    Bnd_Box bBox1, bBox2;
+    BRepBndLib::Add(cellSkinGeometry, bBox1);
+    TopoDS_Edge edge = TopoDS::Edge(m_parent->GetParentElement()
+                                        ->GetStructure()
+                                        .GetWingStructureReference()
+                                        .GetWingComponentSegment()
+                                        .GetWing()
+                                        .GetTransformationMatrix()
+                                        .Inverted()
+                                        .Transform(e));
+    BRepBndLib::Add(edge, bBox2);
+
+    if (bBox1.IsOut(bBox2)) {
+        return false;
+    }
+
+    double u_min = 0., u_max = 0.;
+
+    BRepAdaptor_Curve curve(edge);
+    u_min = curve.FirstParameter();
+    u_max = curve.LastParameter();
+
+    gp_Pnt pTest = curve.Value(u_min + ((u_max - u_min) / 2));
+
+    gp_Pnt midPnt = (pC1.XYZ() + pC2.XYZ()) / 2;
+    gp_Vec vTest(midPnt, pTest);
+    gp_Ax1 a1Test(midPnt, vTest);
+
+    bool sparTest = false, plainTest = false;
+
+    if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+        sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+    }
+    else {
+        plainTest = a1Test.Angle(cutPlaneLE.Axis()) < (90.0 * (M_PI / 180.));
+    }
+
+    if (plainTest || sparTest) {
+        // create an Ax1 from the trailing edge plane origin to the midpoint of the current face
+        midPnt = (pC3.XYZ() + pC4.XYZ()) / 2;
+        vTest  = gp_Vec(midPnt, pTest);
+        a1Test = gp_Ax1(midPnt, vTest);
+
+        sparTest  = false;
+        plainTest = false;
+        if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
+            sparTest = m_parent->GetParentElement()->SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+        }
+        else {
+            plainTest = a1Test.Angle(cutPlaneTE.Axis()) < (90.0 * (M_PI / 180.));
+        }
+
+        if (plainTest || sparTest) {
+            // create an Ax1 from the inner border plane origin to the midpoint of the current face
+            midPnt = (pC1.XYZ() + pC3.XYZ()) / 2;
+            vTest  = gp_Vec(midPnt, pTest);
+            a1Test = gp_Ax1(midPnt, vTest);
+            if (a1Test.Angle(cutPlaneIB.Axis()) < (90.0 * (M_PI / 180.))) {
+                // create an Ax1 from the outer border plane origin to the midpoint of the current face
+                midPnt = (pC2.XYZ() + pC4.XYZ()) / 2;
+                vTest  = gp_Vec(midPnt, pTest);
+                a1Test = gp_Ax1(midPnt, vTest);
+                if (a1Test.Angle(cutPlaneOB.Axis()) < (90.0 * (M_PI / 180.))) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
 } // namespace tigl

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -408,11 +408,11 @@ void CCPACSWingCell::Update() const
     geometryValid = true;
 }
 
-TopoDS_Shape CCPACSWingCell::GetCellSkinGeometry(bool transform) const
+TopoDS_Shape CCPACSWingCell::GetCellSkinGeometry(TiglCoordinateSystem cs) const
 {
     Update();
 
-    if (transform) {
+    if (cs == GLOBAL_COORDINATE_SYSTEM) {
         return m_parent->GetParentElement()
             ->GetStructure()
             .GetWingStructureReference()
@@ -421,8 +421,11 @@ TopoDS_Shape CCPACSWingCell::GetCellSkinGeometry(bool transform) const
             .GetTransformationMatrix()
             .Transform(cellSkinGeometry);
     }
-    else {
+    else if (cs == WING_COORDINATE_SYSTEM) {
         return cellSkinGeometry;
+    }
+    else {
+        throw CTiglError("Invalid coordinate system passed to CCPACSWingCell::GetCellSkinGeometry");
     }
 }
 
@@ -892,7 +895,7 @@ std::string CCPACSWingCell::GetDefaultedUID() const
 
 PNamedShape CCPACSWingCell::GetLoft()
 {
-    return PNamedShape(new CNamedShape(GetCellSkinGeometry(true), GetUID()));
+    return PNamedShape(new CNamedShape(GetCellSkinGeometry(GLOBAL_COORDINATE_SYSTEM), GetUID()));
 }
 
 TiglGeometricComponentType CCPACSWingCell::GetComponentType() const

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -47,7 +47,6 @@
 #include "CCPACSWingRibsDefinition.h"
 #include "CCPACSWingRibsDefinitions.h"
 #include "CCPACSWingRibsPositioning.h"
-#include "CCPACSWingShell.h"
 #include "CCPACSWingSpars.h"
 #include "CCPACSWingSparSegments.h"
 #include "CCPACSWingSparSegment.h"
@@ -609,6 +608,10 @@ void CCPACSWingCell::BuildSkinGeometry() const
     cutPlaneOB   = gp_Pln(refAxOB);
     planeShapeOB = BRepBuilderAPI_MakeFace(cutPlaneOB).Face();
 
+    if (!m_uidMgr) {
+        throw CTiglError("No uid manager in CCPACSWingCell::BuildSkinGeometry");
+    }
+    
     // If any border is defined by a rib or a spar, the cutting plane is changed
     if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
         planeShapeLE = m_uidMgr->ResolveObject<CCPACSWingSparSegment>(m_positioningLeadingEdge.GetSparUId())
@@ -693,7 +696,7 @@ void CCPACSWingCell::BuildSkinGeometry() const
         bool sparTest = false, plainTest = false;
 
         if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-            sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneLE.Axis(), pTest, sparShapeLE);
+            sparTest = PointIsInfrontSparGeometry(cutPlaneLE.Axis(), pTest, sparShapeLE);
         }
         else {
             plainTest = a1Test.Angle(cutPlaneLE.Axis()) < M_PI_2;
@@ -708,7 +711,7 @@ void CCPACSWingCell::BuildSkinGeometry() const
             sparTest  = false;
             plainTest = false;
             if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-                sparTest = CCPACSWingShell::SparSegmentsTest(cutPlaneTE.Axis(), pTest, sparShapeTE);
+                sparTest = PointIsInfrontSparGeometry(cutPlaneTE.Axis(), pTest, sparShapeTE);
             }
             else {
                 plainTest = a1Test.Angle(cutPlaneTE.Axis()) < M_PI_2;
@@ -787,7 +790,7 @@ bool CCPACSWingCell::IsPartOfCellImpl(T t)
     bool sparTest = false, plainTest = false;
 
     if (m_positioningLeadingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-        sparTest = CCPACSWingShell::SparSegmentsTest(m_geometryCache.value().cutPlaneLE.Axis(), pTest, m_geometryCache.value().sparShapeLE);
+        sparTest = PointIsInfrontSparGeometry(m_geometryCache.value().cutPlaneLE.Axis(), pTest, m_geometryCache.value().sparShapeLE);
     }
     else {
         plainTest = a1Test.Angle(m_geometryCache.value().cutPlaneLE.Axis()) < M_PI_2;
@@ -802,7 +805,7 @@ bool CCPACSWingCell::IsPartOfCellImpl(T t)
         sparTest  = false;
         plainTest = false;
         if (m_positioningTrailingEdge.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar) {
-            sparTest = CCPACSWingShell::SparSegmentsTest(m_geometryCache.value().cutPlaneTE.Axis(), pTest, m_geometryCache.value().sparShapeTE);
+            sparTest = PointIsInfrontSparGeometry(m_geometryCache.value().cutPlaneTE.Axis(), pTest, m_geometryCache.value().sparShapeTE);
         }
         else {
             plainTest = a1Test.Angle(m_geometryCache.value().cutPlaneTE.Axis()) < M_PI_2;

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -104,6 +104,14 @@ namespace WingCellInternal
     {
         return GetCentralFacePoint(face);
     }
+
+    Point2D toPoint2D(EtaXsi etaXsi)
+    {
+        Point2D p;
+        p.x = etaXsi.eta;
+        p.y = etaXsi.xsi;
+        return p;
+    }
 }
 
 using namespace WingCellInternal;
@@ -134,12 +142,11 @@ void CCPACSWingCell::Reset()
 bool CCPACSWingCell::IsConvex() const
 {
     Point2D p1, p2, p3, p4;
-
     // calculate for all 4 edges the relative position of eta/xsi
-    GetTrailingEdgeInnerPoint(&p1.x, &p1.y);
-    GetTrailingEdgeOuterPoint(&p2.x, &p2.y);
-    GetLeadingEdgeOuterPoint(&p3.x, &p3.y);
-    GetLeadingEdgeInnerPoint(&p4.x, &p4.y);
+    p1 = toPoint2D(GetTrailingEdgeInnerPoint());
+    p2 = toPoint2D(GetTrailingEdgeOuterPoint());
+    p3 = toPoint2D(GetLeadingEdgeOuterPoint());
+    p4 = toPoint2D(GetLeadingEdgeInnerPoint());
 
     // trailing edge
     bool s1 = sign(p3, p1, p2) > 0.;
@@ -159,10 +166,10 @@ bool CCPACSWingCell::IsInside(double eta, double xsi) const
     p.x = eta;
     p.y = xsi;
 
-    GetTrailingEdgeInnerPoint(&p1.x, &p1.y);
-    GetTrailingEdgeOuterPoint(&p2.x, &p2.y);
-    GetLeadingEdgeOuterPoint(&p3.x, &p3.y);
-    GetLeadingEdgeInnerPoint(&p4.x, &p4.y);
+    p1 = toPoint2D(GetTrailingEdgeInnerPoint());
+    p2 = toPoint2D(GetTrailingEdgeOuterPoint());
+    p3 = toPoint2D(GetLeadingEdgeOuterPoint());
+    p4 = toPoint2D(GetLeadingEdgeInnerPoint());
 
     if (IsConvex()) {
         // calculate for all 4 edges the relative position of eta/xsi
@@ -213,32 +220,32 @@ void CCPACSWingCell::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::
     generated::CPACSWingCell::ReadCPACS(tixiHandle, cellXPath);
 }
 
-void CCPACSWingCell::GetLeadingEdgeInnerPoint(double* eta, double* xsi) const
+EtaXsi CCPACSWingCell::GetLeadingEdgeInnerPoint() const
 {
     UpdateEtaXsiValues();
-    *eta = m_etaXsiCache.value().innerLeadingEdgePoint.eta;
-    *xsi = m_etaXsiCache.value().innerLeadingEdgePoint.xsi;
+    return EtaXsi(m_etaXsiCache.value().innerLeadingEdgePoint.eta,
+                  m_etaXsiCache.value().innerLeadingEdgePoint.xsi);
 }
 
-void CCPACSWingCell::GetLeadingEdgeOuterPoint(double* eta, double* xsi) const
+EtaXsi CCPACSWingCell::GetLeadingEdgeOuterPoint() const
 {
     UpdateEtaXsiValues();
-    *eta = m_etaXsiCache.value().outerLeadingEdgePoint.eta;
-    *xsi = m_etaXsiCache.value().outerLeadingEdgePoint.xsi;
+    return EtaXsi(m_etaXsiCache.value().outerLeadingEdgePoint.eta,
+                  m_etaXsiCache.value().outerLeadingEdgePoint.xsi);
 }
 
-void CCPACSWingCell::GetTrailingEdgeInnerPoint(double* eta, double* xsi) const
+EtaXsi CCPACSWingCell::GetTrailingEdgeInnerPoint() const
 {
     UpdateEtaXsiValues();
-    *eta = m_etaXsiCache.value().innerTrailingEdgePoint.eta;
-    *xsi = m_etaXsiCache.value().innerTrailingEdgePoint.xsi;
+    return EtaXsi(m_etaXsiCache.value().innerTrailingEdgePoint.eta,
+                  m_etaXsiCache.value().innerTrailingEdgePoint.xsi);
 }
 
-void CCPACSWingCell::GetTrailingEdgeOuterPoint(double* eta, double* xsi) const
+EtaXsi CCPACSWingCell::GetTrailingEdgeOuterPoint() const
 {
     UpdateEtaXsiValues();
-    *eta = m_etaXsiCache.value().outerTrailingEdgePoint.eta;
-    *xsi = m_etaXsiCache.value().outerTrailingEdgePoint.xsi;
+    return EtaXsi(m_etaXsiCache.value().outerTrailingEdgePoint.eta,
+                  m_etaXsiCache.value().outerTrailingEdgePoint.xsi);
 }
 
 void CCPACSWingCell::SetLeadingEdgeInnerPoint(double eta1, double xsi1)

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -19,6 +19,11 @@
 #ifndef CCPACSWINGCELL_H
 #define CCPACSWINGCELL_H
 
+#include "ITiglGeometricComponent.h"
+#include "generated/CPACSWingCell.h"
+#include "generated/UniquePtr.h"
+#include "tigletaxsifunctions.h"
+
 #include <gp_Pln.hxx>
 #include <TopoDS_Shape.hxx>
 #include <TopoDS_Face.hxx>
@@ -26,9 +31,6 @@
 
 #include <vector>
 
-#include "generated/CPACSWingCell.h"
-#include "generated/UniquePtr.h"
-#include "tigletaxsifunctions.h"
 
 namespace tigl
 {
@@ -38,7 +40,7 @@ class CCPACSWingCells;
 class CCPACSWingCellPositionChordwise;
 class CCPACSWingCellPositionSpanwise;
 
-class CCPACSWingCell : public generated::CPACSWingCell
+class CCPACSWingCell : public generated::CPACSWingCell, public ITiglGeometricComponent
 {
 public:
     TIGL_EXPORT CCPACSWingCell(CCPACSWingCells* parentCells, CTiglUIDManager* uidMgr);
@@ -83,6 +85,10 @@ public:
 
     TIGL_EXPORT bool IsPartOfCell(TopoDS_Face);
     TIGL_EXPORT bool IsPartOfCell(TopoDS_Edge);
+
+    TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
+    TIGL_EXPORT PNamedShape GetLoft() OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
 
 private:
     std::pair<double, double> computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos,

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -49,22 +49,22 @@ public:
     // determines if a given eta xsi coordinate is inside this cell
     // TODO: missing support for spar cell borders
     TIGL_EXPORT bool IsInside(double eta, double xsi) const;
-    
+
     // determines if the cell defines a convex qudriangle or not
     // TODO: missing support for spar cell borders
     TIGL_EXPORT bool IsConvex() const;
-    
+
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& cellXPath) OVERRIDE;
 
     // get corner coordinates of cell
-    TIGL_EXPORT void GetLeadingEdgeInnerPoint (double* eta, double* xsi) const;
-    TIGL_EXPORT void GetLeadingEdgeOuterPoint (double* eta, double* xsi) const;
+    TIGL_EXPORT void GetLeadingEdgeInnerPoint(double* eta, double* xsi) const;
+    TIGL_EXPORT void GetLeadingEdgeOuterPoint(double* eta, double* xsi) const;
     TIGL_EXPORT void GetTrailingEdgeInnerPoint(double* eta, double* xsi) const;
     TIGL_EXPORT void GetTrailingEdgeOuterPoint(double* eta, double* xsi) const;
-    
+
     // sets corner coordinates of cell
-    TIGL_EXPORT void SetLeadingEdgeInnerPoint (double eta, double xsi);
-    TIGL_EXPORT void SetLeadingEdgeOuterPoint (double eta, double xsi);
+    TIGL_EXPORT void SetLeadingEdgeInnerPoint(double eta, double xsi);
+    TIGL_EXPORT void SetLeadingEdgeOuterPoint(double eta, double xsi);
     TIGL_EXPORT void SetTrailingEdgeInnerPoint(double eta, double xsi);
     TIGL_EXPORT void SetTrailingEdgeOuterPoint(double eta, double xsi);
 
@@ -79,10 +79,15 @@ public:
 
     TIGL_EXPORT void Update() const;
 
+    TIGL_EXPORT TopoDS_Shape GetCellSkinGeometry(bool transform = true) const;
+
+    TIGL_EXPORT bool IsPartOfCell(TopoDS_Face);
+    TIGL_EXPORT bool IsPartOfCell(TopoDS_Edge);
+
 private:
-    std::pair<double, double> computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos, 
-                                                       const CCPACSWingCellPositionChordwise& chordwisePos, 
-                                                       bool inner, bool front) const;
+    std::pair<double, double> computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos,
+                                                       const CCPACSWingCellPositionChordwise& chordwisePos, bool inner,
+                                                       bool front) const;
 
     // calculates the Eta/Xsi values of the the cell's corner points and stores
     // them in the cache
@@ -93,16 +98,34 @@ private:
 
     void Reset();
 
+    void BuildSkinGeometry() const;
+
+    TopoDS_Shape GetSparCutGeometry(const std::string& sparUID) const;
+
+    TopoDS_Shape GetRibCutGeometry(std::pair<std::string, int> ribUidAndIndex) const;
+
+    // TODO: add Cache struct
+    mutable bool geometryValid;
+    mutable TopoDS_Shape cellSkinGeometry;
+
     struct Cache
     {
+        Cache()
+            : valid(false){};
+        bool valid;
         EtaXsi innerLeadingEdgePoint;
         EtaXsi innerTrailingEdgePoint;
         EtaXsi outerLeadingEdgePoint;
         EtaXsi outerTrailingEdgePoint;
     };
 
-    mutable boost::optional<Cache> cache;
+    mutable Cache cache;
 
+    // TODO: add Cache struct
+    mutable gp_Pln cutPlaneLE, cutPlaneTE, cutPlaneIB, cutPlaneOB;
+    mutable TopoDS_Shape planeShapeLE, planeShapeTE, planeShapeIB, planeShapeOB;
+    mutable TopoDS_Shape sparShapeLE, sparShapeTE;
+    mutable gp_Pnt pC1, pC2, pC3, pC4;
 };
 
 namespace WingCellInternal

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -81,7 +81,7 @@ public:
 
     TIGL_EXPORT void Update() const;
 
-    TIGL_EXPORT TopoDS_Shape GetCellSkinGeometry(bool transform = true) const;
+    TIGL_EXPORT TopoDS_Shape GetCellSkinGeometry(TiglCoordinateSystem cs = GLOBAL_COORDINATE_SYSTEM) const;
 
     TIGL_EXPORT bool IsPartOfCell(TopoDS_Face);
     TIGL_EXPORT bool IsPartOfCell(TopoDS_Edge);

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -116,16 +116,13 @@ private:
 
     struct Cache
     {
-        Cache()
-            : valid(false){};
-        bool valid;
         EtaXsi innerLeadingEdgePoint;
         EtaXsi innerTrailingEdgePoint;
         EtaXsi outerLeadingEdgePoint;
         EtaXsi outerTrailingEdgePoint;
     };
 
-    mutable Cache cache;
+    mutable boost::optional<Cache> cache;
 
     // TODO: add Cache struct
     mutable gp_Pln cutPlaneLE, cutPlaneTE, cutPlaneIB, cutPlaneOB;

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -99,9 +99,6 @@ private:
     // them in the cache
     void UpdateEtaXsiValues() const;
 
-    // helper method which updates the cache in case it is not valid
-    void UpdateCache() const;
-
     void Reset();
 
     void BuildSkinGeometry() const;
@@ -110,11 +107,7 @@ private:
 
     TopoDS_Shape GetRibCutGeometry(std::pair<std::string, int> ribUidAndIndex) const;
 
-    // TODO: add Cache struct
-    mutable bool geometryValid;
-    mutable TopoDS_Shape cellSkinGeometry;
-
-    struct Cache
+    struct EtaXsiCache
     {
         EtaXsi innerLeadingEdgePoint;
         EtaXsi innerTrailingEdgePoint;
@@ -122,13 +115,19 @@ private:
         EtaXsi outerTrailingEdgePoint;
     };
 
-    mutable boost::optional<Cache> cache;
+    mutable boost::optional<EtaXsiCache> m_etaXsiCache;
 
-    // TODO: add Cache struct
-    mutable gp_Pln cutPlaneLE, cutPlaneTE, cutPlaneIB, cutPlaneOB;
-    mutable TopoDS_Shape planeShapeLE, planeShapeTE, planeShapeIB, planeShapeOB;
-    mutable TopoDS_Shape sparShapeLE, sparShapeTE;
-    mutable gp_Pnt pC1, pC2, pC3, pC4;
+    struct GeometryCache
+    {
+        TopoDS_Shape cellSkinGeometry;
+        
+        gp_Pln cutPlaneLE, cutPlaneTE, cutPlaneIB, cutPlaneOB;
+        TopoDS_Shape planeShapeLE, planeShapeTE, planeShapeIB, planeShapeOB;
+        TopoDS_Shape sparShapeLE, sparShapeTE;
+        gp_Pnt pC1, pC2, pC3, pC4;
+    };
+    mutable boost::optional<GeometryCache> m_geometryCache;
+
 };
 
 namespace WingCellInternal

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -91,6 +91,9 @@ public:
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
 
 private:
+    template<class T>
+    bool IsPartOfCellImpl(T t);
+    
     std::pair<double, double> computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos,
                                                        const CCPACSWingCellPositionChordwise& chordwisePos, bool inner,
                                                        bool front) const;

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -59,10 +59,10 @@ public:
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& cellXPath) OVERRIDE;
 
     // get corner coordinates of cell
-    TIGL_EXPORT void GetLeadingEdgeInnerPoint(double* eta, double* xsi) const;
-    TIGL_EXPORT void GetLeadingEdgeOuterPoint(double* eta, double* xsi) const;
-    TIGL_EXPORT void GetTrailingEdgeInnerPoint(double* eta, double* xsi) const;
-    TIGL_EXPORT void GetTrailingEdgeOuterPoint(double* eta, double* xsi) const;
+    TIGL_EXPORT EtaXsi GetLeadingEdgeInnerPoint() const;
+    TIGL_EXPORT EtaXsi GetLeadingEdgeOuterPoint() const;
+    TIGL_EXPORT EtaXsi GetTrailingEdgeInnerPoint() const;
+    TIGL_EXPORT EtaXsi GetTrailingEdgeOuterPoint() const;
 
     // sets corner coordinates of cell
     TIGL_EXPORT void SetLeadingEdgeInnerPoint(double eta, double xsi);

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -94,9 +94,9 @@ private:
     template<class T>
     bool IsPartOfCellImpl(T t);
     
-    std::pair<double, double> computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos,
-                                                       const CCPACSWingCellPositionChordwise& chordwisePos, bool inner,
-                                                       bool front) const;
+    EtaXsi computePositioningEtaXsi(const CCPACSWingCellPositionSpanwise& spanwisePos,
+                                    const CCPACSWingCellPositionChordwise& chordwisePos, bool inner,
+                                    bool front) const;
 
     // calculates the Eta/Xsi values of the the cell's corner points and stores
     // them in the cache
@@ -105,8 +105,6 @@ private:
     void Reset();
 
     void BuildSkinGeometry() const;
-
-    TopoDS_Shape GetSparCutGeometry(const std::string& sparUID) const;
 
     TopoDS_Shape GetRibCutGeometry(std::pair<std::string, int> ribUidAndIndex) const;
 

--- a/src/wing/CCPACSWingShell.cpp
+++ b/src/wing/CCPACSWingShell.cpp
@@ -22,6 +22,15 @@
 #include "CTiglError.h"
 #include "CCPACSWingCell.h"
 
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <ShapeAnalysis_Surface.hxx>
+#include <GeomLProp_SLProps.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepTools.hxx>
+
 
 namespace tigl
 {
@@ -97,6 +106,88 @@ TiglLoftSide CCPACSWingShell::GetLoftSide() const
     if (&GetParent()->GetUpperShell() == this)
         return UPPER_SIDE;
     throw CTiglError("Cannot determine loft side, this shell is neither lower nor upper shell of parent");
+}
+
+bool CCPACSWingShell::SparSegmentsTest(gp_Ax1 nNormal, gp_Pnt nTestPoint, TopoDS_Shape nSparSegments) const
+{
+    TopTools_IndexedMapOfShape faceMap;
+    TopExp::MapShapes(nSparSegments, TopAbs_FACE, faceMap);
+    double u_min = 0., u_max = 0., v_min = 0., v_max = 0.;
+
+    // for symmetry
+    nTestPoint.SetY(fabs(nTestPoint.Y()));
+
+    CTiglWingStructureReference wingStructureReference = m_parent->GetWingStructureReference();
+    for (int f = 1; f <= faceMap.Extent(); f++) {
+        TopoDS_Face loftFace = TopoDS::Face(faceMap(f));
+        BRepAdaptor_Surface surf(loftFace);
+        Handle(Geom_Surface) geomSurf = BRep_Tool::Surface(loftFace);
+
+        BRepTools::UVBounds(TopoDS::Face(faceMap(f)), u_min, u_max, v_min, v_max);
+        gp_Pnt midPnt = surf.Value(u_min + ((u_max - u_min) / 2), v_min + ((v_max - v_min) / 2));
+
+        gp_Pnt startPnt = surf.Value(u_min, v_min + ((v_max - v_min) / 2));
+        gp_Pnt endPnt   = surf.Value(u_max, v_min + ((v_max - v_min) / 2));
+
+        // if the U / V direction of the spar plane is changed
+
+        gp_Ax1 a1Test0   = gp_Ax1(startPnt, gp_Vec(startPnt, endPnt));
+        gp_Ax1 a1TestZ   = gp_Ax1(startPnt, gp_Vec(gp_Pnt(0., 0., 0.), gp_Pnt(0., 0., 1.)));
+        gp_Ax1 a1Test_mZ = gp_Ax1(startPnt, gp_Vec(gp_Pnt(0., 0., 0.), gp_Pnt(0., 0., -1.)));
+
+        if (a1Test0.Angle(a1TestZ) < (20.0 * (M_PI / 180.))) {
+            startPnt = surf.Value(u_min + ((u_max - u_min) / 2), v_min);
+            endPnt   = surf.Value(u_min + ((u_max - u_min) / 2), v_max);
+        }
+        else if (a1Test0.Angle(a1Test_mZ) < (20.0 * (M_PI / 180.))) {
+            startPnt = surf.Value(u_min + ((u_max - u_min) / 2), v_min);
+            endPnt   = surf.Value(u_min + ((u_max - u_min) / 2), v_max);
+        }
+
+        // Here it is checked if the stringer is in the Y area of the corresponding spar face
+
+        if (endPnt.Y() > startPnt.Y()) {
+            if (startPnt.Y() > nTestPoint.Y() || endPnt.Y() < nTestPoint.Y()) {
+                continue;
+            }
+        }
+        else {
+            if (startPnt.Y() < fabs(nTestPoint.Y()) || endPnt.Y() > fabs(nTestPoint.Y())) {
+                continue;
+            }
+        }
+
+        // project test point onto the surface
+        Handle(ShapeAnalysis_Surface) SA_surf = new ShapeAnalysis_Surface(geomSurf);
+        gp_Pnt2d uv                           = SA_surf->ValueOfUV(nTestPoint, 0.0);
+        gp_Pnt pTestProj                      = surf.Value(uv.X(), uv.Y());
+
+        GeomLProp_SLProps prop(geomSurf, uv.X(), uv.Y(), 1, 0.01);
+        gp_Dir normal = prop.Normal();
+
+        gp_Ax1 planeNormal(pTestProj, normal);
+
+        if (nNormal.Angle(planeNormal) > (90.0 * (M_PI / 180.))) {
+            planeNormal = planeNormal.Reversed();
+        }
+
+        gp_Vec vTest = gp_Vec(pTestProj, nTestPoint);
+
+        if (vTest.Magnitude() == 0.) {
+            continue;
+        }
+
+        gp_Ax1 a1Test = gp_Ax1(pTestProj, vTest);
+
+        if (a1Test.Angle(planeNormal) < (89.0 * (M_PI / 180.))) {
+            return true;
+        }
+        else {
+            continue;
+        }
+    }
+
+    return false;
 }
 
 } // namespace tigl

--- a/src/wing/CCPACSWingShell.cpp
+++ b/src/wing/CCPACSWingShell.cpp
@@ -23,15 +23,6 @@
 #include "CCPACSWingCell.h"
 #include "tiglcommonfunctions.h"
 
-#include <TopTools_IndexedMapOfShape.hxx>
-#include <TopExp.hxx>
-#include <TopoDS.hxx>
-#include <BRepAdaptor_Surface.hxx>
-#include <ShapeAnalysis_Surface.hxx>
-#include <GeomLProp_SLProps.hxx>
-#include <BRep_Tool.hxx>
-#include <BRepTools.hxx>
-
 
 namespace tigl
 {
@@ -107,81 +98,6 @@ TiglLoftSide CCPACSWingShell::GetLoftSide() const
     if (&GetParent()->GetUpperShell() == this)
         return UPPER_SIDE;
     throw CTiglError("Cannot determine loft side, this shell is neither lower nor upper shell of parent");
-}
-
-bool CCPACSWingShell::SparSegmentsTest(gp_Ax1 nNormal, gp_Pnt nTestPoint, TopoDS_Shape nSparSegments)
-{
-    TopTools_IndexedMapOfShape faceMap;
-    TopExp::MapShapes(nSparSegments, TopAbs_FACE, faceMap);
-    double u_min = 0., u_max = 0., v_min = 0., v_max = 0.;
-
-    // for symmetry
-    nTestPoint.SetY(fabs(nTestPoint.Y()));
-
-    for (int f = 1; f <= faceMap.Extent(); f++) {
-        TopoDS_Face loftFace = TopoDS::Face(faceMap(f));
-        BRepAdaptor_Surface surf(loftFace);
-        Handle(Geom_Surface) geomSurf = BRep_Tool::Surface(loftFace);
-
-        BRepTools::UVBounds(TopoDS::Face(faceMap(f)), u_min, u_max, v_min, v_max);
-
-        gp_Pnt startPnt = surf.Value(u_min, v_min + ((v_max - v_min) / 2));
-        gp_Pnt endPnt   = surf.Value(u_max, v_min + ((v_max - v_min) / 2));
-
-        // if the U / V direction of the spar plane is changed
-        gp_Ax1 a1Test0   = gp_Ax1(startPnt, gp_Vec(startPnt, endPnt));
-        gp_Ax1 a1TestZ   = gp_Ax1(startPnt, gp_Vec(gp_Pnt(0., 0., 0.), gp_Pnt(0., 0., 1.)));
-        gp_Ax1 a1Test_mZ = gp_Ax1(startPnt, gp_Vec(gp_Pnt(0., 0., 0.), gp_Pnt(0., 0., -1.)));
-
-        if (a1Test0.Angle(a1TestZ) < Radians(20.0) || a1Test0.Angle(a1Test_mZ) < Radians(20.0)) {
-            startPnt = surf.Value(u_min + ((u_max - u_min) / 2), v_min);
-            endPnt   = surf.Value(u_min + ((u_max - u_min) / 2), v_max);
-        }
-
-        // Here it is checked if the stringer is in the Y area of the corresponding spar face
-
-        if (endPnt.Y() > startPnt.Y()) {
-            if (startPnt.Y() > nTestPoint.Y() || endPnt.Y() < nTestPoint.Y()) {
-                continue;
-            }
-        }
-        else {
-            if (startPnt.Y() < fabs(nTestPoint.Y()) || endPnt.Y() > fabs(nTestPoint.Y())) {
-                continue;
-            }
-        }
-
-        // project test point onto the surface
-        Handle(ShapeAnalysis_Surface) SA_surf = new ShapeAnalysis_Surface(geomSurf);
-        gp_Pnt2d uv                           = SA_surf->ValueOfUV(nTestPoint, 0.0);
-        gp_Pnt pTestProj                      = surf.Value(uv.X(), uv.Y());
-
-        GeomLProp_SLProps prop(geomSurf, uv.X(), uv.Y(), 1, 0.01);
-        gp_Dir normal = prop.Normal();
-
-        gp_Ax1 planeNormal(pTestProj, normal);
-
-        if (nNormal.Angle(planeNormal) > Radians(90.0)) {
-            planeNormal = planeNormal.Reversed();
-        }
-
-        gp_Vec vTest = gp_Vec(pTestProj, nTestPoint);
-
-        if (vTest.Magnitude() == 0.) {
-            continue;
-        }
-
-        gp_Ax1 a1Test = gp_Ax1(pTestProj, vTest);
-
-        if (a1Test.Angle(planeNormal) < Radians(89.0)) {
-            return true;
-        }
-        else {
-            continue;
-        }
-    }
-
-    return false;
 }
 
 } // namespace tigl

--- a/src/wing/CCPACSWingShell.h
+++ b/src/wing/CCPACSWingShell.h
@@ -27,6 +27,7 @@
 #include "tigl.h"
 
 #include <gp_Vec.hxx>
+#include <TopoDS_Shape.hxx>
 
 #include <string>
 
@@ -60,6 +61,8 @@ public:
 
     TIGL_EXPORT TiglLoftSide GetLoftSide() const;
 
+    // TODO: Description of this method! Can this be put outside of the class?
+    TIGL_EXPORT bool SparSegmentsTest(gp_Ax1 nNormal, gp_Pnt nTestPoint, TopoDS_Shape nSparSegments) const;
 private:
     //@todo stringers
 

--- a/src/wing/CCPACSWingShell.h
+++ b/src/wing/CCPACSWingShell.h
@@ -61,8 +61,12 @@ public:
 
     TIGL_EXPORT TiglLoftSide GetLoftSide() const;
 
-    // TODO: Description of this method! Can this be put outside of the class?
-    TIGL_EXPORT bool SparSegmentsTest(gp_Ax1 nNormal, gp_Pnt nTestPoint, TopoDS_Shape nSparSegments) const;
+    /** 
+     * Tests whether the test point is in front of the spar segment geometry or behind.
+     * 
+     * The reference axis is given in nNormal.
+     */
+    TIGL_EXPORT static bool SparSegmentsTest(gp_Ax1 nNormal, gp_Pnt nTestPoint, TopoDS_Shape nSparSegments);
 private:
     //@todo stringers
 

--- a/src/wing/CCPACSWingShell.h
+++ b/src/wing/CCPACSWingShell.h
@@ -60,13 +60,6 @@ public:
     TIGL_EXPORT void Update() const;
 
     TIGL_EXPORT TiglLoftSide GetLoftSide() const;
-
-    /** 
-     * Tests whether the test point is in front of the spar segment geometry or behind.
-     * 
-     * The reference axis is given in nNormal.
-     */
-    TIGL_EXPORT static bool SparSegmentsTest(gp_Ax1 nNormal, gp_Pnt nTestPoint, TopoDS_Shape nSparSegments);
 private:
     //@todo stringers
 

--- a/src/wing/CCPACSWingSparSegment.h
+++ b/src/wing/CCPACSWingSparSegment.h
@@ -135,6 +135,13 @@ private:
     mutable boost::optional<SparCapsCache> sparCapsCache;
 };
 
+/** 
+ * Tests whether the test point is in front of the spar segment geometry or behind.
+ * 
+ * The reference axis is given in normal.
+ */
+TIGL_EXPORT bool PointIsInfrontSparGeometry(gp_Ax1 normal, gp_Pnt point, TopoDS_Shape sparGeometry);
+
 } // end namespace tigl
 
 #endif // CCPACSWINGSPARSEGMENT_H

--- a/tests/unittests/tiglWingCell.cpp
+++ b/tests/unittests/tiglWingCell.cpp
@@ -27,6 +27,8 @@
 #include "CCPACSWingRibsPositioning.h"
 #include "CCPACSWingSegment.h"
 
+#include <BRepTools.hxx>
+
 using namespace tigl;
 
 typedef std::pair<double, double> DP;
@@ -274,4 +276,23 @@ TEST_F(WingCellRibSpar, etaXsi) {
     expectedEtaXsi = std::vector< std::pair<double, double> > (arr3, arr3 + sizeof(arr3) / sizeof(arr3[0]));
     // precision at 1E-2 since expected values are estimated based on geometric inspection
     checkCellEtaXsis(cell, expectedEtaXsi, 1.E-2);
+}
+
+TEST_F(WingCellRibSpar, computeGeometry) {
+    // See: cell_rib_spar_test.png for placement of cells
+
+    // next compute the expected XSI values on the spar
+    const std::pair<double, double> arr[] = { DP(0.2, 0.3), DP(0.95, 0.4), DP(0.2, 0.8), DP(0.95, 1.0) };
+    std::vector< std::pair<double, double> > expectedEtaXsi (arr, arr + sizeof(arr) / sizeof(arr[0]));
+
+    // get Component Segment
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+    tigl::CCPACSWingComponentSegment& componentSegment = static_cast<tigl::CCPACSWingComponentSegment&>(wing.GetComponentSegment(1));
+    tigl::CCPACSWingCSStructure& structure = *componentSegment.GetStructure();
+
+    tigl::CCPACSWingCell& cell = componentSegment.GetStructure()->GetUpperShell().GetCell(1);
+    TopoDS_Shape cellGeom = cell.GetCellSkinGeometry();
+    BRepTools::Write(cellGeom, "TestData/export/WingCellRibSpar_CellGeometry.brep");
 }

--- a/tests/unittests/tiglWingCell.cpp
+++ b/tests/unittests/tiglWingCell.cpp
@@ -216,33 +216,32 @@ TEST_F(WingCellSpar, sparCellXsi) {
         double xsi2Exp = it->second;
 
         tigl::CCPACSWingCell& cell = componentSegment.GetStructure()->GetUpperShell().GetCell(cellIndex++);
-        double xsi1, xsi2, dummy;
-        cell.GetLeadingEdgeInnerPoint(&dummy, &xsi1);
-        cell.GetLeadingEdgeOuterPoint(&dummy, &xsi2);
-        ASSERT_NEAR(xsi1, xsi1Exp, 1e-7);
-        ASSERT_NEAR(xsi2, xsi2Exp, 1e-7);
+        tigl::EtaXsi etaxsi1 = cell.GetLeadingEdgeInnerPoint();
+        tigl::EtaXsi etaxsi2 = cell.GetLeadingEdgeOuterPoint();
+        ASSERT_NEAR(etaxsi1.xsi, xsi1Exp, 1e-7);
+        ASSERT_NEAR(etaxsi2.xsi, xsi2Exp, 1e-7);
     }
 }
 
 namespace {
     void checkCellEtaXsis(const tigl::CCPACSWingCell& cell, const std::vector< std::pair<double, double> >& expectedEtaXsi, double precision = 1e-7) {
-        double eta, xsi;
-        int etaXsiIndex = 0;
-        cell.GetLeadingEdgeInnerPoint(&eta, &xsi);
-        ASSERT_NEAR(eta, expectedEtaXsi[etaXsiIndex].first, precision);
-        ASSERT_NEAR(xsi, expectedEtaXsi[etaXsiIndex].second, precision);
+        tigl::EtaXsi etaxsi;
+        unsigned int etaXsiIndex = 0;
+        etaxsi = cell.GetLeadingEdgeInnerPoint();
+        ASSERT_NEAR(etaxsi.eta, expectedEtaXsi[etaXsiIndex].first, precision);
+        ASSERT_NEAR(etaxsi.xsi, expectedEtaXsi[etaXsiIndex].second, precision);
         ++etaXsiIndex;
-        cell.GetLeadingEdgeOuterPoint(&eta, &xsi);
-        ASSERT_NEAR(eta, expectedEtaXsi[etaXsiIndex].first, precision);
-        ASSERT_NEAR(xsi, expectedEtaXsi[etaXsiIndex].second, precision);
+        etaxsi = cell.GetLeadingEdgeOuterPoint();
+        ASSERT_NEAR(etaxsi.eta, expectedEtaXsi[etaXsiIndex].first, precision);
+        ASSERT_NEAR(etaxsi.xsi, expectedEtaXsi[etaXsiIndex].second, precision);
         ++etaXsiIndex;
-        cell.GetTrailingEdgeInnerPoint(&eta, &xsi);
-        ASSERT_NEAR(eta, expectedEtaXsi[etaXsiIndex].first, precision);
-        ASSERT_NEAR(xsi, expectedEtaXsi[etaXsiIndex].second, precision);
+        etaxsi = cell.GetTrailingEdgeInnerPoint();
+        ASSERT_NEAR(etaxsi.eta, expectedEtaXsi[etaXsiIndex].first, precision);
+        ASSERT_NEAR(etaxsi.xsi, expectedEtaXsi[etaXsiIndex].second, precision);
         ++etaXsiIndex;
-        cell.GetTrailingEdgeOuterPoint(&eta, &xsi);
-        ASSERT_NEAR(eta, expectedEtaXsi[etaXsiIndex].first, precision);
-        ASSERT_NEAR(xsi, expectedEtaXsi[etaXsiIndex].second, precision);
+        etaxsi = cell.GetTrailingEdgeOuterPoint();
+        ASSERT_NEAR(etaxsi.eta, expectedEtaXsi[etaXsiIndex].first, precision);
+        ASSERT_NEAR(etaxsi.xsi, expectedEtaXsi[etaXsiIndex].second, precision);
     }
 }
 


### PR DESCRIPTION
I integrated the cell geometry from airbus.

The following changes to the original code have been made:
 - Adaptations, since CPACSWingCell::m_skin is not optional in our code
 - Made the cell a geometric component
 - Integrated into the Python wrapper
 - Added Python example

@bernhardmgruber , @rmaierl  Can you please commit a description of CCPACSWingShell::SparSegmentsTest? I don't know what this function is for. Is it possible, to extract this method into a separate function?

Closes #448 