### PR TITLE
Fix non-symmetric B-Spline profiles

### DIFF
--- a/tests/unittests/tiglFuselageGetPoint.cpp
+++ b/tests/unittests/tiglFuselageGetPoint.cpp
@@ -186,10 +186,10 @@ TEST(TiglFuselageGetPointBugs, getPointAngleTranslated)
 
     // this always worked
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetPointAngleTranslated(tiglHandle, 1, 29, 0.5,  8.1795,  0.19097, 0.027451, &x, &y, &z));
-    ASSERT_NEAR(-0.088553, y, 1e-5);
+    ASSERT_NEAR(-0.088661, y, 1e-5);
 
     // this was buggy
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetPointAngleTranslated(tiglHandle, 1, 29, 0.5, -8.1795, -0.19097, 0.027451, &x, &y, &z));
-    ASSERT_NEAR(0.088553, y, 1e-5);
+    ASSERT_NEAR(0.088661, y, 1e-5);
 }
 

--- a/tests/unittests/tiglFuselageSegment.cpp
+++ b/tests/unittests/tiglFuselageSegment.cpp
@@ -648,8 +648,8 @@ TEST_F(TiglFuselageSegmentSimple, getSectionCenter)
     ASSERT_NE(TIGL_NULL_POINTER, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
     ASSERT_EQ(TIGL_SUCCESS, tiglFuselageGetSectionCenter(tiglHandle, "segmentD150_Fuselage_1Segment2ID", eta, &pointX, &pointY, &pointZ));
     EXPECT_NEAR(-0.5, pointX, 1e-15);
-    EXPECT_NEAR(0, pointY, 1e-2);
-    EXPECT_NEAR(0, pointZ, 1e-2);
+    EXPECT_NEAR(0, pointY, 1e-6);
+    EXPECT_NEAR(0, pointZ, 1e-6);
 
     eta = 0.5;
 


### PR DESCRIPTION
By using now our own interpolation algorithm, the
symmetry of the fuselage section is restored and
the z value gets zero.

Fixes #512