### PR TITLE
Added new api function tiglComponentGetType

### DIFF
--- a/bindings/java/src/de/dlr/sc/tigl3/TiglGeometricComponentIntentFlags.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglGeometricComponentIntentFlags.java
@@ -1,0 +1,56 @@
+/* 
+* Copyright (C) 2007-2013 German Aerospace Center (DLR/SC)
+*
+* Created: 2014-10-21 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* 
+* This file is automatically created from tigl.h on 2020-03-20.
+* If you experience any bugs please contact the authors
+*/
+
+package de.dlr.sc.tigl3;
+
+import java.util.ArrayList;
+
+public enum TiglGeometricComponentIntentFlags {
+    TIGL_INTENT_OUTER_AERO_SURFACE(8),
+    TIGL_INTENT_PHYSICAL(1),
+    TIGL_INTENT_LOGICAL(2),
+    TIGL_INTENT_INNER_STRUCTURE(4);
+
+    private static ArrayList<TiglGeometricComponentIntentFlags> codes = new ArrayList<>();
+
+    static {
+        codes.add(TIGL_INTENT_OUTER_AERO_SURFACE);
+        codes.add(TIGL_INTENT_PHYSICAL);
+        codes.add(TIGL_INTENT_LOGICAL);
+        codes.add(TIGL_INTENT_INNER_STRUCTURE);
+    }
+
+    private final int code;
+
+    private TiglGeometricComponentIntentFlags(final int value) {
+         code = value;
+    }
+
+    public static TiglGeometricComponentIntentFlags getEnum(final int value) {
+        return codes.get(Integer.valueOf(value));
+    }
+
+    public int getValue() {
+        return code;
+    }
+};

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglGeometricComponentType.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglGeometricComponentType.java
@@ -1,0 +1,98 @@
+/* 
+* Copyright (C) 2007-2013 German Aerospace Center (DLR/SC)
+*
+* Created: 2014-10-21 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* 
+* This file is automatically created from tigl.h on 2020-03-20.
+* If you experience any bugs please contact the authors
+*/
+
+package de.dlr.sc.tigl3;
+
+import java.util.ArrayList;
+
+public enum TiglGeometricComponentType {
+    TIGL_COMPONENT_PLANE(0),
+    TIGL_COMPONENT_FUSELAGE(1),
+    TIGL_COMPONENT_WING(2),
+    TIGL_COMPONENT_SEGMENT(3),
+    TIGL_COMPONENT_WINGSEGMENT(4),
+    TIGL_COMPONENT_FUSELSEGMENT(5),
+    TIGL_COMPONENT_WINGCOMPSEGMENT(6),
+    TIGL_COMPONENT_WINGSHELL(7),
+    TIGL_COMPONENT_WINGRIB(8),
+    TIGL_COMPONENT_WINGSPAR(9),
+    TIGL_COMPONENT_WINGCELL(10),
+    TIGL_COMPONENT_GENERICSYSTEM(11),
+    TIGL_COMPONENT_ROTOR(12),
+    TIGL_COMPONENT_ROTORBLADE(13),
+    TIGL_COMPONENT_ATTACHED_ROTORBLADE(14),
+    TIGL_COMPONENT_PRESSURE_BULKHEAD(15),
+    TIGL_COMPONENT_CROSS_BEAM_STRUT(16),
+    TIGL_COMPONENT_CARGO_DOOR(17),
+    TIGL_COMPONENT_LONG_FLOOR_BEAM(18),
+    TIGL_COMPONENT_EXTERNAL_OBJECT(19),
+    TIGL_COMPONENT_FARFIELD(20),
+    TIGL_COMPONENT_ENGINE_PYLON(21),
+    TIGL_COMPONENT_ENGINE_NACELLE(22),
+    TIGL_COMPONENT_FUSELAGE_WALL(23),
+    TIGL_COMPONENT_OTHER(24);
+
+    private static ArrayList<TiglGeometricComponentType> codes = new ArrayList<>();
+
+    static {
+        codes.add(TIGL_COMPONENT_PLANE);
+        codes.add(TIGL_COMPONENT_FUSELAGE);
+        codes.add(TIGL_COMPONENT_WING);
+        codes.add(TIGL_COMPONENT_SEGMENT);
+        codes.add(TIGL_COMPONENT_WINGSEGMENT);
+        codes.add(TIGL_COMPONENT_FUSELSEGMENT);
+        codes.add(TIGL_COMPONENT_WINGCOMPSEGMENT);
+        codes.add(TIGL_COMPONENT_WINGSHELL);
+        codes.add(TIGL_COMPONENT_WINGRIB);
+        codes.add(TIGL_COMPONENT_WINGSPAR);
+        codes.add(TIGL_COMPONENT_WINGCELL);
+        codes.add(TIGL_COMPONENT_GENERICSYSTEM);
+        codes.add(TIGL_COMPONENT_ROTOR);
+        codes.add(TIGL_COMPONENT_ROTORBLADE);
+        codes.add(TIGL_COMPONENT_ATTACHED_ROTORBLADE);
+        codes.add(TIGL_COMPONENT_PRESSURE_BULKHEAD);
+        codes.add(TIGL_COMPONENT_CROSS_BEAM_STRUT);
+        codes.add(TIGL_COMPONENT_CARGO_DOOR);
+        codes.add(TIGL_COMPONENT_LONG_FLOOR_BEAM);
+        codes.add(TIGL_COMPONENT_EXTERNAL_OBJECT);
+        codes.add(TIGL_COMPONENT_FARFIELD);
+        codes.add(TIGL_COMPONENT_ENGINE_PYLON);
+        codes.add(TIGL_COMPONENT_ENGINE_NACELLE);
+        codes.add(TIGL_COMPONENT_FUSELAGE_WALL);
+        codes.add(TIGL_COMPONENT_OTHER);
+    }
+
+    private final int code;
+
+    private TiglGeometricComponentType(final int value) {
+         code = value;
+    }
+
+    public static TiglGeometricComponentType getEnum(final int value) {
+        return codes.get(Integer.valueOf(value));
+    }
+
+    public int getValue() {
+        return code;
+    }
+};

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglGetPointBehavior.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglGetPointBehavior.java
@@ -1,0 +1,54 @@
+/* 
+* Copyright (C) 2007-2013 German Aerospace Center (DLR/SC)
+*
+* Created: 2014-10-21 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* 
+* This file is automatically created from tigl.h on 2020-03-20.
+* If you experience any bugs please contact the authors
+*/
+
+package de.dlr.sc.tigl3;
+
+import java.util.ArrayList;
+
+public enum TiglGetPointBehavior {
+    asParameterOnSurface(0),
+    onLinearLoft(1),
+    numGetPointBehaviors(2);
+
+    private static ArrayList<TiglGetPointBehavior> codes = new ArrayList<>();
+
+    static {
+        codes.add(asParameterOnSurface);
+        codes.add(onLinearLoft);
+        codes.add(numGetPointBehaviors);
+    }
+
+    private final int code;
+
+    private TiglGetPointBehavior(final int value) {
+         code = value;
+    }
+
+    public static TiglGetPointBehavior getEnum(final int value) {
+        return codes.get(Integer.valueOf(value));
+    }
+
+    public int getValue() {
+        return code;
+    }
+};

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglNativeInterface.java
@@ -17,7 +17,7 @@
 */
 
 /* 
-* This file is automatically created from tigl.h on 2019-09-24.
+* This file is automatically created from tigl.h on 2020-03-20.
 * If you experience any bugs please contact the authors
 */
 
@@ -77,6 +77,8 @@ public class TiglNativeInterface {
     public static native int tiglWingComponentSegmentComputeEtaIntersection(int cpacsHandle, String componentSegmentUID, double csEta1, double csXsi1, double csEta2, double csXsi2, double eta, DoubleByReference xsi, IntByReference hasWarning);
     public static native int tiglWingComponentSegmentGetNumberOfSegments(int cpacsHandle, String componentSegmentUID, IntByReference nsegments);
     public static native int tiglWingComponentSegmentGetSegmentUID(int cpacsHandle, String componentSegmentUID, int segmentIndex, PointerByReference segmentUID);
+    public static native int tiglWingGetSpan(int cpacsHandle, String wingUID, DoubleByReference pSpan);
+    public static native int tiglWingGetMAC(int cpacsHandle, String wingUID, DoubleByReference mac_chord, DoubleByReference mac_x, DoubleByReference mac_y, DoubleByReference mac_z);
     public static native int tiglGetFuselageCount(int cpacsHandle, IntByReference fuselageCountPtr);
     public static native int tiglFuselageGetSegmentCount(int cpacsHandle, int fuselageIndex, IntByReference segmentCountPtr);
     public static native int tiglFuselageGetSectionCenter(int cpacsHandle, String fuselageSegmentUID, double eta, DoubleByReference pointX, DoubleByReference pointY, DoubleByReference pointZ);
@@ -188,10 +190,9 @@ public class TiglNativeInterface {
     public static native int tiglLogSetVerbosity(int level);
     public static native int tiglCheckPointInside(int cpacsHandle, double px, double py, double pz, String componentUID, IntByReference isInside);
     public static native int tiglComponentGetHashCode(int cpacsHandle, String componentUID, IntByReference hashCodePtr);
+    public static native int tiglComponentGetType(int cpacsHandle, String componentUID, IntByReference typePtr);
     public static native String tiglGetErrorString(int errorCode);
     public static native void tiglSetDebugDataDirectory(String directory);
     public static native int tiglConfigurationGetLength(int cpacsHandle, DoubleByReference pLength);
     public static native int tiglConfigurationGetBoundingBox(int cpacsHandle, DoubleByReference minX, DoubleByReference minY, DoubleByReference minZ, DoubleByReference maxX, DoubleByReference maxY, DoubleByReference maxZ);
-    public static native int tiglWingGetSpan(int cpacsHandle, String wingUID, DoubleByReference pSpan);
-    public static native int tiglWingGetMAC(int cpacsHandle, String wingUID, DoubleByReference mac_chord, DoubleByReference mac_x, DoubleByReference mac_y, DoubleByReference mac_z);
 };

--- a/bindings/java/src/de/dlr/sc/tigl3/TiglShapeModifier.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/TiglShapeModifier.java
@@ -1,0 +1,54 @@
+/* 
+* Copyright (C) 2007-2013 German Aerospace Center (DLR/SC)
+*
+* Created: 2014-10-21 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* 
+* This file is automatically created from tigl.h on 2020-03-20.
+* If you experience any bugs please contact the authors
+*/
+
+package de.dlr.sc.tigl3;
+
+import java.util.ArrayList;
+
+public enum TiglShapeModifier {
+    UNMODIFIED_SHAPE(0),
+    SHARP_TRAILINGEDGE(1),
+    BLUNT_TRAILINGEDGE(2);
+
+    private static ArrayList<TiglShapeModifier> codes = new ArrayList<>();
+
+    static {
+        codes.add(UNMODIFIED_SHAPE);
+        codes.add(SHARP_TRAILINGEDGE);
+        codes.add(BLUNT_TRAILINGEDGE);
+    }
+
+    private final int code;
+
+    private TiglShapeModifier(final int value) {
+         code = value;
+    }
+
+    public static TiglShapeModifier getEnum(final int value) {
+        return codes.get(Integer.valueOf(value));
+    }
+
+    public int getValue() {
+        return code;
+    }
+};

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -6696,6 +6696,50 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglComponentGetHashCode(TiglCPACSConfiguratio
     }
 }
 
+TIGL_COMMON_EXPORT TiglReturnCode tiglComponentGetType(TiglCPACSConfigurationHandle cpacsHandle,
+                                                       const char* componentUID,
+                                                       TiglGeometricComponentType* typePtr)
+{
+    if (!componentUID) {
+        LOG(ERROR) << "Null pointer argument for componentUID\n"
+                   << "in function call to tiglComponentGetType.";
+        return TIGL_NULL_POINTER;
+    }
+
+    if (!typePtr) {
+        LOG(ERROR) << "Null pointer argument for typePtr\n"
+                   << "in function call to tiglComponentGetType.";
+        return TIGL_NULL_POINTER;
+    }
+    try {
+        tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+        tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
+
+        tigl::CTiglUIDManager& uidManager = config.GetUIDManager();
+
+        if (uidManager.HasGeometricComponent(componentUID)) {
+            const auto& component = uidManager.GetGeometricComponent(componentUID);
+            *typePtr = component.GetComponentType();
+            return TIGL_SUCCESS;
+        }
+        else {
+            return TIGL_UID_ERROR;
+        }
+    }
+    catch (const tigl::CTiglError& ex) {
+        LOG(ERROR) << ex.what();
+        return ex.getCode();
+    }
+    catch (std::exception& ex) {
+        LOG(ERROR) << ex.what();
+        return TIGL_ERROR;
+    }
+    catch (...) {
+        LOG(ERROR) << "Caught an exception in tiglComponentGetType!";
+        return TIGL_ERROR;
+    }
+}
+
 TIGL_COMMON_EXPORT const char * tiglGetErrorString(TiglReturnCode code)
 {
     if (code > TIGL_MATH_ERROR || code < 0) {

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -199,9 +199,9 @@ TIGL_COMPONENT_WINGSEGMENT,      /**< The Component is a wing segment */
 TIGL_COMPONENT_FUSELSEGMENT,     /**< The Component is a fuselage segment */
 TIGL_COMPONENT_WINGCOMPSEGMENT,  /**< The Component is a wing component segment */
 TIGL_COMPONENT_WINGSHELL,        /**< The Component is a face of the wing (e.g. upper wing surface) */
-TIGL_COMPONENT_WINGRIB,
-TIGL_COMPONENT_WINGSPAR,
-TIGL_COMPONENT_WINGCELL,
+TIGL_COMPONENT_WINGRIB,          /**< The Component is rib (set) of a wing */
+TIGL_COMPONENT_WINGSPAR,         /**< The Component is a spar segment */
+TIGL_COMPONENT_WINGCELL,         /**< The Component is a cell on the wing */
 TIGL_COMPONENT_GENERICSYSTEM,    /**< The Component is a generic system */
 TIGL_COMPONENT_ROTOR,            /**< The Component is a rotor */
 TIGL_COMPONENT_ROTORBLADE,       /**< The Component is a rotor blade */
@@ -4728,6 +4728,22 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglComponentGetHashCode(TiglCPACSConfiguratio
                                                            const char* componentUID,
                                                            int* hashCodePtr);
 
+/**
+* @brief Returns the type of a geometric component
+* @param[in]  cpacsHandle     Handle for the CPACS configuration
+* @param[in]  componentUID    The uid of the component for which the hash should be computed
+* @param[out] typePtr         A pointer to a TiglGeometricComponentType to store the result
+*
+* @return
+*   - TIGL_SUCCESS if no error occurred
+*   - TIGL_NOT_FOUND if no configuration was found for the given handle
+*   - TIGL_UID_ERROR if the uid is invalid or not a known geometric component
+*   - TIGL_NULL_POINTER if componentUID or typePtr is a null pointer
+*   - TIGL_ERROR if some other error occurred
+*/
+TIGL_COMMON_EXPORT TiglReturnCode tiglComponentGetType(TiglCPACSConfigurationHandle cpacsHandle,
+                                                       const char* componentUID,
+                                                       TiglGeometricComponentType* typePtr);
 
 /**
 * @brief Translates an error code into a string

--- a/tests/unittests/cpacsConfiguration.cpp
+++ b/tests/unittests/cpacsConfiguration.cpp
@@ -261,3 +261,28 @@ TEST_F(SimpleConfigurationTests, GetBoundingBox)
     EXPECT_NEAR(-0.75, minZ, 1e-1);
     EXPECT_NEAR( 0.5, maxZ, 1e-1);
 }
+
+TEST_F(SimpleConfigurationTests, GetComponentType)
+{
+    TiglGeometricComponentType type;
+    EXPECT_EQ(TIGL_SUCCESS, tiglComponentGetType(tiglHandle, "Wing", &type));
+    EXPECT_EQ(TIGL_COMPONENT_WING, type);
+
+    EXPECT_EQ(TIGL_SUCCESS, tiglComponentGetType(tiglHandle, "Cpacs2Test_Wing_Seg_1_2", &type));
+    EXPECT_EQ(TIGL_COMPONENT_WINGSEGMENT, type);
+
+    EXPECT_EQ(TIGL_SUCCESS, tiglComponentGetType(tiglHandle, "WING_CS1", &type));
+    EXPECT_EQ(TIGL_COMPONENT_WINGCOMPSEGMENT, type);
+
+    EXPECT_EQ(TIGL_SUCCESS, tiglComponentGetType(tiglHandle, "SimpleFuselage", &type));
+    EXPECT_EQ(TIGL_COMPONENT_FUSELAGE, type);
+
+    EXPECT_EQ(TIGL_SUCCESS, tiglComponentGetType(tiglHandle, "segmentD150_Fuselage_1Segment2ID", &type));
+    EXPECT_EQ(TIGL_COMPONENT_FUSELSEGMENT, type);
+
+    // test error codes
+    EXPECT_EQ(TIGL_UID_ERROR, tiglComponentGetType(tiglHandle, "this_uid_does_not_exist", &type));
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglComponentGetType(tiglHandle, nullptr, &type));
+    EXPECT_EQ(TIGL_NULL_POINTER, tiglComponentGetType(tiglHandle, "SimpleFuselage", nullptr));
+    EXPECT_EQ(TIGL_NOT_FOUND, tiglComponentGetType(-1, "SimpleFuselage", &type));
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added new api function tiglComponentGetType, which returns the type of a geometric element, given its UID.


## Description
The basically adds an api function for a functionality we already have in TiGL.
Why is this necessary? Sometimes you need to know, whether you are on a component segment or e.g. a trailing edge device. This makes it possible.

Closes #663

## How Has This Been Tested?
I created a simple test that checks some of the most common elements.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] A test for the new functionality was added.
- [X] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [X] New classes have been added to the Python interface. (it is an api function, so it is automatically done)
- [x] API changes were documented properly in tigl.h.
