### PR TITLE
Implemented new symmetry flags

### DIFF
--- a/cpacs_gen_input/cpacs_schema.xsd
+++ b/cpacs_gen_input/cpacs_schema.xsd
@@ -260,8 +260,8 @@ marko.alder@dlr.de
                                             <ddue:listItem>none</ddue:listItem>
                                             <ddue:listItem>inherit</ddue:listItem>
                                         </ddue:list>
-                                        By default, the symmetric of a component is inherited from its parent. If e.g. a wing is symmetricly defined, a pylon will also have a symmetry by default.
-                                        This symmetry inheritance can be broken, by explicitly deleting the symmetric with symmetry="none".
+                                        By default, the symmetry of a component is inherited from its parent. If e.g. a wing is symmetrically defined, a pylon will also have a symmetry by default.
+                                        This symmetry inheritance can be broken, by explicitly deleting the symmetry with symmetry="none".
                                     </ddue:para>
                                 </ddue:content>
                             </ddue:section>

--- a/cpacs_gen_input/cpacs_schema.xsd
+++ b/cpacs_gen_input/cpacs_schema.xsd
@@ -257,7 +257,11 @@ marko.alder@dlr.de
                                             <ddue:listItem>x-y-plane</ddue:listItem>
                                             <ddue:listItem>x-z-plane</ddue:listItem>
                                             <ddue:listItem>y-z-plane</ddue:listItem>
+                                            <ddue:listItem>none</ddue:listItem>
+                                            <ddue:listItem>inherit</ddue:listItem>
                                         </ddue:list>
+                                        By default, the symmetric of a component is inherited from its parent. If e.g. a wing is symmetricly defined, a pylon will also have a symmetry by default.
+                                        This symmetry inheritance can be broken, by explicitly deleting the symmetric with symmetry="none".
                                     </ddue:para>
                                 </ddue:content>
                             </ddue:section>
@@ -21534,6 +21538,8 @@ marko.alder@dlr.de
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -21614,6 +21620,8 @@ marko.alder@dlr.de
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -24621,6 +24629,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -25109,6 +25119,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -25272,6 +25284,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -25711,6 +25725,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -31096,6 +31112,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -33496,6 +33514,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -34505,6 +34525,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -34585,6 +34607,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                         <xsd:restriction base="xsd:string">
                             <xsd:enumeration value="x-axis"/>
                             <xsd:enumeration value="y-axis"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -37090,6 +37114,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>
@@ -42078,6 +42104,8 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             <xsd:enumeration value="x-y-plane"/>
                             <xsd:enumeration value="x-z-plane"/>
                             <xsd:enumeration value="y-z-plane"/>
+                            <xsd:enumeration value="none"/>
+                            <xsd:enumeration value="inherit"/>
                         </xsd:restriction>
                     </xsd:simpleType>
                 </xsd:attribute>

--- a/src/TiglSymmetryAxis.h
+++ b/src/TiglSymmetryAxis.h
@@ -30,13 +30,15 @@ inline std::string TiglSymmetryAxisToString(const TiglSymmetryAxis& value)
 {
     switch (value) {
     case TIGL_NO_SYMMETRY:
-        return "";
+        return "none";
     case TIGL_X_Y_PLANE:
         return "x-y-plane";
     case TIGL_X_Z_PLANE:
         return "x-z-plane";
     case TIGL_Y_Z_PLANE:
         return "y-z-plane";
+    case TIGL_INHERIT_SYMMETRY:
+        return "inherit";
     default:
         throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) +
                          "\" for enum type TiglSymmetryAxis");
@@ -48,11 +50,17 @@ inline TiglSymmetryAxis stringToTiglSymmetryAxis(const std::string& value)
     if (value == "x-y-plane") {
         return TIGL_X_Y_PLANE;
     }
-    if (value == "x-z-plane") {
+    else if (value == "x-z-plane") {
         return TIGL_X_Z_PLANE;
     }
-    if (value == "y-z-plane") {
+    else if (value == "y-z-plane") {
         return TIGL_Y_Z_PLANE;
+    }
+    else if (value == "none") {
+        return TIGL_NO_SYMMETRY;
+    }
+    else if (value == "inherit") {
+        return TIGL_INHERIT_SYMMETRY;
     }
     return TIGL_NO_SYMMETRY;
 } // namespace tigl

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -152,10 +152,11 @@ typedef enum TiglBoolean TiglBoolean;
 */
 enum TiglSymmetryAxis
 {
-    TIGL_NO_SYMMETRY = 0,
-    TIGL_X_Y_PLANE   = 1,
-    TIGL_X_Z_PLANE   = 2,
-    TIGL_Y_Z_PLANE   = 3
+    TIGL_NO_SYMMETRY      = 0,
+    TIGL_X_Y_PLANE        = 1,
+    TIGL_X_Z_PLANE        = 2,
+    TIGL_Y_Z_PLANE        = 3,
+    TIGL_INHERIT_SYMMETRY = 4
 };
 
 /**
@@ -167,6 +168,7 @@ enum TiglSymmetryAxis
 *   - TIGL_X_Y_PLANE
 *   - TIGL_X_Z_PLANE
 *   - TIGL_Y_Z_PLANE
+*   - TIGL_INHERIT_SYMMETRY
 *
 */
 typedef enum TiglSymmetryAxis TiglSymmetryAxis;

--- a/src/engine_pylon/CCPACSEnginePylon.cpp
+++ b/src/engine_pylon/CCPACSEnginePylon.cpp
@@ -26,7 +26,7 @@ namespace tigl
 
 CCPACSEnginePylon::CCPACSEnginePylon(CCPACSEnginePylons* parent, CTiglUIDManager* uidMgr)
     : generated::CPACSEnginePylon(parent, uidMgr)
-    , CTiglRelativelyPositionedComponent(&m_parentUID, &m_transformation)
+    , CTiglRelativelyPositionedComponent(&m_parentUID, &m_transformation, &m_symmetry)
 {
 }
 

--- a/src/generated/CPACSCpacs.h
+++ b/src/generated/CPACSCpacs.h
@@ -120,7 +120,8 @@ namespace generated
     /// UID can either be named according to their appearance in the hierarchy e.g. uid=""mainWingKinkSection" or by automatically placing identifiers e.g. via processor runtime dates
     /// 6. Symmetry
     /// Sometimes it might be useful to specify a part of the aircraft as symmetric instead of holding all the data twice in nearly identical form in the dataset (e.g. left and right wing are usually identical, except for the sign of the y-coordinate). Hence, some parts offer the option to set a symmetry attribute for them, like:
-    /// <wing symmetry="x-z-plane">... This attribute explains that the whole part with all its subnodes is symmetric to the given plane. Possible planes are: x-y-plane x-z-plane y-z-plane 
+    /// <wing symmetry="x-z-plane">... This attribute explains that the whole part with all its subnodes is symmetric to the given plane. Possible planes are: x-y-plane x-z-plane y-z-plane none inherit By default, the symmetric of a component is inherited from its parent. If e.g. a wing is symmetricly defined, a pylon will also have a symmetry by default.
+    /// This symmetry inheritance can be broken, by explicitly deleting the symmetric with symmetry="none".
     /// UIDs, references and symmetry
     /// All nodes, e.g. parentUID, in CPACS that refer to a component that holds symmetry attribute, e.g. wing, have to carry the symmetry attribute as well.
     /// The symmetry attribute may take three values: symm, def, full: def: The element refers to the geometric component that has a symmetry attribute and refers only to the defined side of the geometric component. symm: The element refers to the geometric component that has a symmetry attribute and refers only to the symmetric side of the geometric component. (Similar to the previous _symm solution) full: The element refers to the geometric component that has a symmetry attribute and refers to the complete component. (This is the default behaviour) 

--- a/src/generated/CPACSProfileGeometry2DType_symmetry.h
+++ b/src/generated/CPACSProfileGeometry2DType_symmetry.h
@@ -33,7 +33,9 @@ namespace generated
     enum CPACSProfileGeometry2DType_symmetry
     {
         x_axis,
-        y_axis
+        y_axis,
+        none,
+        inherit
     };
 
     inline std::string CPACSProfileGeometry2DType_symmetryToString(const CPACSProfileGeometry2DType_symmetry& value)
@@ -41,6 +43,8 @@ namespace generated
         switch(value) {
         case x_axis: return "x-axis";
         case y_axis: return "y-axis";
+        case none: return "none";
+        case inherit: return "inherit";
         default: throw CTiglError("Invalid enum value \"" + std_to_string(static_cast<int>(value)) + "\" for enum type CPACSProfileGeometry2DType_symmetry");
         }
     }
@@ -49,6 +53,8 @@ namespace generated
         auto toLower = [](std::string str) { for (char& c : str) { c = std::tolower(c); } return str; };
         if (toLower(value) == "x-axis") { return x_axis; }
         if (toLower(value) == "y-axis") { return y_axis; }
+        if (toLower(value) == "none") { return none; }
+        if (toLower(value) == "inherit") { return inherit; }
         throw CTiglError("Invalid string value \"" + value + "\" for enum type CPACSProfileGeometry2DType_symmetry");
     }
 } // namespace generated

--- a/src/geometry/CCPACSGenericSystem.cpp
+++ b/src/geometry/CCPACSGenericSystem.cpp
@@ -40,7 +40,7 @@ namespace tigl
 // Constructor
 CCPACSGenericSystem::CCPACSGenericSystem(CCPACSGenericSystems* parent, CTiglUIDManager* uidMgr)
 : generated::CPACSGenericSystem(parent, uidMgr)
-, CTiglRelativelyPositionedComponent(NULL, &m_transformation, &m_symmetry)
+, CTiglRelativelyPositionedComponent(static_cast<std::string*>(nullptr), &m_transformation, &m_symmetry)
 {
 }
 

--- a/src/geometry/CTiglRelativelyPositionedComponent.cpp
+++ b/src/geometry/CTiglRelativelyPositionedComponent.cpp
@@ -44,6 +44,9 @@ CTiglRelativelyPositionedComponent::CTiglRelativelyPositionedComponent(boost::op
 CTiglRelativelyPositionedComponent::CTiglRelativelyPositionedComponent(boost::optional<std::string>* parentUid, CCPACSTransformation* trans, TiglSymmetryAxis* symmetryAxis)
     : _parent(NULL), _parentUID(parentUid), _transformation(trans), _symmetryAxis(symmetryAxis) {}
 
+CTiglRelativelyPositionedComponent::CTiglRelativelyPositionedComponent(std::string* parentUid, CCPACSTransformation* trans, boost::optional<TiglSymmetryAxis>* symmetryAxis)
+    : _parent(NULL), _parentUID(parentUid), _transformation(trans), _symmetryAxis(symmetryAxis){}
+
 CTiglRelativelyPositionedComponent::CTiglRelativelyPositionedComponent(boost::optional<std::string>* parentUid, CCPACSTransformation* trans, boost::optional<TiglSymmetryAxis>* symmetryAxis)
     : _parent(NULL), _parentUID(parentUid), _transformation(trans), _symmetryAxis(symmetryAxis){}
 
@@ -62,7 +65,7 @@ TiglSymmetryAxis CTiglRelativelyPositionedComponent::GetSymmetryAxis() const
             : _parent(parent) {}
 
         TiglSymmetryAxis operator()(const TiglSymmetryAxis* s) {
-            if (s)
+            if (s && *s != TIGL_INHERIT_SYMMETRY)
                 return *s;
             else if (_parent)
                 return _parent->GetSymmetryAxis();
@@ -70,7 +73,7 @@ TiglSymmetryAxis CTiglRelativelyPositionedComponent::GetSymmetryAxis() const
                 return TIGL_NO_SYMMETRY;
         }
         TiglSymmetryAxis operator()(const boost::optional<TiglSymmetryAxis>* s) {
-            if (s && *s)
+            if (s && s->is_initialized() && s->value() != TIGL_INHERIT_SYMMETRY)
                 return **s;
             else if (_parent)
                 return _parent->GetSymmetryAxis();

--- a/src/geometry/CTiglRelativelyPositionedComponent.h
+++ b/src/geometry/CTiglRelativelyPositionedComponent.h
@@ -49,6 +49,7 @@ public:
     TIGL_EXPORT explicit CTiglRelativelyPositionedComponent(std::string* parentUid, CCPACSTransformation* trans);
     TIGL_EXPORT explicit CTiglRelativelyPositionedComponent(boost::optional<std::string>* parentUid, CCPACSTransformation* trans);
     TIGL_EXPORT CTiglRelativelyPositionedComponent(boost::optional<std::string>* parentUid, CCPACSTransformation* trans, TiglSymmetryAxis* symmetryAxis);
+    TIGL_EXPORT CTiglRelativelyPositionedComponent(std::string* parentUid, CCPACSTransformation* trans, boost::optional<TiglSymmetryAxis>* symmetryAxis);
     TIGL_EXPORT CTiglRelativelyPositionedComponent(boost::optional<std::string>* parentUid, CCPACSTransformation* trans, boost::optional<TiglSymmetryAxis>* symmetryAxis);
 
     TIGL_EXPORT void Reset() const;

--- a/tests/unittests/testSymmetry.cpp
+++ b/tests/unittests/testSymmetry.cpp
@@ -1,0 +1,101 @@
+/*
+* Copyright (C) 2020 German Aerospace Center (DLR/SC)
+*
+* Created: 2020-07-20 Martin Siggel <martin.siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* @file
+* @brief Tests for the parent / child symmetry behavior
+*/
+
+#include "test.h" // Brings in the GTest framework
+#include "tigl.h"
+#include "tigl_version.h"
+
+#include <CCPACSConfigurationManager.h>
+#include <CCPACSConfiguration.h>
+#include <CCPACSWing.h>
+#include <CCPACSEnginePylon.h>
+
+#include <memory>
+#include <string>
+
+/******************************************************************************/
+
+class tiglSymmetryTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        std::string filename = "TestData/simpletest-pylon.cpacs.xml";
+        phandle.reset(new TiglHandleWrapper(filename, ""));
+
+        auto& manager = tigl::CCPACSConfigurationManager::GetInstance();
+        auto& config = manager.GetConfiguration(*phandle);
+
+        pwing = &config.GetUIDManager().ResolveObject<tigl::CCPACSWing>("Wing");
+        ppylon = &config.GetUIDManager().ResolveObject<tigl::CCPACSEnginePylon>("Pylon");
+        ASSERT_TRUE(pwing && pwing->GetUID() == "Wing");
+        ASSERT_TRUE(ppylon && ppylon->GetUID() == "Pylon");
+    }
+
+    std::unique_ptr<TiglHandleWrapper> phandle;
+    tigl::CCPACSWing* pwing;
+    tigl::CCPACSEnginePylon* ppylon;
+};
+
+TEST_F(tiglSymmetryTest, symDefault)
+{
+    EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_X_Z_PLANE, ppylon->GetSymmetryAxis());
+}
+
+TEST_F(tiglSymmetryTest, symInheritWithParentSymmetry)
+{
+    ppylon->SetSymmetryAxis(TIGL_INHERIT_SYMMETRY);
+    EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_X_Z_PLANE, ppylon->GetSymmetryAxis());
+}
+
+TEST_F(tiglSymmetryTest, symInheritWithoutParentSymmetry)
+{
+    pwing->SetSymmetryAxis(TIGL_NO_SYMMETRY);
+    ppylon->SetSymmetryAxis(TIGL_INHERIT_SYMMETRY);
+    EXPECT_EQ(TIGL_NO_SYMMETRY, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_NO_SYMMETRY, ppylon->GetSymmetryAxis());
+}
+
+TEST_F(tiglSymmetryTest, symNone)
+{
+    ppylon->SetSymmetryAxis(TIGL_NO_SYMMETRY);
+    EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_NO_SYMMETRY, ppylon->GetSymmetryAxis());
+
+    // deleting the symmetry flag should fallback to default
+    // behaviour of inheriting the parent symmetry flag
+    ppylon->SetSymmetry(boost::optional<TiglSymmetryAxis>());
+
+    EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_X_Z_PLANE, ppylon->GetSymmetryAxis());
+}
+
+TEST_F(tiglSymmetryTest, differentSymmetries)
+{
+    pwing->SetSymmetryAxis(TIGL_X_Z_PLANE);
+    ppylon->SetSymmetryAxis(TIGL_X_Y_PLANE);
+    EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_X_Y_PLANE, ppylon->GetSymmetryAxis());
+}

--- a/tests/unittests/testSymmetry.cpp
+++ b/tests/unittests/testSymmetry.cpp
@@ -29,6 +29,7 @@
 #include <CCPACSConfiguration.h>
 #include <CCPACSWing.h>
 #include <CCPACSEnginePylon.h>
+#include <CCPACSFuselage.h>
 
 #include <memory>
 #include <string>
@@ -48,19 +49,23 @@ protected:
 
         pwing = &config.GetUIDManager().ResolveObject<tigl::CCPACSWing>("Wing");
         ppylon = &config.GetUIDManager().ResolveObject<tigl::CCPACSEnginePylon>("Pylon");
+        pfuselage = &config.GetUIDManager().ResolveObject<tigl::CCPACSFuselage>("SimpleFuselage");
         ASSERT_TRUE(pwing && pwing->GetUID() == "Wing");
         ASSERT_TRUE(ppylon && ppylon->GetUID() == "Pylon");
+        ASSERT_TRUE(pfuselage && pfuselage->GetUID() == "SimpleFuselage");
     }
 
     std::unique_ptr<TiglHandleWrapper> phandle;
     tigl::CCPACSWing* pwing;
     tigl::CCPACSEnginePylon* ppylon;
+    tigl::CCPACSFuselage* pfuselage;
 };
 
 TEST_F(tiglSymmetryTest, symDefault)
 {
     EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
     EXPECT_EQ(TIGL_X_Z_PLANE, ppylon->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_NO_SYMMETRY, pfuselage->GetSymmetryAxis());
 }
 
 TEST_F(tiglSymmetryTest, symInheritWithParentSymmetry)
@@ -68,6 +73,14 @@ TEST_F(tiglSymmetryTest, symInheritWithParentSymmetry)
     ppylon->SetSymmetryAxis(TIGL_INHERIT_SYMMETRY);
     EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
     EXPECT_EQ(TIGL_X_Z_PLANE, ppylon->GetSymmetryAxis());
+}
+
+TEST_F(tiglSymmetryTest, symInheritWithParentSymmetry2)
+{
+    pfuselage->SetSymmetryAxis(TIGL_X_Y_PLANE);
+    pwing->SetSymmetryAxis(TIGL_INHERIT_SYMMETRY);
+    EXPECT_EQ(TIGL_X_Y_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_X_Y_PLANE, ppylon->GetSymmetryAxis());
 }
 
 TEST_F(tiglSymmetryTest, symInheritWithoutParentSymmetry)
@@ -92,10 +105,47 @@ TEST_F(tiglSymmetryTest, symNone)
     EXPECT_EQ(TIGL_X_Z_PLANE, ppylon->GetSymmetryAxis());
 }
 
+TEST_F(tiglSymmetryTest, symNone2)
+{
+    pfuselage->SetSymmetryAxis(TIGL_X_Y_PLANE);
+
+    pwing->SetSymmetryAxis(TIGL_NO_SYMMETRY);
+    EXPECT_EQ(TIGL_NO_SYMMETRY, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_NO_SYMMETRY, ppylon->GetSymmetryAxis());
+
+    // deleting the symmetry flag should fallback to default
+    // behaviour of inheriting the parent symmetry flag
+    pwing->SetSymmetry(boost::optional<TiglSymmetryAxis>());
+
+    EXPECT_EQ(TIGL_X_Y_PLANE, pwing->GetSymmetryAxis());
+    EXPECT_EQ(TIGL_X_Y_PLANE, ppylon->GetSymmetryAxis());
+}
+
 TEST_F(tiglSymmetryTest, differentSymmetries)
 {
     pwing->SetSymmetryAxis(TIGL_X_Z_PLANE);
     ppylon->SetSymmetryAxis(TIGL_X_Y_PLANE);
     EXPECT_EQ(TIGL_X_Z_PLANE, pwing->GetSymmetryAxis());
     EXPECT_EQ(TIGL_X_Y_PLANE, ppylon->GetSymmetryAxis());
+}
+
+TEST_F(tiglSymmetryTest, toString)
+{
+   EXPECT_STREQ("none", tigl::TiglSymmetryAxisToString(TIGL_NO_SYMMETRY).c_str());
+   EXPECT_STREQ("x-y-plane", tigl::TiglSymmetryAxisToString(TIGL_X_Y_PLANE).c_str());
+   EXPECT_STREQ("x-z-plane", tigl::TiglSymmetryAxisToString(TIGL_X_Z_PLANE).c_str());
+   EXPECT_STREQ("y-z-plane", tigl::TiglSymmetryAxisToString(TIGL_Y_Z_PLANE).c_str());
+   EXPECT_STREQ("inherit", tigl::TiglSymmetryAxisToString(TIGL_INHERIT_SYMMETRY).c_str());
+
+   EXPECT_THROW(tigl::TiglSymmetryAxisToString(static_cast<TiglSymmetryAxis>(-1)), tigl::CTiglError);
+}
+
+TEST_F(tiglSymmetryTest, fromString)
+{
+    EXPECT_EQ(TIGL_NO_SYMMETRY, tigl::stringToTiglSymmetryAxis("none"));
+    EXPECT_EQ(TIGL_NO_SYMMETRY, tigl::stringToTiglSymmetryAxis(""));
+    EXPECT_EQ(TIGL_INHERIT_SYMMETRY, tigl::stringToTiglSymmetryAxis("inherit"));
+    EXPECT_EQ(TIGL_X_Y_PLANE, tigl::stringToTiglSymmetryAxis("x-y-plane"));
+    EXPECT_EQ(TIGL_X_Z_PLANE, tigl::stringToTiglSymmetryAxis("x-z-plane"));
+    EXPECT_EQ(TIGL_Y_Z_PLANE, tigl::stringToTiglSymmetryAxis("y-z-plane"));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implemented new symmetry flags "none" and "inherit"

## Description
With the current implementation and the CPACS interpretation, it is not possible to remove a symmetry flag from a component, if the parent component has set a symmetry. A current workaround is setting the symmetry flag to an empty string, which is however not CPACS conforming.

This PR makes these implicit behaviour more explicit and adds two new ways to define the symmetry.

 - The flag "none" basically deletes the symmetry flag from the parent and disables the symmetry
 - The flag "inherit" is, what is the currenty default bahaviour of cpacs. It takes the symmetry from the parent. Omitting a symmetry flag is the same as using inherit. The intention of adding "inherit" is, to make the symmetry more explicit from a symantic point of view. It does however not change, how TiGL interprets the symmetry flag and should bd 100% backwards compatible.

This PR contains
 - Introduced new symmetry options "none" and "inherit" into the cpacs schema
 - Added tests that check the behaviour
 - Fixed pylon symmetry, that did not correctly initialized its own symmetry flag
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #702 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it in TiGL Viewer and added unit tests that vary the symmetry flag of a pylon that has a wing parent. The test varies all kind of combination of parent / child inheritance and values for the symmetry flag of the pylon and the wing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [x] New classes have been added to the Python interface.
- [x] API changes were documented properly in tigl.h.
