### PR TITLE
bugfix in tiglWingGetWettedArea

### DIFF
--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -6617,8 +6617,14 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetWettedArea(TiglCPACSConfigurationHa
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSWing& wing = config.GetWing(wingUID);
-        TopoDS_Shape parent = config.GetParentLoft(wingUID);
-        *wettedAreaPtr = wing.GetWettedArea(parent);
+        tigl::CTiglRelativelyPositionedComponent* parent = config.GetUIDManager().GetParentGeometricComponent(wingUID);
+        if (!parent) {
+            *wettedAreaPtr = wing.GetSurfaceArea();
+        }
+        else {
+            TopoDS_Shape parentShape = config.GetParentLoft(wingUID);
+            *wettedAreaPtr = wing.GetWettedArea(parentShape);
+        }
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -4397,7 +4397,8 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetReferenceArea(TiglCPACSConfiguratio
                                                            double *referenceAreaPtr);
 
 /**
-* @brief Returns the wetted area of the wing.
+* @brief Returns the wetted area of the wing. If the wing has no parent (fuselage), it returns the
+* surface area of the wing.
 *
 *
 * @param[in]  cpacsHandle     Handle for the CPACS configuration

--- a/src/configuration/CCPACSConfiguration.cpp
+++ b/src/configuration/CCPACSConfiguration.cpp
@@ -403,7 +403,11 @@ int CCPACSConfiguration::GetRotorIndex(const std::string& UID) const
 
 TopoDS_Shape CCPACSConfiguration::GetParentLoft(const std::string& UID)
 {
-    return uidManager.GetParentGeometricComponent(UID)->GetLoft()->Shape();
+    CTiglRelativelyPositionedComponent* parent = uidManager.GetParentGeometricComponent(UID);
+    if (!parent) {
+        throw CTiglError("CCPACSConfiguration::GetParentLoft: Cannot find parent of component with uID " + UID + ".");
+    }
+    return parent->GetLoft()->Shape();
 }
 
 bool CCPACSConfiguration::HasFuselageProfile(std::string uid) const

--- a/src/cpacs_other/CTiglUIDManager.cpp
+++ b/src/cpacs_other/CTiglUIDManager.cpp
@@ -234,7 +234,7 @@ CTiglRelativelyPositionedComponent* CTiglUIDManager::GetParentGeometricComponent
 {
     CTiglRelativelyPositionedComponent& component = GetRelativeComponent(uid);
     const boost::optional<const std::string&> parentUID = component.GetParentUID();
-    return parentUID ? NULL : &GetRelativeComponent(*parentUID);
+    return parentUID? &GetRelativeComponent(*parentUID) : NULL;
 }
 
 // Returns the container with all root components of the geometric topology that have children.

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -310,3 +310,9 @@ TEST_F(WingSimple, wingGetReferenceArea_success)
     ASSERT_NEAR(1.75, ref, 1e-7);
 
 }
+
+TEST_F(WingSimple, wingGetWettedArea_success)
+{
+    double ref = 0.;
+    ASSERT_EQ(TIGL_SUCCESS, tiglWingGetWettedArea(tiglSimpleWingHandle, "Wing", &ref));
+}


### PR DESCRIPTION
fixes #614

## Description

 - To calculate the wetted area of the wing, the wing must be cut with the fuselage, which is read as the parent geometric component of the wing. But the parentUID element of the wing is optional, and TiGL used to crash if no parent were to be found.

 - Now, the API function tiglGetWettedArea returns the wetted area of the wing if the wing has a parent. Else, it returns the surface area of the wing (API change).

 - In addition, a minor bug in line 237 of CTiglUidManager.cpp was fixed.

## How Has This Been Tested?

A unit test has been added that tests the API function for success.

## Checklist:
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] ~~New classes have been added to the Python interface.~~
- [x] API changes were documented properly in tigl.h.
