### PR TITLE
Fix for rotor transform issue

### DIFF
--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -67,6 +67,13 @@ CTiglTransformation::CTiglTransformation(const gp_Trsf& trans)
     }
 }
 
+CTiglTransformation::CTiglTransformation(const gp_Vec& t)
+{
+    SetIdentity();
+
+    AddTranslation(t.X(), t.Y(), t.Z());
+}
+
 // Destructor
 CTiglTransformation::~CTiglTransformation()
 {
@@ -434,6 +441,16 @@ gp_Pnt CTiglTransformation::Transform(const gp_Pnt& point) const
     return gp_Pnt(transformed.X(), transformed.Y(), transformed.Z());
 }
 
+
+gp_Vec CTiglTransformation::Transform(const gp_Vec& vec) const
+{
+    gp_Pnt pTip = Transform(gp_Pnt(vec.XYZ()));
+    gp_Pnt pRoot = Transform(gp_Pnt(0., 0., 0));
+
+    return pTip.XYZ() - pRoot.XYZ();
+}
+
+
 bool CTiglTransformation::IsUniform() const
 {
     // The following code is copied from gp_Trsf
@@ -520,7 +537,7 @@ bool CTiglTransformation::IsUniform() const
 
 CTiglTransformation CTiglTransformation::Inverted() const
 {
-    return Get_gp_GTrsf().Inverted();
+    return CTiglTransformation(Get_gp_GTrsf().Inverted());
 }
 
 void CTiglTransformation::Decompose(double scale[3], double rotation[3], double translation[3]) const

--- a/src/geometry/CTiglTransformation.h
+++ b/src/geometry/CTiglTransformation.h
@@ -38,10 +38,12 @@ class CTiglTransformation
 public:
     // Constructor
     TIGL_EXPORT CTiglTransformation();
-    TIGL_EXPORT CTiglTransformation(const gp_GTrsf& ocMatrix);
+    TIGL_EXPORT explicit CTiglTransformation(const gp_GTrsf& ocMatrix);
 
     // Constructor for transformation based on gp_Trsf
-    TIGL_EXPORT CTiglTransformation(const gp_Trsf& trans);
+    TIGL_EXPORT explicit CTiglTransformation(const gp_Trsf& trans);
+
+    TIGL_EXPORT explicit CTiglTransformation(const gp_Vec& translation);
 
     // Virtual Destructor
     TIGL_EXPORT virtual ~CTiglTransformation();
@@ -110,6 +112,11 @@ public:
     // Transforms a point with the current transformation matrix and
     // returns the transformed point
     TIGL_EXPORT gp_Pnt Transform(const gp_Pnt& point) const;
+
+    // Transforms a vector with the current transformation matrix and
+    // returns the transformed vector
+    // Note, that the vector transformation does not include the translation part
+    TIGL_EXPORT gp_Vec Transform(const gp_Vec& vec) const;
     
     // Returns the inverted Transformation
     TIGL_EXPORT CTiglTransformation Inverted() const;

--- a/src/rotor/CCPACSRotor.cpp
+++ b/src/rotor/CCPACSRotor.cpp
@@ -87,7 +87,7 @@ void CCPACSRotor::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::str
 CTiglTransformation CCPACSRotor::GetTransformationMatrix() const
 {
     const_cast<CCPACSRotor*>(this)->Update();   // create new transformation matrix if scaling, rotation or translation was changed, TODO: hack
-    return m_transformation.getTransformationMatrix();
+    return CTiglRelativelyPositionedComponent::GetTransformationMatrix();
 }
 
 // Get Translation

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -190,6 +190,14 @@ void CCPACSWing::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::stri
 
     if (wingXPath.find("rotorBlade") != std::string::npos) {
         isRotorBlade = true;
+
+        // WORKAROUND
+        // The rotor blade is attached implicitly to the rotor and should not have an additional parent
+        // See issue #509
+        if (m_parentUID) {
+            LOG(WARNING) << "Parent of rotor blade '" << GetUID() << "' is removed since it will be parented by a rotor. Consider to remove the parentUID node.";
+            m_parentUID = boost::none;
+        }
     }
 
     ConnectGuideCurveSegments();

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -397,9 +397,9 @@ gp_Pnt CCPACSWing::GetLowerPoint(int segmentIndex, double eta, double xsi)
 }
 
 // Gets a point on the chord surface in absolute (world) coordinates for a given segment, eta, xsi
-gp_Pnt CCPACSWing::GetChordPoint(int segmentIndex, double eta, double xsi)
+gp_Pnt CCPACSWing::GetChordPoint(int segmentIndex, double eta, double xsi, TiglCoordinateSystem referenceCS)
 {
-    return  ((CCPACSWingSegment &) GetSegment(segmentIndex)).GetChordPoint(eta, xsi);
+    return  ((CCPACSWingSegment &) GetSegment(segmentIndex)).GetChordPoint(eta, xsi, referenceCS);
 }
 
 // Returns the volume of this wing

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -103,7 +103,7 @@ public:
     TIGL_EXPORT gp_Pnt GetLowerPoint(int segmentIndex, double eta, double xsi);
 
     // Gets a point on the chord surface in absolute (world) coordinates for a given segment, eta, xsi
-    TIGL_EXPORT gp_Pnt GetChordPoint(int segmentIndex, double eta, double xsi);
+    TIGL_EXPORT gp_Pnt GetChordPoint(int segmentIndex, double eta, double xsi, TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM);
 
     // Gets the loft of the whole wing
     TIGL_EXPORT TopoDS_Shape & GetLoftWithLeadingEdge();

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -87,9 +87,7 @@ public:
     TIGL_EXPORT gp_Pnt GetLowerPoint(double eta, double xsi) const;
 
     // Gets the point on the wing chord surface in relative wing coordinates for a given eta and xsi
-    TIGL_EXPORT gp_Pnt GetChordPoint(double eta, double xsi) const;
-    // Gets the point on the wing chord surface in relative wing coordinates for a given eta and xsi
-    TIGL_EXPORT gp_Pnt GetChordPoint(double eta, double xsi, TiglCoordinateSystem referenceCS) const;
+    TIGL_EXPORT gp_Pnt GetChordPoint(double eta, double xsi, TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM) const;
 
     // Gets the point on the wing chord surface in relative wing coordinates for a given eta and xsi
     TIGL_EXPORT gp_Pnt GetChordNormal(double eta, double xsi) const;
@@ -247,6 +245,7 @@ private:
     struct SurfaceCache
     {
         CTiglPointTranslator cordSurface;
+        CTiglPointTranslator cordSurfaceLocal;
         Handle(Geom_Surface) cordFace;
         Handle(Geom_Surface) upperSurface;
         Handle(Geom_Surface) lowerSurface;
@@ -266,7 +265,7 @@ private:
     void ComputeVolume(double& cache) const;
 
     // Returns the chord surface (and builds it if required)
-    const CTiglPointTranslator& ChordFace() const;
+    const CTiglPointTranslator& ChordFace(TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM) const;
 
 
     // converts segment eta xsi coordinates to face uv coordinates


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed issue #509 

## Description
I provided a fix for the rotor transform issue. The main problem is, that it is possible via cpacs to give the rotor blade a parent which is not the rotor. This leads to strange transformation chain, resulting in a wrong placement of the rotor.
My workaround simply remove a potential parent from the blade, if it is a rotor blade.

## How Has This Been Tested?
I tested this with the simplerotors example as well as the attached helicopter in the issue. I played around with and without parent and checked, that all tests are still working.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
-  **no new classes** 
-  **no api changes**
