### PR TITLE
Allow compiling with OpenCascade 7.3.0

### DIFF
--- a/src/boolean_operations/CCutShape.cpp
+++ b/src/boolean_operations/CCutShape.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 
+#include <Standard_Version.hxx>
 #include <BOPAlgo_PaveFiller.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
 
@@ -65,7 +66,11 @@ void CCutShape::PrepareFiller()
     }
 
     if (!_dsfiller) {
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+        TopTools_ListOfShape aLS;
+#else
         BOPCol_ListOfShape aLS;
+#endif
         aLS.Append(_tool->Shape());
         aLS.Append(_source->Shape());
 

--- a/src/boolean_operations/CFuseShapes.cpp
+++ b/src/boolean_operations/CFuseShapes.cpp
@@ -35,8 +35,14 @@
 #include <BRepBuilderAPI_MakeSolid.hxx>
 
 #include <BOPAlgo_PaveFiller.hxx>
-#include <BOPCol_ListOfShape.hxx>
 #include <BRepAlgoAPI_Section.hxx>
+#include <Standard_Version.hxx>
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+#include <TopTools_ListOfShape.hxx>
+#else
+#include <BOPCol_ListOfShape.hxx>
+#endif
+
 
 //#define DEBUG_BOP
 
@@ -136,7 +142,11 @@ void CFuseShapes::DoFuse()
             clock_t start, stop;
             start = clock();
 #endif
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+            TopTools_ListOfShape aLS;
+#else
             BOPCol_ListOfShape aLS;
+#endif
             aLS.Append(_trimmedParent->Shape());
             aLS.Append(child->Shape());
             BOPAlgo_PaveFiller DSFill;

--- a/src/boolean_operations/CTrimShape.cpp
+++ b/src/boolean_operations/CTrimShape.cpp
@@ -29,7 +29,6 @@
 #include <string>
 
 #include <BOPAlgo_PaveFiller.hxx>
-#include <BOPCol_ListOfShape.hxx>
 
 #include <Precision.hxx>
 
@@ -48,6 +47,9 @@
 #include <Geom_Surface.hxx>
 #include <BRepBuilderAPI_MakeShape.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
+#if OCC_VERSION_HEX < VERSION_HEX_CODE(7,3,0)
+#include <BOPCol_ListOfShape.hxx>
+#endif
 
 namespace
 {
@@ -194,7 +196,11 @@ void CTrimShape::PrepareFiller()
     }
 
     if (!_dsfiller) {
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+        TopTools_ListOfShape aLS;
+#else
         BOPCol_ListOfShape aLS;
+#endif
         aLS.Append(_tool->Shape());
         aLS.Append(_source->Shape());
 

--- a/src/boolean_operations/GEOMAlgo_Splitter.hxx
+++ b/src/boolean_operations/GEOMAlgo_Splitter.hxx
@@ -30,6 +30,7 @@
 #include "tigl_internal.h"
 
 #include <Standard.hxx>
+#include <Standard_Version.hxx>
 #include <Standard_Macro.hxx>
 #include <Standard_Boolean.hxx>
 #include <Standard_Integer.hxx>
@@ -40,8 +41,13 @@
 
 #include <TopoDS_Shape.hxx>
 
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+#include <TopTools_ListOfShape.hxx>
+#include <TopTools_MapOfShape.hxx>
+#else
 #include <BOPCol_ListOfShape.hxx>
 #include <BOPCol_MapOfShape.hxx>
+#endif
 
 #include <BOPAlgo_Builder.hxx>
 
@@ -65,8 +71,13 @@ public:
   TIGL_EXPORT
     void AddTool(const TopoDS_Shape& theShape);
 
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+  TIGL_EXPORT
+    const TopTools_ListOfShape& Tools()const;
+#else
   TIGL_EXPORT
     const BOPCol_ListOfShape& Tools()const;
+#endif
 
   TIGL_EXPORT
     void SetLimit(const TopAbs_ShapeEnum aLimit);
@@ -91,8 +102,13 @@ public:
     void PostTreat() OVERRIDE;
   
  protected:
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+  TopTools_ListOfShape myTools;
+  TopTools_MapOfShape myMapTools;
+#else
   BOPCol_ListOfShape myTools;
   BOPCol_MapOfShape myMapTools;
+#endif
   TopAbs_ShapeEnum myLimit;
   Standard_Integer myLimitMode;
 };

--- a/src/configuration/CTiglFusePlane.cpp
+++ b/src/configuration/CTiglFusePlane.cpp
@@ -27,10 +27,15 @@
 #include "CTrimShape.h"
 #include "tiglcommonfunctions.h"
 
-#include <BOPCol_ListOfShape.hxx>
 #include <BOPAlgo_PaveFiller.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
 #include <BRepAlgoAPI_Common.hxx>
+#include <Standard_Version.hxx>
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+#include <TopTools_ListOfShape.hxx>
+#else
+#include <BOPCol_ListOfShape.hxx>
+#endif
 
 
 #include <string>
@@ -160,7 +165,11 @@ void CTiglFusePlane::Perform()
         PNamedShape ff = farfield.GetLoft();
         assert(_result);
 
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+        TopTools_ListOfShape aLS;
+#else
         BOPCol_ListOfShape aLS;
+#endif
         aLS.Append(_result->Shape());
         aLS.Append(ff->Shape());
 

--- a/src/contrib/MakePatches.cxx
+++ b/src/contrib/MakePatches.cxx
@@ -37,7 +37,6 @@
 #include <BRepLib.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
-#include <BOPCol_ListOfShape.hxx>
 #include <BOPAlgo_PaveFiller.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <Precision.hxx>

--- a/tests/unittests/guideCurvePatchesMakeLoops.cpp
+++ b/tests/unittests/guideCurvePatchesMakeLoops.cpp
@@ -27,7 +27,6 @@
 #include <GeomFill_FillingStyle.hxx>
 
 #include <BRepAlgoAPI_Fuse.hxx>
-#include <BOPCol_ListOfShape.hxx>
 #include <BOPAlgo_PaveFiller.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopTools_ListIteratorOfListOfShape.hxx>
@@ -124,7 +123,11 @@ protected:
         // *******************************************************************
         BRepAlgoAPI_Fuse* Fuser;
 
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)
+        TopTools_ListOfShape aLC;
+#else
         BOPCol_ListOfShape aLC;
+#endif
         aLC.Append(guides);
         aLC.Append(profiles);
 

--- a/tests/unittests/tiglFuseAircraft.cpp
+++ b/tests/unittests/tiglFuseAircraft.cpp
@@ -31,7 +31,6 @@
 #include <BRepTools.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
-#include <BOPCol_ListOfShape.hxx>
 #include <BOPAlgo_PaveFiller.hxx>
 #include <BRepAlgoAPI_Section.hxx>
 #include <BRepCheck_Analyzer.hxx>


### PR DESCRIPTION
Basically some of the BOP*** classes have been replaced by TopTools. Please have a look if older OCC versions still compile.