### PR TITLE
Remove Miniconda from Linux/MacOS Build Chain in Github CI

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -78,11 +78,15 @@ jobs:
   
     - name: Install dependencies (ubuntu)
       if: contains(matrix.config.os, 'ubuntu')
-      run: |
-        curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_18.04/Release.key | sudo apt-key add -
-        echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_18.04/ /" | sudo tee -a /etc/apt/sources.list 
-        sudo apt-get update -qq
-        sudo apt-get install -y lcov gcovr  libtixi3-dev liboce-dev doxygen cmake cmake-data sshpass
+      uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: |
+          curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_18.04/Release.key | sudo apt-key add -
+          echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_18.04/ /" | sudo tee -a /etc/apt/sources.list 
+          sudo apt-get update -qq
+          sudo apt-get install -y lcov gcovr  libtixi3-dev liboce-dev doxygen cmake cmake-data sshpass
         
     - name: Install dependencies (macos)
       if: contains(matrix.config.os, 'macos')
@@ -105,7 +109,7 @@ jobs:
           echo "::set-env name=CMAKE_PREFIX_PATH::${{ github.workspace }}/TIXI-3.0.3-Darwin:${{ github.workspace }}/oce.0.17.2.macos_static:/usr/local/opt/qt/"
           brew install qt
           
-    - name: Setup conda
+    - name: Setup conda (windows)
       if: contains(matrix.config.os, 'windows')
       uses: goanpeca/setup-miniconda@v1.0.2
       with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -12,6 +12,7 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/compiler-cache
   CLCACHE_DIR: ${{ github.workspace }}\compiler-cache
   CLCACHE_HARDLINK: 1
+  MACOSX_DEPLOYMENT_TARGET: "10.9"
   TIGL_NIGHTLY: "ON"
   TIGL_PYTHON_VER: "=3.6"
   TIGL_TIXI3_VER: ">=3.0.3"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -103,6 +103,7 @@ jobs:
           echo "::add-path::/tmp/doxygen"
           echo "::set-env name=DYLD_LIBRARY_PATH::${{ github.workspace }}/TIXI-3.0.3-Darwin/lib"
           echo "::set-env name=CMAKE_PREFIX_PATH::${{ github.workspace }}/TIXI-3.0.3-Darwin:${{ github.workspace }}/oce.0.17.2.macos_static:/usr/local/opt/qt/"
+          brew install qt
           
     - name: Setup conda
       if: contains(matrix.config.os, 'windows')

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TiGL
 
-![Continuous Integration](https://github.com/dlr-sc/tigl/workflows/Continuous%20Integration/badge.svg?event=schedule)
+![Continuous Integration](https://github.com/dlr-sc/tigl/workflows/Continuous%20Integration/badge.svg)
 [![codecov](https://codecov.io/gh/dlr-sc/tigl/branch/master/graph/badge.svg)](https://codecov.io/gh/dlr-sc/tigl)
 [![Apache 2.0](https://img.shields.io/crates/l/k)](https://github.com/DLR-SC/tigl/blob/cpacs_3/LICENSE.txt)
 [![Install with conda](https://anaconda.org/dlr-sc/tigl/badges/installer/conda.svg)](https://conda.anaconda.org/dlr-sc/tigl3)


### PR DESCRIPTION
@rainman110, could you please check if the MacOS artifact works on older distros than 10.15 once the CI runs are through?

fixes #676 
