### PR TITLE
Add bounding box check to `tiglCheckPointInside`

### DIFF
--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -6895,10 +6895,10 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglCheckPointInside(TiglCPACSConfigurationHan
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
 
         // get component
-        tigl::ITiglGeometricComponent& component = config.GetUIDManager().GetGeometricComponent(componentUID);
+        tigl::CTiglAbstractGeometricComponent& component = static_cast<tigl::CTiglAbstractGeometricComponent&>(config.GetUIDManager().GetGeometricComponent(componentUID));
 
         const TopoDS_Shape shape = component.GetLoft()->Shape();
-        *isInside = IsPointInsideShape(shape, gp_Pnt(px, py, pz)) ? TIGL_TRUE : TIGL_FALSE;
+        *isInside = IsPointInsideShape(shape, gp_Pnt(px, py, pz), &component.GetBoundingBox()) ? TIGL_TRUE : TIGL_FALSE;
 
         return TIGL_SUCCESS;
     }

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -4683,6 +4683,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglLogSetVerbosity(TiglLogLevel level);
 
 /**
  * @brief Checks whether a point lies inside the given geometric object.
+ * Note that the symmetry attribute is ignored.
  *
  * This function works only for solid objects!
  *

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1547,6 +1547,14 @@ bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point)
         throw tigl::CTiglError("The shape is not a solid");
     }
 
+    // first, check if the point is in the bounding box
+    Bnd_Box boundingBox;
+    BRepBndLib::Add(s, boundingBox);
+    if ( boundingBox.IsOut(point) ) {
+        return false;
+    }
+
+    // if the point is inside the bounding box, classify the point using BRepClass3d_SolidClassifier
     BRepClass3d_SolidClassifier algo(s);
 
     // test whether a point at infinity lies inside. If yes, then the shape is reversed

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1538,6 +1538,8 @@ TopoDS_Shape RemoveDuplicateEdges(const TopoDS_Shape& shape)
 
 bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point)
 {
+    double tol = 1e-3;
+
     // check if solid
     TopoDS_Solid s;
     try {
@@ -1550,6 +1552,7 @@ bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point)
     // first, check if the point is in the bounding box
     Bnd_Box boundingBox;
     BRepBndLib::Add(s, boundingBox);
+    boundingBox.Enlarge(tol);
     if ( boundingBox.IsOut(point) ) {
         return false;
     }
@@ -1558,11 +1561,11 @@ bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point)
     BRepClass3d_SolidClassifier algo(s);
 
     // test whether a point at infinity lies inside. If yes, then the shape is reversed
-    algo.PerformInfinitePoint(1e-3);
+    algo.PerformInfinitePoint(tol);
 
     bool shapeIsReversed = (algo.State() == TopAbs_IN);
 
-    algo.Perform(point, 1e-3);
+    algo.Perform(point, tol);
 
     return ((algo.State() == TopAbs_IN) != shapeIsReversed ) || (algo.State() == TopAbs_ON);
 }

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1536,7 +1536,7 @@ TopoDS_Shape RemoveDuplicateEdges(const TopoDS_Shape& shape)
 }
 
 
-bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point)
+bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point, Bnd_Box const* bounding_box)
 {
     double tol = 1e-3;
 
@@ -1550,11 +1550,14 @@ bool IsPointInsideShape(const TopoDS_Shape &solid, gp_Pnt point)
     }
 
     // first, check if the point is in the bounding box
-    Bnd_Box boundingBox;
-    BRepBndLib::Add(s, boundingBox);
-    boundingBox.Enlarge(tol);
-    if ( boundingBox.IsOut(point) ) {
-        return false;
+    if (bounding_box) {
+        // create a copy of the const bounding box to be able to enlarge by tolerance
+        Bnd_Box bb;
+        bb.Add(*bounding_box);
+        bb.Enlarge(tol);
+        if ( bb.IsOut(point) ) {
+            return false;
+        }
     }
 
     // if the point is inside the bounding box, classify the point using BRepClass3d_SolidClassifier

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -151,8 +151,9 @@ TIGL_EXPORT bool GetIntersectionPoint(const TopoDS_Face& face, const TopoDS_Wire
 // Comuptes the intersection points of two wires
 TIGL_EXPORT bool GetIntersectionPoint(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2, intersectionPointList& intersectionPoints, const double tolerance=Precision::SquareConfusion());
 
-// Checks, whether a points lies inside a given shape, which must be a solid
-TIGL_EXPORT bool IsPointInsideShape(const TopoDS_Shape& solid, gp_Pnt point);
+// Checks, whether a points lies inside a given shape, which must be a solid.
+// An optional bounding box can be passed to include a bounding box test as a prephase
+TIGL_EXPORT bool IsPointInsideShape(const TopoDS_Shape& solid, gp_Pnt point, Bnd_Box const* bounding_box = nullptr);
 
 // Checks, whether a point lies inside a given face
 TIGL_EXPORT bool IsPointInsideFace(const TopoDS_Face& face, gp_Pnt point);

--- a/src/geometry/CTiglAbstractGeometricComponent.cpp
+++ b/src/geometry/CTiglAbstractGeometricComponent.cpp
@@ -36,10 +36,12 @@ namespace tigl
 {
 CTiglAbstractGeometricComponent::CTiglAbstractGeometricComponent()
     : loft(*this, &CTiglAbstractGeometricComponent::BuildLoft)
+    , bounding_box(*this, &CTiglAbstractGeometricComponent::CalcBoundingBox)
 {
 }
 
 void CTiglAbstractGeometricComponent::Reset() {
+    bounding_box.clear();
     loft.clear();
 }
 
@@ -51,6 +53,11 @@ TiglSymmetryAxis CTiglAbstractGeometricComponent::GetSymmetryAxis() const
 PNamedShape CTiglAbstractGeometricComponent::GetLoft() const
 {
     return *loft;
+}
+
+Bnd_Box const& CTiglAbstractGeometricComponent::GetBoundingBox() const
+{
+    return *bounding_box;
 }
 
 PNamedShape CTiglAbstractGeometricComponent::GetMirroredLoft()
@@ -143,6 +150,11 @@ bool CTiglAbstractGeometricComponent::GetIsOnMirrored(const gp_Pnt& pnt)
 void CTiglAbstractGeometricComponent::BuildLoft(PNamedShape& cache) const
 {
     cache = BuildLoft();
+}
+
+void CTiglAbstractGeometricComponent::CalcBoundingBox(Bnd_Box& bb) const
+{
+    BRepBndLib::Add(loft->get()->Shape(), bb);
 }
 
 } // end namespace tigl

--- a/src/geometry/CTiglAbstractGeometricComponent.h
+++ b/src/geometry/CTiglAbstractGeometricComponent.h
@@ -29,6 +29,8 @@
 #include "ITiglGeometricComponent.h"
 #include "Cache.h"
 
+#include "Bnd_Box.hxx"
+
 namespace tigl
 {
 class CCPACSTransformation;
@@ -56,16 +58,21 @@ public:
     // if the loft as no symmetry, false is returned
     TIGL_EXPORT bool GetIsOnMirrored(const gp_Pnt &pnt);
 
+    // returns the bounding box of this component's loft
+    TIGL_EXPORT Bnd_Box const& GetBoundingBox() const;
+
 protected:
     virtual PNamedShape BuildLoft() const = 0;
 
     Cache<PNamedShape, CTiglAbstractGeometricComponent> loft;
+    Cache<Bnd_Box, CTiglAbstractGeometricComponent> bounding_box;
 
 private:
     CTiglAbstractGeometricComponent(const CTiglAbstractGeometricComponent&);
     void operator=(const CTiglAbstractGeometricComponent&);
 
     void BuildLoft(PNamedShape& cache) const;
+    void CalcBoundingBox(Bnd_Box& bb) const;
 };
 
 } // end namespace tigl

--- a/tests/unittests/testperformance.cpp
+++ b/tests/unittests/testperformance.cpp
@@ -178,8 +178,7 @@ TEST_F(TestPerformance, tiglCheckPointInside_false)
     ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_SL1", &point_inside));
     ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_FL1", &point_inside));
 
-
-    int nruns = 1000;
+    int nruns = 100000;
     double n;
 
     clock_t start, stop;

--- a/tests/unittests/testperformance.cpp
+++ b/tests/unittests/testperformance.cpp
@@ -161,3 +161,85 @@ TEST_F(TestPerformance, pointTranslator)
 
     ASSERT_TRUE(true);
 }
+
+
+TEST_F(TestPerformance, tiglCheckPointInside)
+{
+    // some points that are exclusively in one component
+    tigl::CTiglPoint pointInFuselage(5., 0., 0.);
+    tigl::CTiglPoint pointInWing(16., 6., -1.);
+    tigl::CTiglPoint pointInVTP(34., 0., 4.);
+    tigl::CTiglPoint pointInSpace(1000., 1000., 1000.);
+
+    TiglBoolean fusePointInside  = TIGL_FALSE;
+    TiglBoolean wingPointInside  = TIGL_FALSE;
+    TiglBoolean vtpPointInside   = TIGL_FALSE;
+    TiglBoolean spacePointInside = TIGL_FALSE;
+
+    int nruns = 50;
+    double n;
+
+    clock_t start, stop;
+    double time_elapsed;
+
+    // test the four points against the wing
+    n = 0.;
+    start = clock();
+    for(int i = 0; i < nruns; ++i){
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInFuselage.x, pointInFuselage.y, pointInFuselage.z, "D150_VAMP_W1", &fusePointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInWing.x    , pointInWing.y    , pointInWing.z    , "D150_VAMP_W1", &wingPointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInVTP.x     , pointInVTP.y     , pointInVTP.z     , "D150_VAMP_W1", &vtpPointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInSpace.x   , pointInSpace.y   , pointInSpace.z   , "D150_VAMP_W1", &spacePointInside));
+        n += 1.;  //dummy to prevent compiler optimization
+    }
+    stop = clock();
+
+    ASSERT_FALSE(fusePointInside);
+    ASSERT_TRUE(wingPointInside);
+    ASSERT_FALSE(vtpPointInside);
+    ASSERT_FALSE(spacePointInside);
+
+    time_elapsed = (double)(stop - start)/(double)CLOCKS_PER_SEC/(double)nruns * 1000000.;
+    std::cout << "Time tiglCheckPointInside wing [us]: " << time_elapsed << std::endl;
+
+    // test the four points against the vtp
+    n = 0.;
+    start = clock();
+    for(int i = 0; i < nruns; ++i){
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInFuselage.x, pointInFuselage.y, pointInFuselage.z, "D150_VAMP_SL1", &fusePointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInWing.x    , pointInWing.y    , pointInWing.z    , "D150_VAMP_SL1", &wingPointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInVTP.x     , pointInVTP.y     , pointInVTP.z     , "D150_VAMP_SL1", &vtpPointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInSpace.x   , pointInSpace.y   , pointInSpace.z   , "D150_VAMP_SL1", &spacePointInside));
+        n += 1.;  //dummy to prevent compiler optimization
+    }
+    stop = clock();
+
+    ASSERT_FALSE(fusePointInside);
+    ASSERT_FALSE(wingPointInside);
+    ASSERT_TRUE(vtpPointInside);
+    ASSERT_FALSE(spacePointInside);
+
+    time_elapsed = (double)(stop - start)/(double)CLOCKS_PER_SEC/(double)nruns * 1000000.;
+    std::cout << "Time tiglCheckPointInside vtp [us]: " << time_elapsed << std::endl;
+
+
+    // test the four points against the fuselage
+    n = 0.;
+    start = clock();
+    for(int i = 0; i < nruns; ++i){
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInFuselage.x, pointInFuselage.y, pointInFuselage.z, "D150_VAMP_FL1", &fusePointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInWing.x    , pointInWing.y    , pointInWing.z    , "D150_VAMP_FL1", &wingPointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInVTP.x     , pointInVTP.y     , pointInVTP.z     , "D150_VAMP_FL1", &vtpPointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInSpace.x   , pointInSpace.y   , pointInSpace.z   , "D150_VAMP_FL1", &spacePointInside));
+        n += 1.;  //dummy to prevent compiler optimization
+    }
+    stop = clock();
+
+    ASSERT_TRUE(fusePointInside);
+    ASSERT_FALSE(wingPointInside);
+    ASSERT_FALSE(vtpPointInside);
+    ASSERT_FALSE(spacePointInside);
+
+    time_elapsed = (double)(stop - start)/(double)CLOCKS_PER_SEC/(double)nruns * 1000000.;
+    std::cout << "Time tiglCheckPointInside fuselage [us]: " << time_elapsed << std::endl;
+}

--- a/tests/unittests/testperformance.cpp
+++ b/tests/unittests/testperformance.cpp
@@ -22,6 +22,9 @@
 #include "CTiglPoint.h"
 #include "CTiglPointTranslator.h"
 
+#include "CNamedShape.h"
+#include "CCPACSConfigurationManager.h"
+
 #include <string.h>
 #include <ctime>
 
@@ -163,20 +166,20 @@ TEST_F(TestPerformance, pointTranslator)
 }
 
 
-TEST_F(TestPerformance, tiglCheckPointInside)
+TEST_F(TestPerformance, tiglCheckPointInside_false)
 {
-    // some points that are exclusively in one component
-    tigl::CTiglPoint pointInFuselage(5., 0., 0.);
-    tigl::CTiglPoint pointInWing(16., 6., -1.);
-    tigl::CTiglPoint pointInVTP(34., 0., 4.);
-    tigl::CTiglPoint pointInSpace(1000., 1000., 1000.);
 
-    TiglBoolean fusePointInside  = TIGL_FALSE;
-    TiglBoolean wingPointInside  = TIGL_FALSE;
-    TiglBoolean vtpPointInside   = TIGL_FALSE;
-    TiglBoolean spacePointInside = TIGL_FALSE;
+    // define some points that are exclusively in one component
+    tigl::CTiglPoint point(1000., 1000., 1000.);
+    TiglBoolean point_inside = TIGL_FALSE;
 
-    int nruns = 50;
+    // pre-build some geometries to warm start performance tests
+    ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_W1" , &point_inside));
+    ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_SL1", &point_inside));
+    ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_FL1", &point_inside));
+
+
+    int nruns = 1000;
     double n;
 
     clock_t start, stop;
@@ -186,18 +189,11 @@ TEST_F(TestPerformance, tiglCheckPointInside)
     n = 0.;
     start = clock();
     for(int i = 0; i < nruns; ++i){
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInFuselage.x, pointInFuselage.y, pointInFuselage.z, "D150_VAMP_W1", &fusePointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInWing.x    , pointInWing.y    , pointInWing.z    , "D150_VAMP_W1", &wingPointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInVTP.x     , pointInVTP.y     , pointInVTP.z     , "D150_VAMP_W1", &vtpPointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInSpace.x   , pointInSpace.y   , pointInSpace.z   , "D150_VAMP_W1", &spacePointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_W1", &point_inside));
         n += 1.;  //dummy to prevent compiler optimization
     }
     stop = clock();
-
-    ASSERT_FALSE(fusePointInside);
-    ASSERT_TRUE(wingPointInside);
-    ASSERT_FALSE(vtpPointInside);
-    ASSERT_FALSE(spacePointInside);
+    ASSERT_FALSE(point_inside);
 
     time_elapsed = (double)(stop - start)/(double)CLOCKS_PER_SEC/(double)nruns * 1000000.;
     std::cout << "Time tiglCheckPointInside wing [us]: " << time_elapsed << std::endl;
@@ -206,18 +202,11 @@ TEST_F(TestPerformance, tiglCheckPointInside)
     n = 0.;
     start = clock();
     for(int i = 0; i < nruns; ++i){
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInFuselage.x, pointInFuselage.y, pointInFuselage.z, "D150_VAMP_SL1", &fusePointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInWing.x    , pointInWing.y    , pointInWing.z    , "D150_VAMP_SL1", &wingPointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInVTP.x     , pointInVTP.y     , pointInVTP.z     , "D150_VAMP_SL1", &vtpPointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInSpace.x   , pointInSpace.y   , pointInSpace.z   , "D150_VAMP_SL1", &spacePointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_SL1", &point_inside));
         n += 1.;  //dummy to prevent compiler optimization
     }
     stop = clock();
-
-    ASSERT_FALSE(fusePointInside);
-    ASSERT_FALSE(wingPointInside);
-    ASSERT_TRUE(vtpPointInside);
-    ASSERT_FALSE(spacePointInside);
+    ASSERT_FALSE(point_inside);
 
     time_elapsed = (double)(stop - start)/(double)CLOCKS_PER_SEC/(double)nruns * 1000000.;
     std::cout << "Time tiglCheckPointInside vtp [us]: " << time_elapsed << std::endl;
@@ -227,18 +216,11 @@ TEST_F(TestPerformance, tiglCheckPointInside)
     n = 0.;
     start = clock();
     for(int i = 0; i < nruns; ++i){
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInFuselage.x, pointInFuselage.y, pointInFuselage.z, "D150_VAMP_FL1", &fusePointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInWing.x    , pointInWing.y    , pointInWing.z    , "D150_VAMP_FL1", &wingPointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInVTP.x     , pointInVTP.y     , pointInVTP.z     , "D150_VAMP_FL1", &vtpPointInside));
-        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, pointInSpace.x   , pointInSpace.y   , pointInSpace.z   , "D150_VAMP_FL1", &spacePointInside));
+        ASSERT_EQ(TIGL_SUCCESS, tiglCheckPointInside(tiglHandle, point.x, point.y, point.z, "D150_VAMP_FL1", &point_inside));
         n += 1.;  //dummy to prevent compiler optimization
     }
     stop = clock();
-
-    ASSERT_TRUE(fusePointInside);
-    ASSERT_FALSE(wingPointInside);
-    ASSERT_FALSE(vtpPointInside);
-    ASSERT_FALSE(spacePointInside);
+    ASSERT_FALSE(point_inside);
 
     time_elapsed = (double)(stop - start)/(double)CLOCKS_PER_SEC/(double)nruns * 1000000.;
     std::cout << "Time tiglCheckPointInside fuselage [us]: " << time_elapsed << std::endl;


### PR DESCRIPTION
## Description

This PR adds a bounding box check as a pre-phase to `IsPointInsideShape` to improve the performance of `tiglCheckPointInside`.

This PR fixes #646

## How Has This Been Tested?

A new performance test has been added to the unit tests. For the [`CPACS_30_D150`](https://github.com/DLR-SC/tigl/blob/master/tests/unittests/TestData/CPACS_30_D150.xml) test case, four points are tested against three components, the wing, the VTP and the fuselage. Of the four points, one is exclusively in the wing, one in the VTP, one in the fuselage and one does not lie in any component. 

Thus, for each of the three tested components, three of four points are outside of the bounding box, and one point should result in a return value `true`.

### Before

```bash
[ RUN      ] TestPerformance.tiglCheckPointInside
Time tiglCheckPointInside wing [us]: 8380
Time tiglCheckPointInside vtp [us]: 6520
Time tiglCheckPointInside fuselage [us]: 1.13424e+06
```

### After

```bash
[ RUN      ] TestPerformance.tiglCheckPointInside
Time tiglCheckPointInside wing [us]: 3260
Time tiglCheckPointInside vtp [us]: 1880
Time tiglCheckPointInside fuselage [us]: 335260
```

The new test also reveals some problems with the complexity of the fuselage shape, which is a known regression: #365.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- ~~New classes have been added to the Python interface.~~
- ~~API changes were documented properly in tigl.h.~~
