### PR TITLE
Jk/transformationmatrix 544

### DIFF
--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -262,6 +262,11 @@ inline double Radians(double degree)
     return degree / 180. * M_PI;
 }
 
+inline double Degrees(double radians)
+{
+    return 180.*radians / M_PI;
+}
+
 // Clamps val between min and max
 TIGL_EXPORT int Clamp(int val, int min, int max);
 TIGL_EXPORT double Clamp(double val, double min, double max);

--- a/src/geometry/CCPACSTransformation.cpp
+++ b/src/geometry/CCPACSTransformation.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "CCPACSTransformation.h"
+#include "tiglcommonfunctions.h"
 #include "CTiglError.h"
 
 namespace tigl
@@ -118,10 +119,10 @@ void CCPACSTransformation::setTransformationMatrix(const CTiglTransformation& ma
     }
     double rot[3] = {0., 0., 0.};
     if( fabs( fabs(m_rot[2][0]) - 1) > 1e-10 ){
-        rot[2] = -asin(m_rot[2][0]);
+        rot[1] = -asin(m_rot[2][0]);
         double cosTheta = cos(rot[2]);
         rot[0] = atan2(m_rot[2][1]/cosTheta, m_rot[2][2]/cosTheta);
-        rot[1] = atan2(m_rot[1][0]/cosTheta, m_rot[0][0]/cosTheta);
+        rot[2] = atan2(m_rot[1][0]/cosTheta, m_rot[0][0]/cosTheta);
     }
     else {
         if ( fabs(m_rot[2][0] + 1) > 1e-10 ) {
@@ -136,9 +137,9 @@ void CCPACSTransformation::setTransformationMatrix(const CTiglTransformation& ma
     if (!m_rotation) {
         m_rotation = boost::in_place(m_uidMgr);
     }
-    m_rotation->SetX(rot[0]);
-    m_rotation->SetY(rot[1]);
-    m_rotation->SetZ(rot[2]);
+    m_rotation->SetX(Degrees(rot[0]));
+    m_rotation->SetY(Degrees(rot[1]));
+    m_rotation->SetZ(Degrees(rot[2]));
 }
 
 void CCPACSTransformation::updateMatrix(CTiglTransformation& cache) const

--- a/src/geometry/CCPACSTransformation.cpp
+++ b/src/geometry/CCPACSTransformation.cpp
@@ -77,8 +77,68 @@ void CCPACSTransformation::setScaling(const CTiglPoint& scale)
 
 void CCPACSTransformation::setTransformationMatrix(const CTiglTransformation& matrix)
 {
-    // TODO(bgruber): implement matrix decomposition into m_rotation, m_scaling and m_translation
     *_transformationMatrix.writeAccess() = matrix;
+
+    // decompose matrix into scaling, rotation and translation
+    if (!m_translation) {
+        m_translation = boost::in_place(m_uidMgr);
+    }
+    m_translation->SetX(matrix.GetValue(0,3));
+    m_translation->SetY(matrix.GetValue(1,3));
+    m_translation->SetZ(matrix.GetValue(2,3));
+
+    // CPACS transformation order is scale before translate, this means scale
+    // is length of the columns in matrices upper 3x3 block
+    double m_rot[3][3];
+    double scale[3] = {0., 0., 0.};
+    for (int i = 0; i<3; ++i ) {
+        for (int j=0; j<3; ++j ) {
+            m_rot[i][j] = matrix.GetValue(i,j);
+            scale[j] += m_rot[i][j]*m_rot[i][j];
+        }
+    }
+    for (int i=0; i<3; ++i) {
+        scale[i] = sqrt(scale[i]);
+    }
+    if (!m_scaling) {
+        m_scaling = boost::in_place(m_uidMgr);
+    }
+    m_scaling->SetX(scale[0]);
+    m_scaling->SetY(scale[1]);
+    m_scaling->SetZ(scale[2]);
+
+    // CPACS rotation is Euler xyz.
+    // This implementation is based on http://www.gregslabaugh.net/publications/euler.pdf
+
+    // remove scaling from upper 3x3 block to obtain orthonormal matrix
+    for (int i = 0; i<3; ++i ) {
+        for (int j=0; j<3; ++j ) {
+            m_rot[i][j] /= scale[j];
+        }
+    }
+    double rot[3] = {0., 0., 0.};
+    if( fabs( fabs(m_rot[2][0]) - 1) > 1e-10 ){
+        rot[2] = -asin(m_rot[2][0]);
+        double cosTheta = cos(rot[2]);
+        rot[0] = atan2(m_rot[2][1]/cosTheta, m_rot[2][2]/cosTheta);
+        rot[1] = atan2(m_rot[1][0]/cosTheta, m_rot[0][0]/cosTheta);
+    }
+    else {
+        if ( fabs(m_rot[2][0] + 1) > 1e-10 ) {
+            rot[0] = rot[2] + atan2(m_rot[0][1], m_rot[0][2]);
+            rot[1] = M_PI/2;
+        }
+        else{
+            rot[0] = -rot[2] + atan2(-m_rot[0][1], -m_rot[0][2]);
+            rot[1] = -M_PI/2;
+        }
+    }
+    if (!m_rotation) {
+        m_rotation = boost::in_place(m_uidMgr);
+    }
+    m_rotation->SetX(rot[0]);
+    m_rotation->SetY(rot[1]);
+    m_rotation->SetZ(rot[2]);
 }
 
 void CCPACSTransformation::updateMatrix(CTiglTransformation& cache) const

--- a/src/geometry/CCPACSTransformation.h
+++ b/src/geometry/CCPACSTransformation.h
@@ -40,7 +40,7 @@ public:
     TIGL_EXPORT void setTranslation(const CTiglPoint& translation, ECPACSTranslationType);
     TIGL_EXPORT void setRotation(const CTiglPoint& rotation);
     TIGL_EXPORT void setScaling(const CTiglPoint& scale);
-    TIGL_EXPORT void setTransformationMatrix(const CTiglTransformation& matrix); // sets only the current matrix, does not update rotation, scaling and translation, changes are lost when updateMatrix() is called
+    TIGL_EXPORT void setTransformationMatrix(const CTiglTransformation& matrix);
     
     TIGL_EXPORT CTiglPoint getTranslationVector() const;
     TIGL_EXPORT CTiglPoint getRotation() const;

--- a/tests/unittests/tiglTransformation.cpp
+++ b/tests/unittests/tiglTransformation.cpp
@@ -1,0 +1,50 @@
+/*
+* Copyright (C) 2015 German Aerospace Center (DLR/SC)
+*
+* Created: 2018-12-04 Jan Kleinert <Jan.Kleinert@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h" // Brings in the GTest framework
+#include "CCPACSTransformation.h"
+
+TEST(tiglTransformation, setTransformationMatrix)
+{
+    double scale[3] = {2., 4., 8.};
+    double rot[3]   = {50., 70., 10.};
+    double trans[3] = {1., 2., 3.};
+
+    // create CPACS-conform tigl-transformation (i.e. scaling -> euler-xyz-Rotation -> translation)
+    tigl::CTiglTransformation tiglTrafo;
+    tiglTrafo.AddScaling(scale[0], scale[1], scale[2]);
+    tiglTrafo.AddRotationX(rot[0]);
+    tiglTrafo.AddRotationY(rot[1]);
+    tiglTrafo.AddRotationZ(rot[2]);
+    tiglTrafo.AddTranslation(trans[0], trans[1], trans[2]);
+
+    tigl::CCPACSTransformation cpacsTrafo(NULL);
+    cpacsTrafo.setTransformationMatrix(tiglTrafo);
+
+    EXPECT_NEAR(*cpacsTrafo.GetScaling()->GetX(), scale[0], 1e-8);
+    EXPECT_NEAR(*cpacsTrafo.GetScaling()->GetY(), scale[1], 1e-8);
+    EXPECT_NEAR(*cpacsTrafo.GetScaling()->GetZ(), scale[2], 1e-8);
+
+    EXPECT_NEAR(*cpacsTrafo.GetRotation()->GetX(), rot[0], 1e-8);
+    EXPECT_NEAR(*cpacsTrafo.GetRotation()->GetY(), rot[1], 1e-8);
+    EXPECT_NEAR(*cpacsTrafo.GetRotation()->GetZ(), rot[2], 1e-8);
+
+    EXPECT_NEAR(*cpacsTrafo.GetTranslation()->GetX(), trans[0], 1e-8);
+    EXPECT_NEAR(*cpacsTrafo.GetTranslation()->GetY(), trans[1], 1e-8);
+    EXPECT_NEAR(*cpacsTrafo.GetTranslation()->GetZ(), trans[2], 1e-8);
+}


### PR DESCRIPTION
See comments in #544. I don't think these are big issues. 

We could optionally check if the upper 3x3 block of the transformation matrix is orthogonal and output a warning if not, but that would add some additional overhead.