### PR TITLE
Make engine nacelle creation more robust

### DIFF
--- a/src/engine_nacelle/CCPACSNacelleCowl.cpp
+++ b/src/engine_nacelle/CCPACSNacelleCowl.cpp
@@ -340,7 +340,7 @@ void RemoveBlendingPart(TopoDS_Edge const lowerEdge,
 
     double umin, umax;
     double par1 = -1.;
-    double par2 = -1.;
+    double par2 = 0.;
     Handle_Geom_Curve curve = BRep_Tool::Curve(lowerEdge, umin, umax);
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );

--- a/src/engine_nacelle/CCPACSNacelleCowl.cpp
+++ b/src/engine_nacelle/CCPACSNacelleCowl.cpp
@@ -339,7 +339,8 @@ void RemoveBlendingPart(TopoDS_Edge const lowerEdge,
     }
 
     double umin, umax;
-    double par1, par2;
+    double par1 = -1.;
+    double par2 = -1.;
     Handle_Geom_Curve curve = BRep_Tool::Curve(lowerEdge, umin, umax);
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
@@ -350,9 +351,15 @@ void RemoveBlendingPart(TopoDS_Edge const lowerEdge,
     if (algo1.IsDone()) {
         par1 = algo1.Parameter();
     }
+    else {
+        throw tigl::CTiglError("RemoveBlendingPart: Unable to cut lower profile for CCPACSNacelleCowl", TIGL_ERROR);
+    }
     GCPnts_AbscissaPoint algo2(adaptorCurve, len*(zeta2 + 1.), umin);
     if (algo2.IsDone()) {
         par2 = algo2.Parameter();
+    }
+    else {
+        throw tigl::CTiglError("RemoveBlendingPart: Unable to cut lower profile for CCPACSNacelleCowl", TIGL_ERROR);
     }
     curve = new Geom_TrimmedCurve(curve, umin,  par1);
     edge1 = BRepBuilderAPI_MakeEdge(curve);

--- a/src/engine_nacelle/CCPACSNacelleProfile.cpp
+++ b/src/engine_nacelle/CCPACSNacelleProfile.cpp
@@ -85,12 +85,12 @@ TopoDS_Wire CCPACSNacelleProfile::GetWire(TiglShapeModifier mod) const
         wire = closedWireBuilder.Wire();
     }
     else if ( algoType == Simple ) {
-        // TODO
         if ( !GetPointList_choice1() ) {
             throw CTiglError("CCPACSNacelleProfile::GetWire() uses point list algorithm type \"Simple\", but the CPACSProfileGeometry2D type is not defined using a list of points (Maybe CST type?)");
         }
         const std::vector<CTiglPoint>& tiglpoints = GetPointList_choice1()->AsVector();
         ITiglWireAlgorithm::CPointContainer points;
+
         for ( size_t i = 0; i<tiglpoints.size(); ++i) {
             points.push_back(gp_Pnt(tiglpoints[i].x, tiglpoints[i].y, tiglpoints[i].z) );
         }

--- a/src/geometry/CCPACSRotationCurve.cpp
+++ b/src/geometry/CCPACSRotationCurve.cpp
@@ -29,6 +29,11 @@
 #include "Geom_SurfaceOfRevolution.hxx"
 #include "BRep_Builder.hxx"
 
+#include "GeomAdaptor_Curve.hxx"
+#include "GCPnts_AbscissaPoint.hxx"
+#include "BRepBuilderAPI_MakeWire.hxx"
+#include "BRepBuilderAPI_MakeEdge.hxx"
+
 namespace tigl {
 
 TopoDS_Wire CCPACSRotationCurve::GetCurve() const
@@ -39,7 +44,8 @@ TopoDS_Wire CCPACSRotationCurve::GetCurve() const
 
     // apply transform of reference section
     CCPACSNacelleSection& section = m_uidMgr->ResolveObject<CCPACSNacelleSection>(GetReferenceSectionUID());
-    TopoDS_Shape transformedShape(profile.GetWire());
+    TopoDS_Wire wire = CutCurveAtZetas(profile.GetWire());
+    TopoDS_Shape transformedShape(wire);
 
     CTiglTransformation trafo = section.GetTransformationMatrix();
     transformedShape = trafo.Transform(transformedShape);
@@ -71,6 +77,66 @@ TopoDS_Face CCPACSRotationCurve::GetRotationSurface(gp_Pnt origin, axis dir) con
 
 
     return TopoDS::Face(BRepPrimAPI_MakeRevol(edge, ax));
+}
+
+TopoDS_Wire CCPACSRotationCurve::CutCurveAtZetas(const TopoDS_Wire wire) const
+{
+
+    double zeta1 = GetStartZeta();
+    double zeta2 = GetEndZeta();
+
+    if ( zeta1 > 0 || zeta2 > 0 || zeta1 < -1 || zeta2 < -1 ) {
+        throw CTiglError("CCPACSRotationCurve: StartZetaBlending and EndZetaBlending must be between 0 and -1.");
+    }
+
+    TopTools_IndexedMapOfShape map;
+    TopExp::MapShapes(wire, TopAbs_EDGE, map);
+    if ( map.Extent() ==0 || map.Extent() > 1 ) {
+        CTiglError("CCPACSRotationCurve::CutCurveAtZetaBlending: Rotation Curve is currently only supported for a single edge.\n", TIGL_ERROR);
+    }
+    TopoDS_Edge edge = TopoDS::Edge(map(1));
+
+    double umin, umax;
+    double par1 = -1;
+    double par2 = -1;
+    Handle_Geom_Curve curve = BRep_Tool::Curve(edge, umin, umax);
+    GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
+    Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
+    if (len < Precision::Confusion()) {
+        throw tigl::CTiglError("CutCurveAtZetaBlending: Unable to cut rotation curve of zero length for CCPACSNacelleCowl", TIGL_MATH_ERROR);
+    }
+    // cut at startZetaBlending
+    if ( zeta1 > -1. ) {
+        GCPnts_AbscissaPoint algo1(adaptorCurve, len*(zeta1 + 1.), umin);
+        if (algo1.IsDone()) {
+            par1 = algo1.Parameter();
+        }
+        else {
+            throw tigl::CTiglError("CutCurveAtZetaBlending: Unable to cut rotation curve for CCPACSNacelleCowl", TIGL_ERROR);
+        }
+    }
+    else {
+        par1 = umin;
+    }
+    // cut at endZetaBlending
+    if ( zeta2 < 0 ) {
+        GCPnts_AbscissaPoint algo2(adaptorCurve, len*(zeta2 + 1.), umin);
+        if (algo2.IsDone()) {
+            par2 = algo2.Parameter();
+        }
+        else {
+            throw tigl::CTiglError("CutCurveAtZetaBlending: Unable to cut rotation curve for CCPACSNacelleCowl", TIGL_ERROR);
+        }
+    }
+    else {
+        par2 = umax;
+    }
+
+    // return trimmed curve
+    curve = new Geom_TrimmedCurve(curve, par1,  par2);
+    BRepBuilderAPI_MakeWire wireBuilder;
+    wireBuilder.Add(BRepBuilderAPI_MakeEdge(curve));
+    return wireBuilder.Wire();
 }
 
 }

--- a/src/geometry/CCPACSRotationCurve.h
+++ b/src/geometry/CCPACSRotationCurve.h
@@ -23,7 +23,9 @@
 #include "TopoDS_Wire.hxx"
 
 namespace tigl {
-
+/*
+ * This class is used for the rotationally symmetric inner surface of an engine nacelle
+ */
 class CCPACSRotationCurve : public generated::CPACSRotationCurve
 {
 public:
@@ -39,6 +41,9 @@ public:
 
     TIGL_EXPORT TopoDS_Wire GetCurve() const;
     TIGL_EXPORT TopoDS_Face GetRotationSurface(gp_Pnt origin = {0., 0., 0.},axis dir=x) const;
+
+private:
+    TopoDS_Wire CutCurveAtZetas(const TopoDS_Wire wire) const;
 };
 
 

--- a/src/geometry/CCPACSRotationCurve.h
+++ b/src/geometry/CCPACSRotationCurve.h
@@ -43,7 +43,7 @@ public:
     TIGL_EXPORT TopoDS_Face GetRotationSurface(gp_Pnt origin = {0., 0., 0.},axis dir=x) const;
 
 private:
-    TopoDS_Wire CutCurveAtZetas(const TopoDS_Wire wire) const;
+    void CutCurveAtZetas(TopoDS_Edge& edge) const;
 };
 
 

--- a/tests/unittests/TestData/simpletest-simplenacelle.cpacs.xml
+++ b/tests/unittests/TestData/simpletest-simplenacelle.cpacs.xml
@@ -34,6 +34,8 @@
             <xOffset>0.0</xOffset>
           </centerCowl>
           <fanCowl uID="SimpleNacelle_fanCowl">
+		    <guideCurves>
+			</guideCurves>
             <sections>
               <section uID="fanCowl_section_1">
                 <description>First Section containing the profile curve in flow direction of the nacelle</description>
@@ -61,8 +63,8 @@
             <rotationCurve uID="fanCowl_rotationCurve">
               <referenceSectionUID>fanCowl_section_1</referenceSectionUID>
               <curveProfileUID>fanCowlRotationCurve</curveProfileUID>
-              <startZeta>-0.3</startZeta>
-              <endZeta>-0.6</endZeta>
+              <startZeta>-0.6</startZeta>
+              <endZeta>-0.3</endZeta>
               <startZetaBlending>-0.7</startZetaBlending>
               <endZetaBlending>-0.2</endZetaBlending>
             </rotationCurve>
@@ -676,7 +678,7 @@
           <description>rotational symmetric part of fan cowl</description>
           <pointList>
             <x mapType="vector">
-				0.6;0.3</x>
+				0;1</x>
             <y mapType="vector">
 				-0.06;-0.06;</y>
           </pointList>


### PR DESCRIPTION
This PR fixes a few small issues that came up with the engine nacelle generation, if the CPACS file is not perfectly according to the current standard.

## Description
This PR fixes #586 #603 and #605

## How Has This Been Tested?
So far only manually, no tests added to test suite

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~A test for the new functionality was added.~ *(no new functionality)*
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- ~New classes have been added to the Python interface.~ *(no new classes)*
- ~API changes were documented properly in tigl.h.~ *(no new API changes)*
