### PR TITLE
Implemented GetUpperShape(), GetLowerShape() and GetTrailingEdgeShape() using face traits

### DIFF
--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1586,4 +1586,24 @@ TopoDS_Shape TransformedShape(const tigl::CTiglRelativelyPositionedComponent& co
     return TransformedShape(component.GetTransformationMatrix(), cs, shape);
 }
 
-
+TopoDS_Shape GetFacesByName(const PNamedShape shape, const std::string &name)
+{
+    std::vector<TopoDS_Face> faces;
+    for (int i = 0; i < static_cast<int>(shape->GetFaceCount()); i++) {
+        if (shape->GetFaceTraits(i).Name() == name) {
+            faces.push_back(GetFace(shape->Shape(), i));
+        }
+    }
+    
+    if (faces.empty())
+        throw tigl::CTiglError("Could not find faces named " + name);
+    if (faces.size() == 1)
+        return faces[0];
+    
+    TopoDS_Compound c;
+    TopoDS_Builder b;
+    b.MakeCompound(c);
+    for (std::size_t i = 0; i < faces.size(); i++)
+        b.Add(c, faces[i]);
+    return c;
+}

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -118,6 +118,8 @@ TIGL_EXPORT gp_Pnt GetCentralFacePoint(const class TopoDS_Face& face);
 // Maps all compounds with its name in the map
 TIGL_EXPORT ListPNamedShape GroupFaces(const PNamedShape shape, tigl::ShapeGroupMode groupType);
 
+TIGL_EXPORT TopoDS_Shape GetFacesByName(const PNamedShape shape, const std::string& name);
+
 // Returns the coordinates of the bounding box of the shape
 TIGL_EXPORT void GetShapeExtension(const TopoDS_Shape& shape,
                                    double& minx, double& maxx,

--- a/src/configuration/CTiglShapeGeomComponentAdaptor.h
+++ b/src/configuration/CTiglShapeGeomComponentAdaptor.h
@@ -54,10 +54,10 @@ public:
     void SetUID(const std::string &uid)
     {
         unregisterShape();
+        m_uid = uid;
         if (!m_uid.empty() && m_uidMgr) {
             m_uidMgr->RegisterObject(m_uid, *this);
         }
-        m_uid = uid;
     }
 
 

--- a/src/geometry/CNamedShape.cpp
+++ b/src/geometry/CNamedShape.cpp
@@ -24,6 +24,8 @@
 #include <TopExp.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
 
+#include "tiglcommonfunctions.h"
+
 CNamedShape::CNamedShape()
 {
     Clear();
@@ -133,6 +135,28 @@ const CFaceTraits& CNamedShape::GetFaceTraits(int iFace) const
 CFaceTraits& CNamedShape::FaceTraits(int iFace)
 {
     return  _myfaceTraits.at(iFace);
+}
+
+TopoDS_Shape CNamedShape::GetFacesByName(const std::string& name) const
+{
+    std::vector<TopoDS_Face> faces;
+    for (unsigned int i = 0; i < GetFaceCount(); i++) {
+        if (GetFaceTraits(i).Name() == name) {
+            faces.push_back(GetFace(Shape(), i));
+        }
+    }
+
+    if (faces.empty())
+        throw tigl::CTiglError("Could not find faces named " + name);
+    if (faces.size() == 1)
+        return faces[0];
+
+    TopoDS_Compound c;
+    TopoDS_Builder b;
+    b.MakeCompound(c);
+    for (std::size_t i = 0; i < faces.size(); i++)
+        b.Add(c, faces[i]);
+    return c;
 }
 
 void CNamedShape::SetFaceTraits(int iFace, const CFaceTraits &traits)

--- a/src/geometry/CNamedShape.cpp
+++ b/src/geometry/CNamedShape.cpp
@@ -137,28 +137,6 @@ CFaceTraits& CNamedShape::FaceTraits(int iFace)
     return  _myfaceTraits.at(iFace);
 }
 
-TopoDS_Shape CNamedShape::GetFacesByName(const std::string& name) const
-{
-    std::vector<TopoDS_Face> faces;
-    for (unsigned int i = 0; i < GetFaceCount(); i++) {
-        if (GetFaceTraits(i).Name() == name) {
-            faces.push_back(GetFace(Shape(), i));
-        }
-    }
-
-    if (faces.empty())
-        throw tigl::CTiglError("Could not find faces named " + name);
-    if (faces.size() == 1)
-        return faces[0];
-
-    TopoDS_Compound c;
-    TopoDS_Builder b;
-    b.MakeCompound(c);
-    for (std::size_t i = 0; i < faces.size(); i++)
-        b.Add(c, faces[i]);
-    return c;
-}
-
 void CNamedShape::SetFaceTraits(int iFace, const CFaceTraits &traits)
 {
     _myfaceTraits.at(iFace) = traits;

--- a/src/geometry/CNamedShape.h
+++ b/src/geometry/CNamedShape.h
@@ -93,9 +93,6 @@ public:
     TIGL_EXPORT const CFaceTraits& GetFaceTraits(int iFace) const;
     TIGL_EXPORT CFaceTraits& FaceTraits(int iFace);
 
-    // returns the subface or a compound of faces with the specified name, throws if no face could be found
-    TIGL_EXPORT TopoDS_Shape GetFacesByName(const std::string& name) const;
-    
     // setters
     TIGL_EXPORT void SetShape(const TopoDS_Shape&);
     TIGL_EXPORT void SetName(const std::string&);

--- a/src/geometry/CNamedShape.h
+++ b/src/geometry/CNamedShape.h
@@ -92,6 +92,9 @@ public:
     TIGL_EXPORT unsigned int GetFaceCount() const;
     TIGL_EXPORT const CFaceTraits& GetFaceTraits(int iFace) const;
     TIGL_EXPORT CFaceTraits& FaceTraits(int iFace);
+
+    // returns the subface or a compound of faces with the specified name, throws if no face could be found
+    TIGL_EXPORT TopoDS_Shape GetFacesByName(const std::string& name) const;
     
     // setters
     TIGL_EXPORT void SetShape(const TopoDS_Shape&);

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -762,8 +762,8 @@ PNamedShape CCPACSWingComponentSegment::BuildLoft()
         debug.addShape(lowerSegmentShape, "lowerSegmentShape" + std::to_string(i));
         upperShellSewing.Add(upperSegmentShape);
         lowerShellSewing.Add(lowerSegmentShape);
-        sewing.Add(upperSegmentShape);
         sewing.Add(lowerSegmentShape);
+        sewing.Add(upperSegmentShape);
         i++;
     }
 

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -43,6 +43,7 @@
 #include "CTiglWingChordface.h"
 #include "CTiglShapeGeomComponentAdaptor.h"
 #include "CNamedShape.h"
+#include "Debugging.h"
 
 #include "BRepOffsetAPI_ThruSections.hxx"
 #include "TopoDS_Edge.hxx"
@@ -740,6 +741,7 @@ std::string CCPACSWingComponentSegment::GetShortShapeName()
 PNamedShape CCPACSWingComponentSegment::BuildLoft()
 {
     loft.reset();
+    DEBUG_SCOPE(debug);
 
     // use sewing for full loft
     BRepBuilderAPI_Sewing sewing;
@@ -751,14 +753,18 @@ PNamedShape CCPACSWingComponentSegment::BuildLoft()
         throw CTiglError("Could not find segments in CCPACSWingComponentSegment::BuildLoft", TIGL_ERROR);
     }
 
+    int i = 0;
     for (SegmentList::const_iterator it = segments.begin(); it != segments.end(); ++it) {
         CCPACSWingSegment& segment = **it;
-        TopoDS_Face lowerSegmentFace = GetSingleFace(segment.GetLowerShape(WING_COORDINATE_SYSTEM));
-        TopoDS_Face upperSegmentFace = GetSingleFace(segment.GetUpperShape(WING_COORDINATE_SYSTEM));
-        upperShellSewing.Add(upperSegmentFace);
-        lowerShellSewing.Add(lowerSegmentFace);
-        sewing.Add(lowerSegmentFace);
-        sewing.Add(upperSegmentFace);
+        TopoDS_Shape upperSegmentShape = segment.GetUpperShape(WING_COORDINATE_SYSTEM);
+        TopoDS_Shape lowerSegmentShape = segment.GetLowerShape(WING_COORDINATE_SYSTEM);
+        debug.addShape(upperSegmentShape, "upperSegmentShape" + std::to_string(i));
+        debug.addShape(lowerSegmentShape, "lowerSegmentShape" + std::to_string(i));
+        upperShellSewing.Add(upperSegmentShape);
+        lowerShellSewing.Add(lowerSegmentShape);
+        sewing.Add(upperSegmentShape);
+        sewing.Add(lowerSegmentShape);
+        i++;
     }
 
 
@@ -772,6 +778,7 @@ PNamedShape CCPACSWingComponentSegment::BuildLoft()
 
     sewing.Perform();
     TopoDS_Shape loftShape = sewing.SewedShape();
+    debug.addShape(loftShape, "sewedShape");
     // convert loft to solid for correct normals
     if (loftShape.ShapeType() == TopAbs_SHELL) {
         BRepBuilderAPI_MakeSolid ms;

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -1005,49 +1005,19 @@ Handle(Geom_Surface) CCPACSWingSegment::GetUpperSurface(TiglCoordinateSystem ref
 // Returns the upper wing shape of this Segment
 TopoDS_Shape CCPACSWingSegment::GetUpperShape(TiglCoordinateSystem referenceCS, TiglShapeModifier mod) const
 {
-    const PNamedShape loft = GetLoft(mod);
-    for (unsigned int i = 0; i < loft->GetFaceCount(); i++) {
-        if (loft->GetFaceTraits(i).Name() == "Top") {
-            const TopoDS_Face f = GetFace(loft->Shape(), i);
-            if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
-                return f;
-            return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(f);
-        }
-    }
-
-    throw CTiglError("Could not identify upper shape in loft. Maybe face traits are wrong?");
+    return GetLoft(mod)->GetFacesByName("Top");
 }
 
 // Returns the lower wing shape of this Segment
 TopoDS_Shape CCPACSWingSegment::GetLowerShape(TiglCoordinateSystem referenceCS, TiglShapeModifier mod) const
 {
-    const PNamedShape loft = GetLoft(mod);
-    for (unsigned int i = 0; i < loft->GetFaceCount(); i++) {
-        if (loft->GetFaceTraits(i).Name() == "Bottom") {
-            const TopoDS_Face f = GetFace(loft->Shape(), i);
-            if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
-                return f;
-            return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(f);
-        }
-    }
-
-    throw CTiglError("Could not identify upper shape in loft. Maybe face traits are wrong?");
+    return GetLoft(mod)->GetFacesByName("Bottom");
 }
 
 TIGL_EXPORT TopoDS_Shape CCPACSWingSegment::GetTrailingEdgeShape(TiglCoordinateSystem referenceCS,
                                                                  TiglShapeModifier mod) const
 {
-    const PNamedShape loft = GetLoft(mod);
-    for (unsigned int i = 0; i < loft->GetFaceCount(); i++) {
-        if (loft->GetFaceTraits(i).Name() == "TrailingEdge") {
-            const TopoDS_Face f = GetFace(loft->Shape(), i);
-            if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
-                return f;
-            return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(f);
-        }
-    }
-
-    throw CTiglError("Could not identify upper shape in loft. Maybe face traits are wrong?");
+    return GetLoft(mod)->GetFacesByName("TrailingEdge");
 }
 
 } // end namespace tigl

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -1004,19 +1004,28 @@ Handle(Geom_Surface) CCPACSWingSegment::GetUpperSurface(TiglCoordinateSystem ref
 // Returns the upper wing shape of this Segment
 TopoDS_Shape CCPACSWingSegment::GetUpperShape(TiglCoordinateSystem referenceCS, TiglShapeModifier mod) const
 {
-    return GetLoft(mod)->GetFacesByName("Top");
+    TopoDS_Shape s = GetLoft(mod)->GetFacesByName("Top");
+    if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
+        return s;
+    return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(s);
 }
 
 // Returns the lower wing shape of this Segment
 TopoDS_Shape CCPACSWingSegment::GetLowerShape(TiglCoordinateSystem referenceCS, TiglShapeModifier mod) const
 {
-    return GetLoft(mod)->GetFacesByName("Bottom");
+    TopoDS_Shape s = GetLoft(mod)->GetFacesByName("Bottom");
+    if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
+        return s;
+    return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(s);
 }
 
-TIGL_EXPORT TopoDS_Shape CCPACSWingSegment::GetTrailingEdgeShape(TiglCoordinateSystem referenceCS,
+TopoDS_Shape CCPACSWingSegment::GetTrailingEdgeShape(TiglCoordinateSystem referenceCS,
                                                                  TiglShapeModifier mod) const
 {
-    return GetLoft(mod)->GetFacesByName("TrailingEdge");
+    TopoDS_Shape s = GetLoft(mod)->GetFacesByName("TrailingEdge");
+    if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
+        return s;
+    return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(s);
 }
 
 } // end namespace tigl

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -983,11 +983,10 @@ double CCPACSWingSegment::GetReferenceArea(TiglSymmetryAxis symPlane) const
 
 PNamedShape CCPACSWingSegment::GetLoft(TiglShapeModifier mod) const
 {
-    // TODO
-    //const bool hasBluntTE = innerConnection.GetProfile().HasBluntTE();
-    //if (mod == UNMODIFIED_SHAPE || (mod == BLUNT_TRAILINGEDGE) == hasBluntTE)
-        return const_cast<CCPACSWingSegment&>(*this).GetLoft();
-    //return *loft2;
+    if (mod != UNMODIFIED_SHAPE)
+        throw CTiglError("TiglShapeModifier is not yet supported for CCPACSWingSegment::GetLoft");
+
+    return const_cast<CCPACSWingSegment&>(*this).GetLoft();
 }
 
 // Returns the lower Surface of this Segment

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -1004,7 +1004,7 @@ Handle(Geom_Surface) CCPACSWingSegment::GetUpperSurface(TiglCoordinateSystem ref
 // Returns the upper wing shape of this Segment
 TopoDS_Shape CCPACSWingSegment::GetUpperShape(TiglCoordinateSystem referenceCS, TiglShapeModifier mod) const
 {
-    TopoDS_Shape s = GetLoft(mod)->GetFacesByName("Top");
+    TopoDS_Shape s = GetFacesByName(GetLoft(mod), "Top");
     if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
         return s;
     return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(s);
@@ -1013,7 +1013,7 @@ TopoDS_Shape CCPACSWingSegment::GetUpperShape(TiglCoordinateSystem referenceCS, 
 // Returns the lower wing shape of this Segment
 TopoDS_Shape CCPACSWingSegment::GetLowerShape(TiglCoordinateSystem referenceCS, TiglShapeModifier mod) const
 {
-    TopoDS_Shape s = GetLoft(mod)->GetFacesByName("Bottom");
+    TopoDS_Shape s = GetFacesByName(GetLoft(mod), "Bottom");
     if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
         return s;
     return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(s);
@@ -1022,7 +1022,7 @@ TopoDS_Shape CCPACSWingSegment::GetLowerShape(TiglCoordinateSystem referenceCS, 
 TopoDS_Shape CCPACSWingSegment::GetTrailingEdgeShape(TiglCoordinateSystem referenceCS,
                                                                  TiglShapeModifier mod) const
 {
-    TopoDS_Shape s = GetLoft(mod)->GetFacesByName("TrailingEdge");
+    TopoDS_Shape s = GetFacesByName(GetLoft(mod), "TrailingEdge");
     if (referenceCS == GLOBAL_COORDINATE_SYSTEM)
         return s;
     return GetParent()->GetParent()->GetTransformationMatrix().Inverted().Transform(s);

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -43,6 +43,7 @@
 #include "TopoDS_Wire.hxx"
 #include "TopTools_SequenceOfShape.hxx"
 #include "Geom_BSplineSurface.hxx"
+#include "Cache.h"
 
 
 namespace tigl
@@ -173,6 +174,9 @@ public:
     // by projecting the wing segment into the plane defined by the user
     TIGL_EXPORT double GetReferenceArea(TiglSymmetryAxis symPlane) const;
 
+    using CTiglAbstractSegment<CCPACSWingSegment>::GetLoft;
+    TIGL_EXPORT PNamedShape GetLoft(TiglShapeModifier mod) const;
+
     // Returns the lower Surface of this Segment
     TIGL_EXPORT Handle(Geom_Surface) GetLowerSurface(TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM,
                                                      TiglShapeModifier mod            = UNMODIFIED_SHAPE) const;
@@ -222,17 +226,6 @@ protected:
     PNamedShape BuildLoft() OVERRIDE;
 
 private:
-    struct SurfaceCache
-    {
-        bool bluntTE;                        ///< Information whether trailing edge is blunt
-        double mySurfaceArea;                ///< Surface area of this segment
-        TopoDS_Face upperShapeSharp;        ///< Upper shape of this segment with sharp trailing edge
-        TopoDS_Face upperShapeBlunt;        ///< Upper shape of this segment with blunt trailing edge
-        TopoDS_Face lowerShapeSharp;        ///< Lower shape of this segment with sharp trailing edge
-        TopoDS_Face lowerShapeBlunt;        ///< Lower shape of this segment with blunt trailing edge
-        TopoDS_Face trailingEdgeShapeBlunt; ///< Shape of blunt trailing edge
-    };
-
     struct SurfaceCoordCache
     {
         CTiglPointTranslator cordSurface;
@@ -243,7 +236,7 @@ private:
     std::string GetShortShapeName ();
 
     // Builds upper and lower surfaces
-    void MakeSurfaces(SurfaceCache& cache) const;
+    void ComputeArea(double& cache) const;
 
     // Builds the chord surface
     void MakeChordSurface(SurfaceCoordCache& cache) const;
@@ -265,8 +258,8 @@ private:
                                                  * the fuselage loft at the price of a
                                                  * nonsmooth fuselage                       */
 
-    Cache<SurfaceCache, CCPACSWingSegment> surfaceCache;
     Cache<SurfaceCoordCache, CCPACSWingSegment> surfaceCoordCache;
+    Cache<double, CCPACSWingSegment>            areaCache;
 
     unique_ptr<IGuideCurveBuilder> m_guideCurveBuilder;
 };


### PR DESCRIPTION
This PR changes existing behavior. GetUpperShape(), GetLowerShape() and GetTrailingEdgeShape() now ignore the TiglShapeModifier (for now), but return shapes taking guide curves into account (which they previously didn't).