### PR TITLE
Introduced intents of geometric shapes

### DIFF
--- a/TIGLViewer/src/TIGLViewerDocument.h
+++ b/TIGLViewer/src/TIGLViewerDocument.h
@@ -64,6 +64,7 @@ public slots:
     void drawFarField();
     void drawSystems();
     void drawComponent();
+    void drawComponentByUID(const QString& uid);
 
     // Wing slots
     void drawWingProfiles();
@@ -100,6 +101,7 @@ public slots:
     void drawRotorBladeShells();
 
     // Rotorcraft slots
+    void drawRotorByUID(const QString& uid);
     void drawRotor();
     void drawRotorDisk();
     void showRotorProperties();
@@ -129,6 +131,7 @@ public slots:
 
     // General slots
     void updateConfiguration();
+
 
 private slots:
 

--- a/TIGLViewer/src/TIGLViewerWindow.cpp
+++ b/TIGLViewer/src/TIGLViewerWindow.cpp
@@ -619,7 +619,6 @@ void TIGLViewerWindow::connectConfiguration()
 
     // CPACS Rotorcraft Actions
     connect(drawRotorsAction, SIGNAL(triggered()), cpacsConfiguration, SLOT(drawRotor()));
-    connect(drawRotorDisksAction, SIGNAL(triggered()), cpacsConfiguration, SLOT(drawRotorDisk()));
     connect(showRotorPropertiesAction, SIGNAL(triggered()), cpacsConfiguration, SLOT(showRotorProperties()));
 
     // Export functions
@@ -823,7 +822,6 @@ void TIGLViewerWindow::updateMenus()
     drawFarFieldAction->setEnabled(hasFarField);
     drawSystemsAction->setEnabled(hasACSystems);
     drawRotorsAction->setEnabled(nRotors > 0);
-    drawRotorDisksAction->setEnabled(nRotors > 0);
     menuRotorcraft->setEnabled((nRotors > 0) || (nRotorBlades > 0));
     menuRotorBlades->setEnabled(nRotorBlades > 0);
     menuWings->setEnabled(nWings - nRotorBlades > 0);

--- a/TIGLViewer/src/TIGLViewerWindow.ui
+++ b/TIGLViewer/src/TIGLViewerWindow.ui
@@ -203,7 +203,6 @@
       <string>Rotorcraft</string>
      </property>
      <addaction name="drawRotorsAction"/>
-     <addaction name="drawRotorDisksAction"/>
      <addaction name="showRotorPropertiesAction"/>
     </widget>
     <widget class="QMenu" name="menuRotorBlades">
@@ -706,14 +705,6 @@
    </property>
    <property name="toolTip">
     <string>Show only one rotor</string>
-   </property>
-  </action>
-  <action name="drawRotorDisksAction">
-   <property name="text">
-    <string>Show a Rotor Disk</string>
-   </property>
-   <property name="toolTip">
-    <string>Show only one rotor disk</string>
    </property>
   </action>
   <action name="showRotorPropertiesAction">

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -218,9 +218,15 @@ TIGL_COMPONENT_OTHER
 
 typedef enum TiglGeometricComponentType TiglGeometricComponentType;
 
-#define TIGL_INTENT_PHYSICAL           1 << 0   /**< A phyisical component like a fuselage, wing, nacelle, something you could touch */
-#define TIGL_INTENT_LOGICAL            1 << 1   /**< A logical component, like a wing segment */
-#define TIGL_INTENT_INNER_STRUCTURE    1 << 2   /**< A logical component, like a wing segment */
+enum TiglGeometricComponentIntentFlags
+{
+    TIGL_INTENT_PHYSICAL           = 1,   /**< A phyisical component like a fuselage, wing, nacelle, something you could touch */
+    TIGL_INTENT_LOGICAL            = 2,   /**< A logical component, like a wing segment */
+    TIGL_INTENT_INNER_STRUCTURE    = 4,   /**< Part of  the aircrafts structure geometry */
+    TIGL_INTENT_OUTER_AERO_SURFACE = 8    /**< Part of the outer aircraft (wing, fuselage, nacelle)  */
+};
+
+typedef enum TiglGeometricComponentIntentFlags TiglGeometricComponentIntentFlags;
 
 typedef unsigned long TiglGeometricComponentIntent;
 

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -189,28 +189,40 @@ enum TiglAlgorithmCode
   Definition of possible types for geometric components. Used for calculations where
   the type if the component changes the way of behavior.
 */
-typedef unsigned int TiglGeometricComponentType;
+enum TiglGeometricComponentType
+{
+TIGL_COMPONENT_PLANE,            /**< The whole aircraft */
+TIGL_COMPONENT_FUSELAGE,         /**< The Component is a fuselage */
+TIGL_COMPONENT_WING,             /**< The Component is a wing */
+TIGL_COMPONENT_SEGMENT,          /**< The Component is a general segment */
+TIGL_COMPONENT_WINGSEGMENT,      /**< The Component is a wing segment */
+TIGL_COMPONENT_FUSELSEGMENT,     /**< The Component is a fuselage segment */
+TIGL_COMPONENT_WINGCOMPSEGMENT,  /**< The Component is a wing component segment */
+TIGL_COMPONENT_WINGSHELL,        /**< The Component is a face of the wing (e.g. upper wing surface) */
+TIGL_COMPONENT_WINGRIB,
+TIGL_COMPONENT_WINGSPAR,
+TIGL_COMPONENT_WINGCELL,
+TIGL_COMPONENT_GENERICSYSTEM,    /**< The Component is a generic system */
+TIGL_COMPONENT_ROTOR,            /**< The Component is a rotor */
+TIGL_COMPONENT_ROTORBLADE,       /**< The Component is a rotor blade */
+TIGL_COMPONENT_ATTACHED_ROTORBLADE, /**< The Component is a attached rotor blade */
+TIGL_COMPONENT_PRESSURE_BULKHEAD,/**< The Component is a pressure bulkhead */
+TIGL_COMPONENT_CROSS_BEAM_STRUT, /**< The Component is a cross beam strut */
+TIGL_COMPONENT_CARGO_DOOR,       /**< The Component is a cargo door */
+TIGL_COMPONENT_LONG_FLOOR_BEAM,  /**< The Component is a long floor beam */
+TIGL_COMPONENT_EXTERNAL_OBJECT,  /**< The Component is a long floor beam */
+TIGL_COMPONENT_FARFIELD,         /**< The Component is a far field */
+TIGL_COMPONENT_ENGINE_PYLON,     /**< The Component is a engine pylon */
+TIGL_COMPONENT_OTHER
+};
 
-#define  TIGL_COMPONENT_PHYSICAL          1        /**< A phyisical component like a fuselage, wing, nacelle, something you could touch */
-#define  TIGL_COMPONENT_LOGICAL           2        /**< A logical component, like a wing segment */
-#define  TIGL_COMPONENT_PLANE             4        /**< The whole aircraft */
-#define  TIGL_COMPONENT_FUSELAGE          8        /**< The Component is a fuselage */
-#define  TIGL_COMPONENT_WING              16       /**< The Component is a wing */
-#define  TIGL_COMPONENT_SEGMENT           32       /**< The Component is a general segment */
-#define  TIGL_COMPONENT_WINGSEGMENT       64       /**< The Component is a wing segment */
-#define  TIGL_COMPONENT_FUSELSEGMENT      128      /**< The Component is a fuselage segment */
-#define  TIGL_COMPONENT_WINGCOMPSEGMENT   256      /**< The Component is a wing component segment */
-#define  TIGL_COMPONENT_WINGSHELL         512      /**< The Component is a face of the wing (e.g. upper wing surface) */
-#define  TIGL_COMPONENT_GENERICSYSTEM     1024     /**< The Component is a generic system */
-#define  TIGL_COMPONENT_ROTOR             2048     /**< The Component is a rotor */
-#define  TIGL_COMPONENT_ROTORBLADE        4096     /**< The Component is a rotor blade */
-#define  TIGL_COMPONENT_PRESSURE_BULKHEAD 8192     /**< The Component is a pressure bulkhead */
-#define  TIGL_COMPONENT_CROSS_BEAM_STRUT  16384    /**< The Component is a cross beam strut */
+typedef enum TiglGeometricComponentType TiglGeometricComponentType;
 
-#define  TIGL_COMPONENT_CARGO_DOOR        32768    /**< The Component is a cargo door */
+#define TIGL_INTENT_PHYSICAL           1 << 0   /**< A phyisical component like a fuselage, wing, nacelle, something you could touch */
+#define TIGL_INTENT_LOGICAL            1 << 1   /**< A logical component, like a wing segment */
+#define TIGL_INTENT_INNER_STRUCTURE    1 << 2   /**< A logical component, like a wing segment */
 
-#define  TIGL_COMPONENT_LONG_FLOOR_BEAM   65536    /**< The Component is a long floor beam */
-#define  TIGL_COMPONENT_ENGINE_PYLON      131072   /**< The Component is a engine pylon */
+typedef unsigned long TiglGeometricComponentIntent;
 
 enum TiglStructureType 
 {

--- a/src/configuration/CTiglShapeGeomComponentAdaptor.h
+++ b/src/configuration/CTiglShapeGeomComponentAdaptor.h
@@ -80,7 +80,12 @@ public:
 
     TiglGeometricComponentType GetComponentType() const OVERRIDE
     {
-        return TIGL_COMPONENT_PHYSICAL;
+        return TIGL_COMPONENT_OTHER;
+    }
+
+    TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE
+    {
+        return TIGL_INTENT_PHYSICAL;
     }
 
 private:

--- a/src/cpacs_other/CCPACSAircraftModel.cpp
+++ b/src/cpacs_other/CCPACSAircraftModel.cpp
@@ -42,8 +42,14 @@ std::string CCPACSAircraftModel::GetDefaultedUID() const {
 // Returns the Geometric type of this component, e.g. Wing or Fuselage
 TiglGeometricComponentType CCPACSAircraftModel::GetComponentType() const
 {
-    return (TIGL_COMPONENT_PHYSICAL | TIGL_COMPONENT_PLANE);
+    return TIGL_COMPONENT_PLANE;
 }
+
+TiglGeometricComponentIntent CCPACSAircraftModel::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
+}
+
 
 PNamedShape CCPACSAircraftModel::BuildLoft() const
 {

--- a/src/cpacs_other/CCPACSAircraftModel.h
+++ b/src/cpacs_other/CCPACSAircraftModel.h
@@ -44,6 +44,7 @@ public:
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
     TIGL_EXPORT CCPACSConfiguration& GetConfiguration() const;
 

--- a/src/cpacs_other/CCPACSExternalObject.cpp
+++ b/src/cpacs_other/CCPACSExternalObject.cpp
@@ -93,7 +93,12 @@ const std::string& CCPACSExternalObject::GetFilePath() const
 
 TiglGeometricComponentType CCPACSExternalObject::GetComponentType() const
 {
-    return TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_EXTERNAL_OBJECT;
+}
+
+TiglGeometricComponentIntent CCPACSExternalObject::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
 }
 
 PNamedShape CCPACSExternalObject::BuildLoft() const

--- a/src/cpacs_other/CCPACSExternalObject.h
+++ b/src/cpacs_other/CCPACSExternalObject.h
@@ -39,6 +39,7 @@ public:
     TIGL_EXPORT const std::string& GetFilePath() const;
     
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
 private:
     /// reads in the CAD file

--- a/src/cpacs_other/CCPACSRotorcraftModel.cpp
+++ b/src/cpacs_other/CCPACSRotorcraftModel.cpp
@@ -35,8 +35,14 @@ std::string CCPACSRotorcraftModel::GetDefaultedUID() const {
 // Returns the Geometric type of this component, e.g. Wing or Fuselage
 TiglGeometricComponentType CCPACSRotorcraftModel::GetComponentType() const
 {
-    return (TIGL_COMPONENT_PHYSICAL | TIGL_COMPONENT_PLANE);
+    return TIGL_COMPONENT_PLANE;
 }
+
+TiglGeometricComponentIntent CCPACSRotorcraftModel::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
+}
+
 
 PNamedShape CCPACSRotorcraftModel::BuildLoft() const
 {

--- a/src/cpacs_other/CCPACSRotorcraftModel.h
+++ b/src/cpacs_other/CCPACSRotorcraftModel.h
@@ -37,6 +37,7 @@ public:
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
     TIGL_EXPORT CCPACSConfiguration& GetConfiguration() const;
 

--- a/src/cpacs_other/CTiglUIDManager.cpp
+++ b/src/cpacs_other/CTiglUIDManager.cpp
@@ -155,7 +155,7 @@ void CTiglUIDManager::AddGeometricComponent(const std::string& uid, ITiglGeometr
     }
 
     CTiglRelativelyPositionedComponent* tmp = dynamic_cast<CTiglRelativelyPositionedComponent*>(componentPtr);
-    if (tmp && (componentPtr->GetComponentType() & TIGL_COMPONENT_PHYSICAL) ) {
+    if (tmp && (componentPtr->GetComponentIntent() & TIGL_INTENT_PHYSICAL) ) {
         relativeComponents[uid] = tmp;
     }
     allShapes[uid] = componentPtr;

--- a/src/engine_pylon/CCPACSEnginePylon.h
+++ b/src/engine_pylon/CCPACSEnginePylon.h
@@ -32,7 +32,8 @@ public:
 
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
 
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_ENGINE_PYLON | TIGL_COMPONENT_PHYSICAL; }
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_ENGINE_PYLON; }
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE { return TIGL_INTENT_PHYSICAL; }
 
     TIGL_EXPORT void Invalidate();
 

--- a/src/fuselage/CCPACSCrossBeamAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSCrossBeamAssemblyPosition.cpp
@@ -62,8 +62,15 @@ PNamedShape CCPACSCrossBeamAssemblyPosition::GetLoft() const
 
 TiglGeometricComponentType CCPACSCrossBeamAssemblyPosition::GetComponentType() const
 {
-    return TIGL_COMPONENT_GENERICSYSTEM | TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_GENERICSYSTEM;
 }
+
+TiglGeometricComponentIntent CCPACSCrossBeamAssemblyPosition::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
+}
+
+
 
 void CCPACSCrossBeamAssemblyPosition::Invalidate()
 {

--- a/src/fuselage/CCPACSCrossBeamAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSCrossBeamAssemblyPosition.cpp
@@ -67,7 +67,7 @@ TiglGeometricComponentType CCPACSCrossBeamAssemblyPosition::GetComponentType() c
 
 TiglGeometricComponentIntent CCPACSCrossBeamAssemblyPosition::GetComponentIntent() const
 {
-    return TIGL_INTENT_PHYSICAL;
+    return TIGL_INTENT_PHYSICAL | TIGL_INTENT_INNER_STRUCTURE;
 }
 
 

--- a/src/fuselage/CCPACSCrossBeamAssemblyPosition.h
+++ b/src/fuselage/CCPACSCrossBeamAssemblyPosition.h
@@ -32,6 +32,7 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
     TIGL_EXPORT PNamedShape GetLoft() const OVERRIDE;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
     TIGL_EXPORT void Invalidate();
 

--- a/src/fuselage/CCPACSCrossBeamStrutAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSCrossBeamStrutAssemblyPosition.cpp
@@ -67,7 +67,7 @@ TiglGeometricComponentType CCPACSCrossBeamStrutAssemblyPosition::GetComponentTyp
 
 TiglGeometricComponentIntent CCPACSCrossBeamStrutAssemblyPosition::GetComponentIntent() const
 {
-    return TIGL_INTENT_PHYSICAL;
+    return TIGL_INTENT_PHYSICAL | TIGL_INTENT_INNER_STRUCTURE;
 }
 
 

--- a/src/fuselage/CCPACSCrossBeamStrutAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSCrossBeamStrutAssemblyPosition.cpp
@@ -62,8 +62,14 @@ PNamedShape CCPACSCrossBeamStrutAssemblyPosition::GetLoft() const
 
 TiglGeometricComponentType CCPACSCrossBeamStrutAssemblyPosition::GetComponentType() const
 {
-    return TIGL_COMPONENT_CROSS_BEAM_STRUT | TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_CROSS_BEAM_STRUT;
 }
+
+TiglGeometricComponentIntent CCPACSCrossBeamStrutAssemblyPosition::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
+}
+
 
 void CCPACSCrossBeamStrutAssemblyPosition::Invalidate()
 {

--- a/src/fuselage/CCPACSCrossBeamStrutAssemblyPosition.h
+++ b/src/fuselage/CCPACSCrossBeamStrutAssemblyPosition.h
@@ -33,6 +33,7 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
     TIGL_EXPORT PNamedShape GetLoft() const OVERRIDE;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
     TIGL_EXPORT void Invalidate();
 

--- a/src/fuselage/CCPACSDoorAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSDoorAssemblyPosition.cpp
@@ -39,7 +39,12 @@ PNamedShape CCPACSDoorAssemblyPosition::GetLoft() const
 
 TiglGeometricComponentType CCPACSDoorAssemblyPosition::GetComponentType() const
 {
-    return TIGL_COMPONENT_CARGO_DOOR | TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_CARGO_DOOR ;
+}
+
+TiglGeometricComponentIntent CCPACSDoorAssemblyPosition::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
 }
 
 } // namespace tigl

--- a/src/fuselage/CCPACSDoorAssemblyPosition.h
+++ b/src/fuselage/CCPACSDoorAssemblyPosition.h
@@ -30,6 +30,7 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
     TIGL_EXPORT PNamedShape GetLoft() const OVERRIDE;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 };
 
 } // namespace tigl

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -103,7 +103,8 @@ public:
     TIGL_EXPORT double GetCircumference(int segmentIndex, double eta);
 
     // Returns the Component Type TIGL_COMPONENT_FUSELAGE
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE {return TIGL_COMPONENT_FUSELAGE | TIGL_COMPONENT_PHYSICAL;}
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE {return TIGL_COMPONENT_FUSELAGE; }
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE {return TIGL_INTENT_PHYSICAL;}
 
     // Returns the point where the distance between the selected fuselage and the ground is at minimum.
     // The Fuselage could be turned with a given angle at at given axis, specified by a point and a direction.

--- a/src/fuselage/CCPACSFuselageSegment.h
+++ b/src/fuselage/CCPACSFuselageSegment.h
@@ -156,7 +156,7 @@ public:
     TIGL_EXPORT std::vector<CTiglPoint> GetRawEndProfilePoints();
 
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_FUSELSEGMENT; }
-    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE { return  TIGL_COMPONENT_SEGMENT | TIGL_INTENT_LOGICAL; }
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE { return  TIGL_INTENT_LOGICAL; }
 
     // Returns the number of faces in the loft. This depends on the number of guide curves as well as if the fuselage has a symmetry plane.
     TIGL_EXPORT int GetNumberOfLoftFaces() const;

--- a/src/fuselage/CCPACSFuselageSegment.h
+++ b/src/fuselage/CCPACSFuselageSegment.h
@@ -155,7 +155,8 @@ public:
     // Returns the outer profile points as read from TIXI. The points are already transformed.
     TIGL_EXPORT std::vector<CTiglPoint> GetRawEndProfilePoints();
 
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_FUSELSEGMENT | TIGL_COMPONENT_SEGMENT | TIGL_COMPONENT_LOGICAL; }
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_FUSELSEGMENT; }
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE { return  TIGL_COMPONENT_SEGMENT | TIGL_INTENT_LOGICAL; }
 
     // Returns the number of faces in the loft. This depends on the number of guide curves as well as if the fuselage has a symmetry plane.
     TIGL_EXPORT int GetNumberOfLoftFaces() const;

--- a/src/fuselage/CCPACSLongFloorBeam.cpp
+++ b/src/fuselage/CCPACSLongFloorBeam.cpp
@@ -49,7 +49,12 @@ PNamedShape CCPACSLongFloorBeam::GetLoft() const
 
 TiglGeometricComponentType CCPACSLongFloorBeam::GetComponentType() const
 {
-    return TIGL_COMPONENT_LONG_FLOOR_BEAM | TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_LONG_FLOOR_BEAM;
+}
+
+TiglGeometricComponentIntent CCPACSLongFloorBeam::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
 }
 
 void CCPACSLongFloorBeam::Invalidate()

--- a/src/fuselage/CCPACSLongFloorBeam.cpp
+++ b/src/fuselage/CCPACSLongFloorBeam.cpp
@@ -54,7 +54,7 @@ TiglGeometricComponentType CCPACSLongFloorBeam::GetComponentType() const
 
 TiglGeometricComponentIntent CCPACSLongFloorBeam::GetComponentIntent() const
 {
-    return TIGL_INTENT_PHYSICAL;
+    return TIGL_INTENT_PHYSICAL | TIGL_INTENT_INNER_STRUCTURE;
 }
 
 void CCPACSLongFloorBeam::Invalidate()

--- a/src/fuselage/CCPACSLongFloorBeam.h
+++ b/src/fuselage/CCPACSLongFloorBeam.h
@@ -32,6 +32,7 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
     TIGL_EXPORT PNamedShape GetLoft() const OVERRIDE;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
     TIGL_EXPORT void Invalidate();
 

--- a/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
@@ -72,7 +72,12 @@ PNamedShape CCPACSPressureBulkheadAssemblyPosition::GetLoft() const
 
 TiglGeometricComponentType CCPACSPressureBulkheadAssemblyPosition::GetComponentType() const
 {
-    return TIGL_COMPONENT_PHYSICAL | TIGL_COMPONENT_PRESSURE_BULKHEAD;
+    return TIGL_COMPONENT_PRESSURE_BULKHEAD;
+}
+
+TiglGeometricComponentIntent CCPACSPressureBulkheadAssemblyPosition::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
 }
 
 void CCPACSPressureBulkheadAssemblyPosition::Invalidate()

--- a/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
@@ -77,7 +77,7 @@ TiglGeometricComponentType CCPACSPressureBulkheadAssemblyPosition::GetComponentT
 
 TiglGeometricComponentIntent CCPACSPressureBulkheadAssemblyPosition::GetComponentIntent() const
 {
-    return TIGL_INTENT_PHYSICAL;
+    return TIGL_INTENT_PHYSICAL | TIGL_INTENT_INNER_STRUCTURE;
 }
 
 void CCPACSPressureBulkheadAssemblyPosition::Invalidate()

--- a/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.h
+++ b/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.h
@@ -36,6 +36,7 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
     TIGL_EXPORT PNamedShape GetLoft() const OVERRIDE;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
     TIGL_EXPORT void Invalidate();
 

--- a/src/geometry/CCPACSFarField.cpp
+++ b/src/geometry/CCPACSFarField.cpp
@@ -107,8 +107,14 @@ PNamedShape CCPACSFarField::BuildLoft() const
 
 TiglGeometricComponentType CCPACSFarField::GetComponentType() const
 {
-    return TIGL_COMPONENT_LOGICAL;
+    return TIGL_COMPONENT_FARFIELD;
 }
+
+TiglGeometricComponentIntent CCPACSFarField::GetComponentIntent() const
+{
+    return TIGL_INTENT_LOGICAL;
+}
+
 
 } // namespace tigl
 

--- a/src/geometry/CCPACSFarField.h
+++ b/src/geometry/CCPACSFarField.h
@@ -40,6 +40,7 @@ public:
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
 protected:
     PNamedShape BuildLoft() const OVERRIDE;

--- a/src/geometry/CCPACSGenericSystem.h
+++ b/src/geometry/CCPACSGenericSystem.h
@@ -60,8 +60,8 @@ public:
     TIGL_EXPORT CCPACSConfiguration & GetConfiguration() const;
 
     // Returns the Component Type TIGL_COMPONENT_GENERICSYSTEM.
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE {return TIGL_COMPONENT_GENERICSYSTEM | TIGL_COMPONENT_PHYSICAL;}
-
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE {return TIGL_COMPONENT_GENERICSYSTEM;}
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE {return TIGL_INTENT_PHYSICAL;}
 
 protected:
     // Cleanup routine

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -113,7 +113,7 @@ void CTiglTriangularizer::writeFaceDummyMeta(unsigned long iPolyLower, unsigned 
 
 bool CTiglTriangularizer::writeWingMeta(ITiglGeometricComponent& wingComponent, gp_Pnt centralP, unsigned long iPolyLower, unsigned long iPolyUpper)
 {
-    if (wingComponent.GetComponentType() & TIGL_COMPONENT_WING) {
+    if (wingComponent.GetComponentType() == TIGL_COMPONENT_WING) {
         CCPACSWing& wing = dynamic_cast<CCPACSWing&>(wingComponent);
         for (int iSegment = 1 ; iSegment <= wing.GetSegmentCount(); ++iSegment) {
             CCPACSWingSegment& segment = (CCPACSWingSegment&) wing.GetSegment(iSegment);
@@ -206,7 +206,7 @@ int CTiglTriangularizer::triangularizeComponent(const CTiglUIDManager* uidMgr, P
  */
 bool CTiglTriangularizer::writeWingSegmentMeta(tigl::ITiglGeometricComponent &segmentComponent, gp_Pnt pointOnSegmentFace, unsigned long iPolyLower, unsigned long iPolyUpper)
 {
-    if (!(segmentComponent.GetComponentType() & TIGL_COMPONENT_WINGSEGMENT)) {
+    if (!(segmentComponent.GetComponentType() == TIGL_COMPONENT_WINGSEGMENT)) {
         return false;
     }
     

--- a/src/geometry/ITiglGeometricComponent.h
+++ b/src/geometry/ITiglGeometricComponent.h
@@ -41,6 +41,9 @@ public:
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage
     TIGL_EXPORT virtual TiglGeometricComponentType GetComponentType() const = 0;
+
+    // Returns the Geometric type of this component, e.g. Wing or Fuselage
+    TIGL_EXPORT virtual TiglGeometricComponentIntent GetComponentIntent() const = 0;
 };
 
 } // end namespace tigl

--- a/src/rotor/CCPACSRotor.h
+++ b/src/rotor/CCPACSRotor.h
@@ -117,7 +117,12 @@ public:
     // Returns the Component Type TIGL_COMPONENT_ROTOR.
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE
     {
-        return TIGL_COMPONENT_ROTOR | TIGL_COMPONENT_PHYSICAL;
+        return TIGL_COMPONENT_ROTOR;
+    }
+
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE
+    {
+        return TIGL_INTENT_PHYSICAL;
     }
 
 protected:

--- a/src/rotor/CTiglAttachedRotorBlade.h
+++ b/src/rotor/CTiglAttachedRotorBlade.h
@@ -57,7 +57,12 @@ public:
     // Returns the Component Type TIGL_COMPONENT_ROTORBLADE
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE
     {
-        return TIGL_COMPONENT_ROTORBLADE;
+        return TIGL_COMPONENT_ATTACHED_ROTORBLADE;
+    }
+
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE
+    {
+        return TIGL_INTENT_PHYSICAL;
     }
 
     // Returns the original unattached rotor blade

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -139,7 +139,12 @@ public:
     TIGL_EXPORT int GetSegmentEtaXsi(const gp_Pnt& xyz, double& eta, double& xsi, bool &onTop);
 
     // Returns the Component Type TIGL_COMPONENT_WING.
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_WING | TIGL_COMPONENT_PHYSICAL; }
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE
+    {
+        return !IsRotorBlade() ? TIGL_COMPONENT_WING : TIGL_COMPONENT_ROTORBLADE;
+    }
+
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE {return TIGL_INTENT_PHYSICAL; }
 
     // Returns the lower Surface of a Segment
     TIGL_EXPORT Handle(Geom_Surface) GetLowerSegmentSurface(int index);

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -755,7 +755,13 @@ PNamedShape CCPACSWingCell::GetLoft() const
 
 TiglGeometricComponentType CCPACSWingCell::GetComponentType() const
 {
-    return TIGL_COMPONENT_LOGICAL;
+    return TIGL_COMPONENT_WINGCELL;
 }
+
+TiglGeometricComponentIntent CCPACSWingCell::GetComponentIntent() const
+{
+    return TIGL_INTENT_LOGICAL;
+}
+
 
 } // namespace tigl

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -88,6 +88,7 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const OVERRIDE;
     TIGL_EXPORT PNamedShape GetLoft() const OVERRIDE;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
 private:
     struct EtaXsiCache

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -127,7 +127,7 @@ public:
     TIGL_EXPORT const CCPACSWingSegment* findSegment(double x, double y, double z, gp_Pnt& nearestPoint, double& deviation, double maxDeviation = 1.e-2) const;
 
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_WINGCOMPSEGMENT; }
-    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE {return TIGL_COMPONENT_SEGMENT | TIGL_INTENT_LOGICAL; }
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE {return TIGL_INTENT_LOGICAL; }
 
     TIGL_EXPORT MaterialList GetMaterials(double eta, double xsi, TiglStructureType);
 

--- a/src/wing/CCPACSWingComponentSegment.h
+++ b/src/wing/CCPACSWingComponentSegment.h
@@ -126,7 +126,8 @@ public:
     // Returns null if the point is not an that wing, i.e. deviates more than 1 cm from the wing
     TIGL_EXPORT const CCPACSWingSegment* findSegment(double x, double y, double z, gp_Pnt& nearestPoint, double& deviation, double maxDeviation = 1.e-2) const;
 
-    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_WINGCOMPSEGMENT | TIGL_COMPONENT_SEGMENT | TIGL_COMPONENT_LOGICAL; }
+    TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE { return TIGL_COMPONENT_WINGCOMPSEGMENT; }
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE {return TIGL_COMPONENT_SEGMENT | TIGL_INTENT_LOGICAL; }
 
     TIGL_EXPORT MaterialList GetMaterials(double eta, double xsi, TiglStructureType);
 

--- a/src/wing/CCPACSWingRibsDefinition.cpp
+++ b/src/wing/CCPACSWingRibsDefinition.cpp
@@ -929,7 +929,7 @@ TiglGeometricComponentType CCPACSWingRibsDefinition::GetComponentType() const
 
 TiglGeometricComponentIntent CCPACSWingRibsDefinition::GetComponentIntent() const
 {
-    return TIGL_INTENT_PHYSICAL;
+    return TIGL_INTENT_PHYSICAL | TIGL_INTENT_INNER_STRUCTURE;
 }
 
 PNamedShape CCPACSWingRibsDefinition::BuildLoft() const

--- a/src/wing/CCPACSWingRibsDefinition.cpp
+++ b/src/wing/CCPACSWingRibsDefinition.cpp
@@ -924,9 +924,13 @@ std::string CCPACSWingRibsDefinition::GetDefaultedUID() const
 
 TiglGeometricComponentType CCPACSWingRibsDefinition::GetComponentType() const
 {
-    return TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_WINGRIB;
 }
 
+TiglGeometricComponentIntent CCPACSWingRibsDefinition::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
+}
 
 PNamedShape CCPACSWingRibsDefinition::BuildLoft() const
 {

--- a/src/wing/CCPACSWingRibsDefinition.h
+++ b/src/wing/CCPACSWingRibsDefinition.h
@@ -100,6 +100,7 @@ public:
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage
     TIGL_EXPORT virtual TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
 protected:
     PNamedShape BuildLoft() const OVERRIDE;

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -211,7 +211,12 @@ public:
 
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE
     {
-        return TIGL_COMPONENT_WINGSEGMENT | TIGL_COMPONENT_SEGMENT | TIGL_COMPONENT_LOGICAL;
+        return TIGL_COMPONENT_WINGSEGMENT;
+    }
+
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE
+    {
+        return TIGL_COMPONENT_SEGMENT | TIGL_INTENT_LOGICAL;
     }
 
     TIGL_EXPORT CTiglTransformation GetParentTransformation() const;

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -216,7 +216,7 @@ public:
 
     TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE
     {
-        return TIGL_COMPONENT_SEGMENT | TIGL_INTENT_LOGICAL;
+        return TIGL_INTENT_LOGICAL;
     }
 
     TIGL_EXPORT CTiglTransformation GetParentTransformation() const;

--- a/src/wing/CCPACSWingSparSegment.cpp
+++ b/src/wing/CCPACSWingSparSegment.cpp
@@ -261,8 +261,14 @@ std::string CCPACSWingSparSegment::GetDefaultedUID() const
 
 TiglGeometricComponentType CCPACSWingSparSegment::GetComponentType() const
 {
-    return TIGL_COMPONENT_PHYSICAL;
+    return TIGL_COMPONENT_WINGSPAR;
 }
+
+TiglGeometricComponentIntent CCPACSWingSparSegment::GetComponentIntent() const
+{
+    return TIGL_INTENT_PHYSICAL;
+}
+
 
 // Builds the cutting geometry for the spar as well as the midplane line
 void CCPACSWingSparSegment::BuildAuxiliaryGeometry(AuxiliaryGeomCache& cache) const

--- a/src/wing/CCPACSWingSparSegment.cpp
+++ b/src/wing/CCPACSWingSparSegment.cpp
@@ -266,7 +266,7 @@ TiglGeometricComponentType CCPACSWingSparSegment::GetComponentType() const
 
 TiglGeometricComponentIntent CCPACSWingSparSegment::GetComponentIntent() const
 {
-    return TIGL_INTENT_PHYSICAL;
+    return TIGL_INTENT_PHYSICAL | TIGL_INTENT_INNER_STRUCTURE;
 }
 
 

--- a/src/wing/CCPACSWingSparSegment.h
+++ b/src/wing/CCPACSWingSparSegment.h
@@ -83,6 +83,7 @@ public:
 
     // Returns the Geometric type of this component, e.g. Wing or Fuselage
     TIGL_EXPORT virtual TiglGeometricComponentType GetComponentType() const OVERRIDE;
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE;
 
 private:
     struct AuxiliaryGeomCache

--- a/src/wing/CTiglWingChordface.h
+++ b/src/wing/CTiglWingChordface.h
@@ -53,9 +53,13 @@ public:
 
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const OVERRIDE
     {
-        return TIGL_COMPONENT_PHYSICAL;
+        return TIGL_COMPONENT_OTHER;
     }
 
+     TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const OVERRIDE
+     {
+         return TIGL_INTENT_LOGICAL;
+     }
 
     /**
      * @brief Returns the Eta coordinate of each element


### PR DESCRIPTION
An intent can be outer shape, structure, logical, physical. They shall be used to group shapes with common intents together. This decouples the intent from the actual shape type.

Closes #523 