### PR TITLE
591 custom crashinfo path

### DIFF
--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -187,6 +187,9 @@ TiglReturnCode TIGLViewerDocument::openCpacsConfiguration(const QString fileName
 
     }
 
+    // set the debug data output directory relative to the opened file
+    tiglSetDebugDataDirectory((QFileInfo(fileName).dir().path().toStdString() + "/CrashInfo").c_str());
+
     // Get configuration from user and open with TIGL
     TiglReturnCode tiglRet = TIGL_UNINITIALIZED;
     if (countRotorcrafts + countAircrafts == 0) {
@@ -1113,8 +1116,6 @@ void TIGLViewerDocument::drawAllFuselagesAndWingsSurfacePoints()
 void TIGLViewerDocument::exportAsIges()
 {
     QString     fileName;
-    QString        fileType;
-    QFileInfo    fileInfo;
 
     TIGLViewerInputOutput writer;
 
@@ -1136,7 +1137,6 @@ void TIGLViewerDocument::exportFusedAsIges()
 {
     QString     fileName;
     QString        fileType;
-    QFileInfo    fileInfo;
 
     TIGLViewerInputOutput writer;
 
@@ -1156,8 +1156,6 @@ void TIGLViewerDocument::exportFusedAsIges()
 void TIGLViewerDocument::exportAsStep()
 {
     QString     fileName;
-    QString     fileType;
-    QFileInfo   fileInfo;
 
     TIGLViewerInputOutput writer;
 
@@ -1300,8 +1298,6 @@ void TIGLViewerDocument::exportMeshedWingVTK()
 void TIGLViewerDocument::exportMeshedWingVTKsimple()
 {
     QString     fileName;
-    QString        fileType;
-    QFileInfo    fileInfo;
     TIGLViewerInputOutput writer;
 
     QString wingUid = dlgGetWingOrRotorBladeSelection();

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
@@ -17,7 +17,7 @@
 */
 
 /* 
-* This file is automatically created from tigl.h on 2018-04-09.
+* This file is automatically created from tigl.h on 2019-09-24.
 * If you experience any bugs please contact the authors
 */
 
@@ -46,6 +46,7 @@ public class TiglNativeInterface {
     public static native int tiglWingGetComponentSegmentIndex(int cpacsHandle, int wingIndex, String compSegmentUID, IntByReference segmentIndexPtr);
     public static native int tiglWingGetUpperPoint(int cpacsHandle, int wingIndex, int segmentIndex, double eta, double xsi, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglWingGetLowerPoint(int cpacsHandle, int wingIndex, int segmentIndex, double eta, double xsi, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
+    public static native int tiglWingSetGetPointBehavior(int cpacsHandle, int behavior);
     public static native int tiglWingGetChordPoint(int cpacsHandle, int wingIndex, int segmentIndex, double eta, double xsi, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglWingGetChordNormal(int cpacsHandle, int wingIndex, int segmentIndex, double eta, double xsi, DoubleByReference normalXPtr, DoubleByReference normalYPtr, DoubleByReference normalZPtr);
     public static native int tiglWingGetUpperPointAtDirection(int cpacsHandle, int wingIndex, int segmentIndex, double eta, double xsi, double dirx, double diry, double dirz, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr, DoubleByReference errorDistance);
@@ -82,6 +83,7 @@ public class TiglNativeInterface {
     public static native int tiglFuselageGetCrossSectionArea(int cpacsHandle, String fuselageSegmentUID, double eta, DoubleByReference area);
     public static native int tiglFuselageGetCenterLineLength(int cpacsHandle, String fuselageUID, DoubleByReference length);
     public static native int tiglFuselageGetPoint(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double zeta, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
+    public static native int tiglFuselageSetGetPointBehavior(int cpacsHandle, int behavior);
     public static native int tiglFuselageGetPointAngle(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double alpha, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglFuselageGetPointAngleTranslated(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double alpha, double y_cs, double z_cs, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
     public static native int tiglFuselageGetPointOnXPlane(int cpacsHandle, int fuselageIndex, int segmentIndex, double eta, double xpos, int pointIndex, DoubleByReference pointXPtr, DoubleByReference pointYPtr, DoubleByReference pointZPtr);
@@ -187,7 +189,9 @@ public class TiglNativeInterface {
     public static native int tiglCheckPointInside(int cpacsHandle, double px, double py, double pz, String componentUID, IntByReference isInside);
     public static native int tiglComponentGetHashCode(int cpacsHandle, String componentUID, IntByReference hashCodePtr);
     public static native String tiglGetErrorString(int errorCode);
+    public static native void tiglSetDebugDataDirectory(String directory);
     public static native int tiglConfigurationGetLength(int cpacsHandle, DoubleByReference pLength);
+    public static native int tiglConfigurationGetBoundingBox(int cpacsHandle, DoubleByReference minX, DoubleByReference minY, DoubleByReference minZ, DoubleByReference maxX, DoubleByReference maxY, DoubleByReference maxZ);
     public static native int tiglWingGetSpan(int cpacsHandle, String wingUID, DoubleByReference pSpan);
     public static native int tiglWingGetMAC(int cpacsHandle, String wingUID, DoubleByReference mac_chord, DoubleByReference mac_x, DoubleByReference mac_y, DoubleByReference mac_z);
 };

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -50,6 +50,7 @@
 #include "CCPACSRotorBladeAttachment.h"
 #include "CTiglAttachedRotorBlade.h"
 #include "CGlobalExporterConfigs.h"
+#include "Debugging.h"
 
 #include "CTiglPoint.h"
 
@@ -6702,6 +6703,17 @@ TIGL_COMMON_EXPORT const char * tiglGetErrorString(TiglReturnCode code)
         return "TIGL_UNKNOWN_ERROR";
     }
     return TiglErrorStrings[code];
+}
+
+
+TIGL_COMMON_EXPORT void tiglSetDebugDataDirectory(const char* directory)
+{
+    if (directory == NULL) {
+        tigl::TracePoint::setDebugDataDir("CrashInfo");
+    }
+    else {
+        tigl::TracePoint::setDebugDataDir(directory);
+    }
 }
 
 TIGL_COMMON_EXPORT TiglReturnCode tiglConfigurationGetLength(TiglCPACSConfigurationHandle cpacsHandle, double * pLength)

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -4696,6 +4696,18 @@ TIGL_COMMON_EXPORT const char * tiglGetErrorString(TiglReturnCode errorCode);
 
 
 /**
+ * @brief Set the directory path for debug data
+ * 
+ * These data are written, in case a tigl function has an internal error.
+ * 
+ * By default (directory==NULL), these files are written into the current working directory.
+ * There, the subdirectory CrashInfo is created.
+ * 
+ * @param[in] directory Path of the debugging directory.
+ */
+TIGL_COMMON_EXPORT void tiglSetDebugDataDirectory(const char* directory);
+
+/**
 * @brief Returns the length of the plane
 *
 * The calculation of the airplane lenght is realized as follows:

--- a/src/common/Debugging.cpp
+++ b/src/common/Debugging.cpp
@@ -39,6 +39,8 @@ void createDirs(const std::string& path)
 namespace tigl
 {
 
+std::string TracePoint::m_debugDataDir = "CrashInfo";
+
 void dumpShape(const TopoDS_Shape& shape, const std::string& outputDir, const std::string& filename, int counter)
 {
     std::stringstream ss;
@@ -52,7 +54,9 @@ void dumpShape(const TopoDS_Shape& shape, const std::string& outputDir, const st
 
     try {
         createDirs(file);
-        BRepTools::Write(shape, file.c_str());
+        if (BRepTools::Write(shape, file.c_str()) == Standard_False) {
+            LOG(WARNING) << "Failed to dump debug shape " << file;
+        }
     }
     catch (const std::exception& e) {
         LOG(WARNING) << "Failed to dump debug shape " << file << ": " << e.what();
@@ -63,10 +67,18 @@ TracePoint::TracePoint(const std::string& outputDir)
     : m_outputDir(outputDir)
     , m_counter(0)
 {
-    for (std::string::iterator it = m_outputDir.begin(); it != m_outputDir.end(); ++it) {
+    size_t pos = 0;
+    for (std::string::iterator it = m_outputDir.begin(); it != m_outputDir.end(); ++it, pos++) {
         char& c = *it;
-        if (!std::isalnum(c) && c != '/') {
+        if (!std::isalnum(c) && c != '/'  && c != '\\') {
+#if defined _WIN32 || defined __WIN32__
+            if (c != ':' || pos != 1) {
+                 // Don't overwrite the drive letter on windows
+                 c = '_';
+            }
+#else
             c = '_';
+#endif
         }
     }
 }

--- a/src/common/Debugging.h
+++ b/src/common/Debugging.h
@@ -36,9 +36,21 @@ public:
     int hitCount() const;
     void dumpShape(const TopoDS_Shape& shape, const std::string& filename);
 
+    static void setDebugDataDir(const std::string& dir)
+    {
+        m_debugDataDir = dir;
+    }
+    
+    static std::string debugDataDir()
+    {
+        return m_debugDataDir;
+    }
+
 private:
     std::string m_outputDir;
     boost::atomic<int> m_counter;
+
+    static std::string m_debugDataDir;
 };
 
 // creates a trace point at the location of this macro with the specified variable name and output directory
@@ -46,7 +58,7 @@ private:
 #define TRACE_POINT_OUTPUT_DIR(variableName, outputDir) static ::tigl::TracePoint variableName(outputDir); variableName++
 
 // uses the function inside which the macro is expanded as output directory, __FUNCTION__ may not be supported by each compiler
-#define TRACE_POINT(variableName) TRACE_POINT_OUTPUT_DIR(variableName, std::string("CrashInfo/") + __FUNCTION__)
+#define TRACE_POINT(variableName) TRACE_POINT_OUTPUT_DIR(variableName, std::string(tigl::TracePoint::debugDataDir() + "/") + __FUNCTION__)
 
 // allows dumping shapes in case an object of this class is destroyed by an exception
 class DebugScope


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added api function ```tiglSetDebugDataDirectory``` to specifiy the directory of the crashdump data.


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Added api function ```tiglSetDebugDataDirectory``` to specifiy the directory of the crashdump data.
TiGL Viewer used the function by setting this directory relative to the currently opened CPACS file.
This was necessary, as installed TiGL Viewer could not write into the current working directory.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* Installed TiGL into system directory.
* Provoked an error. The crashdump was written into the directory relative to the cpacs file.
* If the cpacs file is in a write-protected directory, a warning will be logged. No crash occured.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [x] API changes were documented properly in tigl.h.
