### PR TITLE
Fix wrong matrix decomposition

### DIFF
--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -295,6 +295,15 @@ void CTiglTransformation::AddRotationZ(double degreeZ)
     PreMultiply(trans);
 }
 
+// Adds a rotation in intrinsic x-y'-z'' Euler convention to the matrix
+void CTiglTransformation::AddRotationIntrinsicXYZ(double phi, double theta, double psi)
+{
+    // intrinsic x-y'-z'' corresponds to extrinsic z-y-x, i.e. Rx*Ry*Rz:
+    AddRotationZ(psi);
+    AddRotationY(theta);
+    AddRotationX(phi);
+}
+
 // Adds projection an xy plane by setting the z coordinate to 0
 void CTiglTransformation::AddProjectionOnXYPlane()
 {

--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -538,22 +538,32 @@ void CTiglTransformation::Decompose(double scale[3], double rotation[3], double 
         LOG(WARNING) << "CTiglTransformation::Decompose: The Transformation contains a Shearing, that will be discarded in the decomposition!";
     }
 
-    // calculate extrinsic Euler angles from rotation matrix U
-    // This implementation is based on http://www.gregslabaugh.net/publications/euler.pdf
-    if( fabs( fabs(U(3,1)) - 1) > 1e-10 ){
-        rotation[1] = -asin(U(3,1));
+    // calculate intrinsic Euler angles from rotation matrix U
+    //
+    // This implementation is based on http://www.gregslabaugh.net/publications/euler.pdf, where the same argumentation
+    // is used for intrinsic x,y',z'' angles and the rotatation matrix
+    //
+    //                |                        cos(y)*cos(z) |               -        cos(y)*cos(z) |         sin(y) |
+    // U = Rx*Ry*Rz = | cos(x)*sin(z) + sin(x)*sin(y)*cos(z) | cos(x)*cos(z) - sin(x)*sin(y)*sin(z) | -sin(x)*cos(y) |
+    //                | sin(x)*sin(z) - cos(x)*sin(y)*cos(z) | sin(x)*cos(z) + cos(x)*sin(y)*sin*z( |  cos(x)*cos(y) |
+    //
+    // rather than extrinsic angles and the Rotation matrix mentioned in that pdf.
+
+    if( fabs( fabs(U(1, 3)) - 1) > 1e-10 ){
+        rotation[1] = asin(U(1, 3));
         double cosTheta = cos(rotation[1]);
-        rotation[0] = atan2(U(3,2)/cosTheta, U(3,3)/cosTheta);
-        rotation[2] = atan2(U(2,1)/cosTheta, U(1,1)/cosTheta);
+        rotation[0] = -atan2(U(2,3)/cosTheta, U(3,3)/cosTheta);
+        rotation[2] = -atan2(U(1,2)/cosTheta, U(1,1)/cosTheta);
     }
     else {
-        if ( fabs(U(3,1) + 1) > 1e-10 ) {
-            rotation[0] = rotation[2] + atan2(U(1,2), U(1,3));
-            rotation[1] = M_PI/2;
+        rotation[0] = 0;
+        if ( fabs(U(1,3) + 1) > 1e-10 ) {
+            rotation[2] = -rotation[0] - atan2(U(2,1), U(2,2));
+            rotation[1] = -M_PI/2;
         }
         else{
-            rotation[0] = -rotation[2] + atan2(-U(1,2), -U(1,3));
-            rotation[1] = -M_PI/2;
+            rotation[2] = -rotation[0] + atan2(U(2,1), U(2,2));
+            rotation[1] = M_PI/2;
         }
     }
 

--- a/src/geometry/CTiglTransformation.h
+++ b/src/geometry/CTiglTransformation.h
@@ -82,6 +82,9 @@ public:
     TIGL_EXPORT void AddRotationY(double degreeY);
     TIGL_EXPORT void AddRotationZ(double degreeZ);
 
+    // Adds a rotation in intrinsic x-y'-z'' Euler convention to the matrix
+    TIGL_EXPORT void AddRotationIntrinsicXYZ(double phi, double theta, double psi);
+
     // Adds projection on xy plane by setting the z coordinate to 0
     TIGL_EXPORT void AddProjectionOnXYPlane();
 

--- a/tests/unittests/tiglMath.cpp
+++ b/tests/unittests/tiglMath.cpp
@@ -362,6 +362,42 @@ TEST(TiglMath, CTiglTransform_Decompose)
     EXPECT_NEAR(T[0], 0., 1e-8);
 }
 
+TEST(TiglMath, CTiglTransform_Decompose2)
+{
+    // Simulate the case where a cpacs transformation as a rotation RX:0;RY:30;RZ:20
+    // Remember that cpacs transformation has intrinsic rotation X,Y',Z'' so it corresponding to extrinsic rotation Z,Y,X
+    // This above process is similar at the one used at CCPACSTransformation::updateMatrix
+    tigl::CTiglTransformation rot;
+    rot.AddRotationZ(20);
+    rot.AddRotationY(30);
+    rot.AddRotationX(0);
+
+    // So now, as we can expected rotating the x basis vector (1,0,0) will output (0.81379768134, 0.34202014332 , -0.46984631039);
+    gp_Pnt resultV = rot.Transform(gp_Pnt(1., 0. ,0.));
+    gp_Pnt expectV = gp_Pnt(0.81379768134, 0.34202014332 , -0.46984631039);
+    EXPECT_NEAR(resultV.X(), expectV.X(), 1e-8 );
+    EXPECT_NEAR(resultV.Y(), expectV.Y(), 1e-8 );
+    EXPECT_NEAR(resultV.Z(), expectV.Z(), 1e-8 );
+
+    // but decomposing the rotation seems to output the X,Y,Z extrinsic angle
+    double S[3] = {0., 0., 0.};
+    double R[3] = {0., 0., 0.};
+    double T[3] = {0., 0., 0.};
+    rot.Decompose(S, R, T);
+
+    // so if we put back this value in transformation
+    tigl::CTiglTransformation rot2;
+    rot2.AddRotationZ(R[2]);
+    rot2.AddRotationY(R[1]);
+    rot2.AddRotationX(R[0]);
+
+    // we do not get the expected result
+    resultV = rot2.Transform(gp_Pnt(1., 0., 0.));
+    EXPECT_NEAR(resultV.X(), expectV.X(), 1e-8 );
+    EXPECT_NEAR(resultV.Y(), expectV.Y(), 1e-8 );
+    EXPECT_NEAR(resultV.Z(), expectV.Z(), 1e-8 );
+}
+
 TEST(TiglMath, CTiglTransform_setTransformationMatrix)
 {
     double scale[3] = {2., 4., 8.};

--- a/tests/unittests/tiglMath.cpp
+++ b/tests/unittests/tiglMath.cpp
@@ -407,9 +407,7 @@ TEST(TiglMath, CTiglTransform_setTransformationMatrix)
     // create CPACS-conform tigl-transformation (i.e. scaling -> euler-xyz-Rotation -> translation)
     tigl::CTiglTransformation tiglTrafo;
     tiglTrafo.AddScaling(scale[0], scale[1], scale[2]);
-    tiglTrafo.AddRotationZ(rot[2]);
-    tiglTrafo.AddRotationY(rot[1]);
-    tiglTrafo.AddRotationX(rot[0]);
+    tiglTrafo.AddRotationIntrinsicXYZ(rot[0], rot[1], rot[2]);
     tiglTrafo.AddTranslation(trans[0], trans[1], trans[2]);
 
     tigl::CCPACSTransformation cpacsTrafo(NULL);

--- a/tests/unittests/tiglMath.cpp
+++ b/tests/unittests/tiglMath.cpp
@@ -407,9 +407,9 @@ TEST(TiglMath, CTiglTransform_setTransformationMatrix)
     // create CPACS-conform tigl-transformation (i.e. scaling -> euler-xyz-Rotation -> translation)
     tigl::CTiglTransformation tiglTrafo;
     tiglTrafo.AddScaling(scale[0], scale[1], scale[2]);
-    tiglTrafo.AddRotationX(rot[0]);
-    tiglTrafo.AddRotationY(rot[1]);
     tiglTrafo.AddRotationZ(rot[2]);
+    tiglTrafo.AddRotationY(rot[1]);
+    tiglTrafo.AddRotationX(rot[0]);
     tiglTrafo.AddTranslation(trans[0], trans[1], trans[2]);
 
     tigl::CCPACSTransformation cpacsTrafo(NULL);


### PR DESCRIPTION
## Description
The matrix decomposition in CTiglTransformation wrongly produced extrinsic xyz Euler angles, rather than intrinsic xy'z'' Euler angles. 

Fixes #590

## How Has This Been Tested?
Includes the Unit test provided by @cfsengineering in the original issue #590

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- ~~New classes have been added to the Python interface.~~
- ~~API changes were documented properly in tigl.h.~~
