### PR TITLE
Robust B-Spline Intersection Algorithm

### DIFF
--- a/bindings/python_internal/geometry.i
+++ b/bindings/python_internal/geometry.i
@@ -68,6 +68,7 @@
 #include "CTiglInterpolateCurveNetwork.h"
 #include "CTiglPointsToBSplineInterpolation.h"
 #include "CTiglCurvesToSurface.h"
+#include "CTiglIntersectBSplines.h"
 %}
 
 
@@ -80,6 +81,7 @@
 %template(CPointContainer) std::vector<gp_Pnt>;
 %template(BSplineCurveList) std::vector<Handle_Geom_BSplineCurve>;
 %template(CurveList) std::vector<Handle_Geom_Curve>;
+%template(CurveIntersectionResultList) std::vector<tigl::CurveIntersectionResult>;
 
 %boost_optional(tigl::CCPACSPointAbsRel)
 %boost_optional(tigl::CCPACSPoint)
@@ -88,6 +90,7 @@
 %boost_optional(tigl::generated::CPACSPointXYZ)
 %boost_optional(tigl::CCPACSPointListXYZVector)
 
+%include "CTiglIntersectBSplines.h"
 %include "CTiglPointsToBSplineInterpolation.h"
 %include "CTiglInterpolateCurveNetwork.h"
 %include "CTiglCurvesToSurface.h"

--- a/bindings/python_internal/tigl3/curve_factories.py
+++ b/bindings/python_internal/tigl3/curve_factories.py
@@ -1,6 +1,6 @@
-import tigl3.occ_helpers.containers
 from tigl3.geometry import CTiglPointsToBSplineInterpolation
-
+from tigl3.occ_helpers.containers import float_array, int_array, point_array
+from OCC.Geom import Geom_BSplineCurve
 
 def interpolate_points(points, params=None, degree=3, close_continuous=False):
     """
@@ -16,7 +16,7 @@ def interpolate_points(points, params=None, degree=3, close_continuous=False):
     :return: The resulting curve (Handle to Geom_BSplineCurve)
     """
 
-    occ_points_array = tigl3.occ_helpers.containers.point_array(points)
+    occ_points_array = point_array(points)
     if params is None:
         interp = CTiglPointsToBSplineInterpolation(occ_points_array.GetHandle(), degree, close_continuous)
     else:
@@ -25,4 +25,26 @@ def interpolate_points(points, params=None, degree=3, close_continuous=False):
         interp = CTiglPointsToBSplineInterpolation(occ_points_array.GetHandle(), params, degree, close_continuous)
 
     curve = interp.curve()
+    return curve
+
+def bspline_curve(cp, knots, mults, degree):
+    """
+    Creates a BSplineCurve from the control points, knots, multiplicites and degree
+
+    :param points: Array of points (numpy array also works!). First dimension over number of points, second must be 3!
+    :param knots: Knot vector (not flattened)
+    :param mults: Multiplicity vector. Each entry defined the multiplicity of the corresponding knot
+    :param degree: Polynomial degree of the resulting b-spline curve.
+
+    :return: The resulting curve (Handle to Geom_BSplineCurve)
+    """
+
+    assert(len(knots) == len(mults))
+    assert(degree >= 1)
+
+    occ_cp = point_array(cp)
+    occ_knots = float_array(knots)
+    occ_mults = int_array(mults)
+    curve = Geom_BSplineCurve(occ_cp.Array1(), occ_knots.Array1(), occ_mults.Array1(), degree).GetHandle()
+
     return curve

--- a/bindings/python_internal/tigl3/occ_helpers/containers.py
+++ b/bindings/python_internal/tigl3/occ_helpers/containers.py
@@ -27,7 +27,7 @@ def int_array(int_list):
     """
     result = TColStd_HArray1OfInteger(1, len(int_list))
     for i, value in enumerate(int_list):
-        result.SetValue(i, value)
+        result.SetValue(i+1, value)
     return result
 
 

--- a/examples/python/example_bspline_intersection.py
+++ b/examples/python/example_bspline_intersection.py
@@ -1,0 +1,36 @@
+import numpy as np
+from tigl3.curve_factories import bspline_curve
+from tigl3.geometry import intersect_bsplines
+
+if __name__ == "__main__":
+    """
+    This example shows, how to compute the intersection points between two b-spline curves
+    """
+
+    cp1 = np.array([[0., 0., 0.],
+                    [1., 5., 0.],
+                    [2., 0., 0.],
+                    [3., 5., 0.],
+                    [4., 0., 0.],
+                    [5., 5., 0.]])
+
+    cp2 = np.array([[0., 0., 0.],
+                    [10., 1., 0.],
+                    [-1.62, 2., 0.],
+                    [4.78, 3., 0.],
+                    [0., 4., 0.],
+                    [5., 5., 0.]])
+
+    knots1 = np.array([0., 0.25, 0.5, 0.75, 1.]) * 5.
+    mults = [3, 1, 1, 1, 3]
+
+    curve1 = bspline_curve(cp1, knots1, mults, 2)
+    curve2 = bspline_curve(cp2, knots1, mults, 2)
+
+    results = intersect_bsplines(curve1, curve2, 0.03)
+    print("Number of intersections: " + str(len(results)))
+
+    for result in results:
+        p = result.point
+        print([p.x, p.y, p.z])
+

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -91,6 +91,8 @@
 #include <Geom_TrimmedCurve.hxx>
 #include <GeomConvert.hxx>
 #include <TColgp_HArray1OfPnt.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <TColStd_HArray1OfInteger.hxx>
 #include <ShapeAnalysis_FreeBounds.hxx>
 #include <ShapeFix_EdgeConnect.hxx>
 #include <BRep_Tool.hxx>
@@ -1659,7 +1661,7 @@ TopoDS_Shape GetFacesByName(const PNamedShape shape, const std::string &name)
     return c;
 }
 
-TIGL_EXPORT Handle(TColgp_HArray1OfPnt) OccArray(const std::vector<gp_Pnt>& pnts)
+Handle(TColgp_HArray1OfPnt) OccArray(const std::vector<gp_Pnt>& pnts)
 {
     Handle(TColgp_HArray1OfPnt) result = new TColgp_HArray1OfPnt(1, static_cast<int>(pnts.size()));
     int idx = 1;
@@ -1667,4 +1669,27 @@ TIGL_EXPORT Handle(TColgp_HArray1OfPnt) OccArray(const std::vector<gp_Pnt>& pnts
         result->SetValue(idx, *it);
     }
     return result;
+}
+
+Handle(TColStd_HArray1OfReal) OccFArray(const std::vector<double>& vector)
+{
+    Handle(TColStd_HArray1OfReal) array = new TColStd_HArray1OfReal(1, static_cast<int>(vector.size()));
+    int ipos = 1;
+    for (const auto& value : vector) {
+        array->SetValue(ipos, value);
+        ipos++;
+    }
+    
+    return array;
+}
+
+Handle(TColStd_HArray1OfInteger) OccIArray(const std::vector<int>& vector)
+{
+    Handle(TColStd_HArray1OfInteger) array = new TColStd_HArray1OfInteger(1, static_cast<int>(vector.size()));
+    int ipos = 1;
+    for (const auto& value : vector) {
+        array->SetValue(ipos++, value);
+    }
+    
+    return array;
 }

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -284,7 +284,10 @@ TIGL_EXPORT std::vector<double> LinspaceWithBreaks(double umin, double umax, siz
 TIGL_EXPORT TopoDS_Shape TransformedShape(const tigl::CTiglTransformation& transformationToGlobal, TiglCoordinateSystem cs, const TopoDS_Shape& shape);
 TIGL_EXPORT TopoDS_Shape TransformedShape(const tigl::CTiglRelativelyPositionedComponent& component, TiglCoordinateSystem cs, const TopoDS_Shape& shape);
 
+/// Converters between std::vectors and opencascade vectors
 TIGL_EXPORT Handle(TColgp_HArray1OfPnt) OccArray(const std::vector<gp_Pnt>& pnts);
+TIGL_EXPORT Handle(TColStd_HArray1OfReal) OccFArray(const std::vector<double>& vector);
+TIGL_EXPORT Handle(TColStd_HArray1OfInteger) OccIArray(const std::vector<int>& vector);
 
 template <typename T>
 size_t IndexFromUid(const std::vector<std::unique_ptr<T> >& vectorOfPointers, const std::string& uid)

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -295,4 +295,25 @@ size_t IndexFromUid(const std::vector<std::unique_ptr<T> >& vectorOfPointers, co
     return found - vectorOfPointers.begin();
 }
 
+template <class ArrayType, typename BinaryPredicate, typename BinaryMerge>
+void ReplaceAdjacentWithMerged(ArrayType& list, BinaryPredicate is_adjacent, BinaryMerge merged)
+{
+    for(auto it = std::begin(list); it != std::end(list);) {
+        auto nextIt = it;
+        
+        if (++nextIt == std::end(list)) {
+            return;
+        }
+        
+        if (is_adjacent(*it, *nextIt)) {
+            typename ArrayType::value_type merged_val = merged(*it, *nextIt);
+            it = list.erase(it, ++nextIt);
+            it = list.insert(it, merged_val);
+        }
+        else {
+            it = nextIt;
+        }
+    }
+}
+
 #endif // TIGLCOMMONFUNCTIONS_H

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -301,7 +301,7 @@ size_t IndexFromUid(const std::vector<std::unique_ptr<T> >& vectorOfPointers, co
 template <class ArrayType, typename BinaryPredicate, typename BinaryMerge>
 void ReplaceAdjacentWithMerged(ArrayType& list, BinaryPredicate is_adjacent, BinaryMerge merged)
 {
-    for(auto it = std::begin(list); it != std::end(list);) {
+    for (auto it = std::begin(list); it != std::end(list);) {
         auto nextIt = it;
         
         if (++nextIt == std::end(list)) {
@@ -309,7 +309,7 @@ void ReplaceAdjacentWithMerged(ArrayType& list, BinaryPredicate is_adjacent, Bin
         }
         
         if (is_adjacent(*it, *nextIt)) {
-            typename ArrayType::value_type merged_val = merged(*it, *nextIt);
+            const auto merged_val = merged(*it, *nextIt);
             it = list.erase(it, ++nextIt);
             it = list.insert(it, merged_val);
         }

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -311,17 +311,7 @@ namespace
     {
         return array2GetRow<TColgp_Array2OfPnt, TColgp_HArray1OfPnt, Handle_TColgp_HArray1OfPnt>(matrix, rowIndex);
     }
-    
-    Handle(TColStd_HArray1OfReal) toArray(const std::vector<double>& vector)
-    {
-        Handle(TColStd_HArray1OfReal) array = new TColStd_HArray1OfReal(1, static_cast<int>(vector.size()));
-        int ipos = 1;
-        for (std::vector<double>::const_iterator it = vector.begin(); it != vector.end(); ++it, ipos++) {
-            array->SetValue(ipos, *it);
-        }
-
-        return array;
-    }
+    		
 } // namespace
 
 
@@ -612,7 +602,7 @@ Handle(Geom_BSplineCurve) CTiglBSplineAlgorithms::reparametrizeBSplineContinuous
         old_parameters_pnts->SetValue(occIdx, gp_Pnt2d(old_parameters[parameter_idx], 0));
     }
 
-    Geom2dAPI_Interpolate interpolationObject(old_parameters_pnts, toArray(new_parameters), false, 1e-15);
+    Geom2dAPI_Interpolate interpolationObject(old_parameters_pnts, OccFArray(new_parameters), false, 1e-15);
     interpolationObject.Perform();
 
     // check that interpolation was successful

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -886,4 +886,11 @@ Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::trimSurface(const Handle(Geo
     return trimmedSurface;
 }
 
+Handle(Geom_BSplineCurve) CTiglBSplineAlgorithms::trimCurve(const Handle(Geom_BSplineCurve)& curve, double umin, double umax)
+{
+    Handle(Geom_BSplineCurve) copy = Handle(Geom_BSplineCurve)::DownCast(curve->Copy());
+    copy->Segment(umin, umax);
+    return copy;
+}
+
 } // namespace tigl

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -234,6 +234,9 @@ public:
 
     /// Trims a bspline surface
     TIGL_EXPORT static Handle(Geom_BSplineSurface) trimSurface(const Handle(Geom_Surface)& surface, double umin, double umax, double vmin, double vmax);
+
+    /// Trims a bspline curve
+    TIGL_EXPORT static Handle(Geom_BSplineCurve) trimCurve(const Handle(Geom_BSplineCurve)& curve, double umin, double umax);
 };
 } // namespace tigl
 

--- a/src/geometry/CTiglLineSegment.cpp
+++ b/src/geometry/CTiglLineSegment.cpp
@@ -1,3 +1,21 @@
+/*
+* Copyright (C) 2019 German Aerospace Center (DLR/SC)
+*
+* Created: 2019-09-30 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "CTiglLineSegment.h"
 
 #include "tiglcommonfunctions.h"
@@ -19,12 +37,14 @@ double CTiglLineSegment::distance(const CTiglLineSegment& other) const
 {
     // Christer Ericson, Real Time Collision Detection
     
-    CTiglPoint r = p - other.p;
-    double a = d.norm2Sqr();
-    double e = other.d.norm2Sqr();
-    double f = CTiglPoint::inner_prod(other.d, r);
+    const CTiglPoint r = p - other.p;
+    const double a = d.norm2Sqr();
+    const double e = other.d.norm2Sqr();
+    const double f = CTiglPoint::inner_prod(other.d, r);
     
     const double EPS = 1e-8;
+
+    // The parameters of the points of minimal distance
     double s = 0., t = 0.;
     
     if (a <= EPS && e <= EPS) {
@@ -42,7 +62,7 @@ double CTiglLineSegment::distance(const CTiglLineSegment& other) const
         }
         else {
             double b = CTiglPoint::inner_prod(d, other.d);
-            float denom = a*e - b*b;
+            double denom = a*e - b*b;
             
             if (denom != 0.) {
                 s = Clamp((b*f - c*e)/ denom, 0., 1.);
@@ -66,8 +86,8 @@ double CTiglLineSegment::distance(const CTiglLineSegment& other) const
         }
     }
     
-    CTiglPoint c1 = value(s);
-    CTiglPoint c2 = other.value(t);
+    const CTiglPoint c1 = value(s);
+    const CTiglPoint c2 = other.value(t);
     return sqrt(c1.distance2(c2));
 }
 

--- a/src/geometry/CTiglLineSegment.cpp
+++ b/src/geometry/CTiglLineSegment.cpp
@@ -1,0 +1,74 @@
+#include "CTiglLineSegment.h"
+
+#include "tiglcommonfunctions.h"
+
+namespace tigl
+{
+
+CTiglLineSegment::CTiglLineSegment(const tigl::CTiglPoint &p1, const tigl::CTiglPoint &p2)
+    : p(p1), d(p2 - p1)
+{
+}
+
+CTiglPoint CTiglLineSegment::value(double u) const
+{
+    return p + d*u;
+}
+
+double CTiglLineSegment::distance(const CTiglLineSegment& other) const
+{
+    // Christer Ericson, Real Time Collision Detection
+    
+    CTiglPoint r = p - other.p;
+    double a = d.norm2Sqr();
+    double e = other.d.norm2Sqr();
+    double f = CTiglPoint::inner_prod(other.d, r);
+    
+    const double EPS = 1e-8;
+    double s = 0., t = 0.;
+    
+    if (a <= EPS && e <= EPS) {
+        s = t = 0.;
+    }
+    else if(a <= EPS) {
+        s = 0.;
+        t = Clamp(f/e, 0., 1.);
+    }
+    else {
+        double c = CTiglPoint::inner_prod(d, r);
+        if (e <= EPS) {
+            t = 0.;
+            s = Clamp(-c/a, 0., 1.);
+        }
+        else {
+            double b = CTiglPoint::inner_prod(d, other.d);
+            float denom = a*e - b*b;
+            
+            if (denom != 0.) {
+                s = Clamp((b*f - c*e)/ denom, 0., 1.);
+            }
+            else {
+                s = 0.;
+            }
+            t = (b*s + f);
+            
+            if (t < 0.) {
+                t = 0.;
+                s = Clamp( -c/a, 0., 1.);
+            }
+            else if (t > e) {
+                t = 1.;
+                s = Clamp((b-c) / a, 0., 1.);
+            }
+            else {
+                t = t / e;
+            }
+        }
+    }
+    
+    CTiglPoint c1 = value(s);
+    CTiglPoint c2 = other.value(t);
+    return sqrt(c1.distance2(c2));
+}
+
+} // namespace tigl

--- a/src/geometry/CTiglLineSegment.h
+++ b/src/geometry/CTiglLineSegment.h
@@ -1,3 +1,21 @@
+/*
+* Copyright (C) 2019 German Aerospace Center (DLR/SC)
+*
+* Created: 2019-09-30 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #ifndef CTIGLLINESEGMENT_H
 #define CTIGLLINESEGMENT_H
 
@@ -6,13 +24,27 @@
 namespace tigl
 {
 
+/**
+ * @brief A simple line segment
+ */
 class CTiglLineSegment
 {
 public:
     CTiglLineSegment(const CTiglPoint& p1, const CTiglPoint& p2);
     
+    /**
+     * @brief Returns a point on the line segment (u = 0 ... 1)
+     * @param u Line parameter
+     * @return The point on the line
+     */
     CTiglPoint value(double u) const;
     
+    /**
+     * @brief Computes the minimal distance to another line segment
+     *
+     * We use the algorithm from Christer Ericson (Real Time Collision Detection).
+     * It is robust, also in the near parallel case.
+     */
     double distance(const CTiglLineSegment& other) const;
 
 private:

--- a/src/geometry/CTiglLineSegment.h
+++ b/src/geometry/CTiglLineSegment.h
@@ -1,0 +1,25 @@
+#ifndef CTIGLLINESEGMENT_H
+#define CTIGLLINESEGMENT_H
+
+#include "CTiglPoint.h"
+
+namespace tigl
+{
+
+class CTiglLineSegment
+{
+public:
+    CTiglLineSegment(const CTiglPoint& p1, const CTiglPoint& p2);
+    
+    CTiglPoint value(double u) const;
+    
+    double distance(const CTiglLineSegment& other) const;
+
+private:
+    CTiglPoint p;
+    CTiglPoint d;
+};
+
+} // namespace tigl
+
+#endif // CTIGLLINESEGMENT_H

--- a/src/math/CTiglIntersectBSplines.cpp
+++ b/src/math/CTiglIntersectBSplines.cpp
@@ -43,7 +43,7 @@ namespace
         double min;
         double max;
         
-        bool operator==(const Intervall& other)
+        bool operator==(const Intervall& other) const
         {
             const double EPS = 1e-15;
             return fabs(min - other.min) < EPS && fabs(max - other.max) < EPS;
@@ -73,7 +73,8 @@ namespace
             return (min.x < max.x + eps) && (min.y < max.y + eps) && (min.z < max.z + eps);
         }
         
-        BoundingBox& Merge(const BoundingBox& other) {
+        BoundingBox& Merge(const BoundingBox& other)
+        {
             assert(range.max == other.range.min);
             range.max = other.range.max;
             high = maxCoords(high, other.high);
@@ -82,7 +83,7 @@ namespace
             return *this;
         }
         
-        bool operator==(const BoundingBox& other)
+        bool operator==(const BoundingBox& other) const
         {
             return range == other.range;
         }

--- a/src/math/CTiglIntersectBSplines.cpp
+++ b/src/math/CTiglIntersectBSplines.cpp
@@ -226,11 +226,8 @@ namespace
             m_c1->D1(u, p1, d1);
             m_c2->D1(v, p2, d2);
 
-            F = p1.SquareDistance(p2);
-
             gp_Vec diff = p1.XYZ() - p2.XYZ();
             F = diff.SquareMagnitude();
-
 
             G(1) = 2. * diff.Dot(d1);
             G(2) = -2. * diff.Dot(d2);

--- a/src/math/CTiglIntersectBSplines.cpp
+++ b/src/math/CTiglIntersectBSplines.cpp
@@ -1,0 +1,325 @@
+#include "CTiglIntersectBSplines.h"
+#include "CTiglBSplineAlgorithms.h"
+#include "CTiglLineSegment.h"
+#include "tiglcommonfunctions.h"
+
+#include <math_MultipleVarFunctionWithGradient.hxx>
+#include <math_BFGS.hxx>
+
+#include <limits>
+#include <list>
+#include <algorithm>
+
+#include <cassert>
+
+namespace
+{
+    tigl::CTiglPoint minCoords(const tigl::CTiglPoint& p1, const tigl::CTiglPoint& p2)
+    {
+        tigl::CTiglPoint result = p1;
+        result.x = p1.x < p2.x? p1.x : p2.x;
+        result.y = p1.y < p2.y? p1.y : p2.y;
+        result.z = p1.z < p2.z? p1.z : p2.z;
+        return result;
+        
+    }
+    
+    tigl::CTiglPoint maxCoords(const tigl::CTiglPoint& p1, const tigl::CTiglPoint& p2)
+    {
+        tigl::CTiglPoint result = p1;
+        result.x = p1.x > p2.x? p1.x : p2.x;
+        result.y = p1.y > p2.y? p1.y : p2.y;
+        result.z = p1.z > p2.z? p1.z : p2.z;
+        return result;
+        
+    }
+
+    class Intervall
+    {
+    public:
+        Intervall(double mmin, double mmax)
+            : min(mmin), max(mmax)
+        {}
+        double min;
+        double max;
+        
+        bool operator==(const Intervall& other)
+        {
+            const double EPS = 1e-15;
+            return fabs(min - other.min) < EPS && fabs(max - other.max) < EPS;
+        }
+    };
+    
+    class BoundingBox
+    {
+    public:
+        BoundingBox(const Handle(Geom_BSplineCurve) curve)
+            : range(curve->FirstParameter(), curve->LastParameter())
+        {
+            low.x = low.y = low.z = std::numeric_limits<double>::max();
+            high.x = high.y = high.z = -std::numeric_limits<double>::max();
+            // compute min / max from control points
+            for (Standard_Integer i = 1; i <= curve->NbPoles(); ++i) {
+                gp_XYZ p = curve->Pole(i).XYZ();
+                low = minCoords(low, p);
+                high = maxCoords(high, p);
+            }
+        }
+        
+        bool Intersects(const BoundingBox& other, double eps) const
+        {
+            tigl::CTiglPoint min = maxCoords(low, other.low);
+            tigl::CTiglPoint max = minCoords(high, other.high);
+            return (min.x < max.x + eps) && (min.y < max.y + eps) && (min.z < max.z + eps);
+        }
+        
+        BoundingBox& Merge(const BoundingBox& other) {
+            assert(range.max == other.range.min);
+            range.max = other.range.max;
+            high = maxCoords(high, other.high);
+            low = minCoords(low, other.low);
+
+            return *this;
+        }
+        
+        bool operator==(const BoundingBox& other)
+        {
+            return range == other.range;
+        }
+        
+        tigl::CTiglPoint low, high;
+        Intervall range;
+    };
+
+    // Computes the total curvature of the curve
+    // A curvature of 1 is equivalent to a straight line
+    double curvature(const Handle(Geom_BSplineCurve)& curve)
+    {
+        double len = curve->Pole(1).Distance(curve->Pole(curve->NbPoles()));
+        double total = 0.;
+        for (Standard_Integer i = 1; i < curve->NbPoles(); ++i)
+        {
+            gp_Pnt p1 = curve->Pole(i);
+            gp_Pnt p2 = curve->Pole(i+1);
+            double dist = p1.Distance(p2);
+            total += dist;
+        }
+        
+        return total / len;
+    }
+    
+    struct BoundingBoxPair
+    {
+        BoundingBoxPair (const BoundingBox& i1, const BoundingBox& i2)
+            : b1(i1), b2(i2)
+        {}
+        BoundingBox b1;
+        BoundingBox b2;
+    };
+
+    
+    /// Computes possible ranges of intersections by a bracketing approach
+    std::list<BoundingBoxPair> getRangesOfIntersection(const Handle(Geom_BSplineCurve) curve1, const Handle(Geom_BSplineCurve) curve2, double tolerance)
+    {
+        BoundingBox h1(curve1);
+        BoundingBox h2(curve2);
+        
+        if (!h1.Intersects(h2, tolerance)) {
+            return {};
+        }
+        
+        double c1_curvature = curvature(curve1);
+        double c2_curvature = curvature(curve2);
+        double max_curvature = 1.0005;
+        
+        if (c1_curvature <= max_curvature && c2_curvature <= max_curvature) {
+            // both curves are now almost linear. check approximate distance between line segments
+            tigl::CTiglLineSegment l1(curve1->Pole(1).XYZ(), curve1->Pole(curve1->NbPoles()).XYZ());
+            tigl::CTiglLineSegment l2(curve2->Pole(1).XYZ(), curve2->Pole(curve2->NbPoles()).XYZ());
+            
+            if (l1.distance(l2) < tolerance){
+                return {BoundingBoxPair(h1, h2)};
+            }
+            else {
+                return {};
+            }
+        }
+        
+        double curve1MidParm = 0.5*(curve1->FirstParameter() + curve1->LastParameter());
+        double curve2MidParm = 0.5*(curve2->FirstParameter() + curve2->LastParameter());
+        
+        if (c1_curvature > max_curvature && c2_curvature > max_curvature) {
+            Handle_Geom_BSplineCurve c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
+            Handle_Geom_BSplineCurve c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
+            
+            Handle_Geom_BSplineCurve c21 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2->FirstParameter(), curve2MidParm);
+            Handle_Geom_BSplineCurve c22 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2MidParm, curve2->LastParameter());
+            
+            auto result1 = getRangesOfIntersection(c11, c21, tolerance);
+            auto result2 = getRangesOfIntersection(c11, c22, tolerance);
+            auto result3 = getRangesOfIntersection(c12, c21, tolerance);
+            auto result4 = getRangesOfIntersection(c12, c22, tolerance);
+            
+            // append all results
+            result1.splice(std::begin(result1), result2);
+            result1.splice(std::begin(result1), result3);
+            result1.splice(std::begin(result1), result4);
+            
+            return result1;
+        }
+        else if (c1_curvature <= max_curvature && max_curvature < c2_curvature) {
+            Handle_Geom_BSplineCurve c21 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2->FirstParameter(), curve2MidParm);
+            Handle_Geom_BSplineCurve c22 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2MidParm, curve2->LastParameter());
+            
+            auto result1 = getRangesOfIntersection(curve1, c21, tolerance);
+            auto result2 = getRangesOfIntersection(curve1, c22, tolerance);
+            
+            result1.splice(std::begin(result1), result2);
+            return result1;
+        }
+        else if(c2_curvature <= max_curvature && max_curvature < c1_curvature) {
+            Handle_Geom_BSplineCurve c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
+            Handle_Geom_BSplineCurve c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
+            
+            auto result1 = getRangesOfIntersection(c11, curve2, tolerance);
+            auto result2 = getRangesOfIntersection(c12, curve2, tolerance);
+            
+            result1.splice(std::begin(result1), result2);
+            return result1;
+        }
+        
+        return {};
+    }
+
+    class CurveCurveDistanceObjective : public math_MultipleVarFunctionWithGradient
+    {
+    public:
+        CurveCurveDistanceObjective(const Handle(Geom_Curve)& c1, const Handle(Geom_Curve)& c2)
+            : m_c1(c1), m_c2(c2)
+        {}
+
+        virtual Standard_Integer NbVariables()  const override
+        {
+            return 2;
+        }
+
+        Standard_Boolean Value (const math_Vector& X, Standard_Real& F) override
+        {
+            math_Vector G(1, 2);
+            return Values(X, F, G);
+        }
+
+        Standard_Boolean Gradient (const math_Vector& X, math_Vector& G) override
+        {
+            Standard_Real F = 0.;
+            return Values(X, F, G);
+        }
+
+        virtual  Standard_Boolean Values (const math_Vector& X, Standard_Real& F, math_Vector& G) override
+        {
+            //@TODO: check, if intersection point lies outside the curve's range
+            double u = X.Value(1);
+            double v = X.Value(2);
+
+            gp_Pnt p1, p2;
+            gp_Vec d1, d2;
+            m_c1->D1(u, p1, d1);
+            m_c2->D1(v, p2, d2);
+
+            F = p1.SquareDistance(p2);
+
+            gp_Vec diff = p1.XYZ() - p2.XYZ();
+            F = diff.SquareMagnitude();
+
+
+            G(1) = 2. * diff.Dot(d1);
+            G(2) = -2. * diff.Dot(d2);
+
+            return true;
+        }
+
+    private:
+        const Handle(Geom_Curve) m_c1, m_c2;
+    };
+   
+
+} // namespace
+
+namespace tigl
+{
+
+
+std::vector<tigl::CurveIntersectionResult> IntersectBSplines(const Handle(Geom_BSplineCurve) curve1, const Handle(Geom_BSplineCurve) curve2, double tolerance)
+{
+    auto hulls = getRangesOfIntersection(curve1, curve2, tolerance);
+    
+    std::list<BoundingBox> curve1_ints, curve2_ints;
+    for (const auto& hull : hulls) {
+        curve1_ints.push_back(hull.b1);
+        curve2_ints.push_back(hull.b2);
+    }
+    
+    auto compare = [](const BoundingBox& b1, const BoundingBox& b2) {
+        return b1.range.min < b2.range.min;
+    };
+    
+    // sort ascending parameter
+    curve1_ints.sort(compare);
+    curve2_ints.sort(compare);
+
+    // Remove duplicates
+    curve1_ints.unique();
+    curve2_ints.unique();
+    
+    auto is_adjacent = [](const BoundingBox& b1, const BoundingBox& b2) {
+        const double EPS = 1e-15;
+        return fabs(b1.range.max - b2.range.min) < EPS;
+    };
+    
+    auto merge_boxes = [](const BoundingBox& b1, const BoundingBox& b2) {
+        BoundingBox result(b1);
+        return result.Merge(b2);
+    };
+    
+    // merge neighboring intervals
+    ReplaceAdjacentWithMerged(curve1_ints, is_adjacent, merge_boxes);
+    ReplaceAdjacentWithMerged(curve2_ints, is_adjacent, merge_boxes);
+    
+    // combine intersection intervals
+    std::vector<BoundingBoxPair> intersectionCandidates;
+    for (const BoundingBox& b1 : curve1_ints) {
+        for (const BoundingBox& b2 : curve2_ints) {
+            if (b1.Intersects(b2, tolerance)) {
+                intersectionCandidates.push_back(BoundingBoxPair(b1, b2));
+            }
+        }
+    }
+
+    CurveCurveDistanceObjective obj(curve1, curve2);
+
+    std::vector<tigl::CurveIntersectionResult> results;
+
+    for (const BoundingBoxPair& boxes : intersectionCandidates) {
+        math_BFGS mimizer(obj, 1e-12);
+        math_Vector guess(1, 2);
+        guess(1) = 0.5*(boxes.b1.range.min + boxes.b1.range.max);
+        guess(2) = 0.5*(boxes.b2.range.min + boxes.b2.range.max);
+
+        mimizer.Perform(obj, guess);
+
+        double u = Clamp(mimizer.Location().Value(1), curve1->FirstParameter(), curve1->LastParameter());
+        double v = Clamp(mimizer.Location().Value(2), curve2->FirstParameter(), curve2->LastParameter());
+        CurveIntersectionResult result;
+        result.parmOnCurve1 = u;
+        result.parmOnCurve2 = v;
+        result.point = (CTiglPoint(curve1->Value(u).XYZ()) + CTiglPoint(curve2->Value(v).XYZ()))*0.5;
+
+        results.push_back(result);
+    }
+    
+    return results;
+}
+
+
+
+} // namespace tigl

--- a/src/math/CTiglIntersectBSplines.cpp
+++ b/src/math/CTiglIntersectBSplines.cpp
@@ -1,3 +1,21 @@
+/*
+* Copyright (C) 2019 German Aerospace Center (DLR/SC)
+*
+* Created: 2019-09-30 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "CTiglIntersectBSplines.h"
 #include "CTiglBSplineAlgorithms.h"
 #include "CTiglLineSegment.h"
@@ -110,8 +128,7 @@ namespace
     {
         double len = curve->Pole(1).Distance(curve->Pole(curve->NbPoles()));
         double total = 0.;
-        for (Standard_Integer i = 1; i < curve->NbPoles(); ++i)
-        {
+        for (Standard_Integer i = 1; i < curve->NbPoles(); ++i) {
             gp_Pnt p1 = curve->Pole(i);
             gp_Pnt p2 = curve->Pole(i+1);
             double dist = p1.Distance(p2);
@@ -190,7 +207,7 @@ namespace
             result1.splice(std::begin(result1), result2);
             return result1;
         }
-        else if(c2_curvature <= max_curvature && max_curvature < c1_curvature) {
+        else if (c2_curvature <= max_curvature && max_curvature < c1_curvature) {
             Handle_Geom_BSplineCurve c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
             Handle_Geom_BSplineCurve c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
             

--- a/src/math/CTiglIntersectBSplines.h
+++ b/src/math/CTiglIntersectBSplines.h
@@ -1,3 +1,21 @@
+/*
+* Copyright (C) 2019 German Aerospace Center (DLR/SC)
+*
+* Created: 2019-09-30 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #ifndef CTIGLINTERSECTBSPLINES_H
 #define CTIGLINTERSECTBSPLINES_H
 
@@ -22,7 +40,7 @@ struct CurveIntersectionResult
  * An intersection is counted, whenever the two curves come closer than tolerance.
  * If a whole interval is closes than tolerance, the nearest point in the interval is searched.
  *
- * The function devides the imput curves and check, if their bounding boxes (convex hulls)
+ * The function divides the input curves and checks, if their bounding boxes (convex hulls)
  * intersect each other. If so, this process is repeated until the curve segment is almost a line segment.
  * This result is used to locally optimize into a true minimum.
  */

--- a/src/math/CTiglIntersectBSplines.h
+++ b/src/math/CTiglIntersectBSplines.h
@@ -16,6 +16,16 @@ struct CurveIntersectionResult
     CTiglPoint point;
 };
 
+/**
+ * @brief Computes all intersections of 2 B-Splines curves
+ *
+ * An intersection is counted, whenever the two curves come closer than tolerance.
+ * If a whole interval is closes than tolerance, the nearest point in the interval is searched.
+ *
+ * The function devides the imput curves and check, if their bounding boxes (convex hulls)
+ * intersect each other. If so, this process is repeated until the curve segment is almost a line segment.
+ * This result is used to locally optimize into a true minimum.
+ */
 TIGL_EXPORT std::vector<CurveIntersectionResult> IntersectBSplines(const Handle(Geom_BSplineCurve) curve1, const Handle(Geom_BSplineCurve) curve2, double tolerance=1e-5);
 
 } // namespace tigl

--- a/src/math/CTiglIntersectBSplines.h
+++ b/src/math/CTiglIntersectBSplines.h
@@ -1,0 +1,23 @@
+#ifndef CTIGLINTERSECTBSPLINES_H
+#define CTIGLINTERSECTBSPLINES_H
+
+#include <Geom_BSplineCurve.hxx>
+#include "CTiglPoint.h"
+
+#include <vector>
+
+namespace tigl
+{
+
+struct CurveIntersectionResult
+{
+    double parmOnCurve1;
+    double parmOnCurve2;
+    CTiglPoint point;
+};
+
+TIGL_EXPORT std::vector<CurveIntersectionResult> IntersectBSplines(const Handle(Geom_BSplineCurve) curve1, const Handle(Geom_BSplineCurve) curve2, double tolerance=1e-5);
+
+} // namespace tigl
+
+#endif // CTIGLINTERSECTBSPLINES_H

--- a/src/math/CTiglProjectPointOnCurveAtAngle.cpp
+++ b/src/math/CTiglProjectPointOnCurveAtAngle.cpp
@@ -100,7 +100,7 @@ namespace
             return Values(X, F, G);
         }
 
-        virtual  Standard_Boolean Values (const math_Vector& X, Standard_Real& F, math_Vector& G)
+        virtual  Standard_Boolean Values (const math_Vector& X, Standard_Real& F, math_Vector& G) override
         {
             double u = X.Value(1);
 

--- a/tests/unittests/test.h
+++ b/tests/unittests/test.h
@@ -22,3 +22,29 @@
  * Define tests here
  *      
  */
+
+template <typename Array>
+::testing::AssertionResult ArraysMatch(const Array& expected,
+                                       const Array& actual){
+    
+    if (expected.size() != actual.size()) {
+        return ::testing::AssertionFailure() << "Expected size (" << expected.size() << ") != actual size (" << actual.size() <<  ")";
+    }
+    
+    
+    auto it1 = std::begin(expected);
+    auto it2 = std::begin(actual);
+    int idx = 0;
+    while(it1 != std::end(expected) && it2 != std::end(actual)){
+        if (*it1 != *it2){
+            return ::testing::AssertionFailure() << "array[" << idx
+                                                 << "] (" << *it2 << ") != expected[" << idx
+                                                 << "] (" << *it1 << ")";
+        }
+        ++idx;
+        ++it1;
+        ++it2;
+    }
+    
+    return ::testing::AssertionSuccess();
+}

--- a/tests/unittests/testBSplineIntersection.cpp
+++ b/tests/unittests/testBSplineIntersection.cpp
@@ -34,9 +34,16 @@ TEST(BSplineIntersection, ex1)
     Handle(Geom_BSplineCurve) c1 = new Geom_BSplineCurve(cp->Array1(), knots->Array1(), mults->Array1(), 2);
     Handle(Geom_BSplineCurve) c2 = new Geom_BSplineCurve(cp2->Array1(), knots->Array1(), mults->Array1(), 2);
 
-    auto results = tigl::IntersectBSplines(c1, c2, 0.03);
+    const double tolerance = 0.03;
+    auto results = tigl::IntersectBSplines(c1, c2, tolerance);
 
     EXPECT_EQ(11, results.size());
+
+    for (auto result : results) {
+        gp_Pnt p1 = c1->Value(result.parmOnCurve1);
+        gp_Pnt p2 = c2->Value(result.parmOnCurve2);
+        EXPECT_LE(p1.Distance(p2), tolerance);
+    }
 
     // Values from Python Code / Manually verified
     EXPECT_NEAR(0.0, tigl::CTiglPoint(9.025569161817309e-09, 3.7549883362060295e-09, 0.).distance2(results[0].point), 1e-8);
@@ -50,4 +57,37 @@ TEST(BSplineIntersection, ex1)
     EXPECT_NEAR(0.0, tigl::CTiglPoint(3.3861085187441030, 3.0046010587661650, 0.).distance2(results[8].point), 1e-8);
     EXPECT_NEAR(0.0, tigl::CTiglPoint(3.3346825588859490, 3.1899379238877654, 0.).distance2(results[9].point), 1e-8);
     EXPECT_NEAR(0.0, tigl::CTiglPoint(4.9999999788784610, 4.9999999788908305, 0.).distance2(results[10].point), 1e-8);
+}
+
+TEST(BSplineIntersection, ex2)
+{
+    auto knots = OccFArray({0., 5.});
+    auto mults = OccIArray({2, 2});
+
+    auto cp = OccArray({
+        gp_Pnt(0., 0., 0.),
+        gp_Pnt(0.95, 0., 0.)
+    });
+
+    auto cp2 = OccArray({
+        gp_Pnt(1., 1., 0.),
+        gp_Pnt(1., .05, 0.)
+    });
+
+    Handle(Geom_BSplineCurve) c1 = new Geom_BSplineCurve(cp->Array1(), knots->Array1(), mults->Array1(), 1);
+    Handle(Geom_BSplineCurve) c2 = new Geom_BSplineCurve(cp2->Array1(), knots->Array1(), mults->Array1(), 1);
+
+    const double tolerance = 0.1;
+    auto results = tigl::IntersectBSplines(c1, c2, tolerance);
+
+    EXPECT_EQ(1, results.size());
+
+    for (auto result : results) {
+        gp_Pnt p1 = c1->Value(result.parmOnCurve1);
+        gp_Pnt p2 = c2->Value(result.parmOnCurve2);
+        EXPECT_LE(p1.Distance(p2), tolerance);
+    }
+
+    // Values from Python Code / Manually verified
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(0.975, 0.025, 0.).distance2(results[0].point), 1e-8);
 }

--- a/tests/unittests/testBSplineIntersection.cpp
+++ b/tests/unittests/testBSplineIntersection.cpp
@@ -1,0 +1,61 @@
+#include "test.h"
+
+#include <Geom_BSplineCurve.hxx>
+#include <TColStd_Array1OfReal.hxx>
+#include <TColStd_Array1OfInteger.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+
+#include "CTiglIntersectBSplines.h"
+
+TEST(BSplineIntersection, ex1)
+{
+    TColStd_Array1OfReal knots1(1, 5);
+    knots1.SetValue(1, 0.);
+    knots1.SetValue(2, 1.25);
+    knots1.SetValue(3, 2.5);
+    knots1.SetValue(4, 3.75);
+    knots1.SetValue(5, 5.);
+
+    TColStd_Array1OfInteger mults1(1, 5);
+    mults1.SetValue(1, 3);
+    mults1.SetValue(2, 1);
+    mults1.SetValue(3, 1);
+    mults1.SetValue(4, 1);
+    mults1.SetValue(5, 3);
+
+    TColgp_Array1OfPnt cp1(1, 6);
+    cp1.SetValue(1, gp_Pnt(0., 0., 0.));
+    cp1.SetValue(2, gp_Pnt(1., 5., 0.));
+    cp1.SetValue(3, gp_Pnt(2., 0., 0.));
+    cp1.SetValue(4, gp_Pnt(3., 5., 0.));
+    cp1.SetValue(5, gp_Pnt(4., 0., 0.));
+    cp1.SetValue(6, gp_Pnt(5., 5., 0.));
+
+    TColgp_Array1OfPnt cp2(1, 6);
+    cp2.SetValue(1, gp_Pnt(0., 0., 0.));
+    cp2.SetValue(2, gp_Pnt(10., 1., 0.));
+    cp2.SetValue(3, gp_Pnt(-1.62, 2., 0.));
+    cp2.SetValue(4, gp_Pnt(4.78, 3., 0.));
+    cp2.SetValue(5, gp_Pnt(0., 4., 0.));
+    cp2.SetValue(6, gp_Pnt(5., 5., 0.));
+
+    Handle(Geom_BSplineCurve) c1 = new Geom_BSplineCurve(cp1, knots1, mults1, 2);
+    Handle(Geom_BSplineCurve) c2 = new Geom_BSplineCurve(cp2, knots1, mults1, 2);
+
+    auto results = tigl::IntersectBSplines(c1, c2, 0.03);
+
+    EXPECT_EQ(11, results.size());
+
+    // Values from Python Code / Manually verified
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(9.025569161817309e-09, 3.7549883362060295e-09, 0.).distance2(results[0].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(0.4822782514496766, 2.0792221838260083, 0.).distance2(results[1].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(0.5299902542589878, 2.2428238892925423, 0.).distance2(results[2].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(1.6759669326608981, 1.7749871436459341, 0.).distance2(results[3].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(1.5024716597735064, 2.4876722466426440, 0.).distance2(results[4].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(2.2970753765027037, 1.6912688966211170, 0.).distance2(results[5].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(2.5367033831340510, 2.6767812240028290, 0.).distance2(results[6].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(2.7425055392358964, 3.4184830133790154, 0.).distance2(results[7].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(3.3861085187441030, 3.0046010587661650, 0.).distance2(results[8].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(3.3346825588859490, 3.1899379238877654, 0.).distance2(results[9].point), 1e-8);
+    EXPECT_NEAR(0.0, tigl::CTiglPoint(4.9999999788784610, 4.9999999788908305, 0.).distance2(results[10].point), 1e-8);
+}

--- a/tests/unittests/testBSplineIntersection.cpp
+++ b/tests/unittests/testBSplineIntersection.cpp
@@ -1,46 +1,38 @@
 #include "test.h"
 
 #include <Geom_BSplineCurve.hxx>
-#include <TColStd_Array1OfReal.hxx>
-#include <TColStd_Array1OfInteger.hxx>
-#include <TColgp_Array1OfPnt.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <TColStd_HArray1OfInteger.hxx>
+#include <TColgp_HArray1OfPnt.hxx>
 
 #include "CTiglIntersectBSplines.h"
+#include "tiglcommonfunctions.h"
 
 TEST(BSplineIntersection, ex1)
 {
-    TColStd_Array1OfReal knots1(1, 5);
-    knots1.SetValue(1, 0.);
-    knots1.SetValue(2, 1.25);
-    knots1.SetValue(3, 2.5);
-    knots1.SetValue(4, 3.75);
-    knots1.SetValue(5, 5.);
+    auto knots = OccFArray({0., 1.25, 2.5, 3.75, 5.});
+    auto mults = OccIArray({3, 1, 1, 1, 3});
 
-    TColStd_Array1OfInteger mults1(1, 5);
-    mults1.SetValue(1, 3);
-    mults1.SetValue(2, 1);
-    mults1.SetValue(3, 1);
-    mults1.SetValue(4, 1);
-    mults1.SetValue(5, 3);
+    auto cp = OccArray({
+        gp_Pnt(0., 0., 0.),
+        gp_Pnt(1., 5., 0.),
+        gp_Pnt(2., 0., 0.),
+        gp_Pnt(3., 5., 0.),
+        gp_Pnt(4., 0., 0.),
+        gp_Pnt(5., 5., 0.)
+    });
 
-    TColgp_Array1OfPnt cp1(1, 6);
-    cp1.SetValue(1, gp_Pnt(0., 0., 0.));
-    cp1.SetValue(2, gp_Pnt(1., 5., 0.));
-    cp1.SetValue(3, gp_Pnt(2., 0., 0.));
-    cp1.SetValue(4, gp_Pnt(3., 5., 0.));
-    cp1.SetValue(5, gp_Pnt(4., 0., 0.));
-    cp1.SetValue(6, gp_Pnt(5., 5., 0.));
+    auto cp2 = OccArray({
+        gp_Pnt(0., 0., 0.),
+        gp_Pnt(10., 1., 0.),
+        gp_Pnt(-1.62, 2., 0.),
+        gp_Pnt(4.78, 3., 0.),
+        gp_Pnt(0., 4., 0.),
+        gp_Pnt(5., 5., 0.)
+    });
 
-    TColgp_Array1OfPnt cp2(1, 6);
-    cp2.SetValue(1, gp_Pnt(0., 0., 0.));
-    cp2.SetValue(2, gp_Pnt(10., 1., 0.));
-    cp2.SetValue(3, gp_Pnt(-1.62, 2., 0.));
-    cp2.SetValue(4, gp_Pnt(4.78, 3., 0.));
-    cp2.SetValue(5, gp_Pnt(0., 4., 0.));
-    cp2.SetValue(6, gp_Pnt(5., 5., 0.));
-
-    Handle(Geom_BSplineCurve) c1 = new Geom_BSplineCurve(cp1, knots1, mults1, 2);
-    Handle(Geom_BSplineCurve) c2 = new Geom_BSplineCurve(cp2, knots1, mults1, 2);
+    Handle(Geom_BSplineCurve) c1 = new Geom_BSplineCurve(cp->Array1(), knots->Array1(), mults->Array1(), 2);
+    Handle(Geom_BSplineCurve) c2 = new Geom_BSplineCurve(cp2->Array1(), knots->Array1(), mults->Array1(), 2);
 
     auto results = tigl::IntersectBSplines(c1, c2, 0.03);
 

--- a/tests/unittests/testBSplineIntersection.cpp
+++ b/tests/unittests/testBSplineIntersection.cpp
@@ -1,3 +1,21 @@
+/*
+* Copyright (C) 2019 German Aerospace Center (DLR/SC)
+*
+* Created: 2019-09-30 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "test.h"
 
 #include <Geom_BSplineCurve.hxx>
@@ -88,6 +106,15 @@ TEST(BSplineIntersection, ex2)
         EXPECT_LE(p1.Distance(p2), tolerance);
     }
 
-    // Values from Python Code / Manually verified
     EXPECT_NEAR(0.0, tigl::CTiglPoint(0.975, 0.025, 0.).distance2(results[0].point), 1e-8);
+    EXPECT_NEAR(5.0, results[0].parmOnCurve1, 1e-8);
+    EXPECT_NEAR(5.0, results[0].parmOnCurve2, 1e-8);
+
+    // The true distance is 0.070711
+
+    results = tigl::IntersectBSplines(c1, c2, 0.07072);
+    EXPECT_EQ(1, results.size());
+
+    results = tigl::IntersectBSplines(c1, c2, 0.07071);
+    EXPECT_EQ(0, results.size());
 }

--- a/tests/unittests/tiglCommonFunctions.cpp
+++ b/tests/unittests/tiglCommonFunctions.cpp
@@ -127,8 +127,8 @@ TEST(TiglCommonFunctions, tiglCheckPointInside_api)
     // test errors
     EXPECT_EQ(TIGL_UID_ERROR, tiglCheckPointInside(tiglSimpleWingHandle, 0., 0., 0., "wrongUID", &isInside));
     EXPECT_EQ(TIGL_NOT_FOUND, tiglCheckPointInside(-1, 0., 0., 0., "wrongUID", &isInside));
-    EXPECT_EQ(TIGL_NULL_POINTER, tiglCheckPointInside(tiglSimpleWingHandle, 0., 0., 0., NULL, &isInside));
-    EXPECT_EQ(TIGL_NULL_POINTER, tiglCheckPointInside(tiglSimpleWingHandle, 0., 0., 0., "wrongUID", NULL));
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglCheckPointInside(tiglSimpleWingHandle, 0., 0., 0., nullptr, &isInside));
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglCheckPointInside(tiglSimpleWingHandle, 0., 0., 0., "wrongUID", nullptr));
 
 
 }
@@ -163,7 +163,7 @@ TEST(TiglCommonFunctions, ReplaceAdjacentWith)
         return v1 + 1 == v2;
     };
     
-    auto merged = [](int v1, int v2) {
+    auto merged = [](int /* v1 */, int v2) {
         return v2;
     };
     
@@ -171,7 +171,7 @@ TEST(TiglCommonFunctions, ReplaceAdjacentWith)
     ReplaceAdjacentWithMerged(a, is_adjacent, merged);
     EXPECT_TRUE(ArraysMatch({3, 10}, a));
     
-    a = {1, 2, 5, 6, 7, 9, 11, 23,24};
+    a = {1, 2, 5, 6, 7, 9, 11, 23, 24};
     ReplaceAdjacentWithMerged(a, is_adjacent, merged);
     EXPECT_TRUE(ArraysMatch({2, 7, 9, 11, 24}, a));
     

--- a/tests/unittests/tiglCommonFunctions.cpp
+++ b/tests/unittests/tiglCommonFunctions.cpp
@@ -25,6 +25,8 @@
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
 
+#include <list>
+
 TEST(TiglCommonFunctions, isPathRelative)
 {
     ASSERT_TRUE(IsPathRelative("./test.txt"));
@@ -153,4 +155,36 @@ TEST(TiglCommonFunctions, LinspaceWithBreaks)
     EXPECT_NEAR(0.80, res[9], 1e-10);
     EXPECT_NEAR(0.90, res[10], 1e-10);
     EXPECT_NEAR(1.00, res[11], 1e-10);
+}
+
+TEST(TiglCommonFunctions, ReplaceAdjacentWith)
+{
+    auto is_adjacent = [](int v1, int v2) {
+        return v1 + 1 == v2;
+    };
+    
+    auto merged = [](int v1, int v2) {
+        return v2;
+    };
+    
+    std::list<int> a = {1, 2, 3, 10};
+    ReplaceAdjacentWithMerged(a, is_adjacent, merged);
+    EXPECT_TRUE(ArraysMatch({3, 10}, a));
+    
+    a = {1, 2, 5, 6, 7, 9, 11, 23,24};
+    ReplaceAdjacentWithMerged(a, is_adjacent, merged);
+    EXPECT_TRUE(ArraysMatch({2, 7, 9, 11, 24}, a));
+    
+    a = {5};
+    ReplaceAdjacentWithMerged(a, is_adjacent, merged);
+    EXPECT_TRUE(ArraysMatch({5}, a));
+    
+    a = {5, 6};
+    ReplaceAdjacentWithMerged(a, is_adjacent, merged);
+    EXPECT_TRUE(ArraysMatch({6}, a));
+    
+    a = {};
+    ReplaceAdjacentWithMerged(a, is_adjacent, merged);
+    EXPECT_TRUE(ArraysMatch({}, a));
+ 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implemented a 3D intersection algorithm for B-splines.

## Description
A hopefully robust 3D intersection algorithm for B-splines was implemented.
The previous implementation basically used OpenCASCADE often lead to wrong or
missing intersection points. A robust algorithm is required for the curve network interpolation
though.

The implementation  divides the input curves and checks, if their bounding boxes (convex hulls)) intersect each other. If so, this process is repeated until the curve segment is almost a line segment. This result is used to locally optimize into a true minimum.

## How Has This Been Tested?
 1. Prototypical implementation in SplineLib with many different examples
 2. Manual verification of the results
 3. Unit test that compares the results with the python results, that turned out to be correct.
 4. Another unit test, where the intersection point is slightly outside the curve's parameter interval.

## Screenshots, that help to understand the changes(if applicable):
![CurveIntersection](https://user-images.githubusercontent.com/3213107/66060020-4252d000-e53d-11e9-989a-fc116631eeb9.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [x] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h. (not required)
