### PR TITLE
Fixed unordered fuselage segments

### DIFF
--- a/src/common/sorting.h
+++ b/src/common/sorting.h
@@ -1,0 +1,68 @@
+/*
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-11-23 Martin Siggel <martin.siggel@dlr.de>
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef SORTING_H
+#define SORTING_H
+
+#include <algorithm>
+
+namespace tigl
+{
+
+template<class ForwardIterator>
+void rotate_right(ForwardIterator begin, ForwardIterator last)
+{
+    for (; begin != last; ++begin) {
+        std::swap(*begin, *last);
+    }
+}
+
+/**
+ * Sorts an array that contains a continous number of entries, possible unordered
+ */
+template<class ForwardIterator, class UnaryPredicate>
+void follow_sort(ForwardIterator begin, ForwardIterator end, UnaryPredicate follows)
+{
+
+    ForwardIterator sorted = begin;
+
+    bool swapped = true;
+    while (swapped) {
+        swapped = false;
+        for (ForwardIterator it = sorted + 1; it != end; ++it) {
+            if (follows(*it, *sorted)) {
+                sorted++;
+                std::swap(*it, *sorted);
+                swapped = true;
+            }
+            else if (follows(*begin, *it)) {
+                sorted++;
+                std::swap(*it, *sorted);
+                rotate_right(begin, sorted);
+                swapped = true;
+            }
+        }
+    }
+
+    if (sorted+1 != end) {
+        throw std::invalid_argument("Vector not continous");
+    }
+}
+
+}
+
+#endif // SORTING_H

--- a/src/fuselage/CCPACSFuselageSegments.cpp
+++ b/src/fuselage/CCPACSFuselageSegments.cpp
@@ -28,6 +28,20 @@
 #include "CCPACSFuselageSegment.h"
 #include "CCPACSFuselage.h"
 #include "CTiglError.h"
+#include "sorting.h"
+#include "CTiglLogging.h"
+
+namespace
+{
+    bool segment_follows(const tigl::unique_ptr<tigl::CCPACSFuselageSegment>& s2, const tigl::unique_ptr<tigl::CCPACSFuselageSegment>& s1)
+    {
+        if (!s2 || !s1) {
+            return false;
+        }
+
+        return s2->GetFromElementUID() == s1->GetToElementUID();
+    }
+}
 
 namespace tigl
 {
@@ -72,6 +86,41 @@ CCPACSFuselageSegment & CCPACSFuselageSegments::GetSegment(const std::string& se
 int CCPACSFuselageSegments::GetSegmentCount() const
 {
     return static_cast<int>(m_segments.size());
+}
+
+void tigl::CCPACSFuselageSegments::ReadCPACS(const TixiDocumentHandle &tixiHandle, const std::string &xpath)
+{
+    tigl::generated::CPACSFuselageSegments::ReadCPACS(tixiHandle, xpath);
+
+    if (GetSegmentCount() <= 0) {
+        return;
+    }
+
+    // check order of segments - each segment must start with the element of the previous segment
+    bool mustReorderSegments = false;
+    std::string prevElementUID = GetSegment(1).GetToElementUID();
+    for (int i = 2; i <= GetSegmentCount(); ++i) {
+        CCPACSFuselageSegment& segment = GetSegment(i);
+        if (prevElementUID != segment.GetFromElementUID()) {
+            mustReorderSegments = true;
+        }
+        prevElementUID = segment.GetToElementUID();
+    }
+
+    if (mustReorderSegments) {
+        LOG(WARNING) << "Fuselage segments in wrong order! Trying to reorder.";
+        ReorderSegments();
+    }
+
+}
+
+void CCPACSFuselageSegments::ReorderSegments()
+{
+    try {
+        tigl::follow_sort(GetSegments().begin(), GetSegments().end(), segment_follows);
+    } catch (std::invalid_argument) {
+        throw CTiglError("Fuselage segments not continous.");
+    }
 }
 
 } // end namespace tigl

--- a/src/fuselage/CCPACSFuselageSegments.h
+++ b/src/fuselage/CCPACSFuselageSegments.h
@@ -45,6 +45,13 @@ public:
 
     // Gets total segment count
     TIGL_EXPORT int GetSegmentCount() const;
+
+    // CPACSFuselageSegments interface
+public:
+    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle &tixiHandle, const std::string &xpath) OVERRIDE;
+
+private:
+    void ReorderSegments();
 };
 
 } // end namespace tigl

--- a/tests/unittests/testsorting.cpp
+++ b/tests/unittests/testsorting.cpp
@@ -1,0 +1,80 @@
+/*
+* Copyright (C) 2018 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-11-23 Martin Siggel <martin.siggel@dlr.de>
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h"
+
+#include "sorting.h"
+
+bool int_follows(int v2, int v1)
+{
+    return v2 == v1 + 1;
+}
+
+
+TEST(Sorting, FollowSort)
+{
+    std::vector<int> v{5, 3, 8, 2,9, 1, 7, 0, 4, 6};
+
+    ASSERT_NO_THROW(tigl::follow_sort(v.begin(), v.begin()+ 10, int_follows));
+
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(static_cast<int>(i), v[i]);
+    }
+
+    v = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    ASSERT_NO_THROW(tigl::follow_sort(v.begin(), v.begin()+ 10, int_follows));
+
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(static_cast<int>(i), v[i]);
+    }
+
+    v = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+
+    ASSERT_NO_THROW(tigl::follow_sort(v.begin(), v.begin()+ 10, int_follows));
+
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(static_cast<int>(i), v[i]);
+    }
+
+    v = {5, 3, 8, 2,9, 1, 7, 0, 4, 6};
+    ASSERT_THROW(tigl::follow_sort(v.begin(), v.begin()+ 5, int_follows), std::invalid_argument);
+
+    v = {1, 2, 3, 4, 5, 1, 7, 0, 4, 6};
+    ASSERT_NO_THROW(tigl::follow_sort(v.begin(), v.begin()+ 5, int_follows));
+
+    v = {5, 4, 3, 2, 1, 1, 7, 0, 4, 6};
+    ASSERT_NO_THROW(tigl::follow_sort(v.begin(), v.begin()+ 5, int_follows));
+
+    std::vector<int> expected = {1, 2, 3, 4, 5, 1, 7, 0, 4, 6};
+
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(expected[i], v[i]);
+    }
+}
+
+
+TEST(Sorting, RotateRight)
+{
+    std::vector<int> v{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    ASSERT_NO_THROW(tigl::rotate_right(v.begin(), v.begin() + 4));
+
+    std::vector<int> expected =  {4, 0, 1, 2, 3, 5, 6, 7, 8, 9};
+
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(expected[i], v[i]);
+    }
+}


### PR DESCRIPTION
When the segments are in wrong order,
a warning is printed and the segments will be ordered.

Fixes #540