### PR TITLE
add CTiglControlSurfaceTransformation to python bindings

### DIFF
--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -77,6 +77,7 @@
 #include "generated/CPACSControlSurfaceTracks.h"
 #include "generated/CPACSControlSurfaceTrackType.h"
 #include "generated/CPACSTrailingEdgeDevice.h"
+#include "CTiglControLSurfaceTransformation.h"
 #include "CCPACSTrailingEdgeDevice.h"
 #include "CCPACSEnginePylons.h"
 #include "CCPACSEnginePylon.h"
@@ -258,6 +259,7 @@ namespace tigl
 %include "generated/CPACSControlSurfaceSkinCutOutBorder.h"
 %include "generated/CPACSCutOutControlPoints.h"
 %include "generated/CPACSControlSurfacePath.h"
+%include "CTiglControLSurfaceTransformation.h"
 %include "CTiglControlSurfaceBorderCoordinateSystem.h"
 %ignore ComponentSegment(const CCPACSControlSurfaceBorderTrailingEdge&);
 %include "generated/CPACSControlSurfaceBorderTrailingEdge.h"


### PR DESCRIPTION
fixes #692
