### PR TITLE
Updated cpacs_gen

### DIFF
--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -125,7 +125,7 @@ std::string CCPACSFuselage::GetDefaultedUID() const
     return generated::CPACSFuselage::GetUID();
 }
 
-PNamedShape CCPACSFuselage::GetLoft(TiglCoordinateSystem cs)
+PNamedShape CCPACSFuselage::GetLoft(TiglCoordinateSystem cs) const
 {
     PNamedShape loft = CTiglRelativelyPositionedComponent::GetLoft();
     if (!loft) {

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -66,7 +66,7 @@ public:
 
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
-    TIGL_EXPORT PNamedShape GetLoft(TiglCoordinateSystem cs = GLOBAL_COORDINATE_SYSTEM);
+    TIGL_EXPORT PNamedShape GetLoft(TiglCoordinateSystem cs = GLOBAL_COORDINATE_SYSTEM) const;
 
     // Get section count
     TIGL_EXPORT int GetSectionCount() const;

--- a/src/fuselage/CCPACSFuselageStringerFramePosition.cpp
+++ b/src/fuselage/CCPACSFuselageStringerFramePosition.cpp
@@ -133,7 +133,7 @@ void CCPACSFuselageStringerFramePosition::GetZBorders(double& zmin, double& zmax
 
 void CCPACSFuselageStringerFramePosition::UpdateRelativePositioning(RelativePositionCache& cache) const
 {
-    CCPACSFuselageStructure* structure = NULL;
+    const CCPACSFuselageStructure* structure = NULL;
     if (IsParent<CCPACSFuselageStringer>())
         structure = GetParent<CCPACSFuselageStringer>()->GetParent()->GetParent();
     else if (IsParent<CCPACSFrame>())

--- a/src/generated/CPACSCargoCrossBeamStrutsAssembly.cpp
+++ b/src/generated/CPACSCargoCrossBeamStrutsAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSCargoCrossBeamStrutsAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSCargoCrossBeamStrutsAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSCargoCrossBeamStrutsAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCargoCrossBeamStrutsAssembly.h
+++ b/src/generated/CPACSCargoCrossBeamStrutsAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCargoCrossBeamStrutsAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSCargoCrossBeamsAssembly.cpp
+++ b/src/generated/CPACSCargoCrossBeamsAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSCargoCrossBeamsAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSCargoCrossBeamsAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSCargoCrossBeamsAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCargoCrossBeamsAssembly.h
+++ b/src/generated/CPACSCargoCrossBeamsAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCargoCrossBeamsAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSCargoDoorsAssembly.cpp
+++ b/src/generated/CPACSCargoDoorsAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSCargoDoorsAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSCargoDoorsAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSCargoDoorsAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCargoDoorsAssembly.h
+++ b/src/generated/CPACSCargoDoorsAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCargoDoorsAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSCellPositioningChordwise.cpp
+++ b/src/generated/CPACSCellPositioningChordwise.cpp
@@ -36,7 +36,12 @@ namespace generated
     {
     }
 
-    CCPACSWingCell* CPACSCellPositioningChordwise::GetParent() const
+    const CCPACSWingCell* CPACSCellPositioningChordwise::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingCell* CPACSCellPositioningChordwise::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCellPositioningChordwise.h
+++ b/src/generated/CPACSCellPositioningChordwise.h
@@ -40,7 +40,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCellPositioningChordwise();
 
-        TIGL_EXPORT CCPACSWingCell* GetParent() const;
+        TIGL_EXPORT CCPACSWingCell* GetParent();
+
+        TIGL_EXPORT const CCPACSWingCell* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSCellPositioningSpanwise.cpp
+++ b/src/generated/CPACSCellPositioningSpanwise.cpp
@@ -36,7 +36,12 @@ namespace generated
     {
     }
 
-    CCPACSWingCell* CPACSCellPositioningSpanwise::GetParent() const
+    const CCPACSWingCell* CPACSCellPositioningSpanwise::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingCell* CPACSCellPositioningSpanwise::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCellPositioningSpanwise.h
+++ b/src/generated/CPACSCellPositioningSpanwise.h
@@ -40,7 +40,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCellPositioningSpanwise();
 
-        TIGL_EXPORT CCPACSWingCell* GetParent() const;
+        TIGL_EXPORT CCPACSWingCell* GetParent();
+
+        TIGL_EXPORT const CCPACSWingCell* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSComponentSegment.cpp
+++ b/src/generated/CPACSComponentSegment.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSWingComponentSegments* CPACSComponentSegment::GetParent() const
+    const CCPACSWingComponentSegments* CPACSComponentSegment::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingComponentSegments* CPACSComponentSegment::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSComponentSegment.h
+++ b/src/generated/CPACSComponentSegment.h
@@ -44,7 +44,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSComponentSegment();
 
-        TIGL_EXPORT CCPACSWingComponentSegments* GetParent() const;
+        TIGL_EXPORT CCPACSWingComponentSegments* GetParent();
+
+        TIGL_EXPORT const CCPACSWingComponentSegments* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSComponentSegments.cpp
+++ b/src/generated/CPACSComponentSegments.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWing* CPACSComponentSegments::GetParent() const
+    const CCPACSWing* CPACSComponentSegments::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWing* CPACSComponentSegments::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSComponentSegments.h
+++ b/src/generated/CPACSComponentSegments.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSComponentSegments();
 
-        TIGL_EXPORT CCPACSWing* GetParent() const;
+        TIGL_EXPORT CCPACSWing* GetParent();
+
+        TIGL_EXPORT const CCPACSWing* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSContinuity.h
+++ b/src/generated/CPACSContinuity.h
@@ -31,7 +31,7 @@ namespace generated
     // CPACSLongFloorBeamPosition
     // CPACSStringerFramePosition
 
-    // generated from /xsd:schema/xsd:complexType[516]/xsd:complexContent/xsd:extension/xsd:all/xsd:element[5]/xsd:complexType/xsd:simpleContent
+    // generated from /xsd:schema/xsd:complexType[391]/xsd:complexContent/xsd:extension/xsd:all/xsd:element[12]/xsd:complexType/xsd:simpleContent
     enum CPACSContinuity
     {
         CPACSContinuity_0,

--- a/src/generated/CPACSContinuityAtP.h
+++ b/src/generated/CPACSContinuityAtP.h
@@ -33,26 +33,26 @@ namespace generated
     // generated from /xsd:schema/xsd:complexType[801]/xsd:complexContent/xsd:extension/xsd:all/xsd:element[4]/xsd:complexType/xsd:simpleContent
     enum CPACSContinuityAtP
     {
-        CPACSContinuityAtP_0,
+        _0,
         CPACSContinuityAtP_1,
-        CPACSContinuityAtP_2
+        _2
     };
 
     inline std::string CPACSContinuityAtPToString(const CPACSContinuityAtP& value)
     {
         switch(value) {
-        case CPACSContinuityAtP_0: return "0";
+        case _0: return "0";
         case CPACSContinuityAtP_1: return "1";
-        case CPACSContinuityAtP_2: return "2";
+        case _2: return "2";
         default: throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) + "\" for enum type CPACSContinuityAtP");
         }
     }
     inline CPACSContinuityAtP stringToCPACSContinuityAtP(const std::string& value)
     {
         struct ToLower { std::string operator()(std::string str) { for (std::size_t i = 0; i < str.length(); i++) { str[i] = std::tolower(str[i]); } return str; } } toLower;
-        if (toLower(value) == "0") { return CPACSContinuityAtP_0; }
+        if (toLower(value) == "0") { return _0; }
         if (toLower(value) == "1") { return CPACSContinuityAtP_1; }
-        if (toLower(value) == "2") { return CPACSContinuityAtP_2; }
+        if (toLower(value) == "2") { return _2; }
         throw CTiglError("Invalid string value \"" + value + "\" for enum type CPACSContinuityAtP");
     }
 } // namespace generated
@@ -63,7 +63,7 @@ using ECPACSContinuityAtP = generated::CPACSContinuityAtP;
 #else
 typedef generated::CPACSContinuityAtP ECPACSContinuityAtP;
 #endif
-using generated::CPACSContinuityAtP_0;
+using generated::_0;
 using generated::CPACSContinuityAtP_1;
-using generated::CPACSContinuityAtP_2;
+using generated::_2;
 } // namespace tigl

--- a/src/generated/CPACSControlSurfaceBorderTrailingEdge.cpp
+++ b/src/generated/CPACSControlSurfaceBorderTrailingEdge.cpp
@@ -36,7 +36,12 @@ namespace generated
     {
     }
 
-    CPACSControlSurfaceOuterShapeTrailingEdge* CPACSControlSurfaceBorderTrailingEdge::GetParent() const
+    const CPACSControlSurfaceOuterShapeTrailingEdge* CPACSControlSurfaceBorderTrailingEdge::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSControlSurfaceOuterShapeTrailingEdge* CPACSControlSurfaceBorderTrailingEdge::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceBorderTrailingEdge.h
+++ b/src/generated/CPACSControlSurfaceBorderTrailingEdge.h
@@ -46,7 +46,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceBorderTrailingEdge();
 
-        TIGL_EXPORT CPACSControlSurfaceOuterShapeTrailingEdge* GetParent() const;
+        TIGL_EXPORT CPACSControlSurfaceOuterShapeTrailingEdge* GetParent();
+
+        TIGL_EXPORT const CPACSControlSurfaceOuterShapeTrailingEdge* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSControlSurfaceHingePoint.cpp
+++ b/src/generated/CPACSControlSurfaceHingePoint.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CPACSControlSurfacePath* CPACSControlSurfaceHingePoint::GetParent() const
+    const CPACSControlSurfacePath* CPACSControlSurfaceHingePoint::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSControlSurfacePath* CPACSControlSurfaceHingePoint::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceHingePoint.h
+++ b/src/generated/CPACSControlSurfaceHingePoint.h
@@ -38,7 +38,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceHingePoint();
 
-        TIGL_EXPORT CPACSControlSurfacePath* GetParent() const;
+        TIGL_EXPORT CPACSControlSurfacePath* GetParent();
+
+        TIGL_EXPORT const CPACSControlSurfacePath* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSControlSurfaceOuterShapeTrailingEdge.cpp
+++ b/src/generated/CPACSControlSurfaceOuterShapeTrailingEdge.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSTrailingEdgeDevice* CPACSControlSurfaceOuterShapeTrailingEdge::GetParent() const
+    const CCPACSTrailingEdgeDevice* CPACSControlSurfaceOuterShapeTrailingEdge::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSTrailingEdgeDevice* CPACSControlSurfaceOuterShapeTrailingEdge::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceOuterShapeTrailingEdge.h
+++ b/src/generated/CPACSControlSurfaceOuterShapeTrailingEdge.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceOuterShapeTrailingEdge();
 
-        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent() const;
+        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent();
+
+        TIGL_EXPORT const CCPACSTrailingEdgeDevice* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSControlSurfacePath.cpp
+++ b/src/generated/CPACSControlSurfacePath.cpp
@@ -41,7 +41,12 @@ namespace generated
     {
     }
 
-    CCPACSTrailingEdgeDevice* CPACSControlSurfacePath::GetParent() const
+    const CCPACSTrailingEdgeDevice* CPACSControlSurfacePath::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSTrailingEdgeDevice* CPACSControlSurfacePath::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfacePath.h
+++ b/src/generated/CPACSControlSurfacePath.h
@@ -41,7 +41,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfacePath();
 
-        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent() const;
+        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent();
+
+        TIGL_EXPORT const CCPACSTrailingEdgeDevice* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSControlSurfaceSkinCutOut.cpp
+++ b/src/generated/CPACSControlSurfaceSkinCutOut.cpp
@@ -36,7 +36,12 @@ namespace generated
     {
     }
 
-    CPACSControlSurfaceWingCutOut* CPACSControlSurfaceSkinCutOut::GetParent() const
+    const CPACSControlSurfaceWingCutOut* CPACSControlSurfaceSkinCutOut::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSControlSurfaceWingCutOut* CPACSControlSurfaceSkinCutOut::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceSkinCutOut.h
+++ b/src/generated/CPACSControlSurfaceSkinCutOut.h
@@ -40,7 +40,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceSkinCutOut();
 
-        TIGL_EXPORT CPACSControlSurfaceWingCutOut* GetParent() const;
+        TIGL_EXPORT CPACSControlSurfaceWingCutOut* GetParent();
+
+        TIGL_EXPORT const CPACSControlSurfaceWingCutOut* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSControlSurfaceSkinCutOutBorder.cpp
+++ b/src/generated/CPACSControlSurfaceSkinCutOutBorder.cpp
@@ -36,7 +36,12 @@ namespace generated
     {
     }
 
-    CPACSControlSurfaceWingCutOut* CPACSControlSurfaceSkinCutOutBorder::GetParent() const
+    const CPACSControlSurfaceWingCutOut* CPACSControlSurfaceSkinCutOutBorder::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSControlSurfaceWingCutOut* CPACSControlSurfaceSkinCutOutBorder::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceSkinCutOutBorder.h
+++ b/src/generated/CPACSControlSurfaceSkinCutOutBorder.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceSkinCutOutBorder();
 
-        TIGL_EXPORT CPACSControlSurfaceWingCutOut* GetParent() const;
+        TIGL_EXPORT CPACSControlSurfaceWingCutOut* GetParent();
+
+        TIGL_EXPORT const CPACSControlSurfaceWingCutOut* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSControlSurfaceStep.cpp
+++ b/src/generated/CPACSControlSurfaceStep.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSControlSurfaceSteps* CPACSControlSurfaceStep::GetParent() const
+    const CCPACSControlSurfaceSteps* CPACSControlSurfaceStep::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSControlSurfaceSteps* CPACSControlSurfaceStep::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceStep.h
+++ b/src/generated/CPACSControlSurfaceStep.h
@@ -44,7 +44,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceStep();
 
-        TIGL_EXPORT CCPACSControlSurfaceSteps* GetParent() const;
+        TIGL_EXPORT CCPACSControlSurfaceSteps* GetParent();
+
+        TIGL_EXPORT const CCPACSControlSurfaceSteps* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSControlSurfaceSteps.cpp
+++ b/src/generated/CPACSControlSurfaceSteps.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CPACSControlSurfacePath* CPACSControlSurfaceSteps::GetParent() const
+    const CPACSControlSurfacePath* CPACSControlSurfaceSteps::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSControlSurfacePath* CPACSControlSurfaceSteps::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceSteps.h
+++ b/src/generated/CPACSControlSurfaceSteps.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceSteps();
 
-        TIGL_EXPORT CPACSControlSurfacePath* GetParent() const;
+        TIGL_EXPORT CPACSControlSurfacePath* GetParent();
+
+        TIGL_EXPORT const CPACSControlSurfacePath* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSControlSurfaceTrackType.cpp
+++ b/src/generated/CPACSControlSurfaceTrackType.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CPACSControlSurfaceTracks* CPACSControlSurfaceTrackType::GetParent() const
+    const CPACSControlSurfaceTracks* CPACSControlSurfaceTrackType::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSControlSurfaceTracks* CPACSControlSurfaceTrackType::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceTrackType.h
+++ b/src/generated/CPACSControlSurfaceTrackType.h
@@ -48,7 +48,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceTrackType();
 
-        TIGL_EXPORT CPACSControlSurfaceTracks* GetParent() const;
+        TIGL_EXPORT CPACSControlSurfaceTracks* GetParent();
+
+        TIGL_EXPORT const CPACSControlSurfaceTracks* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSControlSurfaceTracks.cpp
+++ b/src/generated/CPACSControlSurfaceTracks.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSTrailingEdgeDevice* CPACSControlSurfaceTracks::GetParent() const
+    const CCPACSTrailingEdgeDevice* CPACSControlSurfaceTracks::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSTrailingEdgeDevice* CPACSControlSurfaceTracks::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceTracks.h
+++ b/src/generated/CPACSControlSurfaceTracks.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceTracks();
 
-        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent() const;
+        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent();
+
+        TIGL_EXPORT const CCPACSTrailingEdgeDevice* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSControlSurfaceWingCutOut.cpp
+++ b/src/generated/CPACSControlSurfaceWingCutOut.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSTrailingEdgeDevice* CPACSControlSurfaceWingCutOut::GetParent() const
+    const CCPACSTrailingEdgeDevice* CPACSControlSurfaceWingCutOut::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSTrailingEdgeDevice* CPACSControlSurfaceWingCutOut::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaceWingCutOut.h
+++ b/src/generated/CPACSControlSurfaceWingCutOut.h
@@ -45,7 +45,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceWingCutOut();
 
-        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent() const;
+        TIGL_EXPORT CCPACSTrailingEdgeDevice* GetParent();
+
+        TIGL_EXPORT const CCPACSTrailingEdgeDevice* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSControlSurfaces.cpp
+++ b/src/generated/CPACSControlSurfaces.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSWingComponentSegment* CPACSControlSurfaces::GetParent() const
+    const CCPACSWingComponentSegment* CPACSControlSurfaces::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingComponentSegment* CPACSControlSurfaces::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSControlSurfaces.h
+++ b/src/generated/CPACSControlSurfaces.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSControlSurfaces();
 
-        TIGL_EXPORT CCPACSWingComponentSegment* GetParent() const;
+        TIGL_EXPORT CCPACSWingComponentSegment* GetParent();
+
+        TIGL_EXPORT const CCPACSWingComponentSegment* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSCrossBeamAssemblyPosition.cpp
+++ b/src/generated/CPACSCrossBeamAssemblyPosition.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSCargoCrossBeamsAssembly* CPACSCrossBeamAssemblyPosition::GetParent() const
+    const CCPACSCargoCrossBeamsAssembly* CPACSCrossBeamAssemblyPosition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSCargoCrossBeamsAssembly* CPACSCrossBeamAssemblyPosition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCrossBeamAssemblyPosition.h
+++ b/src/generated/CPACSCrossBeamAssemblyPosition.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCrossBeamAssemblyPosition();
 
-        TIGL_EXPORT CCPACSCargoCrossBeamsAssembly* GetParent() const;
+        TIGL_EXPORT CCPACSCargoCrossBeamsAssembly* GetParent();
+
+        TIGL_EXPORT const CCPACSCargoCrossBeamsAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSCrossBeamStrutAssemblyPosition.cpp
+++ b/src/generated/CPACSCrossBeamStrutAssemblyPosition.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSCargoCrossBeamStrutsAssembly* CPACSCrossBeamStrutAssemblyPosition::GetParent() const
+    const CCPACSCargoCrossBeamStrutsAssembly* CPACSCrossBeamStrutAssemblyPosition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSCargoCrossBeamStrutsAssembly* CPACSCrossBeamStrutAssemblyPosition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSCrossBeamStrutAssemblyPosition.h
+++ b/src/generated/CPACSCrossBeamStrutAssemblyPosition.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSCrossBeamStrutAssemblyPosition();
 
-        TIGL_EXPORT CCPACSCargoCrossBeamStrutsAssembly* GetParent() const;
+        TIGL_EXPORT CCPACSCargoCrossBeamStrutsAssembly* GetParent();
+
+        TIGL_EXPORT const CCPACSCargoCrossBeamStrutsAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSDoorAssemblyPosition.cpp
+++ b/src/generated/CPACSDoorAssemblyPosition.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CPACSCargoDoorsAssembly* CPACSDoorAssemblyPosition::GetParent() const
+    const CPACSCargoDoorsAssembly* CPACSDoorAssemblyPosition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSCargoDoorsAssembly* CPACSDoorAssemblyPosition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSDoorAssemblyPosition.h
+++ b/src/generated/CPACSDoorAssemblyPosition.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSDoorAssemblyPosition();
 
-        TIGL_EXPORT CPACSCargoDoorsAssembly* GetParent() const;
+        TIGL_EXPORT CPACSCargoDoorsAssembly* GetParent();
+
+        TIGL_EXPORT const CPACSCargoDoorsAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFrame.cpp
+++ b/src/generated/CPACSFrame.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSFramesAssembly* CPACSFrame::GetParent() const
+    const CCPACSFramesAssembly* CPACSFrame::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFramesAssembly* CPACSFrame::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFrame.h
+++ b/src/generated/CPACSFrame.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFrame();
 
-        TIGL_EXPORT CCPACSFramesAssembly* GetParent() const;
+        TIGL_EXPORT CCPACSFramesAssembly* GetParent();
+
+        TIGL_EXPORT const CCPACSFramesAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFramesAssembly.cpp
+++ b/src/generated/CPACSFramesAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSFramesAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSFramesAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSFramesAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFramesAssembly.h
+++ b/src/generated/CPACSFramesAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFramesAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselage.cpp
+++ b/src/generated/CPACSFuselage.cpp
@@ -42,7 +42,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSFuselages* CPACSFuselage::GetParent() const
+    const CCPACSFuselages* CPACSFuselage::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselages* CPACSFuselage::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselage.h
+++ b/src/generated/CPACSFuselage.h
@@ -48,7 +48,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselage();
 
-        TIGL_EXPORT CCPACSFuselages* GetParent() const;
+        TIGL_EXPORT CCPACSFuselages* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselages* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageElement.cpp
+++ b/src/generated/CPACSFuselageElement.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSFuselageSectionElements* CPACSFuselageElement::GetParent() const
+    const CCPACSFuselageSectionElements* CPACSFuselageElement::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageSectionElements* CPACSFuselageElement::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageElement.h
+++ b/src/generated/CPACSFuselageElement.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageElement();
 
-        TIGL_EXPORT CCPACSFuselageSectionElements* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageSectionElements* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageSectionElements* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageElements.cpp
+++ b/src/generated/CPACSFuselageElements.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageSection* CPACSFuselageElements::GetParent() const
+    const CCPACSFuselageSection* CPACSFuselageElements::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageSection* CPACSFuselageElements::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageElements.h
+++ b/src/generated/CPACSFuselageElements.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageElements();
 
-        TIGL_EXPORT CCPACSFuselageSection* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageSection* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageSection* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageSection.cpp
+++ b/src/generated/CPACSFuselageSection.cpp
@@ -41,7 +41,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSFuselageSections* CPACSFuselageSection::GetParent() const
+    const CCPACSFuselageSections* CPACSFuselageSection::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageSections* CPACSFuselageSection::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageSection.h
+++ b/src/generated/CPACSFuselageSection.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageSection();
 
-        TIGL_EXPORT CCPACSFuselageSections* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageSections* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageSections* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageSections.cpp
+++ b/src/generated/CPACSFuselageSections.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselage* CPACSFuselageSections::GetParent() const
+    const CCPACSFuselage* CPACSFuselageSections::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselage* CPACSFuselageSections::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageSections.h
+++ b/src/generated/CPACSFuselageSections.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageSections();
 
-        TIGL_EXPORT CCPACSFuselage* GetParent() const;
+        TIGL_EXPORT CCPACSFuselage* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselage* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageSegment.cpp
+++ b/src/generated/CPACSFuselageSegment.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSFuselageSegments* CPACSFuselageSegment::GetParent() const
+    const CCPACSFuselageSegments* CPACSFuselageSegment::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageSegments* CPACSFuselageSegment::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageSegment.h
+++ b/src/generated/CPACSFuselageSegment.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageSegment();
 
-        TIGL_EXPORT CCPACSFuselageSegments* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageSegments* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageSegments* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageSegments.cpp
+++ b/src/generated/CPACSFuselageSegments.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselage* CPACSFuselageSegments::GetParent() const
+    const CCPACSFuselage* CPACSFuselageSegments::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselage* CPACSFuselageSegments::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageSegments.h
+++ b/src/generated/CPACSFuselageSegments.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageSegments();
 
-        TIGL_EXPORT CCPACSFuselage* GetParent() const;
+        TIGL_EXPORT CCPACSFuselage* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselage* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselageStructure.cpp
+++ b/src/generated/CPACSFuselageStructure.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselage* CPACSFuselageStructure::GetParent() const
+    const CCPACSFuselage* CPACSFuselageStructure::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselage* CPACSFuselageStructure::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSFuselageStructure.h
+++ b/src/generated/CPACSFuselageStructure.h
@@ -50,7 +50,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSFuselageStructure();
 
-        TIGL_EXPORT CCPACSFuselage* GetParent() const;
+        TIGL_EXPORT CCPACSFuselage* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselage* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSFuselages.h
+++ b/src/generated/CPACSFuselages.h
@@ -54,7 +54,19 @@ namespace generated
         }
 
         template<typename P>
-        P* GetParent() const
+        P* GetParent()
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSFuselages");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
+
+        template<typename P>
+        const P* GetParent() const
         {
 #ifdef HAVE_STDIS_SAME
             static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSFuselages");

--- a/src/generated/CPACSGenericGeometricComponent.cpp
+++ b/src/generated/CPACSGenericGeometricComponent.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSExternalObjects* CPACSGenericGeometricComponent::GetParent() const
+    const CCPACSExternalObjects* CPACSGenericGeometricComponent::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSExternalObjects* CPACSGenericGeometricComponent::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSGenericGeometricComponent.h
+++ b/src/generated/CPACSGenericGeometricComponent.h
@@ -44,7 +44,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSGenericGeometricComponent();
 
-        TIGL_EXPORT CCPACSExternalObjects* GetParent() const;
+        TIGL_EXPORT CCPACSExternalObjects* GetParent();
+
+        TIGL_EXPORT const CCPACSExternalObjects* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSGenericGeometryComponents.cpp
+++ b/src/generated/CPACSGenericGeometryComponents.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSAircraftModel* CPACSGenericGeometryComponents::GetParent() const
+    const CCPACSAircraftModel* CPACSGenericGeometryComponents::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSAircraftModel* CPACSGenericGeometryComponents::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSGenericGeometryComponents.h
+++ b/src/generated/CPACSGenericGeometryComponents.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSGenericGeometryComponents();
 
-        TIGL_EXPORT CCPACSAircraftModel* GetParent() const;
+        TIGL_EXPORT CCPACSAircraftModel* GetParent();
+
+        TIGL_EXPORT const CCPACSAircraftModel* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSInterpolation.h
+++ b/src/generated/CPACSInterpolation.h
@@ -31,26 +31,26 @@ namespace generated
     // CPACSLongFloorBeamPosition
     // CPACSStringerFramePosition
 
-    // generated from /xsd:schema/xsd:complexType[838]/xsd:complexContent/xsd:extension/xsd:all/xsd:element[8]/xsd:complexType/xsd:simpleContent
+    // generated from /xsd:schema/xsd:complexType[391]/xsd:complexContent/xsd:extension/xsd:all/xsd:element[13]/xsd:complexType/xsd:simpleContent
     enum CPACSInterpolation
     {
-        _0,
-        CPACSInterpolation_1
+        CPACSInterpolation_0,
+        _1
     };
 
     inline std::string CPACSInterpolationToString(const CPACSInterpolation& value)
     {
         switch(value) {
-        case _0: return "0";
-        case CPACSInterpolation_1: return "1";
+        case CPACSInterpolation_0: return "0";
+        case _1: return "1";
         default: throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) + "\" for enum type CPACSInterpolation");
         }
     }
     inline CPACSInterpolation stringToCPACSInterpolation(const std::string& value)
     {
         struct ToLower { std::string operator()(std::string str) { for (std::size_t i = 0; i < str.length(); i++) { str[i] = std::tolower(str[i]); } return str; } } toLower;
-        if (toLower(value) == "0") { return _0; }
-        if (toLower(value) == "1") { return CPACSInterpolation_1; }
+        if (toLower(value) == "0") { return CPACSInterpolation_0; }
+        if (toLower(value) == "1") { return _1; }
         throw CTiglError("Invalid string value \"" + value + "\" for enum type CPACSInterpolation");
     }
 } // namespace generated
@@ -61,6 +61,6 @@ using ECPACSInterpolation = generated::CPACSInterpolation;
 #else
 typedef generated::CPACSInterpolation ECPACSInterpolation;
 #endif
-using generated::_0;
-using generated::CPACSInterpolation_1;
+using generated::CPACSInterpolation_0;
+using generated::_1;
 } // namespace tigl

--- a/src/generated/CPACSLongFloorBeam.cpp
+++ b/src/generated/CPACSLongFloorBeam.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSLongFloorBeamsAssembly* CPACSLongFloorBeam::GetParent() const
+    const CCPACSLongFloorBeamsAssembly* CPACSLongFloorBeam::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSLongFloorBeamsAssembly* CPACSLongFloorBeam::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSLongFloorBeam.h
+++ b/src/generated/CPACSLongFloorBeam.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSLongFloorBeam();
 
-        TIGL_EXPORT CCPACSLongFloorBeamsAssembly* GetParent() const;
+        TIGL_EXPORT CCPACSLongFloorBeamsAssembly* GetParent();
+
+        TIGL_EXPORT const CCPACSLongFloorBeamsAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSLongFloorBeamPosition.cpp
+++ b/src/generated/CPACSLongFloorBeamPosition.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSLongFloorBeam* CPACSLongFloorBeamPosition::GetParent() const
+    const CCPACSLongFloorBeam* CPACSLongFloorBeamPosition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSLongFloorBeam* CPACSLongFloorBeamPosition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSLongFloorBeamPosition.h
+++ b/src/generated/CPACSLongFloorBeamPosition.h
@@ -45,7 +45,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSLongFloorBeamPosition();
 
-        TIGL_EXPORT CCPACSLongFloorBeam* GetParent() const;
+        TIGL_EXPORT CCPACSLongFloorBeam* GetParent();
+
+        TIGL_EXPORT const CCPACSLongFloorBeam* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSLongFloorBeamsAssembly.cpp
+++ b/src/generated/CPACSLongFloorBeamsAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSLongFloorBeamsAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSLongFloorBeamsAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSLongFloorBeamsAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSLongFloorBeamsAssembly.h
+++ b/src/generated/CPACSLongFloorBeamsAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSLongFloorBeamsAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSPressureBulkhead.cpp
+++ b/src/generated/CPACSPressureBulkhead.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSPressureBulkheads* CPACSPressureBulkhead::GetParent() const
+    const CCPACSPressureBulkheads* CPACSPressureBulkhead::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSPressureBulkheads* CPACSPressureBulkhead::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSPressureBulkhead.h
+++ b/src/generated/CPACSPressureBulkhead.h
@@ -41,7 +41,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSPressureBulkhead();
 
-        TIGL_EXPORT CCPACSPressureBulkheads* GetParent() const;
+        TIGL_EXPORT CCPACSPressureBulkheads* GetParent();
+
+        TIGL_EXPORT const CCPACSPressureBulkheads* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSPressureBulkheadAssembly.cpp
+++ b/src/generated/CPACSPressureBulkheadAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSPressureBulkheadAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSPressureBulkheadAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSPressureBulkheadAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSPressureBulkheadAssembly.h
+++ b/src/generated/CPACSPressureBulkheadAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSPressureBulkheadAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSPressureBulkheadAssemblyPosition.cpp
+++ b/src/generated/CPACSPressureBulkheadAssemblyPosition.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSPressureBulkheadAssembly* CPACSPressureBulkheadAssemblyPosition::GetParent() const
+    const CCPACSPressureBulkheadAssembly* CPACSPressureBulkheadAssemblyPosition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSPressureBulkheadAssembly* CPACSPressureBulkheadAssemblyPosition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSPressureBulkheadAssemblyPosition.h
+++ b/src/generated/CPACSPressureBulkheadAssemblyPosition.h
@@ -39,7 +39,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSPressureBulkheadAssemblyPosition();
 
-        TIGL_EXPORT CCPACSPressureBulkheadAssembly* GetParent() const;
+        TIGL_EXPORT CCPACSPressureBulkheadAssembly* GetParent();
+
+        TIGL_EXPORT const CCPACSPressureBulkheadAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRibCrossingBehaviour.h
+++ b/src/generated/CPACSRibCrossingBehaviour.h
@@ -30,7 +30,7 @@ namespace generated
     // This enum is used in:
     // CPACSWingRibsPositioning
 
-    // generated from /xsd:schema/xsd:complexType[949]/xsd:complexContent/xsd:extension/xsd:sequence/xsd:element[4]/xsd:complexType/xsd:simpleContent
+    // generated from /xsd:schema/xsd:complexType[744]/xsd:complexContent/xsd:extension/xsd:sequence/xsd:element[4]/xsd:complexType/xsd:simpleContent
     enum CPACSRibCrossingBehaviour
     {
         cross,

--- a/src/generated/CPACSRibRotation.cpp
+++ b/src/generated/CPACSRibRotation.cpp
@@ -37,7 +37,12 @@ namespace generated
     {
     }
 
-    CCPACSWingRibsPositioning* CPACSRibRotation::GetParent() const
+    const CCPACSWingRibsPositioning* CPACSRibRotation::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingRibsPositioning* CPACSRibRotation::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRibRotation.h
+++ b/src/generated/CPACSRibRotation.h
@@ -41,7 +41,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRibRotation();
 
-        TIGL_EXPORT CCPACSWingRibsPositioning* GetParent() const;
+        TIGL_EXPORT CCPACSWingRibsPositioning* GetParent();
+
+        TIGL_EXPORT const CCPACSWingRibsPositioning* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSRotor.cpp
+++ b/src/generated/CPACSRotor.cpp
@@ -41,7 +41,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSRotors* CPACSRotor::GetParent() const
+    const CCPACSRotors* CPACSRotor::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotors* CPACSRotor::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotor.h
+++ b/src/generated/CPACSRotor.h
@@ -45,7 +45,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotor();
 
-        TIGL_EXPORT CCPACSRotors* GetParent() const;
+        TIGL_EXPORT CCPACSRotors* GetParent();
+
+        TIGL_EXPORT const CCPACSRotors* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotorBladeAttachment.cpp
+++ b/src/generated/CPACSRotorBladeAttachment.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSRotorBladeAttachments* CPACSRotorBladeAttachment::GetParent() const
+    const CCPACSRotorBladeAttachments* CPACSRotorBladeAttachment::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotorBladeAttachments* CPACSRotorBladeAttachment::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotorBladeAttachment.h
+++ b/src/generated/CPACSRotorBladeAttachment.h
@@ -44,7 +44,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotorBladeAttachment();
 
-        TIGL_EXPORT CCPACSRotorBladeAttachments* GetParent() const;
+        TIGL_EXPORT CCPACSRotorBladeAttachments* GetParent();
+
+        TIGL_EXPORT const CCPACSRotorBladeAttachments* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotorBladeAttachments.cpp
+++ b/src/generated/CPACSRotorBladeAttachments.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSRotorHub* CPACSRotorBladeAttachments::GetParent() const
+    const CCPACSRotorHub* CPACSRotorBladeAttachments::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotorHub* CPACSRotorBladeAttachments::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotorBladeAttachments.h
+++ b/src/generated/CPACSRotorBladeAttachments.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotorBladeAttachments();
 
-        TIGL_EXPORT CCPACSRotorHub* GetParent() const;
+        TIGL_EXPORT CCPACSRotorHub* GetParent();
+
+        TIGL_EXPORT const CCPACSRotorHub* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotorBlades.cpp
+++ b/src/generated/CPACSRotorBlades.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSRotorcraftModel* CPACSRotorBlades::GetParent() const
+    const CCPACSRotorcraftModel* CPACSRotorBlades::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotorcraftModel* CPACSRotorBlades::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotorBlades.h
+++ b/src/generated/CPACSRotorBlades.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotorBlades();
 
-        TIGL_EXPORT CCPACSRotorcraftModel* GetParent() const;
+        TIGL_EXPORT CCPACSRotorcraftModel* GetParent();
+
+        TIGL_EXPORT const CCPACSRotorcraftModel* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotorHub.cpp
+++ b/src/generated/CPACSRotorHub.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSRotor* CPACSRotorHub::GetParent() const
+    const CCPACSRotor* CPACSRotorHub::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotor* CPACSRotorHub::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotorHub.h
+++ b/src/generated/CPACSRotorHub.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotorHub();
 
-        TIGL_EXPORT CCPACSRotor* GetParent() const;
+        TIGL_EXPORT CCPACSRotor* GetParent();
+
+        TIGL_EXPORT const CCPACSRotor* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotorHubHinge.cpp
+++ b/src/generated/CPACSRotorHubHinge.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSRotorHinges* CPACSRotorHubHinge::GetParent() const
+    const CCPACSRotorHinges* CPACSRotorHubHinge::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotorHinges* CPACSRotorHubHinge::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotorHubHinge.h
+++ b/src/generated/CPACSRotorHubHinge.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotorHubHinge();
 
-        TIGL_EXPORT CCPACSRotorHinges* GetParent() const;
+        TIGL_EXPORT CCPACSRotorHinges* GetParent();
+
+        TIGL_EXPORT const CCPACSRotorHinges* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotorHubHinges.cpp
+++ b/src/generated/CPACSRotorHubHinges.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSRotorBladeAttachment* CPACSRotorHubHinges::GetParent() const
+    const CCPACSRotorBladeAttachment* CPACSRotorHubHinges::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotorBladeAttachment* CPACSRotorHubHinges::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotorHubHinges.h
+++ b/src/generated/CPACSRotorHubHinges.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotorHubHinges();
 
-        TIGL_EXPORT CCPACSRotorBladeAttachment* GetParent() const;
+        TIGL_EXPORT CCPACSRotorBladeAttachment* GetParent();
+
+        TIGL_EXPORT const CCPACSRotorBladeAttachment* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSRotors.cpp
+++ b/src/generated/CPACSRotors.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSRotorcraftModel* CPACSRotors::GetParent() const
+    const CCPACSRotorcraftModel* CPACSRotors::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSRotorcraftModel* CPACSRotors::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSRotors.h
+++ b/src/generated/CPACSRotors.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSRotors();
 
-        TIGL_EXPORT CCPACSRotorcraftModel* GetParent() const;
+        TIGL_EXPORT CCPACSRotorcraftModel* GetParent();
+
+        TIGL_EXPORT const CCPACSRotorcraftModel* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSheetList.cpp
+++ b/src/generated/CPACSSheetList.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CPACSStructuralProfile* CPACSSheetList::GetParent() const
+    const CPACSStructuralProfile* CPACSSheetList::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSStructuralProfile* CPACSSheetList::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSheetList.h
+++ b/src/generated/CPACSSheetList.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSheetList();
 
-        TIGL_EXPORT CPACSStructuralProfile* GetParent() const;
+        TIGL_EXPORT CPACSStructuralProfile* GetParent();
+
+        TIGL_EXPORT const CPACSStructuralProfile* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSkin.cpp
+++ b/src/generated/CPACSSkin.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSSkin::GetParent() const
+    const CCPACSFuselageStructure* CPACSSkin::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSSkin::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSkin.h
+++ b/src/generated/CPACSSkin.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSkin();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSkinSegment.cpp
+++ b/src/generated/CPACSSkinSegment.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CPACSSkinSegments* CPACSSkinSegment::GetParent() const
+    const CPACSSkinSegments* CPACSSkinSegment::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSSkinSegments* CPACSSkinSegment::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSkinSegment.h
+++ b/src/generated/CPACSSkinSegment.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSkinSegment();
 
-        TIGL_EXPORT CPACSSkinSegments* GetParent() const;
+        TIGL_EXPORT CPACSSkinSegments* GetParent();
+
+        TIGL_EXPORT const CPACSSkinSegments* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSkinSegments.cpp
+++ b/src/generated/CPACSSkinSegments.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CPACSSkin* CPACSSkinSegments::GetParent() const
+    const CPACSSkin* CPACSSkinSegments::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CPACSSkin* CPACSSkinSegments::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSkinSegments.h
+++ b/src/generated/CPACSSkinSegments.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSkinSegments();
 
-        TIGL_EXPORT CPACSSkin* GetParent() const;
+        TIGL_EXPORT CPACSSkin* GetParent();
+
+        TIGL_EXPORT const CPACSSkin* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSparCrossSection.cpp
+++ b/src/generated/CPACSSparCrossSection.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWingSparSegment* CPACSSparCrossSection::GetParent() const
+    const CCPACSWingSparSegment* CPACSSparCrossSection::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSparSegment* CPACSSparCrossSection::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSparCrossSection.h
+++ b/src/generated/CPACSSparCrossSection.h
@@ -45,7 +45,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSparCrossSection();
 
-        TIGL_EXPORT CCPACSWingSparSegment* GetParent() const;
+        TIGL_EXPORT CCPACSWingSparSegment* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSparSegment* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSparPosition.cpp
+++ b/src/generated/CPACSSparPosition.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr && m_uID) m_uidMgr->TryUnregisterObject(*m_uID);
     }
 
-    CCPACSWingSparPositions* CPACSSparPosition::GetParent() const
+    const CCPACSWingSparPositions* CPACSSparPosition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSparPositions* CPACSSparPosition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSparPosition.h
+++ b/src/generated/CPACSSparPosition.h
@@ -41,7 +41,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSparPosition();
 
-        TIGL_EXPORT CCPACSWingSparPositions* GetParent() const;
+        TIGL_EXPORT CCPACSWingSparPositions* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSparPositions* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSparPositions.cpp
+++ b/src/generated/CPACSSparPositions.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWingSpars* CPACSSparPositions::GetParent() const
+    const CCPACSWingSpars* CPACSSparPositions::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSpars* CPACSSparPositions::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSparPositions.h
+++ b/src/generated/CPACSSparPositions.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSparPositions();
 
-        TIGL_EXPORT CCPACSWingSpars* GetParent() const;
+        TIGL_EXPORT CCPACSWingSpars* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSpars* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSparSegment.cpp
+++ b/src/generated/CPACSSparSegment.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr && m_uID) m_uidMgr->TryUnregisterObject(*m_uID);
     }
 
-    CCPACSWingSparSegments* CPACSSparSegment::GetParent() const
+    const CCPACSWingSparSegments* CPACSSparSegment::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSparSegments* CPACSSparSegment::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSparSegment.h
+++ b/src/generated/CPACSSparSegment.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSparSegment();
 
-        TIGL_EXPORT CCPACSWingSparSegments* GetParent() const;
+        TIGL_EXPORT CCPACSWingSparSegments* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSparSegments* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSparSegments.cpp
+++ b/src/generated/CPACSSparSegments.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWingSpars* CPACSSparSegments::GetParent() const
+    const CCPACSWingSpars* CPACSSparSegments::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSpars* CPACSSparSegments::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSSparSegments.h
+++ b/src/generated/CPACSSparSegments.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSSparSegments();
 
-        TIGL_EXPORT CCPACSWingSpars* GetParent() const;
+        TIGL_EXPORT CCPACSWingSpars* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSpars* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSStringer.cpp
+++ b/src/generated/CPACSStringer.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSStringersAssembly* CPACSStringer::GetParent() const
+    const CCPACSStringersAssembly* CPACSStringer::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSStringersAssembly* CPACSStringer::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSStringer.h
+++ b/src/generated/CPACSStringer.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSStringer();
 
-        TIGL_EXPORT CCPACSStringersAssembly* GetParent() const;
+        TIGL_EXPORT CCPACSStringersAssembly* GetParent();
+
+        TIGL_EXPORT const CCPACSStringersAssembly* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSStringerFramePosition.h
+++ b/src/generated/CPACSStringerFramePosition.h
@@ -57,7 +57,19 @@ namespace generated
         }
 
         template<typename P>
-        P* GetParent() const
+        P* GetParent()
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSFrame>::value || std::is_same<P, CCPACSFuselageStringer>::value, "template argument for P is not a parent class of CPACSStringerFramePosition");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
+
+        template<typename P>
+        const P* GetParent() const
         {
 #ifdef HAVE_STDIS_SAME
             static_assert(std::is_same<P, CCPACSFrame>::value || std::is_same<P, CCPACSFuselageStringer>::value, "template argument for P is not a parent class of CPACSStringerFramePosition");

--- a/src/generated/CPACSStringersAssembly.cpp
+++ b/src/generated/CPACSStringersAssembly.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSFuselageStructure* CPACSStringersAssembly::GetParent() const
+    const CCPACSFuselageStructure* CPACSStringersAssembly::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSFuselageStructure* CPACSStringersAssembly::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSStringersAssembly.h
+++ b/src/generated/CPACSStringersAssembly.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSStringersAssembly();
 
-        TIGL_EXPORT CCPACSFuselageStructure* GetParent() const;
+        TIGL_EXPORT CCPACSFuselageStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSFuselageStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSStructuralProfile.cpp
+++ b/src/generated/CPACSStructuralProfile.cpp
@@ -41,7 +41,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSStructuralProfiles* CPACSStructuralProfile::GetParent() const
+    const CCPACSStructuralProfiles* CPACSStructuralProfile::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSStructuralProfiles* CPACSStructuralProfile::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSStructuralProfile.h
+++ b/src/generated/CPACSStructuralProfile.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSStructuralProfile();
 
-        TIGL_EXPORT CCPACSStructuralProfiles* GetParent() const;
+        TIGL_EXPORT CCPACSStructuralProfiles* GetParent();
+
+        TIGL_EXPORT const CCPACSStructuralProfiles* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSSymmetry.h
+++ b/src/generated/CPACSSymmetry.h
@@ -35,7 +35,7 @@ namespace generated
     // CPACSRotor
     // CPACSWing
 
-    // generated from /xsd:schema/xsd:complexType[631]/xsd:complexContent/xsd:extension/xsd:attribute[2]/xsd:simpleType
+    // generated from /xsd:schema/xsd:complexType[309]/xsd:complexContent/xsd:extension/xsd:attribute[2]/xsd:simpleType
     enum CPACSSymmetry
     {
         x_y_plane,

--- a/src/generated/CPACSTrailingEdgeDevice.cpp
+++ b/src/generated/CPACSTrailingEdgeDevice.cpp
@@ -41,7 +41,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent() const
+    const CCPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSTrailingEdgeDevice.h
+++ b/src/generated/CPACSTrailingEdgeDevice.h
@@ -47,7 +47,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSTrailingEdgeDevice();
 
-        TIGL_EXPORT CCPACSTrailingEdgeDevices* GetParent() const;
+        TIGL_EXPORT CCPACSTrailingEdgeDevices* GetParent();
+
+        TIGL_EXPORT const CCPACSTrailingEdgeDevices* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSTrailingEdgeDevices.cpp
+++ b/src/generated/CPACSTrailingEdgeDevices.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSControlSurfaces* CPACSTrailingEdgeDevices::GetParent() const
+    const CCPACSControlSurfaces* CPACSTrailingEdgeDevices::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSControlSurfaces* CPACSTrailingEdgeDevices::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSTrailingEdgeDevices.h
+++ b/src/generated/CPACSTrailingEdgeDevices.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSTrailingEdgeDevices();
 
-        TIGL_EXPORT CCPACSControlSurfaces* GetParent() const;
+        TIGL_EXPORT CCPACSControlSurfaces* GetParent();
+
+        TIGL_EXPORT const CCPACSControlSurfaces* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWing.h
+++ b/src/generated/CPACSWing.h
@@ -60,7 +60,19 @@ namespace generated
         }
 
         template<typename P>
-        P* GetParent() const
+        P* GetParent()
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSRotorBlades>::value || std::is_same<P, CCPACSWings>::value, "template argument for P is not a parent class of CPACSWing");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
+
+        template<typename P>
+        const P* GetParent() const
         {
 #ifdef HAVE_STDIS_SAME
             static_assert(std::is_same<P, CCPACSRotorBlades>::value || std::is_same<P, CCPACSWings>::value, "template argument for P is not a parent class of CPACSWing");

--- a/src/generated/CPACSWingCell.cpp
+++ b/src/generated/CPACSWingCell.cpp
@@ -43,7 +43,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSWingCells* CPACSWingCell::GetParent() const
+    const CCPACSWingCells* CPACSWingCell::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingCells* CPACSWingCell::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingCell.h
+++ b/src/generated/CPACSWingCell.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingCell();
 
-        TIGL_EXPORT CCPACSWingCells* GetParent() const;
+        TIGL_EXPORT CCPACSWingCells* GetParent();
+
+        TIGL_EXPORT const CCPACSWingCells* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingCells.cpp
+++ b/src/generated/CPACSWingCells.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWingShell* CPACSWingCells::GetParent() const
+    const CCPACSWingShell* CPACSWingCells::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingShell* CPACSWingCells::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingCells.h
+++ b/src/generated/CPACSWingCells.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingCells();
 
-        TIGL_EXPORT CCPACSWingShell* GetParent() const;
+        TIGL_EXPORT CCPACSWingShell* GetParent();
+
+        TIGL_EXPORT const CCPACSWingShell* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingComponentSegmentStructure.h
+++ b/src/generated/CPACSWingComponentSegmentStructure.h
@@ -57,7 +57,19 @@ namespace generated
         }
 
         template<typename P>
-        P* GetParent() const
+        P* GetParent()
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSWingComponentSegment>::value || std::is_same<P, CCPACSTrailingEdgeDevice>::value, "template argument for P is not a parent class of CPACSWingComponentSegmentStructure");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
+
+        template<typename P>
+        const P* GetParent() const
         {
 #ifdef HAVE_STDIS_SAME
             static_assert(std::is_same<P, CCPACSWingComponentSegment>::value || std::is_same<P, CCPACSTrailingEdgeDevice>::value, "template argument for P is not a parent class of CPACSWingComponentSegmentStructure");

--- a/src/generated/CPACSWingElement.cpp
+++ b/src/generated/CPACSWingElement.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSWingSectionElements* CPACSWingElement::GetParent() const
+    const CCPACSWingSectionElements* CPACSWingElement::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSectionElements* CPACSWingElement::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingElement.h
+++ b/src/generated/CPACSWingElement.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingElement();
 
-        TIGL_EXPORT CCPACSWingSectionElements* GetParent() const;
+        TIGL_EXPORT CCPACSWingSectionElements* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSectionElements* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingElements.cpp
+++ b/src/generated/CPACSWingElements.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWingSection* CPACSWingElements::GetParent() const
+    const CCPACSWingSection* CPACSWingElements::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSection* CPACSWingElements::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingElements.h
+++ b/src/generated/CPACSWingElements.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingElements();
 
-        TIGL_EXPORT CCPACSWingSection* GetParent() const;
+        TIGL_EXPORT CCPACSWingSection* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSection* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingRibCrossSection.cpp
+++ b/src/generated/CPACSWingRibCrossSection.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSWingRibsDefinition* CPACSWingRibCrossSection::GetParent() const
+    const CCPACSWingRibsDefinition* CPACSWingRibCrossSection::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingRibsDefinition* CPACSWingRibCrossSection::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingRibCrossSection.h
+++ b/src/generated/CPACSWingRibCrossSection.h
@@ -46,7 +46,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingRibCrossSection();
 
-        TIGL_EXPORT CCPACSWingRibsDefinition* GetParent() const;
+        TIGL_EXPORT CCPACSWingRibsDefinition* GetParent();
+
+        TIGL_EXPORT const CCPACSWingRibsDefinition* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingRibExplicitPositioning.cpp
+++ b/src/generated/CPACSWingRibExplicitPositioning.cpp
@@ -38,7 +38,12 @@ namespace generated
     {
     }
 
-    CCPACSWingRibsDefinition* CPACSWingRibExplicitPositioning::GetParent() const
+    const CCPACSWingRibsDefinition* CPACSWingRibExplicitPositioning::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingRibsDefinition* CPACSWingRibExplicitPositioning::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingRibExplicitPositioning.h
+++ b/src/generated/CPACSWingRibExplicitPositioning.h
@@ -38,7 +38,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingRibExplicitPositioning();
 
-        TIGL_EXPORT CCPACSWingRibsDefinition* GetParent() const;
+        TIGL_EXPORT CCPACSWingRibsDefinition* GetParent();
+
+        TIGL_EXPORT const CCPACSWingRibsDefinition* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSWingRibsDefinition.cpp
+++ b/src/generated/CPACSWingRibsDefinition.cpp
@@ -40,7 +40,12 @@ namespace generated
         if (m_uidMgr && m_uID) m_uidMgr->TryUnregisterObject(*m_uID);
     }
 
-    CCPACSWingRibsDefinitions* CPACSWingRibsDefinition::GetParent() const
+    const CCPACSWingRibsDefinitions* CPACSWingRibsDefinition::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingRibsDefinitions* CPACSWingRibsDefinition::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingRibsDefinition.h
+++ b/src/generated/CPACSWingRibsDefinition.h
@@ -45,7 +45,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingRibsDefinition();
 
-        TIGL_EXPORT CCPACSWingRibsDefinitions* GetParent() const;
+        TIGL_EXPORT CCPACSWingRibsDefinitions* GetParent();
+
+        TIGL_EXPORT const CCPACSWingRibsDefinitions* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingRibsDefinitions.cpp
+++ b/src/generated/CPACSWingRibsDefinitions.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWingCSStructure* CPACSWingRibsDefinitions::GetParent() const
+    const CCPACSWingCSStructure* CPACSWingRibsDefinitions::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingCSStructure* CPACSWingRibsDefinitions::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingRibsDefinitions.h
+++ b/src/generated/CPACSWingRibsDefinitions.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingRibsDefinitions();
 
-        TIGL_EXPORT CCPACSWingCSStructure* GetParent() const;
+        TIGL_EXPORT CCPACSWingCSStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSWingCSStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingRibsPositioning.cpp
+++ b/src/generated/CPACSWingRibsPositioning.cpp
@@ -37,7 +37,12 @@ namespace generated
     {
     }
 
-    CCPACSWingRibsDefinition* CPACSWingRibsPositioning::GetParent() const
+    const CCPACSWingRibsDefinition* CPACSWingRibsPositioning::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingRibsDefinition* CPACSWingRibsPositioning::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingRibsPositioning.h
+++ b/src/generated/CPACSWingRibsPositioning.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingRibsPositioning();
 
-        TIGL_EXPORT CCPACSWingRibsDefinition* GetParent() const;
+        TIGL_EXPORT CCPACSWingRibsDefinition* GetParent();
+
+        TIGL_EXPORT const CCPACSWingRibsDefinition* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;

--- a/src/generated/CPACSWingSection.cpp
+++ b/src/generated/CPACSWingSection.cpp
@@ -41,7 +41,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSWingSections* CPACSWingSection::GetParent() const
+    const CCPACSWingSections* CPACSWingSection::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSections* CPACSWingSection::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingSection.h
+++ b/src/generated/CPACSWingSection.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingSection();
 
-        TIGL_EXPORT CCPACSWingSections* GetParent() const;
+        TIGL_EXPORT CCPACSWingSections* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSections* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingSections.cpp
+++ b/src/generated/CPACSWingSections.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWing* CPACSWingSections::GetParent() const
+    const CCPACSWing* CPACSWingSections::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWing* CPACSWingSections::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingSections.h
+++ b/src/generated/CPACSWingSections.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingSections();
 
-        TIGL_EXPORT CCPACSWing* GetParent() const;
+        TIGL_EXPORT CCPACSWing* GetParent();
+
+        TIGL_EXPORT const CCPACSWing* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingSegment.cpp
+++ b/src/generated/CPACSWingSegment.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSWingSegments* CPACSWingSegment::GetParent() const
+    const CCPACSWingSegments* CPACSWingSegment::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingSegments* CPACSWingSegment::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingSegment.h
+++ b/src/generated/CPACSWingSegment.h
@@ -43,7 +43,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingSegment();
 
-        TIGL_EXPORT CCPACSWingSegments* GetParent() const;
+        TIGL_EXPORT CCPACSWingSegments* GetParent();
+
+        TIGL_EXPORT const CCPACSWingSegments* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingSegments.cpp
+++ b/src/generated/CPACSWingSegments.cpp
@@ -39,7 +39,12 @@ namespace generated
     {
     }
 
-    CCPACSWing* CPACSWingSegments::GetParent() const
+    const CCPACSWing* CPACSWingSegments::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWing* CPACSWingSegments::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingSegments.h
+++ b/src/generated/CPACSWingSegments.h
@@ -42,7 +42,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingSegments();
 
-        TIGL_EXPORT CCPACSWing* GetParent() const;
+        TIGL_EXPORT CCPACSWing* GetParent();
+
+        TIGL_EXPORT const CCPACSWing* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingShell.cpp
+++ b/src/generated/CPACSWingShell.cpp
@@ -39,7 +39,12 @@ namespace generated
         if (m_uidMgr) m_uidMgr->TryUnregisterObject(m_uID);
     }
 
-    CCPACSWingCSStructure* CPACSWingShell::GetParent() const
+    const CCPACSWingCSStructure* CPACSWingShell::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingCSStructure* CPACSWingShell::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingShell.h
+++ b/src/generated/CPACSWingShell.h
@@ -44,7 +44,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingShell();
 
-        TIGL_EXPORT CCPACSWingCSStructure* GetParent() const;
+        TIGL_EXPORT CCPACSWingCSStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSWingCSStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWingSpar.cpp
+++ b/src/generated/CPACSWingSpar.cpp
@@ -40,7 +40,12 @@ namespace generated
     {
     }
 
-    CCPACSWingCSStructure* CPACSWingSpar::GetParent() const
+    const CCPACSWingCSStructure* CPACSWingSpar::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSWingCSStructure* CPACSWingSpar::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSWingSpar.h
+++ b/src/generated/CPACSWingSpar.h
@@ -41,7 +41,9 @@ namespace generated
 
         TIGL_EXPORT virtual ~CPACSWingSpar();
 
-        TIGL_EXPORT CCPACSWingCSStructure* GetParent() const;
+        TIGL_EXPORT CCPACSWingCSStructure* GetParent();
+
+        TIGL_EXPORT const CCPACSWingCSStructure* GetParent() const;
 
         TIGL_EXPORT CTiglUIDManager& GetUIDManager();
         TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;

--- a/src/generated/CPACSWings.h
+++ b/src/generated/CPACSWings.h
@@ -54,7 +54,19 @@ namespace generated
         }
 
         template<typename P>
-        P* GetParent() const
+        P* GetParent()
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSWings");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
+
+        template<typename P>
+        const P* GetParent() const
         {
 #ifdef HAVE_STDIS_SAME
             static_assert(std::is_same<P, CCPACSAircraftModel>::value || std::is_same<P, CCPACSRotorcraftModel>::value, "template argument for P is not a parent class of CPACSWings");

--- a/src/generated/TixiHelper.h
+++ b/src/generated/TixiHelper.h
@@ -25,6 +25,9 @@
 #include <ctime>
 
 #include "UniquePtr.h"
+#ifndef CPACS_GEN
+#include "CTiglLogging.h"
+#endif
 
 // some extensions to tixi
 namespace tixi
@@ -76,7 +79,16 @@ namespace tixi
 
         // read child nodes
         for (int i = 0; i < childCount; i++) {
-            children.push_back(readChild(tixiHandle, xpath + "[" + internal::to_string(i + 1) + "]"));
+            const std::string childXPath = xpath + "[" + internal::to_string(i + 1) + "]";
+            try {
+                children.push_back(readChild(tixiHandle, childXPath));
+            } catch (const std::exception& e) {
+#ifdef CPACS_GEN
+                throw;
+#else
+                LOG(ERROR) << "Failed to read element at xpath " << childXPath << ": " << e.what();
+#endif
+            }
         }
     }
 

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -331,7 +331,7 @@ EtaXsi CCPACSWingCell::computePositioningEtaXsi(const CCPACSWingCellPositionSpan
             eta = spanwisePos.GetEta().second;
         }
         // get the spar from the wing structure
-        const CCPACSWingCSStructure& structure = m_parent->GetParentElement()->GetStructure();
+        const CCPACSWingCSStructure& structure = m_parent->GetParent()->GetStructure();
         const CCPACSWingSparSegment& spar      = structure.GetSparSegment(chordwisePos.GetSparUId());
         xsi                                    = computeSparXsiValue(structure.GetWingStructureReference(), spar, eta);
     }
@@ -341,7 +341,7 @@ EtaXsi CCPACSWingCell::computePositioningEtaXsi(const CCPACSWingCellPositionSpan
         int ribIndex;
         // get the ribs definition from the wing structure reference
         spanwisePos.GetRib(ribUid, ribIndex);
-        const CCPACSWingCSStructure& structure         = m_parent->GetParentElement()->GetStructure();
+        const CCPACSWingCSStructure& structure         = m_parent->GetParent()->GetStructure();
         const CCPACSWingRibsDefinition& ribsDefinition = structure.GetRibsDefinition(ribUid);
         if (inner) {
             xsi = chordwisePos.GetXsi().first;
@@ -354,7 +354,7 @@ EtaXsi CCPACSWingCell::computePositioningEtaXsi(const CCPACSWingCellPositionSpan
     else if (spanwisePos.GetInputType() == CCPACSWingCellPositionSpanwise::Rib &&
              chordwisePos.GetInputType() == CCPACSWingCellPositionChordwise::Spar) {
         // get the spar from the wing structure reference
-        const CCPACSWingCSStructure& structure = m_parent->GetParentElement()->GetStructure();
+        const CCPACSWingCSStructure& structure = m_parent->GetParent()->GetStructure();
         CTiglWingStructureReference wsr        = structure.GetWingStructureReference();
         const CCPACSWingSparSegment& spar      = structure.GetSparSegment(chordwisePos.GetSparUId());
         // get the ribs definition from the wing structure reference
@@ -385,7 +385,7 @@ void CCPACSWingCell::UpdateEtaXsiValues(EtaXsiCache& cache) const
 TopoDS_Shape CCPACSWingCell::GetCellSkinGeometry(TiglCoordinateSystem cs) const
 {
     if (cs == GLOBAL_COORDINATE_SYSTEM) {
-        return m_parent->GetParentElement()
+        return m_parent->GetParent()
             ->GetStructure()
             .GetWingStructureReference()
             .GetWingComponentSegment()
@@ -406,7 +406,7 @@ void CCPACSWingCell::BuildSkinGeometry(GeometryCache& cache) const
 
     BRep_Builder builder;
 
-    const CTiglWingStructureReference& wsr = m_parent->GetParentElement()->GetStructure().GetWingStructureReference();
+    const CTiglWingStructureReference& wsr = m_parent->GetParent()->GetStructure().GetWingStructureReference();
     gp_Pnt p1                              = wsr.GetLeadingEdgePoint(0);
     gp_Pnt p2                              = wsr.GetLeadingEdgePoint(1);
     gp_Vec yRefDir(p1, p2);
@@ -432,7 +432,7 @@ void CCPACSWingCell::BuildSkinGeometry(GeometryCache& cache) const
 
     // Step 8: find the correct part of the loft
     TopoDS_Shape loftShape;
-    TiglLoftSide side = m_parent->GetParentElement()->GetLoftSide();
+    TiglLoftSide side = m_parent->GetParent()->GetLoftSide();
     if (side == UPPER_SIDE) {
         loftShape = wsr.GetUpperShape();
     }
@@ -722,7 +722,7 @@ bool CCPACSWingCell::IsPartOfCellImpl(T t)
 {
     Bnd_Box bBox1, bBox2;
     BRepBndLib::Add(m_geometryCache->cellSkinGeometry, bBox1);
-    TopoDS_Shape t_transformed = m_parent->GetParentElement()
+    TopoDS_Shape t_transformed = m_parent->GetParent()
                                         ->GetStructure()
                                         .GetWingStructureReference()
                                         .GetWingComponentSegment()

--- a/src/wing/CCPACSWingCells.cpp
+++ b/src/wing/CCPACSWingCells.cpp
@@ -50,7 +50,7 @@ CCPACSWingCell& CCPACSWingCells::GetCell(int index) const
 // Get parent wing shell element
 CCPACSWingShell* CCPACSWingCells::GetParentElement() const
 {
-    return GetParent();
+    return m_parent; // WARN(bgruber): breaks const propagation
 }
 
 CCPACSWingCell &CCPACSWingCells::GetCell(const std::string &UID) const

--- a/src/wing/CCPACSWingCells.h
+++ b/src/wing/CCPACSWingCells.h
@@ -40,7 +40,7 @@ public:
     TIGL_EXPORT CCPACSWingCell& GetCell(int index) const;
 
     // Get parent wing shell element
-    TIGL_EXPORT CCPACSWingShell* GetParentElement() const;
+    DEPRECATED TIGL_EXPORT CCPACSWingShell* GetParentElement() const;
 
     TIGL_EXPORT CCPACSWingCell& GetCell(const std::string& UID) const;
 };


### PR DESCRIPTION
* generated code now provides const correct GetParent() methods
* added missing const on CCPACSFuslage::GetLoft()
* deprecated CCPACSWingCells::GetParentElement and replaced occurrences in code (breaks const correctness)