### PR TITLE
Added option to draw face boundaries in TiGl Viewer

### DIFF
--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -571,5 +571,11 @@ void TIGLViewerContext::setObjectsColor(const QColor& color)
     }
 }
 
+void TIGLViewerContext::setFaceBoundariesEnabled(bool enabled) {
+    if (myContext && myContext->DefaultDrawer()) {
+        myContext->DefaultDrawer()->SetFaceBoundaryDraw(enabled);
+    }
+}
+
 
 

--- a/TIGLViewer/src/TIGLViewerContext.h
+++ b/TIGLViewer/src/TIGLViewerContext.h
@@ -106,6 +106,7 @@ public slots:
     void setObjectsTexture(const QString& filename);
     void setReflectionlinesEnabled(bool);
     void setObjectsColor(const QColor &color);
+    void setFaceBoundariesEnabled(bool enabled);
 
 signals:
 

--- a/TIGLViewer/src/TIGLViewerSettings.cpp
+++ b/TIGLViewer/src/TIGLViewerSettings.cpp
@@ -24,6 +24,7 @@ const double DEFAULT_TRIANGULATION_ACCURACY = 0.00070;
 const QColor DEFAULT_BGCOLOR(169,237,255);
 const bool DEFAULT_DEBUG_BOPS = false;
 const bool DEFAULT_ENUM_FACES = false;
+const bool DEFAULT_DRAW_FACE_BOUNDARIES = true;
 const int DEFAULT_NISO_FACES = 0;
 
 
@@ -88,6 +89,11 @@ void TIGLViewerSettings::setNumberOfVIsolinesPerFace(int nlines)
     _nVIsosPerFace = nlines;
 }
 
+void TIGLViewerSettings::setDrawFaceBoundariesEnabled(bool enabled)
+{
+    _drawFaceBoundaries = enabled;
+}
+
 bool TIGLViewerSettings::debugBooleanOperations() const
 {
     return _debugBOPs;
@@ -108,6 +114,11 @@ int TIGLViewerSettings::numFaceVIsosForDisplay() const
     return _nVIsosPerFace;
 }
 
+bool TIGLViewerSettings::drawFaceBoundaries() const
+{
+    return _drawFaceBoundaries;
+}
+
 void TIGLViewerSettings::loadSettings()
 {
     QSettings settings("DLR SC-HPC", "TiGLViewer3");
@@ -120,6 +131,7 @@ void TIGLViewerSettings::loadSettings()
     _enumFaces = settings.value("enumerate_faces", false).toBool();
     _nUIsosPerFace = settings.value("number_uisolines_per_face", 0).toInt();
     _nVIsosPerFace = settings.value("number_visolines_per_face", 0).toInt();
+    _drawFaceBoundaries = settings.value("draw_face_boundaries", true).toBool();
 }
 
 void TIGLViewerSettings::storeSettings()
@@ -134,6 +146,7 @@ void TIGLViewerSettings::storeSettings()
     settings.setValue("enumerate_faces", _enumFaces);
     settings.setValue("number_uisolines_per_face", _nUIsosPerFace);
     settings.setValue("number_visolines_per_face", _nVIsosPerFace);
+    settings.setValue("draw_face_boundaries", _drawFaceBoundaries);
 }
 
 void TIGLViewerSettings::restoreDefaults()
@@ -145,6 +158,7 @@ void TIGLViewerSettings::restoreDefaults()
     _enumFaces = DEFAULT_ENUM_FACES;
     _nUIsosPerFace = DEFAULT_NISO_FACES;
     _nVIsosPerFace = DEFAULT_NISO_FACES;
+    _drawFaceBoundaries = DEFAULT_DRAW_FACE_BOUNDARIES;
 }
 
 TIGLViewerSettings::~TIGLViewerSettings() {}

--- a/TIGLViewer/src/TIGLViewerSettings.h
+++ b/TIGLViewer/src/TIGLViewerSettings.h
@@ -44,11 +44,13 @@ public:
     void setEnumerateFacesEnabled(bool);
     void setNumberOfUIsolinesPerFace(int);
     void setNumberOfVIsolinesPerFace(int);
+    void setDrawFaceBoundariesEnabled(bool);
     
     bool debugBooleanOperations() const;
     bool enumerateFaces() const;
     int  numFaceUIsosForDisplay() const;
     int  numFaceVIsosForDisplay() const;
+    bool drawFaceBoundaries() const;
 
     void restoreDefaults();
 
@@ -64,6 +66,7 @@ private:
     bool _enumFaces;
     int  _nUIsosPerFace;
     int  _nVIsosPerFace;
+    bool _drawFaceBoundaries;
 };
 
 #endif /* TIGLVIEWERSETTINGS_H_ */

--- a/TIGLViewer/src/TIGLViewerSettingsDialog.cpp
+++ b/TIGLViewer/src/TIGLViewerSettingsDialog.cpp
@@ -87,6 +87,7 @@ void TIGLViewerSettingsDialog::onSettingsAccepted()
     _settings.setEnumerateFacesEnabled(enumerateFaceCB->isChecked());
     _settings.setNumberOfUIsolinesPerFace(numUIsoLinesSB->value());
     _settings.setNumberOfVIsolinesPerFace(numVIsoLinesSB->value());
+    _settings.setDrawFaceBoundariesEnabled(cbDrawFaceBoundaries->isChecked());
 }
 
 void TIGLViewerSettingsDialog::updateEntries()
@@ -118,6 +119,7 @@ void TIGLViewerSettingsDialog::updateEntries()
     enumerateFaceCB->setChecked(_settings.enumerateFaces());
     numUIsoLinesSB->setValue(_settings.numFaceUIsosForDisplay());
     numVIsoLinesSB->setValue(_settings.numFaceVIsosForDisplay());
+    cbDrawFaceBoundaries->setChecked(_settings.drawFaceBoundaries());
 }
 
 void TIGLViewerSettingsDialog::onSliderTesselationChanged(int val)

--- a/TIGLViewer/src/TIGLViewerSettingsDialog.ui
+++ b/TIGLViewer/src/TIGLViewerSettingsDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>465</width>
-    <height>310</height>
+    <width>509</width>
+    <height>314</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,7 +86,7 @@
         </layout>
        </item>
        <item>
-        <spacer name="verticalSpacer_5">
+        <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -179,22 +179,6 @@
           </widget>
          </item>
         </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Preferred</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item>
         <widget class="QLabel" name="label_5">
@@ -294,27 +278,11 @@
         </layout>
        </item>
        <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Preferred</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>15</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QLabel" name="label_9">
            <property name="text">
-            <string>Background Color</string>
+            <string>Background color</string>
            </property>
           </widget>
          </item>
@@ -346,7 +314,14 @@
         </layout>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <widget class="QCheckBox" name="cbDrawFaceBoundaries">
+         <property name="text">
+          <string>Draw face boundaries</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/TIGLViewer/src/TIGLViewerWindow.cpp
+++ b/TIGLViewer/src/TIGLViewerWindow.cpp
@@ -408,6 +408,7 @@ void TIGLViewerWindow::applySettings()
     myOCC->setBackgroundGradient(col.red(), col.green(), col.blue());
     getScene()->getContext()->SetIsoNumber(tiglViewerSettings->numFaceUIsosForDisplay(), AIS_TOI_IsoU);
     getScene()->getContext()->SetIsoNumber(tiglViewerSettings->numFaceVIsosForDisplay(), AIS_TOI_IsoV);
+    getScene()->setFaceBoundariesEnabled(tiglViewerSettings->drawFaceBoundaries());
     getScene()->getContext()->UpdateCurrentViewer();
     if (tiglViewerSettings->debugBooleanOperations()) {
         qputenv("TIGL_DEBUG_BOP", "1");


### PR DESCRIPTION
Implemented plotting face boundaries as black lines.

This option can be turned on/off in the settings menu.

![Bildschirmfoto von »2019-10-10 13-25-13«](https://user-images.githubusercontent.com/3213107/66807551-93919500-ef29-11e9-9878-8479517fecaa.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
