### PR TITLE
Jk/nacelle cowl gc optional

### DIFF
--- a/cpacs_gen_input/cpacs_schema.xsd
+++ b/cpacs_gen_input/cpacs_schema.xsd
@@ -43714,7 +43714,7 @@ jonas.jepsen@dlr.de
                 	<xsd:element name="sections"
                 		type="nacelleSectionsType">
                 	</xsd:element>
-                	<xsd:element name="guideCurves"
+                	<xsd:element minOccurs="0" name="guideCurves"
                 		type="nacelleGuideCurvesType">
                 	</xsd:element>
                 	<xsd:element name="rotationCurve" type="rotationCurveType"></xsd:element>

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -1565,6 +1565,49 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetSegmentUID(TiglCPAC
                                                                         int  segmentIndex,
                                                                         char ** segmentUID);
 
+/**
+* @brief Returns the span of a wing.
+*
+* The calculation of the wing span is realized as follows:
+*
+* * If the wing is mirrored at a symmetry plane (like the main wing), the wing body and its mirrored counterpart are computed
+* and are put into a bounding box. The length of the box in a specific space dimension is returned as the wing span depending
+* on the symmetry plane (y direction for x-z planes, z direction for x-y planes, x direction for y-z symmetry planes).
+*
+* * If no symmetry plane is defined (e.g. for the fins), the largest dimension of the bounding box around the wing
+* is returned.
+*
+*
+* @param[in]  cpacsHandle Handle for the CPACS configuration
+* @param[in]  wingUID     UID of the Wing
+* @param[out] pSpan       Wing span
+*
+* @returns Error code
+*/
+TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSpan(TiglCPACSConfigurationHandle cpacsHandle, const char* wingUID, double * pSpan);
+
+
+/**
+* @brief This function calculates location of the quarter of mean aerodynamic chord, and gives the chord lenght as well.
+*
+* It uses the classical method that can be applied to trapozaidal wings. This method is used for each segment.
+* The values are found by taking into account of sweep and dihedral. But the effect of insidance angle is neglected.
+* These values should coinside with the values found with tornado tool.
+*
+* @param[in] cpacsHandle Handle for the CPACS configuration
+* @param[in] wingUID     UID of the Wing
+* @param[out] mac_chord  Mean areadynamic chord length
+* @param[out] mac_x, mac_y, mac_z - Position of the MAC
+*
+* @return
+*   - TIGL_SUCCESS if no error occurred
+*   - TIGL_NULL_POINTER if wingUID, mac_chord, mac_x, mac_y or mac_z are null pointers
+*   - TIGL_ERROR In case of an unknown error
+*/
+TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetMAC(TiglCPACSConfigurationHandle cpacsHandle, const char* wingUID, double *mac_chord, double *mac_x, double *mac_y, double *mac_z);
+
+
+
 /*@}*/
 /*****************************************************************************************************/
 
@@ -4734,47 +4777,6 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglConfigurationGetBoundingBox(TiglCPACSConfi
                                                                   double* minX, double* minY, double* minZ,
                                                                   double* maxX, double* maxY, double* maxZ);
 
-
-/**
-* @brief Returns the span of a wing. 
-*
-* The calculation of the wing span is realized as follows:
-*
-* * If the wing is mirrored at a symmetry plane (like the main wing), the wing body and its mirrored counterpart are computed
-* and are put into a bounding box. The length of the box in a specific space dimension is returned as the wing span depending
-* on the symmetry plane (y direction for x-z planes, z direction for x-y planes, x direction for y-z symmetry planes).
-*
-* * If no symmetry plane is defined (e.g. for the fins), the largest dimension of the bounding box around the wing
-* is returned.
-*
-*
-* @param[in]  cpacsHandle Handle for the CPACS configuration
-* @param[in]  wingUID     UID of the Wing
-* @param[out] pSpan       Wing span
-*
-* @returns Error code
-*/
-TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSpan(TiglCPACSConfigurationHandle cpacsHandle, const char* wingUID, double * pSpan);
-
-
-/**
-* @brief This function calculates location of the quarter of mean aerodynamic chord, and gives the chord lenght as well.
-* 
-* It uses the classical method that can be applied to trapozaidal wings. This method is used for each segment.
-* The values are found by taking into account of sweep and dihedral. But the effect of insidance angle is neglected.
-* These values should coinside with the values found with tornado tool.
-* 
-* @param[in] cpacsHandle Handle for the CPACS configuration
-* @param[in] wingUID     UID of the Wing
-* @param[out] mac_chord  Mean areadynamic chord length
-* @param[out] mac_x, mac_y, mac_z - Position of the MAC
-* 
-* @return
-*   - TIGL_SUCCESS if no error occurred
-*   - TIGL_NULL_POINTER if wingUID, mac_chord, mac_x, mac_y or mac_z are null pointers
-*   - TIGL_ERROR In case of an unknown error
-*/
-TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetMAC(TiglCPACSConfigurationHandle cpacsHandle, const char* wingUID, double *mac_chord, double *mac_x, double *mac_y, double *mac_z);
 
 
 /*@}*/ // end of doxygen group

--- a/src/engine_nacelle/CCPACSNacelleCowl.cpp
+++ b/src/engine_nacelle/CCPACSNacelleCowl.cpp
@@ -111,20 +111,22 @@ void CCPACSNacelleCowl::BuildOuterShapeWires(WireCache& cache) const
 
     // get CPACS guide curves
     std::vector<std::pair<double,TopoDS_Wire>> zetaGuides;
-    for(size_t i = 1; i <= m_guideCurves.GetGuideCurveCount(); ++i ) {
-        const CCPACSNacelleGuideCurve& guide = m_guideCurves.GetGuideCurve(i);
+    if ( m_guideCurves ) {
+        for(size_t i = 1; i <= m_guideCurves->GetGuideCurveCount(); ++i ) {
+            const CCPACSNacelleGuideCurve& guide = m_guideCurves->GetGuideCurve(i);
 
-        // check if it is one of the required curves
-        for (int i = 0; i<5; ++i) {
-            if(    fabs(guide.GetFromZeta() - requiredZeta[i]) < Precision::Confusion()
-                && fabs(guide.GetToZeta()   - requiredZeta[i]) < Precision::Confusion() ) {
-                // if the required guide curve is already defined via CPACS, it must not explicitly be built.
-                buildRequiredZeta[i] = false; }
+            // check if it is one of the required curves
+            for (int i = 0; i<5; ++i) {
+                if(    fabs(guide.GetFromZeta() - requiredZeta[i]) < Precision::Confusion()
+                    && fabs(guide.GetToZeta()   - requiredZeta[i]) < Precision::Confusion() ) {
+                    // if the required guide curve is already defined via CPACS, it must not explicitly be built.
+                    buildRequiredZeta[i] = false; }
+            }
+
+            CTiglNacelleGuideCurveBuilder gcbuilder(guide);
+            std::pair<double,TopoDS_Wire> zetaGuidePair(guide.GetFromZeta(), gcbuilder.GetWire());
+            zetaGuides.push_back(zetaGuidePair);
         }
-
-        CTiglNacelleGuideCurveBuilder gcbuilder(guide);
-        std::pair<double,TopoDS_Wire> zetaGuidePair(guide.GetFromZeta(), gcbuilder.GetWire());
-        zetaGuides.push_back(zetaGuidePair);
     }
 
     // explicitly built the guide curves for the required zeta values, that are not defined in CPACS

--- a/src/generated/CPACSNacelleCowl.h
+++ b/src/generated/CPACSNacelleCowl.h
@@ -17,11 +17,14 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
 #include <CCPACSNacelleGuideCurves.h>
 #include <CCPACSNacelleSections.h>
 #include <CCPACSRotationCurve.h>
 #include <string>
 #include <tixi.h>
+#include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
 namespace tigl
@@ -65,21 +68,24 @@ namespace generated
         TIGL_EXPORT virtual const CCPACSNacelleSections& GetSections() const;
         TIGL_EXPORT virtual CCPACSNacelleSections& GetSections();
 
-        TIGL_EXPORT virtual const CCPACSNacelleGuideCurves& GetGuideCurves() const;
-        TIGL_EXPORT virtual CCPACSNacelleGuideCurves& GetGuideCurves();
+        TIGL_EXPORT virtual const boost::optional<CCPACSNacelleGuideCurves>& GetGuideCurves() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSNacelleGuideCurves>& GetGuideCurves();
 
         TIGL_EXPORT virtual const CCPACSRotationCurve& GetRotationCurve() const;
         TIGL_EXPORT virtual CCPACSRotationCurve& GetRotationCurve();
+
+        TIGL_EXPORT virtual CCPACSNacelleGuideCurves& GetGuideCurves(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual void RemoveGuideCurves();
 
     protected:
         CPACSEngineNacelle* m_parent;
 
         CTiglUIDManager* m_uidMgr;
 
-        std::string              m_uID;
-        CCPACSNacelleSections    m_sections;
-        CCPACSNacelleGuideCurves m_guideCurves;
-        CCPACSRotationCurve      m_rotationCurve;
+        std::string                               m_uID;
+        CCPACSNacelleSections                     m_sections;
+        boost::optional<CCPACSNacelleGuideCurves> m_guideCurves;
+        CCPACSRotationCurve                       m_rotationCurve;
 
     private:
         CPACSNacelleCowl(const CPACSNacelleCowl&) = delete;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Changes the CPACS schema and generated code of nacelleCowlType, such that the guideCurves node is optional. If none are given, TiGL creates the guide curves it needs from scratch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
