### PR TITLE
Fix SegFault in CCPACSBulkheadAssemblyPosition with TiXI 3.1.0

### DIFF
--- a/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
@@ -166,6 +166,9 @@ void CCPACSPressureBulkheadAssemblyPosition::BuildGeometry(TopoDS_Shape& cache) 
 
         cache = face;
     }
+    else {
+        throw CTiglError("Cannot build geometry, frame must have at least one frame position defined.");
+    }
 }
 
 } // namespace tigl

--- a/tests/unittests/TestData/bugs/710/test_fuselage_walls_ex1.xml
+++ b/tests/unittests/TestData/bugs/710/test_fuselage_walls_ex1.xml
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cpacs_schema.xsd">
+  <header>
+    <name>fuselage_positioning_tests</name>
+    <creator>Marko Alder</creator>
+    <timestamp>2018-11-20T08:55:23</timestamp>
+    <version>1.1.0</version>
+    <cpacsVersion>3.1</cpacsVersion>
+    <updates>
+      <update>
+        <modification>Converted to CPACS 3.1 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2020-04-26T02:01:38</timestamp>
+        <version>1.1.0</version>
+        <cpacsVersion>3.1</cpacsVersion>
+      </update>
+    </updates>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="aircraft">
+        <name>aircraft</name>
+        <fuselages>
+          <fuselage uID="fuselage">
+            <name>fuselage</name>
+            <transformation uID="fuselage_transformation">
+              <scaling uID="fuselage_transformation_scaling">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+            </transformation>
+            <sections>
+              <section uID="fuselage_section1">
+                <name>fuselage_section1</name>
+                <transformation uID="fuselage_section1_transformation">
+                  <scaling uID="fuselage_section1_transformation_scaling">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <translation uID="fuselage_section1_transformation_translation">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </translation>
+                  <rotation uID="fuselage_section1_transformation_rotation">
+                    <x>0</x>
+                    <y>-25</y>
+                    <z>0</z>
+                  </rotation>
+                </transformation>
+                <elements>
+                  <element uID="fuselage_section1_element1">
+                    <name>fuselage_section1_element1</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="fuselage_section1_element1_transformation">
+                      <scaling uID="fuselage_section1_element1_transformation_scaling">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="fuselage_section2">
+                <name>fuselage_section2</name>
+                <transformation uID="fuselage_section2_transformation">
+                  <scaling uID="fuselage_section2_transformation_scaling">
+                    <x>1</x>
+                    <y>1.5</y>
+                    <z>1.5</z>
+                  </scaling>
+                  <translation uID="fuselage_section2_transformation_translation">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                  <rotation uID="fuselage_section2_transformation_rotation">
+                    <x>0</x>
+                    <y>-10</y>
+                    <z>-10</z>
+                  </rotation>
+                </transformation>
+                <elements>
+                  <element uID="fuselage_section2_element1">
+                    <name>fuselage_section2_element1</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="fuselage_section2_element1_transformation">
+                      <scaling uID="fuselage_section2_element1_transformation_scaling">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="fuselage_section2_element1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="fuselage_section3">
+                <name>fuselage_section2</name>
+                <transformation uID="fuselage_section3_transformation">
+                  <scaling uID="fuselage_section3_transformation_scaling">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <translation uID="fuselage_section3_transformation_translation">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="fuselage_section3_element1">
+                    <name>fuselage_section3_element1</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="fuselage_section3_element1_transformation">
+                      <scaling uID="fuselage_section3_element1_transformation_scaling">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <segments>
+              <segment uID="fuselage_segment1">
+                <name>fuselage_segment1</name>
+                <fromElementUID>fuselage_section1_element1</fromElementUID>
+                <toElementUID>fuselage_section2_element1</toElementUID>
+              </segment>
+              <segment uID="fuselage_segment2">
+                <name>fuselage_segment1</name>
+                <fromElementUID>fuselage_section2_element1</fromElementUID>
+                <toElementUID>fuselage_section3_element1</toElementUID>
+              </segment>
+            </segments>
+            <positionings>
+              <positioning uID="fuselage_positioning1">
+                <name>fuselage_positioning1</name>
+                <length>3</length>
+                <dihedralAngle>0</dihedralAngle>
+                <sweepAngle>90</sweepAngle>
+                <toSectionUID>fuselage_section2</toSectionUID>
+              </positioning>
+              <positioning uID="fuselage_positioning2">
+                <name>fuselage_positioning2</name>
+                <length>3</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>fuselage_section2</fromSectionUID>
+                <toSectionUID>fuselage_section3</toSectionUID>
+              </positioning>
+            </positionings>
+            <structure>
+              <frames>
+                <frame uID="C01">
+                </frame>
+              </frames>
+              <pressureBulkheads>
+                <pressureBulkhead uID="pressureBulkhead1">
+                  <frameUID>C01</frameUID>
+                  <pressureBulkheadElementUID>pressureBulkheadElement1</pressureBulkheadElementUID>
+                </pressureBulkhead>
+              </pressureBulkheads>
+              <walls>
+                <wallPositions>
+                  <wallPosition uID="Wall1Position1">
+                    <fuselageSectionUID>fuselage_section1</fuselageSectionUID>
+                    <y>0.3</y>
+                    <z>0.0</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall1Position2">
+                    <x>2.5</x>
+                    <y>0.3</y>
+                    <z>0.0</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall1Position3">
+                    <x>2.3</x>
+                    <y>0.9</y>
+                    <z>0.0</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall1Position4">
+                    <x>3.7</x>
+                    <y>0.9</y>
+                    <z>0.0</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall1Position5">
+                    <x>3.5</x>
+                    <y>0.3</y>
+                    <z>0.0</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall1Position6">
+                    <bulkheadUID>pressureBulkhead1</bulkheadUID>
+                    <y>0.3</y>
+                    <z>0.0</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall2Position1">
+                    <x>1.</x>
+                    <y>0.</y>
+                    <z>0.</z>
+                  </wallPosition>
+                  <wallPosition uID="Wall2Position2">
+                    <bulkheadUID>pressureBulkhead1</bulkheadUID>
+                    <y>0.</y>
+                    <z>0.</z>
+                  </wallPosition>
+                </wallPositions>
+                <wallSegments>
+                  <wallSegment uID="Wall1">
+                    <phi>-20.</phi>
+                    <wallPositionUIDs>
+                      <wallPositionUID>Wall1Position1</wallPositionUID>
+                      <wallPositionUID>Wall1Position4</wallPositionUID>
+                      <wallPositionUID>Wall1Position6</wallPositionUID>
+                    </wallPositionUIDs>
+                  </wallSegment>
+                  <wallSegment uID="Wall2">
+                    <phi>90.</phi>
+                    <boundingElementUIDs>
+                      <boundingElementUID>Wall1</boundingElementUID>
+                    </boundingElementUIDs>
+                    <wallPositionUIDs>
+                      <wallPositionUID>Wall2Position1</wallPositionUID>
+                      <wallPositionUID>Wall2Position2</wallPositionUID>
+                    </wallPositionUIDs>
+                    <doubleSidedExtrusion>true</doubleSidedExtrusion>
+                  </wallSegment>
+                </wallSegments>
+              </walls>
+            </structure>
+          </fuselage>
+        </fuselages>
+      </model>
+    </aircraft>
+    <profiles>
+      <fuselageProfiles>
+        <fuselageProfile uID="fuselageCircleProfileuID">
+          <name>Circle</name>
+          <description>Profile build up from set of Points on Circle where may Dimensions are 1..-1</description>
+          <pointList>
+            <x mapType="vector">0.0;0.0;0.0;0.0;0.0</x>
+            <y mapType="vector">0.0;1.0;0.0;-1.0;0.0</y>
+            <z mapType="vector">1.0;0.0;-1.0;0.0;1.0</z>
+          </pointList>
+        </fuselageProfile>
+      </fuselageProfiles>
+      <structuralProfiles>
+        <structuralProfile2D uID="structProfile1">
+          <name>Spant-Profil 1</name>
+          <pointList>
+            <point uID="structProfile1_P1">
+              <x>0.02</x>
+              <y>0.032</y>
+            </point>
+            <point uID="structProfile1_P2">
+              <x>0.0</x>
+              <y>0.032</y>
+            </point>
+            <point uID="structProfile1_P3">
+              <x>0.0</x>
+              <y>0.1072</y>
+            </point>
+            <point uID="structProfile1_P4">
+              <x>-0.0206</x>
+              <y>0.1072</y>
+            </point>
+            <point uID="structProfile1_P5">
+              <x>-0.0206</x>
+              <y>0.0992</y>
+            </point>
+            <point uID="structProfile1_P6">
+              <x>-0.02</x>
+              <y>0.001</y>
+            </point>
+            <point uID="structProfile1_P7">
+              <x>0.0</x>
+              <y>0.001</y>
+            </point>
+          </pointList>
+          <sheetList>
+            <sheet uID="structProfile1_sheet1">
+              <fromPointUID>structProfile1_P1</fromPointUID>
+              <toPointUID>structProfile1_P2</toPointUID>
+            </sheet>
+            <sheet uID="structProfile1_sheet2">
+              <fromPointUID>structProfile1_P2</fromPointUID>
+              <toPointUID>structProfile1_P3</toPointUID>
+            </sheet>
+            <sheet uID="structProfile1_sheet3">
+              <fromPointUID>structProfile1_P3</fromPointUID>
+              <toPointUID>structProfile1_P4</toPointUID>
+            </sheet>
+            <sheet uID="structProfile1_sheet4">
+              <fromPointUID>structProfile1_P4</fromPointUID>
+              <toPointUID>structProfile1_P5</toPointUID>
+            </sheet>
+            <sheet uID="structProfile1_sheet5">
+              <fromPointUID>structProfile1_P6</fromPointUID>
+              <toPointUID>structProfile1_P7</toPointUID>
+            </sheet>
+            <sheet uID="structProfile1_sheet6">
+              <fromPointUID>structProfile1_P7</fromPointUID>
+              <toPointUID>structProfile1_P2</toPointUID>
+            </sheet>
+          </sheetList>
+        </structuralProfile2D>
+      </structuralProfiles>
+    </profiles>
+    <materials>
+      <material uID="aluminium2024">
+        <name>Aluminium 2024</name>
+        <rho>1</rho>
+        <k11>1</k11>
+        <k12>1</k12>
+        <k13>1</k13>
+        <k22>1</k22>
+        <k23>1</k23>
+        <k33>1</k33>
+        <k44>1</k44>
+        <k55>1</k55>
+        <k66>1</k66>
+        <sig11t>1</sig11t>
+        <sig11c>1</sig11c>
+        <sig22t>1</sig22t>
+        <sig22c>1</sig22c>
+        <sig33t>1</sig33t>
+        <sig33c>1</sig33c>
+        <tau12>1</tau12>
+        <tau13>1</tau13>
+        <tau23>1</tau23>
+      </material>
+    </materials>
+    <structuralElements>
+      <profileBasedStructuralElements>
+        <profileBasedStructuralElement uID="frame1">
+          <sheetProperties>
+            <sheetUID>structProfile1_sheet1</sheetUID>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.0016</thickness>
+          </sheetProperties>
+          <sheetProperties>
+            <sheetUID>structProfile1_sheet2</sheetUID>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.0016</thickness>
+          </sheetProperties>
+          <sheetProperties>
+            <sheetUID>structProfile1_sheet3</sheetUID>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.0016</thickness>
+          </sheetProperties>
+          <sheetProperties>
+            <sheetUID>structProfile1_sheet4</sheetUID>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.0016</thickness>
+          </sheetProperties>
+          <sheetProperties>
+            <sheetUID>structProfile1_sheet5</sheetUID>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.0020</thickness>
+          </sheetProperties>
+          <sheetProperties>
+            <sheetUID>structProfile1_sheet6</sheetUID>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.0020</thickness>
+          </sheetProperties>
+          <structuralProfileUID>structProfile1</structuralProfileUID>
+          <transformation uID="frame1_transformation">
+            <scaling uID="frame1_transformation_scaling">
+              <x>1.0</x>
+              <y>1.0</y>
+            </scaling>
+            <rotation uID="frame1_transformation_rotation">
+              <z>0.0</z>
+            </rotation>
+            <translation uID="frame1_transformation_translation">
+              <x>0.0</x>
+              <y>0.0</y>
+            </translation>
+          </transformation>
+        </profileBasedStructuralElement>
+      </profileBasedStructuralElements>
+      <pressureBulkheads>
+        <pressureBulkhead uID="pressureBulkheadElement1">
+          <name>pressureBulkheadElement1</name>
+          <description>pressure bulkhead element</description>
+          <sheetElementUID>sheetElement1</sheetElementUID>
+          <reinforcementNumberVertical>5</reinforcementNumberVertical>
+          <structuralElementVerticalUID>frame1</structuralElementVerticalUID>
+          <reinforcementNumberHorizontal>6</reinforcementNumberHorizontal>
+          <structuralElementHorizontalUID>frame1</structuralElementHorizontalUID>
+        </pressureBulkhead>
+      </pressureBulkheads>
+      <sheetBasedStructuralElements>
+        <sheetBasedStructuralElement uID="sheetElement1">
+          <materialDefinition>
+            <materialUID>aluminium2024</materialUID>
+            <thickness>0.005</thickness>
+          </materialDefinition>
+        </sheetBasedStructuralElement>
+      </sheetBasedStructuralElements>
+    </structuralElements>
+  </vehicles>
+</cpacs>

--- a/tests/unittests/TestData/test_fuselage_walls_ex1.xml
+++ b/tests/unittests/TestData/test_fuselage_walls_ex1.xml
@@ -168,16 +168,10 @@
                     <positionX>5.8</positionX>
                     <referenceY>0.0</referenceY>
                     <referenceZ>-3</referenceZ>
-                    <referenceAngle>
-										0.0
-									</referenceAngle>
+                    <referenceAngle>0.0</referenceAngle>
                     <alignment uID="C01_pos1_alignment">
-                      <rotationLocX>
-											0.0
-										</rotationLocX>
-                      <translationLocY>
-											0.0
-										</translationLocY>
+                      <rotationLocX>0.0</rotationLocX>
+                      <translationLocY>0.0</translationLocY>
                       <translationLocZ>0.001</translationLocZ>
                     </alignment>
                   </framePosition>

--- a/tests/unittests/TestData/test_fuselage_walls_ex2.xml
+++ b/tests/unittests/TestData/test_fuselage_walls_ex2.xml
@@ -168,16 +168,10 @@
                     <positionX>5.8</positionX>
                     <referenceY>0.0</referenceY>
                     <referenceZ>-3</referenceZ>
-                    <referenceAngle>
-										0.0
-									</referenceAngle>
+                    <referenceAngle>0.0</referenceAngle>
                     <alignment uID="C01_pos1_alignment">
-                      <rotationLocX>
-											0.0
-										</rotationLocX>
-                      <translationLocY>
-											0.0
-										</translationLocY>
+                      <rotationLocX>0.0</rotationLocX>
+                      <translationLocY>0.0</translationLocY>
                       <translationLocZ>0.001</translationLocZ>
                     </alignment>
                   </framePosition>

--- a/tests/unittests/TestData/test_fuselage_walls_ex3_labyrinth.xml
+++ b/tests/unittests/TestData/test_fuselage_walls_ex3_labyrinth.xml
@@ -168,16 +168,10 @@
                     <positionX>5.8</positionX>
                     <referenceY>0.0</referenceY>
                     <referenceZ>-3</referenceZ>
-                    <referenceAngle>
-										0.0
-									</referenceAngle>
+                    <referenceAngle>0.0</referenceAngle>
                     <alignment uID="C01_pos1_alignment">
-                      <rotationLocX>
-											0.0
-										</rotationLocX>
-                      <translationLocY>
-											0.0
-										</translationLocY>
+                      <rotationLocX>0.0</rotationLocX>
+                      <translationLocY>0.0</translationLocY>
                       <translationLocZ>0.001</translationLocZ>
                     </alignment>
                   </framePosition>

--- a/tests/unittests/TestData/test_fuselage_walls_ex4_compartment.xml
+++ b/tests/unittests/TestData/test_fuselage_walls_ex4_compartment.xml
@@ -168,16 +168,10 @@
                     <positionX>5.8</positionX>
                     <referenceY>0.0</referenceY>
                     <referenceZ>-3</referenceZ>
-                    <referenceAngle>
-										0.0
-									</referenceAngle>
+                    <referenceAngle>0.0</referenceAngle>
                     <alignment uID="C01_pos1_alignment">
-                      <rotationLocX>
-											0.0
-										</rotationLocX>
-                      <translationLocY>
-											0.0
-										</translationLocY>
+                      <rotationLocX>0.0</rotationLocX>
+                      <translationLocY>0.0</translationLocY>
                       <translationLocZ>0.001</translationLocZ>
                     </alignment>
                   </framePosition>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CCPACSBulkheadAssemblyPosition should throw an exception if the reference frame does not have enough frame positions.

## Description

In contrast to TiXI 3.0.3, TiXI 3.1.0 checks in `tixiGetDoubleElement` wether the element string is numeric. Unfortunately -until DLR-SC/tixi#161 is merged - it also throws an error for strings that are numeric, but contain trailing whitespaces. This caused the `ReadCPACS` function to fail if the CPACS file contains any trailing whitespaces. With some relevant CPACS nodes missing, the geometry creation of CCPACSBulkheadAssemblyPosition crashed.

In this PR 
 - The whitespace is removed from some of the affected test cases, so that TiXI does not crash
 - CCPACSBulkheadAssemblyPosition now throws an error instead of crashing, if the number of frame positions in the reference frame are wrong.

Fixes #710

## How Has This Been Tested?

Added unit tests both in TiXI and in TiGL

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
