### PR TITLE
Allow to use geom_curves for surface creation

### DIFF
--- a/bindings/python_internal/geometry.i
+++ b/bindings/python_internal/geometry.i
@@ -78,7 +78,7 @@
 
 %template(CPointContainer) std::vector<gp_Pnt>;
 %template(BSplineCurveList) std::vector<Handle_Geom_BSplineCurve>;
-
+%template(CurveList) std::vector<Handle_Geom_Curve>;
 
 %boost_optional(tigl::CCPACSPointAbsRel)
 %boost_optional(tigl::CCPACSPoint)

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -730,12 +730,12 @@ Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::pointsToSurface(const TColgp
     bool makeUDirClosed = uContinousIfClosed & isUDirClosed(points, tolerance);
 
     // first interpolate all points by B-splines in u-direction
-    std::vector<Handle(Geom_BSplineCurve)> uSplines;
+    std::vector<Handle(Geom_Curve)> uSplines;
     for (int cpVIdx = points.LowerCol(); cpVIdx <= points.UpperCol(); ++cpVIdx) {
         Handle_TColgp_HArray1OfPnt points_u = pntArray2GetColumn(points, cpVIdx);
         CTiglPointsToBSplineInterpolation interpolationObject(points_u, uParams, 3, makeUDirClosed);
 
-        Handle(Geom_BSplineCurve) curve = interpolationObject.Curve();
+        Handle(Geom_Curve) curve = interpolationObject.Curve();
         uSplines.push_back(curve);
     }
 

--- a/src/geometry/CTiglCurvesToSurface.cpp
+++ b/src/geometry/CTiglCurvesToSurface.cpp
@@ -61,26 +61,34 @@ Handle(TColStd_HArray1OfReal) toArray(const std::vector<double>& vector)
 
 namespace tigl {
 
-TIGL_EXPORT CTiglCurvesToSurface::CTiglCurvesToSurface(std::vector<Handle(Geom_BSplineCurve) > const& splines_vector,
+TIGL_EXPORT CTiglCurvesToSurface::CTiglCurvesToSurface(std::vector<Handle(Geom_Curve) > const& splines_vector,
                                                        bool continuousIfClosed)
     : _continuousIfClosed(continuousIfClosed)
-    , _inputCurves(splines_vector)
 {
-    CTiglBSplineAlgorithms::matchDegree(splines_vector);
-    CalculateParameters(splines_vector); //TODO this is only really needed if maxDegree > 1
+    // convert all curves to bspline curves
+    for (std::vector<Handle(Geom_Curve) >::const_iterator curve_iter = splines_vector.begin(); curve_iter != splines_vector.end(); ++curve_iter) {
+        _inputCurves.push_back(GeomConvert::CurveToBSplineCurve(*curve_iter));
+    }
+
+    CTiglBSplineAlgorithms::matchDegree(_inputCurves);
+    CalculateParameters(_inputCurves); //TODO this is only really needed if maxDegree > 1
 }
 
-TIGL_EXPORT CTiglCurvesToSurface::CTiglCurvesToSurface(std::vector<Handle(Geom_BSplineCurve) > const& splines_vector,
+TIGL_EXPORT CTiglCurvesToSurface::CTiglCurvesToSurface(std::vector<Handle(Geom_Curve) > const& splines_vector,
                                                        std::vector<double> const& parameters,
                                                        bool continuousIfClosed)
     : _parameters(parameters)
-    , _inputCurves(splines_vector)
     , _continuousIfClosed(continuousIfClosed)
 {
-    if( parameters.size() == 0) {
-        CalculateParameters(splines_vector);
+    // convert all curves to bspline curves
+    for (std::vector<Handle(Geom_Curve) >::const_iterator curve_iter = splines_vector.begin(); curve_iter != splines_vector.end(); ++curve_iter) {
+        _inputCurves.push_back(GeomConvert::CurveToBSplineCurve(*curve_iter));
     }
-    CTiglBSplineAlgorithms::matchDegree(splines_vector);
+
+    if( parameters.size() == 0) {
+        CalculateParameters(_inputCurves);
+    }
+    CTiglBSplineAlgorithms::matchDegree(_inputCurves);
 }
 
 TIGL_EXPORT void CTiglCurvesToSurface::SetMaxDegree(int degree)

--- a/src/geometry/CTiglCurvesToSurface.h
+++ b/src/geometry/CTiglCurvesToSurface.h
@@ -45,7 +45,7 @@ public:
      * @param splines_vector Curves to be interpolated.
      * @param continuousIfClosed Make a C2 continous surface at the start/end junction if the first and last curve are the same
      */
-    TIGL_EXPORT explicit CTiglCurvesToSurface(const std::vector<Handle(Geom_BSplineCurve) >& splines_vector,
+    TIGL_EXPORT explicit CTiglCurvesToSurface(const std::vector<Handle(Geom_Curve) >& splines_vector,
                                               bool continuousIfClosed = false);
 
     /**
@@ -58,7 +58,7 @@ public:
      * @param parameters Parameters of v-direction at which the resulting surface should interpolate the input curves.
      * @param continuousIfClosed Make a C2 continous surface at the start/end junction if the first and last curve are the same
      */
-    TIGL_EXPORT explicit CTiglCurvesToSurface(const std::vector<Handle(Geom_BSplineCurve) >& splines_vector,
+    TIGL_EXPORT explicit CTiglCurvesToSurface(const std::vector<Handle(Geom_Curve) >& splines_vector,
                                               const std::vector<double>& parameters,
                                               bool continuousIfClosed = false);
     /**

--- a/src/geometry/CTiglGordonSurfaceBuilder.cpp
+++ b/src/geometry/CTiglGordonSurfaceBuilder.cpp
@@ -152,12 +152,12 @@ void CTiglGordonSurfaceBuilder::CreateGordonSurface(const std::vector<Handle(Geo
     bool makeVClosed = CTiglBSplineAlgorithms::isVDirClosed(intersection_pnts, tp_tolerance) && profiles.front()->IsEqual(profiles.back(), curve_v_tolerance);
 
     // Skinning in v-direction with u directional B-Splines
-    CTiglCurvesToSurface surfProfilesSkinner(profiles, intersection_params_spline_v, makeVClosed);
+    CTiglCurvesToSurface surfProfilesSkinner(std::vector<Handle(Geom_Curve)>(profiles.begin(), profiles.end()), intersection_params_spline_v, makeVClosed);
     Handle(Geom_BSplineSurface) surfProfiles = surfProfilesSkinner.Surface();
     // therefore reparametrization before this method
 
     // Skinning in u-direction with v directional B-Splines
-    CTiglCurvesToSurface surfGuidesSkinner(guides, intersection_params_spline_u, makeUClosed);
+    CTiglCurvesToSurface surfGuidesSkinner(std::vector<Handle(Geom_Curve)>(guides.begin(), guides.end()), intersection_params_spline_u, makeUClosed);
     Handle(Geom_BSplineSurface) surfGuides = surfGuidesSkinner.Surface();
 
     // flipping of the surface in v-direction; flipping is redundant here, therefore the next line is a comment!

--- a/src/geometry/CTiglInterpolateCurveNetwork.cpp
+++ b/src/geometry/CTiglInterpolateCurveNetwork.cpp
@@ -29,12 +29,13 @@
 
 #include <math_Matrix.hxx>
 #include <TColStd_HArray1OfReal.hxx>
+#include <GeomConvert.hxx>
 
 namespace tigl
 {
 
-CTiglInterpolateCurveNetwork::CTiglInterpolateCurveNetwork(const std::vector<Handle (Geom_BSplineCurve)> &profiles,
-                                                           const std::vector<Handle (Geom_BSplineCurve)> &guides,
+CTiglInterpolateCurveNetwork::CTiglInterpolateCurveNetwork(const std::vector<Handle (Geom_Curve)> &profiles,
+                                                           const std::vector<Handle (Geom_Curve)> &guides,
                                                            double spatialTol)
     : m_hasPerformed(false)
     , m_spatialTol(spatialTol)
@@ -52,11 +53,11 @@ CTiglInterpolateCurveNetwork::CTiglInterpolateCurveNetwork(const std::vector<Han
     m_guides.reserve(guides.size());
 
     // Copy the curves
-    for (CurveArray::const_iterator it = profiles.begin(); it != profiles.end(); ++it) {
-        m_profiles.push_back(Handle_Geom_BSplineCurve::DownCast((*it)->Copy()));
+    for (std::vector<Handle (Geom_Curve)>::const_iterator it = profiles.begin(); it != profiles.end(); ++it) {
+        m_profiles.push_back(GeomConvert::CurveToBSplineCurve(*it));
     }
-    for (CurveArray::const_iterator it = guides.begin(); it != guides.end(); ++it) {
-        m_guides.push_back(Handle_Geom_BSplineCurve::DownCast((*it)->Copy()));
+    for (std::vector<Handle (Geom_Curve)>::const_iterator it = guides.begin(); it != guides.end(); ++it) {
+        m_guides.push_back(GeomConvert::CurveToBSplineCurve(*it));
     }
 }
 
@@ -400,7 +401,7 @@ void CTiglInterpolateCurveNetwork::Perform()
     m_hasPerformed = true;
 }
 
-Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle (Geom_BSplineCurve)> &profiles, const std::vector<Handle (Geom_BSplineCurve)> &guides, double tol)
+Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle (Geom_Curve)> &profiles, const std::vector<Handle (Geom_Curve)> &guides, double tol)
 {
     return CTiglInterpolateCurveNetwork(profiles, guides, tol).Surface();
 }

--- a/src/geometry/CTiglInterpolateCurveNetwork.h
+++ b/src/geometry/CTiglInterpolateCurveNetwork.h
@@ -50,8 +50,8 @@ public:
      * @param guides   The guides curves to be interpolated
      * @param spatialTolerance Maximum allowed distance between each guide and profile (in theory they must intersect)
      */
-    TIGL_EXPORT CTiglInterpolateCurveNetwork(const std::vector<Handle(Geom_BSplineCurve)>& profiles,
-                                             const std::vector<Handle(Geom_BSplineCurve)>& guides,
+    TIGL_EXPORT CTiglInterpolateCurveNetwork(const std::vector<Handle(Geom_Curve)>& profiles,
+                                             const std::vector<Handle(Geom_Curve)>& guides,
                                              double spatialTolerance);
 
     TIGL_EXPORT operator Handle(Geom_BSplineSurface) ();
@@ -102,8 +102,8 @@ private:
 };
 
 /// Convenience function calling CTiglInterpolateCurveNetwork
-TIGL_EXPORT Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_BSplineCurve)>& profiles,
-                                                              const std::vector<Handle(Geom_BSplineCurve)>& guides,
+TIGL_EXPORT Handle(Geom_BSplineSurface) curveNetworkToSurface(const std::vector<Handle(Geom_Curve)>& profiles,
+                                                              const std::vector<Handle(Geom_Curve)>& guides,
                                                               double spatialTol = 3e-4);
 
 } // namespace tigl

--- a/src/geometry/CTiglMakeLoft.cpp
+++ b/src/geometry/CTiglMakeLoft.cpp
@@ -246,10 +246,10 @@ void CTiglMakeLoft::makeLoftWithoutGuides()
     // CAUTION: Here it is assumed that the edges are ordered
     // in the same way along each profile (e.g. lower edge,
     // upper edge, trailing edge for a wing)
-    for ( unsigned iE = 1; iE<=nEdgesPerProfile; ++iE ) {
+    for ( int iE = 1; iE <= nEdgesPerProfile; ++iE ) {
 
         // get the curves
-        std::vector<Handle(Geom_BSplineCurve)> profileCurves;
+        std::vector<Handle(Geom_Curve)> profileCurves;
         profileCurves.reserve(profiles.size());
         for (unsigned iP=0; iP<profiles.size(); ++iP ) {
 

--- a/tests/unittests/testctiglbsplinealgorithms.cpp
+++ b/tests/unittests/testctiglbsplinealgorithms.cpp
@@ -1090,13 +1090,13 @@ TEST(TiglBSplineAlgorithms, testCreateGordonSurfaceGeneral)
     Handle(Geom_BSplineCurve) spline_v5 = new Geom_BSplineCurve(controlPoints_v5, knots, mults, degree);
 
     // u- and v-directional B-splines are already compatible in B-spline sense (common knot vector, same parametrization)
-    std::vector<Handle(Geom_BSplineCurve)> splines_u_vector;
+    std::vector<Handle(Geom_Curve)> splines_u_vector;
     splines_u_vector.push_back(spline_u3);
     splines_u_vector.push_back(spline_u1);
     splines_u_vector.push_back(spline_u2);
     splines_u_vector.push_back(spline_u4);
 
-    std::vector<Handle(Geom_BSplineCurve)> splines_v_vector;
+    std::vector<Handle(Geom_Curve)> splines_v_vector;
     splines_v_vector.push_back(spline_v5);
     splines_v_vector.push_back(spline_v4);
     splines_v_vector.push_back(spline_v2);
@@ -1344,7 +1344,7 @@ TEST_P(GordonSurface, testFromBRep)
 
     TopExp_Explorer Explorer;
     // get the splines in u-direction from the Edges
-    std::vector<Handle(Geom_BSplineCurve)> splines_u_vector;
+    std::vector<Handle(Geom_Curve)> splines_u_vector;
     for (Explorer.Init(shape_u, TopAbs_EDGE); Explorer.More(); Explorer.Next()) {
         TopoDS_Edge curve_edge = TopoDS::Edge(Explorer.Current());
         double beginning = 0;
@@ -1367,7 +1367,7 @@ TEST_P(GordonSurface, testFromBRep)
     TopExp::MapShapes(shape_v, TopAbs_EDGE, mapEdges_v);
 
     // get the splines in v-direction from the Edges
-    std::vector<Handle(Geom_BSplineCurve)> splines_v_vector;
+    std::vector<Handle(Geom_Curve)> splines_v_vector;
     for (Explorer.Init(shape_v, TopAbs_EDGE); Explorer.More(); Explorer.Next()) {
         TopoDS_Edge curve_edge = TopoDS::Edge(Explorer.Current());
         double beginning = 0;

--- a/tests/unittests/testctiglcurvestosurface.cpp
+++ b/tests/unittests/testctiglcurvestosurface.cpp
@@ -54,7 +54,7 @@ TEST(CTiglCurvesToSurface, testSkinnedBSplineSurface)
 
     Handle(Geom_BSplineCurve) curve2 = new Geom_BSplineCurve(controlPoints2, knots, mults, degree_u);
 
-    std::vector<Handle(Geom_BSplineCurve) > splines_vector;
+    std::vector<Handle(Geom_Curve) > splines_vector;
     splines_vector.push_back(curve1);
     splines_vector.push_back(curve2);
 
@@ -90,7 +90,7 @@ TEST(TiglBSplineAlgorithms, curvesToSurfaceContinous)
     BRepTools::Read(shape_u, "TestData/CurveNetworks/fuselage1/guides.brep", builder_u);
 
     // get the splines in u-direction from the Edges
-    std::vector<Handle(Geom_BSplineCurve)> curves;
+    std::vector<Handle(Geom_Curve)> curves;
     for (TopExp_Explorer exp(shape_u, TopAbs_EDGE); exp.More(); exp.Next()) {
         TopoDS_Edge curve_edge = TopoDS::Edge(exp.Current());
         double beginning = 0;


### PR DESCRIPTION
When using the python api I realized, that I could crash
the surface builders, when not providing b-spline curves,
but e.g. trimmed curves.

This commit makes the use of the surface factories a bit
more generic. They can now be used for arbitrary curves.
The b-spline conversion is performed i a first step.

closes #485