### PR TITLE
Cpacs 3 cell rib modifications

### DIFF
--- a/cpacs_gen_input/CustomTypes.txt
+++ b/cpacs_gen_input/CustomTypes.txt
@@ -27,6 +27,8 @@ CPACSPointListXYZVector            CCPACSPointListXYZ
 CPACSPointListRelXYZVector         CCPACSPointListRelXYZ
 CPACSGenericGeometricComponent     CCPACSExternalObject
 CPACSGenericGeometryComponents     CCPACSExternalObjects
+CPACSEtaIsoLine                    CCPACSEtaIsoLine
+CPACSXsiIsoLine                    CCPACSXsiIsoLine
 
 CPACSFuselage                      CCPACSFuselage
 CPACSFuselages                     CCPACSFuselages
@@ -49,6 +51,7 @@ CPACSWingRibCrossSection           CCPACSWingRibCrossSection
 CPACSRibRotation                   CCPACSWingRibRotation
 CPACSWingRibsDefinition            CCPACSWingRibsDefinition
 CPACSWingRibsDefinitions           CCPACSWingRibsDefinitions
+CPACSWingRibExplicitPositioning    CCPACSWingRibExplicitPositioning
 CPACSWingRibsPositioning           CCPACSWingRibsPositioning
 CPACSWingElement                   CCPACSWingSectionElement
 CPACSWingElements                  CCPACSWingSectionElements

--- a/cpacs_gen_input/ParentPointer.txt
+++ b/cpacs_gen_input/ParentPointer.txt
@@ -28,6 +28,8 @@ CPACSSparSegment
 CPACSSparSegments
 CPACSComponentSegment
 CPACSComponentSegments
+CPACSEtaIsoLine
+CPACSXsiIsoLine
 
 CPACSFuselage
 CPACSFuselages

--- a/cpacs_gen_input/cpacs_schema.xsd
+++ b/cpacs_gen_input/cpacs_schema.xsd
@@ -5667,13 +5667,13 @@ jonas.jepsen@dlr.de
                             <xsd:sequence>
                                     <xsd:choice>
                                             <xsd:sequence>
-                                                    <xsd:element name="eta1" type="doubleBaseType">
+                                                    <xsd:element name="eta1" type="etaIsoLineType">
                                                             <xsd:annotation>
                                                                     <xsd:documentation>Relative spanwise position of the forward
                                                                             end.</xsd:documentation>
                                                             </xsd:annotation>
                                                     </xsd:element>
-                                                    <xsd:element name="eta2" type="doubleBaseType">
+                                                    <xsd:element name="eta2" type="etaIsoLineType">
                                                             <xsd:annotation>
                                                                     <xsd:documentation>Relative spanwise position of the rear end.
                                                                     </xsd:documentation>
@@ -33211,31 +33211,18 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:sequence>
-					<xsd:element minOccurs="0" name="ribRotationReference">
-						<xsd:complexType>
-							<xsd:annotation>
-								<xsd:documentation>RotationReference defines the reference for
-									the z-rotation it is either sparUID or„LeadingEdge“ or
-									„TrailingEdge“. If it is not defined the rotation reference is
-									the eta-axis (=leading edge, that is projected on the wings
-									y-z-plane). A z-rotation angle of 90 degrees means, that the rib
-									is perpendicular on the ribRotationReference (e.g. spar, leading
-									edge...). The rib itself is allways straight, and the rotation
-									is defined with respect of the intersection point of the rib
-									with the ribRotationReference.</xsd:documentation>
-							</xsd:annotation>
-							<xsd:simpleContent>
-								<xsd:restriction base="stringBaseType">
-									<xsd:enumeration value="LeadingEdge"/>
-									<xsd:enumeration value="TrailingEdge"/>
-									<xsd:enumeration value="FrontSpar"/>
-									<xsd:enumeration value="RearSpar"/>
-									<xsd:enumeration value="globalX"/>
-									<xsd:enumeration value="globalY"/>
-									<xsd:enumeration value="globalZ"/>
-								</xsd:restriction>
-							</xsd:simpleContent>
-						</xsd:complexType>
+					<xsd:element minOccurs="0" name="ribRotationReference" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>RotationReference defines the reference for
+								the z-rotation it is either sparUID or„LeadingEdge“ or
+								„TrailingEdge“. If it is not defined the rotation reference is
+								the eta-axis (=leading edge, that is projected on the wings
+								y-z-plane). A z-rotation angle of 90 degrees means, that the rib
+								is perpendicular on the ribRotationReference (e.g. spar, leading
+								edge...). The rib itself is allways straight, and the rotation
+								is defined with respect of the intersection point of the rib
+								with the ribRotationReference.</xsd:documentation>
+						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="z" type="doubleBaseType">
 						<xsd:annotation>

--- a/src/CCPACSEtaIsoLine.cpp
+++ b/src/CCPACSEtaIsoLine.cpp
@@ -1,0 +1,76 @@
+#include "CCPACSEtaIsoLine.h"
+
+#include "CTiglUIDManager.h"
+#include "tigletaxsifunctions.h"
+#include "CCPACSWingCellPositionSpanwise.h"
+#include "generated/CPACSControlSurfaceAirfoil.h"
+#include "CCPACSControlSurfaceBorderTrailingEdge.h"
+#include "CCPACSControlSurfaceSkinCutOutBorder.h"
+#include "CCPACSControlSurfaceTrackType.h"
+#include "generated/CPACSCutOutProfile.h"
+#include "generated/CPACSSparCell.h"
+
+namespace tigl
+{
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSWingCellPositionSpanwise* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSControlSurfaceAirfoil* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSControlSurfaceSkinCutOutBorder* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSControlSurfaceTrackType* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSCutOutProfile* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+CCPACSEtaIsoLine::CCPACSEtaIsoLine(CCPACSSparCell* parent)
+    : generated::CPACSEtaIsoLine(parent)
+{
+}
+
+void CCPACSEtaIsoLine::SetEta(const double& value)
+{
+    generated::CPACSEtaIsoLine::SetEta(value);
+    InvalidateParent();
+}
+
+void CCPACSEtaIsoLine::SetReferenceUID(const std::string& value)
+{
+    generated::CPACSEtaIsoLine::SetReferenceUID(value);
+    InvalidateParent();
+}
+
+//double CCPACSEtaIsoLine::ComputeCSOrTEDEta() const {
+//    return transformEtaXsiToCSOrTed({ m_eta, 0 }, m_referenceUID, std::declval<CTiglUIDManager>()).eta; // TODO
+//}
+
+void CCPACSEtaIsoLine::InvalidateParent()
+{
+    //if (IsParent<CCPACSWingCellPositionSpanwise        >()) GetParent<CCPACSWingCellPositionSpanwise        >()->Invalidate();
+    //if (IsParent<CCPACSControlSurfaceAirfoil           >()) GetParent<CCPACSControlSurfaceAirfoil           >()->Invalidate();
+    //if (IsParent<CCPACSControlSurfaceBorderTrailingEdge>()) GetParent<CCPACSControlSurfaceBorderTrailingEdge>()->Invalidate();
+    //if (IsParent<CCPACSControlSurfaceSkinCutOutBorder  >()) GetParent<CCPACSControlSurfaceSkinCutOutBorder  >()->Invalidate();
+    //if (IsParent<CCPACSControlSurfaceTrackType         >()) GetParent<CCPACSControlSurfaceTrackType         >()->Invalidate();
+    //if (IsParent<CCPACSCutOutProfile                   >()) GetParent<CCPACSCutOutProfile                   >()->Invalidate();
+    //if (IsParent<CCPACSSparCell                        >()) GetParent<CCPACSSparCell                        >()->Invalidate();
+}
+}

--- a/src/CCPACSEtaIsoLine.h
+++ b/src/CCPACSEtaIsoLine.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "generated/CPACSEtaIsoLine.h"
+
+namespace tigl
+{
+
+class CCPACSEtaIsoLine : public generated::CPACSEtaIsoLine
+{
+public:
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSWingCellPositionSpanwise* parent);
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSControlSurfaceAirfoil* parent);
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent);
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSControlSurfaceSkinCutOutBorder* parent);
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSControlSurfaceTrackType* parent);
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSCutOutProfile* parent);
+    TIGL_EXPORT CCPACSEtaIsoLine(CCPACSSparCell* parent);
+
+    TIGL_EXPORT virtual void SetEta(const double& value);
+    TIGL_EXPORT virtual void SetReferenceUID(const std::string& value);
+
+    //TIGL_EXPORT double ComputeCSOrTEDEta() const;
+
+private:
+    void InvalidateParent();
+};
+}

--- a/src/CCPACSXsiIsoLine.cpp
+++ b/src/CCPACSXsiIsoLine.cpp
@@ -1,0 +1,33 @@
+#include "CCPACSXsiIsoLine.h"
+
+#include "CTiglUIDManager.h"
+#include "tigletaxsifunctions.h"
+
+namespace tigl
+{
+CCPACSXsiIsoLine::CCPACSXsiIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent)
+    : generated::CPACSXsiIsoLine(parent)
+{
+}
+
+void CCPACSXsiIsoLine::SetXsi(const double& value)
+{
+    generated::CPACSXsiIsoLine::SetXsi(value);
+    InvalidateParent();
+}
+
+void CCPACSXsiIsoLine::SetReferenceUID(const std::string& value)
+{
+    generated::CPACSXsiIsoLine::SetReferenceUID(value);
+    InvalidateParent();
+}
+
+//double CCPACSXsiIsoLine::ComputeCSOrTEDXsi() const {
+//    return transformEtaXsiToCSOrTed({ 0, m_xsi}, m_referenceUID, std::declval<CTiglUIDManager>()).xsi; // TODO
+//}
+
+void CCPACSXsiIsoLine::InvalidateParent()
+{
+    //if (IsParent<CCPACSControlSurfaceBorderTrailingEdge>()) GetParent<CCPACSControlSurfaceBorderTrailingEdge>()->Invalidate();
+}
+}

--- a/src/CCPACSXsiIsoLine.h
+++ b/src/CCPACSXsiIsoLine.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "generated/CPACSXsiIsoLine.h"
+
+namespace tigl
+{
+class CCPACSXsiIsoLine : public generated::CPACSXsiIsoLine
+{
+public:
+    TIGL_EXPORT CCPACSXsiIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent);
+
+    TIGL_EXPORT virtual void SetXsi(const double& value);
+    TIGL_EXPORT virtual void SetReferenceUID(const std::string& value);
+
+    //TIGL_EXPORT double ComputeCSOrTEDXsi() const;
+
+private:
+    void InvalidateParent();
+};
+}

--- a/src/generated/CPACSCellPositioningSpanwise.cpp
+++ b/src/generated/CPACSCellPositioningSpanwise.cpp
@@ -50,12 +50,24 @@ namespace generated
     {
         // read element eta1
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta1")) {
-            m_eta1_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta1");
+            m_eta1_choice1 = boost::in_place(reinterpret_cast<CCPACSWingCellPositionSpanwise*>(this));
+            try {
+                m_eta1_choice1->ReadCPACS(tixiHandle, xpath + "/eta1");
+            } catch(const std::exception& e) {
+                LOG(ERROR) << "Failed to read eta1 at xpath " << xpath << ": " << e.what();
+                m_eta1_choice1 = boost::none;
+            }
         }
 
         // read element eta2
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta2")) {
-            m_eta2_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta2");
+            m_eta2_choice1 = boost::in_place(reinterpret_cast<CCPACSWingCellPositionSpanwise*>(this));
+            try {
+                m_eta2_choice1->ReadCPACS(tixiHandle, xpath + "/eta2");
+            } catch(const std::exception& e) {
+                LOG(ERROR) << "Failed to read eta2 at xpath " << xpath << ": " << e.what();
+                m_eta2_choice1 = boost::none;
+            }
         }
 
         // read element ribNumber
@@ -81,7 +93,7 @@ namespace generated
         // write element eta1
         if (m_eta1_choice1) {
             tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/eta1");
-            tixi::TixiSaveElement(tixiHandle, xpath + "/eta1", *m_eta1_choice1);
+            m_eta1_choice1->WriteCPACS(tixiHandle, xpath + "/eta1");
         }
         else {
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta1")) {
@@ -92,7 +104,7 @@ namespace generated
         // write element eta2
         if (m_eta2_choice1) {
             tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/eta2");
-            tixi::TixiSaveElement(tixiHandle, xpath + "/eta2", *m_eta2_choice1);
+            m_eta2_choice1->WriteCPACS(tixiHandle, xpath + "/eta2");
         }
         else {
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta2")) {
@@ -162,24 +174,24 @@ namespace generated
         ;
     }
 
-    const boost::optional<double>& CPACSCellPositioningSpanwise::GetEta1_choice1() const
+    const boost::optional<CCPACSEtaIsoLine>& CPACSCellPositioningSpanwise::GetEta1_choice1() const
     {
         return m_eta1_choice1;
     }
 
-    void CPACSCellPositioningSpanwise::SetEta1_choice1(const boost::optional<double>& value)
+    boost::optional<CCPACSEtaIsoLine>& CPACSCellPositioningSpanwise::GetEta1_choice1()
     {
-        m_eta1_choice1 = value;
+        return m_eta1_choice1;
     }
 
-    const boost::optional<double>& CPACSCellPositioningSpanwise::GetEta2_choice1() const
+    const boost::optional<CCPACSEtaIsoLine>& CPACSCellPositioningSpanwise::GetEta2_choice1() const
     {
         return m_eta2_choice1;
     }
 
-    void CPACSCellPositioningSpanwise::SetEta2_choice1(const boost::optional<double>& value)
+    boost::optional<CCPACSEtaIsoLine>& CPACSCellPositioningSpanwise::GetEta2_choice1()
     {
-        m_eta2_choice1 = value;
+        return m_eta2_choice1;
     }
 
     const boost::optional<int>& CPACSCellPositioningSpanwise::GetRibNumber_choice2() const
@@ -200,6 +212,30 @@ namespace generated
     void CPACSCellPositioningSpanwise::SetRibDefinitionUID_choice2(const boost::optional<std::string>& value)
     {
         m_ribDefinitionUID_choice2 = value;
+    }
+
+    CCPACSEtaIsoLine& CPACSCellPositioningSpanwise::GetEta1_choice1(CreateIfNotExistsTag)
+    {
+        if (!m_eta1_choice1)
+            m_eta1_choice1 = boost::in_place(reinterpret_cast<CCPACSWingCellPositionSpanwise*>(this));
+        return *m_eta1_choice1;
+    }
+
+    void CPACSCellPositioningSpanwise::RemoveEta1_choice1()
+    {
+        m_eta1_choice1 = boost::none;
+    }
+
+    CCPACSEtaIsoLine& CPACSCellPositioningSpanwise::GetEta2_choice1(CreateIfNotExistsTag)
+    {
+        if (!m_eta2_choice1)
+            m_eta2_choice1 = boost::in_place(reinterpret_cast<CCPACSWingCellPositionSpanwise*>(this));
+        return *m_eta2_choice1;
+    }
+
+    void CPACSCellPositioningSpanwise::RemoveEta2_choice1()
+    {
+        m_eta2_choice1 = boost::none;
     }
 
 } // namespace generated

--- a/src/generated/CPACSCellPositioningSpanwise.h
+++ b/src/generated/CPACSCellPositioningSpanwise.h
@@ -19,8 +19,10 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+#include <CCPACSEtaIsoLine.h>
 #include <string>
 #include <tixi.h>
+#include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
 namespace tigl
@@ -55,11 +57,11 @@ namespace generated
 
         TIGL_EXPORT bool ValidateChoices() const;
 
-        TIGL_EXPORT virtual const boost::optional<double>& GetEta1_choice1() const;
-        TIGL_EXPORT virtual void SetEta1_choice1(const boost::optional<double>& value);
+        TIGL_EXPORT virtual const boost::optional<CCPACSEtaIsoLine>& GetEta1_choice1() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSEtaIsoLine>& GetEta1_choice1();
 
-        TIGL_EXPORT virtual const boost::optional<double>& GetEta2_choice1() const;
-        TIGL_EXPORT virtual void SetEta2_choice1(const boost::optional<double>& value);
+        TIGL_EXPORT virtual const boost::optional<CCPACSEtaIsoLine>& GetEta2_choice1() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSEtaIsoLine>& GetEta2_choice1();
 
         TIGL_EXPORT virtual const boost::optional<int>& GetRibNumber_choice2() const;
         TIGL_EXPORT virtual void SetRibNumber_choice2(const boost::optional<int>& value);
@@ -67,23 +69,29 @@ namespace generated
         TIGL_EXPORT virtual const boost::optional<std::string>& GetRibDefinitionUID_choice2() const;
         TIGL_EXPORT virtual void SetRibDefinitionUID_choice2(const boost::optional<std::string>& value);
 
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEta1_choice1(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual void RemoveEta1_choice1();
+
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEta2_choice1(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual void RemoveEta2_choice1();
+
     protected:
         CCPACSWingCell* m_parent;
 
         /// Relative spanwise position of the forward
         /// end.
-        boost::optional<double>      m_eta1_choice1;
+        boost::optional<CCPACSEtaIsoLine> m_eta1_choice1;
 
         /// Relative spanwise position of the rear end.
-        boost::optional<double>      m_eta2_choice1;
+        boost::optional<CCPACSEtaIsoLine> m_eta2_choice1;
 
         /// RibNumber is the reference to the rib number
         /// of the rib set which is referenced by 'ribDefinitionUID'.
-        boost::optional<int>         m_ribNumber_choice2;
+        boost::optional<int>              m_ribNumber_choice2;
 
         /// Reference to a ribDefinition set. The single
         /// rib of this ribDefinition set is defined by using 'ribNumber'.
-        boost::optional<std::string> m_ribDefinitionUID_choice2;
+        boost::optional<std::string>      m_ribDefinitionUID_choice2;
 
     private:
 #ifdef HAVE_CPP11

--- a/src/generated/CPACSControlSurfaceAirfoil.cpp
+++ b/src/generated/CPACSControlSurfaceAirfoil.cpp
@@ -25,7 +25,8 @@ namespace tigl
 namespace generated
 {
     CPACSControlSurfaceAirfoil::CPACSControlSurfaceAirfoil()
-        : m_rotX(0)
+        : m_eta(this)
+        , m_rotX(0)
         , m_rotZ(0)
         , m_scalY(0)
         , m_scalZ(0)
@@ -119,12 +120,12 @@ namespace generated
 
     }
 
-    const CPACSEtaIsoLine& CPACSControlSurfaceAirfoil::GetEta() const
+    const CCPACSEtaIsoLine& CPACSControlSurfaceAirfoil::GetEta() const
     {
         return m_eta;
     }
 
-    CPACSEtaIsoLine& CPACSControlSurfaceAirfoil::GetEta()
+    CCPACSEtaIsoLine& CPACSControlSurfaceAirfoil::GetEta()
     {
         return m_eta;
     }

--- a/src/generated/CPACSControlSurfaceAirfoil.h
+++ b/src/generated/CPACSControlSurfaceAirfoil.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include <CCPACSEtaIsoLine.h>
 #include <string>
 #include <tixi.h>
-#include "CPACSEtaIsoLine.h"
 #include "tigl_internal.h"
 
 namespace tigl
@@ -53,8 +53,8 @@ namespace generated
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
 
-        TIGL_EXPORT virtual const CPACSEtaIsoLine& GetEta() const;
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEta();
+        TIGL_EXPORT virtual const CCPACSEtaIsoLine& GetEta() const;
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEta();
 
         TIGL_EXPORT virtual const std::string& GetAirfoilUID() const;
         TIGL_EXPORT virtual void SetAirfoilUID(const std::string& value);
@@ -75,30 +75,30 @@ namespace generated
         /// Relative spanwise coordinate (eta) of the
         /// control surface, where the leading edge of the airfoil is
         /// placed.
-        CPACSEtaIsoLine m_eta;
+        CCPACSEtaIsoLine m_eta;
 
         /// Reference to the airfoil uID.
-        std::string     m_airfoilUID;
+        std::string      m_airfoilUID;
 
         /// Rotation around an axis, going from the
         /// leading edge point to the trailing edge point of the control
         /// surface. Defaults to 90°, which is equivalent to perpendicular
         /// on the control surface middle plane.
-        double          m_rotX;
+        double           m_rotX;
 
         /// Rotation of the airfoil around the control
         /// surface middle plane normal direciotn. Reference point is the
         /// most forward point of the airfoil. Defaults to 90°, which is
         /// equivalent to the airfoilplacement in flight direction (along
         /// wings-x axis).
-        double          m_rotZ;
+        double           m_rotZ;
 
         /// Scaling of the airfoil in spanwise direction
         /// (not used for 2D airfoils).
-        double          m_scalY;
+        double           m_scalY;
 
         /// Scaling in thickness direction of the airfoil.
-        double          m_scalZ;
+        double           m_scalZ;
 
     private:
 #ifdef HAVE_CPP11

--- a/src/generated/CPACSControlSurfaceBorderTrailingEdge.cpp
+++ b/src/generated/CPACSControlSurfaceBorderTrailingEdge.cpp
@@ -27,6 +27,8 @@ namespace tigl
 namespace generated
 {
     CPACSControlSurfaceBorderTrailingEdge::CPACSControlSurfaceBorderTrailingEdge(CPACSControlSurfaceOuterShapeTrailingEdge* parent)
+        : m_etaLE(reinterpret_cast<CCPACSControlSurfaceBorderTrailingEdge*>(this))
+        , m_xsiLE(reinterpret_cast<CCPACSControlSurfaceBorderTrailingEdge*>(this))
     {
         //assert(parent != NULL);
         m_parent = parent;
@@ -58,7 +60,7 @@ namespace generated
 
         // read element etaTE
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/etaTE")) {
-            m_etaTE = boost::in_place();
+            m_etaTE = boost::in_place(reinterpret_cast<CCPACSControlSurfaceBorderTrailingEdge*>(this));
             try {
                 m_etaTE->ReadCPACS(tixiHandle, xpath + "/etaTE");
             } catch(const std::exception& e) {
@@ -166,32 +168,32 @@ namespace generated
 
     }
 
-    const CPACSEtaIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetEtaLE() const
+    const CCPACSEtaIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetEtaLE() const
     {
         return m_etaLE;
     }
 
-    CPACSEtaIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetEtaLE()
+    CCPACSEtaIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetEtaLE()
     {
         return m_etaLE;
     }
 
-    const boost::optional<CPACSEtaIsoLine>& CPACSControlSurfaceBorderTrailingEdge::GetEtaTE() const
+    const boost::optional<CCPACSEtaIsoLine>& CPACSControlSurfaceBorderTrailingEdge::GetEtaTE() const
     {
         return m_etaTE;
     }
 
-    boost::optional<CPACSEtaIsoLine>& CPACSControlSurfaceBorderTrailingEdge::GetEtaTE()
+    boost::optional<CCPACSEtaIsoLine>& CPACSControlSurfaceBorderTrailingEdge::GetEtaTE()
     {
         return m_etaTE;
     }
 
-    const CPACSXsiIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetXsiLE() const
+    const CCPACSXsiIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetXsiLE() const
     {
         return m_xsiLE;
     }
 
-    CPACSXsiIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetXsiLE()
+    CCPACSXsiIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetXsiLE()
     {
         return m_xsiLE;
     }
@@ -226,10 +228,10 @@ namespace generated
         return m_airfoil;
     }
 
-    CPACSEtaIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetEtaTE(CreateIfNotExistsTag)
+    CCPACSEtaIsoLine& CPACSControlSurfaceBorderTrailingEdge::GetEtaTE(CreateIfNotExistsTag)
     {
         if (!m_etaTE)
-            m_etaTE = boost::in_place();
+            m_etaTE = boost::in_place(reinterpret_cast<CCPACSControlSurfaceBorderTrailingEdge*>(this));
         return *m_etaTE;
     }
 

--- a/src/generated/CPACSControlSurfaceBorderTrailingEdge.h
+++ b/src/generated/CPACSControlSurfaceBorderTrailingEdge.h
@@ -19,13 +19,13 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+#include <CCPACSEtaIsoLine.h>
+#include <CCPACSXsiIsoLine.h>
 #include <string>
 #include <tixi.h>
 #include "CPACSContourReference.h"
-#include "CPACSEtaIsoLine.h"
 #include "CPACSLeadingEdgeHollow.h"
 #include "CPACSLeadingEdgeShape.h"
-#include "CPACSXsiIsoLine.h"
 #include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
@@ -73,14 +73,14 @@ namespace generated
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
 
-        TIGL_EXPORT virtual const CPACSEtaIsoLine& GetEtaLE() const;
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEtaLE();
+        TIGL_EXPORT virtual const CCPACSEtaIsoLine& GetEtaLE() const;
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEtaLE();
 
-        TIGL_EXPORT virtual const boost::optional<CPACSEtaIsoLine>& GetEtaTE() const;
-        TIGL_EXPORT virtual boost::optional<CPACSEtaIsoLine>& GetEtaTE();
+        TIGL_EXPORT virtual const boost::optional<CCPACSEtaIsoLine>& GetEtaTE() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSEtaIsoLine>& GetEtaTE();
 
-        TIGL_EXPORT virtual const CPACSXsiIsoLine& GetXsiLE() const;
-        TIGL_EXPORT virtual CPACSXsiIsoLine& GetXsiLE();
+        TIGL_EXPORT virtual const CCPACSXsiIsoLine& GetXsiLE() const;
+        TIGL_EXPORT virtual CCPACSXsiIsoLine& GetXsiLE();
 
         TIGL_EXPORT virtual const boost::optional<CPACSLeadingEdgeHollow>& GetInnerShape() const;
         TIGL_EXPORT virtual boost::optional<CPACSLeadingEdgeHollow>& GetInnerShape();
@@ -91,7 +91,7 @@ namespace generated
         TIGL_EXPORT virtual const boost::optional<CPACSContourReference>& GetAirfoil() const;
         TIGL_EXPORT virtual boost::optional<CPACSContourReference>& GetAirfoil();
 
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEtaTE(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEtaTE(CreateIfNotExistsTag);
         TIGL_EXPORT virtual void RemoveEtaTE();
 
         TIGL_EXPORT virtual CPACSLeadingEdgeHollow& GetInnerShape(CreateIfNotExistsTag);
@@ -109,17 +109,17 @@ namespace generated
         /// Relative spanwise inner/outer position of the
         /// leading edge of the control surface. Reference is eta/xsi from
         /// the parent.
-        CPACSEtaIsoLine                         m_etaLE;
+        CCPACSEtaIsoLine                        m_etaLE;
 
         /// Relative spanwise inner/outer position of the
         /// trailing edge of the control surface. Reference is eta/xsi from
         /// the parent. Defaults to 'etaLE'.
-        boost::optional<CPACSEtaIsoLine>        m_etaTE;
+        boost::optional<CCPACSEtaIsoLine>       m_etaTE;
 
         /// Relative chordwise inner/outer position of the
         /// leading edge of the control surface. Reference is eta/xsi from
         /// the parent.
-        CPACSXsiIsoLine                         m_xsiLE;
+        CCPACSXsiIsoLine                        m_xsiLE;
 
         boost::optional<CPACSLeadingEdgeHollow> m_innerShape;
 

--- a/src/generated/CPACSControlSurfaceSkinCutOutBorder.cpp
+++ b/src/generated/CPACSControlSurfaceSkinCutOutBorder.cpp
@@ -63,7 +63,7 @@ namespace generated
 
         // read element etaLE
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/etaLE")) {
-            m_etaLE_choice2 = boost::in_place();
+            m_etaLE_choice2 = boost::in_place(reinterpret_cast<CCPACSControlSurfaceSkinCutOutBorder*>(this));
             try {
                 m_etaLE_choice2->ReadCPACS(tixiHandle, xpath + "/etaLE");
             } catch(const std::exception& e) {
@@ -74,7 +74,7 @@ namespace generated
 
         // read element etaTE
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/etaTE")) {
-            m_etaTE_choice2 = boost::in_place();
+            m_etaTE_choice2 = boost::in_place(reinterpret_cast<CCPACSControlSurfaceSkinCutOutBorder*>(this));
             try {
                 m_etaTE_choice2->ReadCPACS(tixiHandle, xpath + "/etaTE");
             } catch(const std::exception& e) {
@@ -194,30 +194,30 @@ namespace generated
         m_ribNumber_choice1 = value;
     }
 
-    const boost::optional<CPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaLE_choice2() const
+    const boost::optional<CCPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaLE_choice2() const
     {
         return m_etaLE_choice2;
     }
 
-    boost::optional<CPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaLE_choice2()
+    boost::optional<CCPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaLE_choice2()
     {
         return m_etaLE_choice2;
     }
 
-    const boost::optional<CPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaTE_choice2() const
+    const boost::optional<CCPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaTE_choice2() const
     {
         return m_etaTE_choice2;
     }
 
-    boost::optional<CPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaTE_choice2()
+    boost::optional<CCPACSEtaIsoLine>& CPACSControlSurfaceSkinCutOutBorder::GetEtaTE_choice2()
     {
         return m_etaTE_choice2;
     }
 
-    CPACSEtaIsoLine& CPACSControlSurfaceSkinCutOutBorder::GetEtaLE_choice2(CreateIfNotExistsTag)
+    CCPACSEtaIsoLine& CPACSControlSurfaceSkinCutOutBorder::GetEtaLE_choice2(CreateIfNotExistsTag)
     {
         if (!m_etaLE_choice2)
-            m_etaLE_choice2 = boost::in_place();
+            m_etaLE_choice2 = boost::in_place(reinterpret_cast<CCPACSControlSurfaceSkinCutOutBorder*>(this));
         return *m_etaLE_choice2;
     }
 
@@ -226,10 +226,10 @@ namespace generated
         m_etaLE_choice2 = boost::none;
     }
 
-    CPACSEtaIsoLine& CPACSControlSurfaceSkinCutOutBorder::GetEtaTE_choice2(CreateIfNotExistsTag)
+    CCPACSEtaIsoLine& CPACSControlSurfaceSkinCutOutBorder::GetEtaTE_choice2(CreateIfNotExistsTag)
     {
         if (!m_etaTE_choice2)
-            m_etaTE_choice2 = boost::in_place();
+            m_etaTE_choice2 = boost::in_place(reinterpret_cast<CCPACSControlSurfaceSkinCutOutBorder*>(this));
         return *m_etaTE_choice2;
     }
 

--- a/src/generated/CPACSControlSurfaceSkinCutOutBorder.h
+++ b/src/generated/CPACSControlSurfaceSkinCutOutBorder.h
@@ -19,9 +19,9 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+#include <CCPACSEtaIsoLine.h>
 #include <string>
 #include <tixi.h>
-#include "CPACSEtaIsoLine.h"
 #include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
@@ -64,35 +64,35 @@ namespace generated
         TIGL_EXPORT virtual const boost::optional<int>& GetRibNumber_choice1() const;
         TIGL_EXPORT virtual void SetRibNumber_choice1(const boost::optional<int>& value);
 
-        TIGL_EXPORT virtual const boost::optional<CPACSEtaIsoLine>& GetEtaLE_choice2() const;
-        TIGL_EXPORT virtual boost::optional<CPACSEtaIsoLine>& GetEtaLE_choice2();
+        TIGL_EXPORT virtual const boost::optional<CCPACSEtaIsoLine>& GetEtaLE_choice2() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSEtaIsoLine>& GetEtaLE_choice2();
 
-        TIGL_EXPORT virtual const boost::optional<CPACSEtaIsoLine>& GetEtaTE_choice2() const;
-        TIGL_EXPORT virtual boost::optional<CPACSEtaIsoLine>& GetEtaTE_choice2();
+        TIGL_EXPORT virtual const boost::optional<CCPACSEtaIsoLine>& GetEtaTE_choice2() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSEtaIsoLine>& GetEtaTE_choice2();
 
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEtaLE_choice2(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEtaLE_choice2(CreateIfNotExistsTag);
         TIGL_EXPORT virtual void RemoveEtaLE_choice2();
 
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEtaTE_choice2(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEtaTE_choice2(CreateIfNotExistsTag);
         TIGL_EXPORT virtual void RemoveEtaTE_choice2();
 
     protected:
         CPACSControlSurfaceWingCutOut* m_parent;
 
         /// Link to a rib definition
-        boost::optional<std::string>     m_ribDefinitionUID_choice1;
+        boost::optional<std::string>      m_ribDefinitionUID_choice1;
 
         /// Rib number in the corresponding
         /// ribDefinitionUID
-        boost::optional<int>             m_ribNumber_choice1;
+        boost::optional<int>              m_ribNumber_choice1;
 
         /// Spanwise location of the border at the
         /// leading edge of the cut out
-        boost::optional<CPACSEtaIsoLine> m_etaLE_choice2;
+        boost::optional<CCPACSEtaIsoLine> m_etaLE_choice2;
 
         /// Spanwise location of the border at the
         /// trailing edge of the cut out
-        boost::optional<CPACSEtaIsoLine> m_etaTE_choice2;
+        boost::optional<CCPACSEtaIsoLine> m_etaTE_choice2;
 
     private:
 #ifdef HAVE_CPP11

--- a/src/generated/CPACSControlSurfaceTrackType.cpp
+++ b/src/generated/CPACSControlSurfaceTrackType.cpp
@@ -29,6 +29,7 @@ namespace generated
 {
     CPACSControlSurfaceTrackType::CPACSControlSurfaceTrackType(CPACSControlSurfaceTracks* parent, CTiglUIDManager* uidMgr)
         : m_uidMgr(uidMgr)
+        , m_eta(reinterpret_cast<CCPACSControlSurfaceTrackType*>(this))
     {
         //assert(parent != NULL);
         m_parent = parent;
@@ -180,12 +181,12 @@ namespace generated
         m_uID = value;
     }
 
-    const CPACSEtaIsoLine& CPACSControlSurfaceTrackType::GetEta() const
+    const CCPACSEtaIsoLine& CPACSControlSurfaceTrackType::GetEta() const
     {
         return m_eta;
     }
 
-    CPACSEtaIsoLine& CPACSControlSurfaceTrackType::GetEta()
+    CCPACSEtaIsoLine& CPACSControlSurfaceTrackType::GetEta()
     {
         return m_eta;
     }

--- a/src/generated/CPACSControlSurfaceTrackType.h
+++ b/src/generated/CPACSControlSurfaceTrackType.h
@@ -19,11 +19,11 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+#include <CCPACSEtaIsoLine.h>
 #include <string>
 #include <tixi.h>
 #include "CPACSControlSurfaceTrackType_trackSubType.h"
 #include "CPACSControlSurfaceTrackType_trackType.h"
-#include "CPACSEtaIsoLine.h"
 #include "CPACSTrackActuator.h"
 #include "CPACSTrackStructure.h"
 #include "CreateIfNotExists.h"
@@ -89,8 +89,8 @@ namespace generated
         TIGL_EXPORT virtual const std::string& GetUID() const;
         TIGL_EXPORT virtual void SetUID(const std::string& value);
 
-        TIGL_EXPORT virtual const CPACSEtaIsoLine& GetEta() const;
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEta();
+        TIGL_EXPORT virtual const CCPACSEtaIsoLine& GetEta() const;
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEta();
 
         TIGL_EXPORT virtual const CPACSControlSurfaceTrackType_trackType& GetTrackType() const;
         TIGL_EXPORT virtual void SetTrackType(const CPACSControlSurfaceTrackType_trackType& value);
@@ -119,7 +119,7 @@ namespace generated
 
         /// Relative chordwise position of the track. Eta
         /// refers to the control surface.
-        CPACSEtaIsoLine                                            m_eta;
+        CCPACSEtaIsoLine                                           m_eta;
 
         /// Type of the track. Please refer to the remarks
         /// of the controlSrufaceTrackTypeType for details.

--- a/src/generated/CPACSCutOutProfile.cpp
+++ b/src/generated/CPACSCutOutProfile.cpp
@@ -25,7 +25,8 @@ namespace tigl
 namespace generated
 {
     CPACSCutOutProfile::CPACSCutOutProfile()
-        : m_rotZ(0)
+        : m_eta(this)
+        , m_rotZ(0)
     {
     }
 
@@ -90,12 +91,12 @@ namespace generated
         m_profileUID = value;
     }
 
-    const CPACSEtaIsoLine& CPACSCutOutProfile::GetEta() const
+    const CCPACSEtaIsoLine& CPACSCutOutProfile::GetEta() const
     {
         return m_eta;
     }
 
-    CPACSEtaIsoLine& CPACSCutOutProfile::GetEta()
+    CCPACSEtaIsoLine& CPACSCutOutProfile::GetEta()
     {
         return m_eta;
     }

--- a/src/generated/CPACSCutOutProfile.h
+++ b/src/generated/CPACSCutOutProfile.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include <CCPACSEtaIsoLine.h>
 #include <string>
 #include <tixi.h>
-#include "CPACSEtaIsoLine.h"
 #include "tigl_internal.h"
 
 namespace tigl
@@ -54,8 +54,8 @@ namespace generated
         TIGL_EXPORT virtual const std::string& GetProfileUID() const;
         TIGL_EXPORT virtual void SetProfileUID(const std::string& value);
 
-        TIGL_EXPORT virtual const CPACSEtaIsoLine& GetEta() const;
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetEta();
+        TIGL_EXPORT virtual const CCPACSEtaIsoLine& GetEta() const;
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetEta();
 
         TIGL_EXPORT virtual const double& GetRotZ() const;
         TIGL_EXPORT virtual void SetRotZ(const double& value);
@@ -63,20 +63,20 @@ namespace generated
     protected:
         /// Reference to the profile uID. Profiles should
         /// be linked in profiles/structuralProfiles
-        std::string     m_profileUID;
+        std::string      m_profileUID;
 
         /// Relative spanwise position of the cut out
         /// profile. The eta coordinate refers to the control surface and
         /// desribes the cut out profile at the leading edge of the control
         /// surface.
-        CPACSEtaIsoLine m_eta;
+        CCPACSEtaIsoLine m_eta;
 
         /// Rotation of the airfoil around the control
         /// surface middle plane normal direciotn. Reference point is the
         /// most forward point of the airfoil. Defaults to 90°, which is
         /// equivalent to the airfoilplacement in flight direction (along
         /// wings-x axis).
-        double          m_rotZ;
+        double           m_rotZ;
 
     private:
 #ifdef HAVE_CPP11

--- a/src/generated/CPACSEtaIsoLine.cpp
+++ b/src/generated/CPACSEtaIsoLine.cpp
@@ -15,7 +15,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include "CCPACSControlSurfaceBorderTrailingEdge.h"
+#include "CCPACSControlSurfaceSkinCutOutBorder.h"
+#include "CCPACSControlSurfaceTrackType.h"
+#include "CCPACSWingCellPositionSpanwise.h"
+#include "CPACSControlSurfaceAirfoil.h"
+#include "CPACSCutOutProfile.h"
 #include "CPACSEtaIsoLine.h"
+#include "CPACSSparCell.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
 #include "TixiHelper.h"
@@ -24,9 +32,60 @@ namespace tigl
 {
 namespace generated
 {
-    CPACSEtaIsoLine::CPACSEtaIsoLine()
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CCPACSWingCellPositionSpanwise* parent)
         : m_eta(0)
     {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CCPACSWingCellPositionSpanwise);
+    }
+
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CPACSControlSurfaceAirfoil* parent)
+        : m_eta(0)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CPACSControlSurfaceAirfoil);
+    }
+
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent)
+        : m_eta(0)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CCPACSControlSurfaceBorderTrailingEdge);
+    }
+
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CCPACSControlSurfaceSkinCutOutBorder* parent)
+        : m_eta(0)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CCPACSControlSurfaceSkinCutOutBorder);
+    }
+
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CCPACSControlSurfaceTrackType* parent)
+        : m_eta(0)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CCPACSControlSurfaceTrackType);
+    }
+
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CPACSCutOutProfile* parent)
+        : m_eta(0)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CPACSCutOutProfile);
+    }
+
+    CPACSEtaIsoLine::CPACSEtaIsoLine(CPACSSparCell* parent)
+        : m_eta(0)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CPACSSparCell);
     }
 
     CPACSEtaIsoLine::~CPACSEtaIsoLine()

--- a/src/generated/CPACSEtaIsoLine.h
+++ b/src/generated/CPACSEtaIsoLine.h
@@ -25,9 +25,19 @@
 
 namespace tigl
 {
+class CCPACSWingCellPositionSpanwise;
+class CCPACSControlSurfaceBorderTrailingEdge;
+class CCPACSControlSurfaceSkinCutOutBorder;
+class CCPACSControlSurfaceTrackType;
+
 namespace generated
 {
+    class CPACSControlSurfaceAirfoil;
+    class CPACSCutOutProfile;
+    class CPACSSparCell;
+
     // This class is used in:
+    // CPACSCellPositioningSpanwise
     // CPACSControlSurfaceAirfoil
     // CPACSControlSurfaceBorderTrailingEdge
     // CPACSControlSurfaceSkinCutOutBorder
@@ -44,8 +54,45 @@ namespace generated
     class CPACSEtaIsoLine
     {
     public:
-        TIGL_EXPORT CPACSEtaIsoLine();
+        TIGL_EXPORT CPACSEtaIsoLine(CCPACSWingCellPositionSpanwise* parent);
+        TIGL_EXPORT CPACSEtaIsoLine(CPACSControlSurfaceAirfoil* parent);
+        TIGL_EXPORT CPACSEtaIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent);
+        TIGL_EXPORT CPACSEtaIsoLine(CCPACSControlSurfaceSkinCutOutBorder* parent);
+        TIGL_EXPORT CPACSEtaIsoLine(CCPACSControlSurfaceTrackType* parent);
+        TIGL_EXPORT CPACSEtaIsoLine(CPACSCutOutProfile* parent);
+        TIGL_EXPORT CPACSEtaIsoLine(CPACSSparCell* parent);
+
         TIGL_EXPORT virtual ~CPACSEtaIsoLine();
+
+        template<typename P>
+        bool IsParent() const
+        {
+            return m_parentType != NULL && *m_parentType == typeid(P);
+        }
+
+        template<typename P>
+        P* GetParent()
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSWingCellPositionSpanwise>::value || std::is_same<P, CPACSControlSurfaceAirfoil>::value || std::is_same<P, CCPACSControlSurfaceBorderTrailingEdge>::value || std::is_same<P, CCPACSControlSurfaceSkinCutOutBorder>::value || std::is_same<P, CCPACSControlSurfaceTrackType>::value || std::is_same<P, CPACSCutOutProfile>::value || std::is_same<P, CPACSSparCell>::value, "template argument for P is not a parent class of CPACSEtaIsoLine");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
+
+        template<typename P>
+        const P* GetParent() const
+        {
+#ifdef HAVE_STDIS_SAME
+            static_assert(std::is_same<P, CCPACSWingCellPositionSpanwise>::value || std::is_same<P, CPACSControlSurfaceAirfoil>::value || std::is_same<P, CCPACSControlSurfaceBorderTrailingEdge>::value || std::is_same<P, CCPACSControlSurfaceSkinCutOutBorder>::value || std::is_same<P, CCPACSControlSurfaceTrackType>::value || std::is_same<P, CPACSCutOutProfile>::value || std::is_same<P, CPACSSparCell>::value, "template argument for P is not a parent class of CPACSEtaIsoLine");
+#endif
+            if (!IsParent<P>()) {
+                throw CTiglError("bad parent");
+            }
+            return static_cast<P*>(m_parent);
+        }
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
@@ -57,6 +104,9 @@ namespace generated
         TIGL_EXPORT virtual void SetReferenceUID(const std::string& value);
 
     protected:
+        void* m_parent;
+        const std::type_info* m_parentType;
+
         /// Relative spanwise position. Eta refers to the segment or componentSegment depending on the referenced uID.
         double      m_eta;
 
@@ -80,10 +130,16 @@ namespace generated
     };
 } // namespace generated
 
+// CPACSEtaIsoLine is customized, use type CCPACSEtaIsoLine directly
+
 // Aliases in tigl namespace
 #ifdef HAVE_CPP11
-using CCPACSEtaIsoLine = generated::CPACSEtaIsoLine;
+using CCPACSControlSurfaceAirfoil = generated::CPACSControlSurfaceAirfoil;
+using CCPACSCutOutProfile = generated::CPACSCutOutProfile;
+using CCPACSSparCell = generated::CPACSSparCell;
 #else
-typedef generated::CPACSEtaIsoLine CCPACSEtaIsoLine;
+typedef generated::CPACSControlSurfaceAirfoil CCPACSControlSurfaceAirfoil;
+typedef generated::CPACSCutOutProfile CCPACSCutOutProfile;
+typedef generated::CPACSSparCell CCPACSSparCell;
 #endif
 } // namespace tigl

--- a/src/generated/CPACSRibRotation.cpp
+++ b/src/generated/CPACSRibRotation.cpp
@@ -51,7 +51,10 @@ namespace generated
     {
         // read element ribRotationReference
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribRotationReference")) {
-            m_ribRotationReference = stringToCPACSRibRotation_ribRotationReference(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribRotationReference"));
+            m_ribRotationReference = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribRotationReference");
+            if (m_ribRotationReference->empty()) {
+                LOG(WARNING) << "Optional element ribRotationReference is present but empty at xpath " << xpath;
+            }
         }
 
         // read element z
@@ -69,7 +72,7 @@ namespace generated
         // write element ribRotationReference
         if (m_ribRotationReference) {
             tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/ribRotationReference");
-            tixi::TixiSaveElement(tixiHandle, xpath + "/ribRotationReference", CPACSRibRotation_ribRotationReferenceToString(*m_ribRotationReference));
+            tixi::TixiSaveElement(tixiHandle, xpath + "/ribRotationReference", *m_ribRotationReference);
         }
         else {
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribRotationReference")) {
@@ -83,12 +86,12 @@ namespace generated
 
     }
 
-    const boost::optional<CPACSRibRotation_ribRotationReference>& CPACSRibRotation::GetRibRotationReference() const
+    const boost::optional<std::string>& CPACSRibRotation::GetRibRotationReference() const
     {
         return m_ribRotationReference;
     }
 
-    void CPACSRibRotation::SetRibRotationReference(const boost::optional<CPACSRibRotation_ribRotationReference>& value)
+    void CPACSRibRotation::SetRibRotationReference(const boost::optional<std::string>& value)
     {
         m_ribRotationReference = value;
     }

--- a/src/generated/CPACSRibRotation.h
+++ b/src/generated/CPACSRibRotation.h
@@ -21,7 +21,6 @@
 #include <boost/utility/in_place_factory.hpp>
 #include <string>
 #include <tixi.h>
-#include "CPACSRibRotation_ribRotationReference.h"
 #include "tigl_internal.h"
 
 namespace tigl
@@ -55,8 +54,8 @@ namespace generated
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
 
-        TIGL_EXPORT virtual const boost::optional<CPACSRibRotation_ribRotationReference>& GetRibRotationReference() const;
-        TIGL_EXPORT virtual void SetRibRotationReference(const boost::optional<CPACSRibRotation_ribRotationReference>& value);
+        TIGL_EXPORT virtual const boost::optional<std::string>& GetRibRotationReference() const;
+        TIGL_EXPORT virtual void SetRibRotationReference(const boost::optional<std::string>& value);
 
         TIGL_EXPORT virtual const double& GetZ() const;
         TIGL_EXPORT virtual void SetZ(const double& value);
@@ -64,13 +63,22 @@ namespace generated
     protected:
         CCPACSWingRibsPositioning* m_parent;
 
-        boost::optional<CPACSRibRotation_ribRotationReference> m_ribRotationReference;
+        /// RotationReference defines the reference for
+        /// the z-rotation it is either sparUID or„LeadingEdge“ or
+        /// „TrailingEdge“. If it is not defined the rotation reference is
+        /// the eta-axis (=leading edge, that is projected on the wings
+        /// y-z-plane). A z-rotation angle of 90 degrees means, that the rib
+        /// is perpendicular on the ribRotationReference (e.g. spar, leading
+        /// edge...). The rib itself is allways straight, and the rotation
+        /// is defined with respect of the intersection point of the rib
+        /// with the ribRotationReference.
+        boost::optional<std::string> m_ribRotationReference;
 
         /// The rotation around z describes the rotation
         /// around the wings midplane normal axis. The defaults to 90°. The
         /// reference for the 'zero-angle' of the z-rotation is defined in
         /// ribRotationReference.
-        double                                                 m_z;
+        double                       m_z;
 
     private:
 #ifdef HAVE_CPP11

--- a/src/generated/CPACSSparCell.cpp
+++ b/src/generated/CPACSSparCell.cpp
@@ -27,6 +27,8 @@ namespace generated
 {
     CPACSSparCell::CPACSSparCell(CTiglUIDManager* uidMgr)
         : m_uidMgr(uidMgr)
+        , m_fromEta(this)
+        , m_toEta(this)
         , m_rotation(0)
     {
     }
@@ -177,22 +179,22 @@ namespace generated
         m_uID = value;
     }
 
-    const CPACSEtaIsoLine& CPACSSparCell::GetFromEta() const
+    const CCPACSEtaIsoLine& CPACSSparCell::GetFromEta() const
     {
         return m_fromEta;
     }
 
-    CPACSEtaIsoLine& CPACSSparCell::GetFromEta()
+    CCPACSEtaIsoLine& CPACSSparCell::GetFromEta()
     {
         return m_fromEta;
     }
 
-    const CPACSEtaIsoLine& CPACSSparCell::GetToEta() const
+    const CCPACSEtaIsoLine& CPACSSparCell::GetToEta() const
     {
         return m_toEta;
     }
 
-    CPACSEtaIsoLine& CPACSSparCell::GetToEta()
+    CCPACSEtaIsoLine& CPACSSparCell::GetToEta()
     {
         return m_toEta;
     }

--- a/src/generated/CPACSSparCell.h
+++ b/src/generated/CPACSSparCell.h
@@ -19,10 +19,10 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+#include <CCPACSEtaIsoLine.h>
 #include <string>
 #include <tixi.h>
 #include "CPACSCap.h"
-#include "CPACSEtaIsoLine.h"
 #include "CPACSWeb.h"
 #include "CreateIfNotExists.h"
 #include "tigl_internal.h"
@@ -62,11 +62,11 @@ namespace generated
         TIGL_EXPORT virtual const std::string& GetUID() const;
         TIGL_EXPORT virtual void SetUID(const std::string& value);
 
-        TIGL_EXPORT virtual const CPACSEtaIsoLine& GetFromEta() const;
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetFromEta();
+        TIGL_EXPORT virtual const CCPACSEtaIsoLine& GetFromEta() const;
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetFromEta();
 
-        TIGL_EXPORT virtual const CPACSEtaIsoLine& GetToEta() const;
-        TIGL_EXPORT virtual CPACSEtaIsoLine& GetToEta();
+        TIGL_EXPORT virtual const CCPACSEtaIsoLine& GetToEta() const;
+        TIGL_EXPORT virtual CCPACSEtaIsoLine& GetToEta();
 
         TIGL_EXPORT virtual const CPACSCap& GetUpperCap() const;
         TIGL_EXPORT virtual CPACSCap& GetUpperCap();
@@ -92,10 +92,10 @@ namespace generated
         std::string               m_uID;
 
         /// Beginning (= inner border) of the spar cell.
-        CPACSEtaIsoLine           m_fromEta;
+        CCPACSEtaIsoLine          m_fromEta;
 
         /// Ending (= outer border) of the spar cell.
-        CPACSEtaIsoLine           m_toEta;
+        CCPACSEtaIsoLine          m_toEta;
 
         CPACSCap                  m_upperCap;
 

--- a/src/generated/CPACSWingRibExplicitPositioning.h
+++ b/src/generated/CPACSWingRibExplicitPositioning.h
@@ -97,10 +97,5 @@ namespace generated
     };
 } // namespace generated
 
-// Aliases in tigl namespace
-#ifdef HAVE_CPP11
-using CCPACSWingRibExplicitPositioning = generated::CPACSWingRibExplicitPositioning;
-#else
-typedef generated::CPACSWingRibExplicitPositioning CCPACSWingRibExplicitPositioning;
-#endif
+// CPACSWingRibExplicitPositioning is customized, use type CCPACSWingRibExplicitPositioning directly
 } // namespace tigl

--- a/src/generated/CPACSWingRibsDefinition.cpp
+++ b/src/generated/CPACSWingRibsDefinition.cpp
@@ -264,12 +264,12 @@ namespace generated
         return m_ribsPositioning_choice1;
     }
 
-    const boost::optional<CPACSWingRibExplicitPositioning>& CPACSWingRibsDefinition::GetRibExplicitPositioning_choice2() const
+    const boost::optional<CCPACSWingRibExplicitPositioning>& CPACSWingRibsDefinition::GetRibExplicitPositioning_choice2() const
     {
         return m_ribExplicitPositioning_choice2;
     }
 
-    boost::optional<CPACSWingRibExplicitPositioning>& CPACSWingRibsDefinition::GetRibExplicitPositioning_choice2()
+    boost::optional<CCPACSWingRibExplicitPositioning>& CPACSWingRibsDefinition::GetRibExplicitPositioning_choice2()
     {
         return m_ribExplicitPositioning_choice2;
     }
@@ -286,7 +286,7 @@ namespace generated
         m_ribsPositioning_choice1 = boost::none;
     }
 
-    CPACSWingRibExplicitPositioning& CPACSWingRibsDefinition::GetRibExplicitPositioning_choice2(CreateIfNotExistsTag)
+    CCPACSWingRibExplicitPositioning& CPACSWingRibsDefinition::GetRibExplicitPositioning_choice2(CreateIfNotExistsTag)
     {
         if (!m_ribExplicitPositioning_choice2)
             m_ribExplicitPositioning_choice2 = boost::in_place(reinterpret_cast<CCPACSWingRibsDefinition*>(this));

--- a/src/generated/CPACSWingRibsDefinition.h
+++ b/src/generated/CPACSWingRibsDefinition.h
@@ -20,10 +20,10 @@
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 #include <CCPACSWingRibCrossSection.h>
+#include <CCPACSWingRibExplicitPositioning.h>
 #include <CCPACSWingRibsPositioning.h>
 #include <string>
 #include <tixi.h>
-#include "CPACSWingRibExplicitPositioning.h"
 #include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
@@ -80,13 +80,13 @@ namespace generated
         TIGL_EXPORT virtual const boost::optional<CCPACSWingRibsPositioning>& GetRibsPositioning_choice1() const;
         TIGL_EXPORT virtual boost::optional<CCPACSWingRibsPositioning>& GetRibsPositioning_choice1();
 
-        TIGL_EXPORT virtual const boost::optional<CPACSWingRibExplicitPositioning>& GetRibExplicitPositioning_choice2() const;
-        TIGL_EXPORT virtual boost::optional<CPACSWingRibExplicitPositioning>& GetRibExplicitPositioning_choice2();
+        TIGL_EXPORT virtual const boost::optional<CCPACSWingRibExplicitPositioning>& GetRibExplicitPositioning_choice2() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSWingRibExplicitPositioning>& GetRibExplicitPositioning_choice2();
 
         TIGL_EXPORT virtual CCPACSWingRibsPositioning& GetRibsPositioning_choice1(CreateIfNotExistsTag);
         TIGL_EXPORT virtual void RemoveRibsPositioning_choice1();
 
-        TIGL_EXPORT virtual CPACSWingRibExplicitPositioning& GetRibExplicitPositioning_choice2(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual CCPACSWingRibExplicitPositioning& GetRibExplicitPositioning_choice2(CreateIfNotExistsTag);
         TIGL_EXPORT virtual void RemoveRibExplicitPositioning_choice2();
 
     protected:
@@ -94,19 +94,19 @@ namespace generated
 
         CTiglUIDManager* m_uidMgr;
 
-        boost::optional<std::string>                     m_uID;
+        boost::optional<std::string>                      m_uID;
 
         /// Name of the rib set.
-        std::string                                      m_name;
+        std::string                                       m_name;
 
         /// Description of the rib set.
-        boost::optional<std::string>                     m_description;
+        boost::optional<std::string>                      m_description;
 
-        CCPACSWingRibCrossSection                        m_ribCrossSection;
+        CCPACSWingRibCrossSection                         m_ribCrossSection;
 
-        boost::optional<CCPACSWingRibsPositioning>       m_ribsPositioning_choice1;
+        boost::optional<CCPACSWingRibsPositioning>        m_ribsPositioning_choice1;
 
-        boost::optional<CPACSWingRibExplicitPositioning> m_ribExplicitPositioning_choice2;
+        boost::optional<CCPACSWingRibExplicitPositioning> m_ribExplicitPositioning_choice2;
 
     private:
 #ifdef HAVE_CPP11

--- a/src/generated/CPACSXsiIsoLine.cpp
+++ b/src/generated/CPACSXsiIsoLine.cpp
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include "CCPACSControlSurfaceBorderTrailingEdge.h"
 #include "CPACSXsiIsoLine.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
@@ -24,13 +26,25 @@ namespace tigl
 {
 namespace generated
 {
-    CPACSXsiIsoLine::CPACSXsiIsoLine()
+    CPACSXsiIsoLine::CPACSXsiIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent)
         : m_xsi(0)
     {
+        //assert(parent != NULL);
+        m_parent = parent;
     }
 
     CPACSXsiIsoLine::~CPACSXsiIsoLine()
     {
+    }
+
+    const CCPACSControlSurfaceBorderTrailingEdge* CPACSXsiIsoLine::GetParent() const
+    {
+        return m_parent;
+    }
+
+    CCPACSControlSurfaceBorderTrailingEdge* CPACSXsiIsoLine::GetParent()
+    {
+        return m_parent;
     }
 
     void CPACSXsiIsoLine::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)

--- a/src/generated/CPACSXsiIsoLine.h
+++ b/src/generated/CPACSXsiIsoLine.h
@@ -23,6 +23,8 @@
 
 namespace tigl
 {
+class CCPACSControlSurfaceBorderTrailingEdge;
+
 namespace generated
 {
     // This class is used in:
@@ -37,8 +39,13 @@ namespace generated
     class CPACSXsiIsoLine
     {
     public:
-        TIGL_EXPORT CPACSXsiIsoLine();
+        TIGL_EXPORT CPACSXsiIsoLine(CCPACSControlSurfaceBorderTrailingEdge* parent);
+
         TIGL_EXPORT virtual ~CPACSXsiIsoLine();
+
+        TIGL_EXPORT CCPACSControlSurfaceBorderTrailingEdge* GetParent();
+
+        TIGL_EXPORT const CCPACSControlSurfaceBorderTrailingEdge* GetParent() const;
 
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
@@ -50,6 +57,8 @@ namespace generated
         TIGL_EXPORT virtual void SetReferenceUID(const std::string& value);
 
     protected:
+        CCPACSControlSurfaceBorderTrailingEdge* m_parent;
+
         /// Relative spanwise position. Xsi refers to the segment or componentSegment depending on the referenced uID.
         double      m_xsi;
 
@@ -73,10 +82,5 @@ namespace generated
     };
 } // namespace generated
 
-// Aliases in tigl namespace
-#ifdef HAVE_CPP11
-using CCPACSXsiIsoLine = generated::CPACSXsiIsoLine;
-#else
-typedef generated::CPACSXsiIsoLine CCPACSXsiIsoLine;
-#endif
+// CPACSXsiIsoLine is customized, use type CCPACSXsiIsoLine directly
 } // namespace tigl

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -259,7 +259,7 @@ EtaXsi CCPACSWingCell::GetTrailingEdgeOuterPoint() const
 
 void CCPACSWingCell::SetLeadingEdgeInnerPoint(double eta1, double xsi1)
 {
-    m_positioningInnerBorder.SetEta1_choice1(eta1);
+    m_positioningInnerBorder.SetEta1(eta1);
     m_positioningLeadingEdge.SetXsi1(xsi1);
 }
 

--- a/src/wing/CCPACSWingCellPositionSpanwise.cpp
+++ b/src/wing/CCPACSWingCellPositionSpanwise.cpp
@@ -17,10 +17,26 @@
 #include "CCPACSWingCellPositionSpanwise.h"
 
 #include "CCPACSWingCell.h"
+#include "CCPACSWingCells.h"
+#include "CCPACSWingShell.h"
+#include "CCPACSWingCSStructure.h"
+#include "CTiglWingStructureReference.h"
 #include "CTiglError.h"
+#include "tigletaxsifunctions.h"
 
 namespace tigl
 {
+
+namespace {
+    // return uid of wing structure reference, or the empty string when not all parents are defined
+    std::string tryGetWingStructureReferenceUID(CCPACSWingCell* parent)
+    {
+        if (!parent || !parent->GetParent() || !parent->GetParent()->GetParent() || !parent->GetParent()->GetParent()->GetParent()) {
+            return "";
+        }
+        return CTiglWingStructureReference(*parent->GetParent()->GetParent()->GetParent()).GetUID();
+    }
+}
 
 CCPACSWingCellPositionSpanwise::CCPACSWingCellPositionSpanwise(CCPACSWingCell* parent)
     : generated::CPACSCellPositioningSpanwise(parent) {}
@@ -34,7 +50,9 @@ CCPACSWingCellPositionSpanwise::InputType CCPACSWingCellPositionSpanwise::GetInp
 }
 
 void CCPACSWingCellPositionSpanwise::SetEta1(double eta1) {
-    m_eta1_choice1 = eta1;
+    const std::string uid = tryGetWingStructureReferenceUID(m_parent);
+    GetEta1_choice1(CreateIfNotExists).SetEta(eta1);
+    GetEta1_choice1(CreateIfNotExists).SetReferenceUID(uid);
     m_ribNumber_choice2 = boost::none;
     m_ribDefinitionUID_choice2 = boost::none;
 
@@ -42,16 +60,29 @@ void CCPACSWingCellPositionSpanwise::SetEta1(double eta1) {
 }
 
 void CCPACSWingCellPositionSpanwise::SetEta2(double eta2) {
-    m_eta2_choice1 = eta2;
+    const std::string uid = tryGetWingStructureReferenceUID(m_parent);
+    GetEta2_choice1(CreateIfNotExists).SetEta(eta2);
+    GetEta2_choice1(CreateIfNotExists).SetReferenceUID(uid);
     m_ribNumber_choice2 = boost::none;
     m_ribDefinitionUID_choice2 = boost::none;
 
     InvalidateParent();
 }
 
-void CCPACSWingCellPositionSpanwise::SetEta(double eta1, double eta2) {
-    m_eta1_choice1 = eta1;
-    m_eta2_choice1 = eta2;
+// get and set Eta definition
+void CCPACSWingCellPositionSpanwise::SetEta(double eta1, double eta2)
+{
+    const std::string uid = tryGetWingStructureReferenceUID(m_parent);
+    SetEta(eta1, uid, eta2, uid);
+}
+
+void CCPACSWingCellPositionSpanwise::SetEta(double eta1, const std::string& eta1RefUid, double eta2,
+                                            const std::string& eta2RefUid)
+{
+    GetEta1_choice1(CreateIfNotExists).SetEta(eta1);
+    GetEta1_choice1(CreateIfNotExists).SetReferenceUID(eta1RefUid);
+    GetEta2_choice1(CreateIfNotExists).SetEta(eta2);
+    GetEta2_choice1(CreateIfNotExists).SetReferenceUID(eta2RefUid);
 
     m_ribNumber_choice2 = boost::none;
     m_ribDefinitionUID_choice2 = boost::none;
@@ -70,7 +101,16 @@ std::pair<double, double> CCPACSWingCellPositionSpanwise::GetEta() const {
     if (GetInputType() != Eta) {
         throw CTiglError("CCPACSWingCellPositionSpanwise::GetEta method called, but position is defined via ribDefinitionUID!");
     }
-    return std::make_pair(m_eta1_choice1.value(), m_eta2_choice1.value());
+
+    const CCPACSEtaIsoLine& etaIso1 = m_eta1_choice1.value();
+    const CCPACSEtaIsoLine& etaIso2 = m_eta2_choice1.value();
+    // special handling for testing
+    if (etaIso1.GetReferenceUID().empty() && etaIso2.GetReferenceUID().empty()) {
+        return std::make_pair(etaIso1.GetEta(), etaIso2.GetEta());
+    }
+    const double eta1 = transformEtaToCSOrTed(etaIso1, m_parent->GetUIDManager());
+    const double eta2 = transformEtaToCSOrTed(etaIso2, m_parent->GetUIDManager());
+    return std::make_pair(eta1, eta2);
 }
 
 void CCPACSWingCellPositionSpanwise::SetRib(const std::string& ribUId, int nRib) {
@@ -114,7 +154,9 @@ std::pair<std::string, int> CCPACSWingCellPositionSpanwise::GetRib() const {
 
 void CCPACSWingCellPositionSpanwise::InvalidateParent()
 {
-    GetParent()->Invalidate();
+    if (GetParent()) {
+        GetParent()->Invalidate();
+    }
 }
 
 }

--- a/src/wing/CCPACSWingCellPositionSpanwise.h
+++ b/src/wing/CCPACSWingCellPositionSpanwise.h
@@ -47,6 +47,7 @@ public:
     TIGL_EXPORT void SetEta1(double eta1);
     TIGL_EXPORT void SetEta2(double eta2);
     TIGL_EXPORT void SetEta(double eta1, double eta2);
+    TIGL_EXPORT void SetEta(double eta1, const std::string& eta1RefUid, double eta2, const std::string& eta2RefUid);
 
     TIGL_EXPORT void GetRib(std::string& ribUid, int& ribNumber) const;
     TIGL_EXPORT std::pair<std::string, int> GetRib() const;
@@ -56,6 +57,8 @@ public:
 
 protected:
     void InvalidateParent();
+
+    friend class CCPACSEtaIsoLine;
 };
 
 } // end namespace tigl

--- a/src/wing/CCPACSWingRibExplicitPositioning.cpp
+++ b/src/wing/CCPACSWingRibExplicitPositioning.cpp
@@ -1,0 +1,62 @@
+/*
+* Copyright (C) 2016 Airbus Defence and Space
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#include "CCPACSWingRibExplicitPositioning.h"
+
+#include "CCPACSWingCSStructure.h"
+#include "CCPACSWingRibsDefinition.h"
+
+namespace tigl
+{
+CCPACSWingRibExplicitPositioning::CCPACSWingRibExplicitPositioning(CCPACSWingRibsDefinition* parent)
+    : generated::CPACSWingRibExplicitPositioning(parent)
+{
+}
+
+void CCPACSWingRibExplicitPositioning::SetStartReference(const std::string& ref)
+{
+    generated::CPACSWingRibExplicitPositioning::SetStartReference(ref);
+    // invalidate whole component segment structure since rib could be referenced anywhere
+    m_parent->GetParent()->Invalidate();
+}
+
+void CCPACSWingRibExplicitPositioning::SetEndReference(const std::string& ref)
+{
+    generated::CPACSWingRibExplicitPositioning::SetEndReference(ref);
+    // invalidate whole component segment structure since rib could be referenced anywhere
+    m_parent->GetParent()->Invalidate();
+}
+
+void CCPACSWingRibExplicitPositioning::SetStartEta(double eta, const std::string& referenceUid)
+{
+    generated::CPACSWingRibExplicitPositioning::GetEtaStart().SetEta(eta);
+    generated::CPACSWingRibExplicitPositioning::GetEtaStart().SetReferenceUID(referenceUid);
+    // invalidate whole component segment structure since rib could be referenced anywhere
+    m_parent->GetParent()->Invalidate();
+}
+
+void CCPACSWingRibExplicitPositioning::SetEndEta(double eta, const std::string& referenceUid)
+{
+    generated::CPACSWingRibExplicitPositioning::GetEtaEnd().SetEta(eta);
+    generated::CPACSWingRibExplicitPositioning::GetEtaEnd().SetReferenceUID(referenceUid);
+    // invalidate whole component segment structure since rib could be referenced anywhere
+    m_parent->GetParent()->Invalidate();
+}
+
+void CCPACSWingRibExplicitPositioning::Invalidate()
+{
+    m_parent->GetParent()->Invalidate();
+}
+}

--- a/src/wing/CCPACSWingRibExplicitPositioning.cpp
+++ b/src/wing/CCPACSWingRibExplicitPositioning.cpp
@@ -39,18 +39,16 @@ void CCPACSWingRibExplicitPositioning::SetEndReference(const std::string& ref)
     m_parent->GetParent()->Invalidate();
 }
 
-void CCPACSWingRibExplicitPositioning::SetStartEta(double eta, const std::string& referenceUid)
+void CCPACSWingRibExplicitPositioning::SetStartEta(double eta)
 {
-    generated::CPACSWingRibExplicitPositioning::GetEtaStart().SetEta(eta);
-    generated::CPACSWingRibExplicitPositioning::GetEtaStart().SetReferenceUID(referenceUid);
+    generated::CPACSWingRibExplicitPositioning::SetEtaStart(eta);
     // invalidate whole component segment structure since rib could be referenced anywhere
     m_parent->GetParent()->Invalidate();
 }
 
-void CCPACSWingRibExplicitPositioning::SetEndEta(double eta, const std::string& referenceUid)
+void CCPACSWingRibExplicitPositioning::SetEndEta(double eta)
 {
-    generated::CPACSWingRibExplicitPositioning::GetEtaEnd().SetEta(eta);
-    generated::CPACSWingRibExplicitPositioning::GetEtaEnd().SetReferenceUID(referenceUid);
+    generated::CPACSWingRibExplicitPositioning::SetEtaEnd(eta);
     // invalidate whole component segment structure since rib could be referenced anywhere
     m_parent->GetParent()->Invalidate();
 }

--- a/src/wing/CCPACSWingRibExplicitPositioning.h
+++ b/src/wing/CCPACSWingRibExplicitPositioning.h
@@ -27,8 +27,8 @@ public:
 
     TIGL_EXPORT void SetStartReference(const std::string&);
     TIGL_EXPORT void SetEndReference(const std::string&);
-    TIGL_EXPORT void SetStartEta(double eta, const std::string& referenceUid);
-    TIGL_EXPORT void SetEndEta(double eta, const std::string& referenceUid);
+    TIGL_EXPORT void SetStartEta(double eta);
+    TIGL_EXPORT void SetEndEta(double eta);
     TIGL_EXPORT void Invalidate();
 };
 }

--- a/src/wing/CCPACSWingRibExplicitPositioning.h
+++ b/src/wing/CCPACSWingRibExplicitPositioning.h
@@ -1,0 +1,34 @@
+/*
+* Copyright (C) 2016 Airbus Defence and Space
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include "generated/CPACSWingRibExplicitPositioning.h"
+
+namespace tigl
+{
+class CCPACSWingRibExplicitPositioning : public generated::CPACSWingRibExplicitPositioning
+{
+public:
+    TIGL_EXPORT CCPACSWingRibExplicitPositioning(CCPACSWingRibsDefinition* parent);
+
+    TIGL_EXPORT void SetStartReference(const std::string&);
+    TIGL_EXPORT void SetEndReference(const std::string&);
+    TIGL_EXPORT void SetStartEta(double eta, const std::string& referenceUid);
+    TIGL_EXPORT void SetEndEta(double eta, const std::string& referenceUid);
+    TIGL_EXPORT void Invalidate();
+};
+}

--- a/src/wing/CCPACSWingRibRotation.cpp
+++ b/src/wing/CCPACSWingRibRotation.cpp
@@ -28,7 +28,7 @@ CCPACSWingRibRotation::CCPACSWingRibRotation(CCPACSWingRibsPositioning* parent)
     m_z = 90;
 }
 
-void CCPACSWingRibRotation::SetRibRotationReference(const boost::optional<ECPACSRibRotation_ribRotationReference>& value)
+void CCPACSWingRibRotation::SetRibRotationReference(const boost::optional<std::string>& value)
 {
     generated::CPACSRibRotation::SetRibRotationReference(value);
     m_parent->invalidateStructure();

--- a/src/wing/CCPACSWingRibRotation.h
+++ b/src/wing/CCPACSWingRibRotation.h
@@ -25,7 +25,7 @@ class CCPACSWingRibRotation : public generated::CPACSRibRotation
 public:
     TIGL_EXPORT CCPACSWingRibRotation(CCPACSWingRibsPositioning* parent);
 
-    TIGL_EXPORT void SetRibRotationReference(const boost::optional<ECPACSRibRotation_ribRotationReference>& value) OVERRIDE;
+    TIGL_EXPORT void SetRibRotationReference(const boost::optional<std::string>& value) OVERRIDE;
 
     TIGL_EXPORT void SetZ(const double& value) OVERRIDE;
 };

--- a/src/wing/tigletaxsifunctions.h
+++ b/src/wing/tigletaxsifunctions.h
@@ -32,6 +32,9 @@ class CCPACSWingComponentSegment;
 class CCPACSWingRibsDefinition;
 class CCPACSWingSparSegment;
 class CTiglWingStructureReference;
+class CTiglUIDManager;
+class CCPACSEtaIsoLine;
+class CCPACSXsiIsoLine;
 
 /**
 * @brief Returns the chordline point of the section element at the passed xsi value
@@ -53,6 +56,12 @@ TIGL_EXPORT double computeRibEtaValue(const CTiglWingStructureReference& wsr, co
 */
 TIGL_EXPORT EtaXsi computeRibSparIntersectionEtaXsi(const CTiglWingStructureReference& wsr, const CCPACSWingRibsDefinition& rib, int ribIndex, const CCPACSWingSparSegment& spar);
 
+TIGL_EXPORT double transformEtaToCSOrTed(const CCPACSEtaIsoLine& eta, const CTiglUIDManager& uidMgr);
+TIGL_EXPORT double transformXsiToCSOrTed(const CCPACSXsiIsoLine& xsi, const CTiglUIDManager& uidMgr);
+TIGL_EXPORT double transformEtaToCSOrTed(double eta, const std::string& referenceUid, const CTiglUIDManager& uidMgr);
+TIGL_EXPORT double transformXsiToCSOrTed(double xsi, const std::string& referenceUid, const CTiglUIDManager& uidMgr);
+
+TIGL_EXPORT EtaXsi transformEtaXsiToCSOrTed(EtaXsi etaXsi, const std::string& referenceUid, const CTiglUIDManager& uidMgr);
 
 }
 

--- a/src/wing/tigletaxsifunctions.h
+++ b/src/wing/tigletaxsifunctions.h
@@ -56,6 +56,9 @@ TIGL_EXPORT double computeRibEtaValue(const CTiglWingStructureReference& wsr, co
 */
 TIGL_EXPORT EtaXsi computeRibSparIntersectionEtaXsi(const CTiglWingStructureReference& wsr, const CCPACSWingRibsDefinition& rib, int ribIndex, const CCPACSWingSparSegment& spar);
 
+/**
+ * Following are routines, that transform e.g. segment eta/xsi coordinates into the CS system or into TED system
+ */
 TIGL_EXPORT double transformEtaToCSOrTed(const CCPACSEtaIsoLine& eta, const CTiglUIDManager& uidMgr);
 TIGL_EXPORT double transformXsiToCSOrTed(const CCPACSXsiIsoLine& xsi, const CTiglUIDManager& uidMgr);
 TIGL_EXPORT double transformEtaToCSOrTed(double eta, const std::string& referenceUid, const CTiglUIDManager& uidMgr);

--- a/tests/unittests/TestData/CPACS_30_D250_10.xml
+++ b/tests/unittests/TestData/CPACS_30_D250_10.xml
@@ -2114,8 +2114,14 @@
                           <sparUID>rearSpar</sparUID>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>D250_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>D250_wing_CS</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
                           <ribNumber>27</ribNumber>
@@ -2151,8 +2157,14 @@
                           <sparUID>rearSpar</sparUID>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>D250_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>D250_wing_CS</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
                           <ribNumber>27</ribNumber>
@@ -3030,12 +3042,24 @@
                                 <sparUID>T1Spar2_IF</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -3067,12 +3091,24 @@
                                 <sparUID>T1Spar2_IF</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerFlap</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -3431,12 +3467,24 @@
                                 <sparUID>T1Spar2_OF</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -3468,12 +3516,24 @@
                                 <sparUID>T1Spar2_OF</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterFlap</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -4005,12 +4065,24 @@
                                 <sparUID>T1Spar2_IA</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -4042,12 +4114,24 @@
                                 <sparUID>T1Spar2_IA</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_InnerAileron</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -4328,12 +4412,24 @@
                                 <sparUID>T1Spar2_OA</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -4365,12 +4461,24 @@
                                 <sparUID>T1Spar2_OA</sparUID>
                               </positioningTrailingEdge>
                               <positioningInnerBorder>
-                                <eta1>0.0</eta1>
-                                <eta2>0.0</eta2>
+                                <eta1>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>0</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta2>
                               </positioningInnerBorder>
                               <positioningOuterBorder>
-                                <eta1>1.0</eta1>
-                                <eta2>1.0</eta2>
+                                <eta1>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta1>
+                                <eta2>
+                                  <eta>1</eta>
+                                  <referenceUID>D250_OuterAileron</referenceUID>
+                                </eta2>
                               </positioningOuterBorder>
                             </cell>
                           </cells>
@@ -4672,12 +4780,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -4894,12 +5014,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5116,12 +5248,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5338,12 +5482,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5560,12 +5716,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5782,12 +5950,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D250_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>

--- a/tests/unittests/TestData/D150_v30.xml
+++ b/tests/unittests/TestData/D150_v30.xml
@@ -3745,12 +3745,24 @@
                           <xsi2>0.20</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.19230</eta1>
-                          <eta2>0.19230</eta2>
+                          <eta1>
+                            <eta>0.1923</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.1923</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>1.00</eta1>
-                          <eta2>1.00</eta2>
+                          <eta1>
+                            <eta>1</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>1</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <!--cell uID="cell_us_cap">
@@ -3793,12 +3805,24 @@
                           <xsi2>0.90</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.19230</eta1>
-                          <eta2>0.19230</eta2>
+                          <eta1>
+                            <eta>0.1923</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.1923</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>1.00</eta1>
-                          <eta2>1.00</eta2>
+                          <eta1>
+                            <eta>1</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>1</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <cell uID="cell_us_te">
@@ -3817,12 +3841,24 @@
                           <xsi2>1.0</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.19230</eta1>
-                          <eta2>0.19230</eta2>
+                          <eta1>
+                            <eta>0.1923</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.1923</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>1.00</eta1>
-                          <eta2>1.00</eta2>
+                          <eta1>
+                            <eta>1</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>1</eta>
+                            <referenceUID>D150_wing_CS</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>
@@ -5156,12 +5192,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5389,12 +5437,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5622,12 +5682,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -5855,12 +5927,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>
@@ -6088,12 +6172,24 @@
                               <xsi2>1</xsi2>
                             </positioningTrailingEdge>
                             <positioningInnerBorder>
-                              <eta1>0.0</eta1>
-                              <eta2>0.0</eta2>
+                              <eta1>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>0</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningInnerBorder>
                             <positioningOuterBorder>
-                              <eta1>1</eta1>
-                              <eta2>1</eta2>
+                              <eta1>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta1>
+                              <eta2>
+                                <eta>1</eta>
+                                <referenceUID>D150_wing_CS</referenceUID>
+                              </eta2>
                             </positioningOuterBorder>
                             <material>
                               <materialUID>aluminium 2024</materialUID>

--- a/tests/unittests/TestData/bellyfairingtest.cpacs.xml
+++ b/tests/unittests/TestData/bellyfairingtest.cpacs.xml
@@ -626,12 +626,24 @@
                           <xsi2>1.0</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.5</eta1>
-                          <eta2>0.5</eta2>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>

--- a/tests/unittests/TestData/cell_test_spars.xml
+++ b/tests/unittests/TestData/cell_test_spars.xml
@@ -167,12 +167,24 @@
                           <xsi2>0.8</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.1</eta1>
-                          <eta2>0.1</eta2>
+                          <eta1>
+                            <eta>0.1</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.1</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <cell uID="Wing_CS_upperShell_Cell2">
@@ -189,12 +201,24 @@
                           <xsi2>0.7</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.3</eta1>
-                          <eta2>0.3</eta2>
+                          <eta1>
+                            <eta>0.3</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.3</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.4</eta1>
-                          <eta2>0.45</eta2>
+                          <eta1>
+                            <eta>0.4</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.45</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <cell uID="Wing_CS_upperShell_Cell3">
@@ -211,12 +235,24 @@
                           <xsi2>0.8</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.2</eta1>
-                          <eta2>0.2</eta2>
+                          <eta1>
+                            <eta>0.2</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.2</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.55</eta1>
-                          <eta2>0.55</eta2>
+                          <eta1>
+                            <eta>0.55</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.55</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <cell uID="Wing_CS_upperShell_Cell4">
@@ -233,12 +269,24 @@
                           <xsi2>0.9</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.15</eta1>
-                          <eta2>0.15</eta2>
+                          <eta1>
+                            <eta>0.15</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.15</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.95</eta1>
-                          <eta2>0.95</eta2>
+                          <eta1>
+                            <eta>0.95</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.95</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <cell uID="Wing_CS_upperShell_Cell5">
@@ -255,12 +303,24 @@
                           <xsi2>0.8</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.75</eta1>
-                          <eta2>0.75</eta2>
+                          <eta1>
+                            <eta>0.75</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.75</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.95</eta1>
-                          <eta2>0.9</eta2>
+                          <eta1>
+                            <eta>0.95</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.9</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                       <cell uID="Wing_CS_upperShell_Cell6">
@@ -277,12 +337,24 @@
                           <xsi2>0.7</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.9</eta1>
-                          <eta2>0.9</eta2>
+                          <eta1>
+                            <eta>0.9</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.9</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>1.0</eta1>
-                          <eta2>1.0</eta2>
+                          <eta1>
+                            <eta>1</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>1</eta>
+                            <referenceUID>CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>

--- a/tests/unittests/TestData/simpletest-halfmodel.cpacs.xml
+++ b/tests/unittests/TestData/simpletest-halfmodel.cpacs.xml
@@ -444,12 +444,24 @@
                           <xsi2>1.0</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.5</eta1>
-                          <eta2>0.5</eta2>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>

--- a/tests/unittests/TestData/simpletest-nacelle.xml
+++ b/tests/unittests/TestData/simpletest-nacelle.xml
@@ -444,12 +444,24 @@
                           <xsi2>1.0</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.5</eta1>
-                          <eta2>0.5</eta2>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>

--- a/tests/unittests/TestData/simpletest-pylon.cpacs.xml
+++ b/tests/unittests/TestData/simpletest-pylon.cpacs.xml
@@ -444,12 +444,24 @@
                           <xsi2>1.0</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.5</eta1>
-                          <eta2>0.5</eta2>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>
@@ -490,11 +502,11 @@
               <section uID="Pylon_Sec1">
                 <name>Pylon Section 1</name>
                 <transformation uID="Pylon_Sec1_transformation1">
-                    <scaling uID="Pylon_Sec1_transformation1_scaling1">
-                        <x>0.25</x>
-                        <y>0.25</y>
-                        <z>0.20</z>
-                    </scaling>
+                  <scaling uID="Pylon_Sec1_transformation1_scaling1">
+                    <x>0.25</x>
+                    <y>0.25</y>
+                    <z>0.20</z>
+                  </scaling>
                 </transformation>
                 <elements>
                   <element uID="Pylon_Sec1_El1">
@@ -507,11 +519,11 @@
               <section uID="Pylon_Sec2">
                 <name>Pylon Section 2</name>
                 <transformation uID="Pylon_Sec2_transformation1">
-                    <scaling uID="Pylon_Sec2_transformation1_scaling1">
-                        <x>0.45</x>
-                        <y>0.35</y>
-                        <z>0.25</z>
-                    </scaling>
+                  <scaling uID="Pylon_Sec2_transformation1_scaling1">
+                    <x>0.45</x>
+                    <y>0.35</y>
+                    <z>0.25</z>
+                  </scaling>
                 </transformation>
                 <elements>
                   <element uID="Pylon_Sec2_El1">
@@ -524,11 +536,11 @@
               <section uID="Pylon_Sec3">
                 <name>Pylon Section 3</name>
                 <transformation uID="Pylon_Sec3_transformation1">
-                    <scaling uID="Pylon_Sec3_transformation1_scaling1">
-                        <x>0.1</x>
-                        <y>0.1</y>
-                        <z>0.05</z>
-                    </scaling>
+                  <scaling uID="Pylon_Sec3_transformation1_scaling1">
+                    <x>0.1</x>
+                    <y>0.1</y>
+                    <z>0.05</z>
+                  </scaling>
                 </transformation>
                 <elements>
                   <element uID="Pylon_Sec3_El1">

--- a/tests/unittests/TestData/simpletest.cpacs.xml
+++ b/tests/unittests/TestData/simpletest.cpacs.xml
@@ -444,12 +444,24 @@
                           <xsi2>1.0</xsi2>
                         </positioningTrailingEdge>
                         <positioningInnerBorder>
-                          <eta1>0.0</eta1>
-                          <eta2>0.0</eta2>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningInnerBorder>
                         <positioningOuterBorder>
-                          <eta1>0.5</eta1>
-                          <eta2>0.5</eta2>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
                         </positioningOuterBorder>
                       </cell>
                     </cells>


### PR DESCRIPTION
Changes to make the types `cellPositioningSpanwiseType` and `ribRotationReferenceType` compliant to CPACS3.