### PR TITLE
CI matlab issues

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -24,6 +24,7 @@ env:
   TIGL_OCE_VER: "=0.17.2"
   TIGL_FREEIMAGEPLUS_VER: ""
   TIGL_NINJA_VER: ""
+  TIGL_MATLAB_LIBS: ""
  
 jobs:
 
@@ -121,22 +122,14 @@ jobs:
     - name: Install dependencies using Miniconda (dynamic, windows)
       if: matrix.config.link_type == 'dynamic' && contains(matrix.config.os, 'windows')
       run: |
-        conda install pip python${{ env.TIGL_PYTHON_VER }} pythonocc-core${{ env.TIGL_PYTHONOCC_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} swig${{ env.TIGL_SWIG_VER }} tixi3${{ env.TIGL_TIXI3_VER }} qt${{ env.TIGL_QT_VER }} oce${{ env.TIGL_OCE_VER }} freeimageplus${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} -c dlr-sc -c dlr-sc/label/tigl-dev
+        conda install pip python${{ env.TIGL_PYTHON_VER }} pythonocc-core${{ env.TIGL_PYTHONOCC_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} swig${{ env.TIGL_SWIG_VER }} tixi3${{ env.TIGL_TIXI3_VER }} qt${{ env.TIGL_QT_VER }} oce${{ env.TIGL_OCE_VER }} freeimageplus${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} matlab-libs${{ env.TIGL_MATLAB_LIBS }} -c dlr-sc -c dlr-sc/label/tigl-dev
         conda info -a
         conda list
         
     - name: Install dependencies using Miniconda (static, windows)
       if: matrix.config.link_type == 'static' && contains(matrix.config.os, 'windows')
       run: |
-        conda install tixi3${{ env.TIGL_TIXI3_VER }} oce-static${{ env.TIGL_OCE_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} qt${{ env.TIGL_QT_VER }} freetype-static=2.6 freeimageplus-static${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} -c dlr-sc -c dlr-sc/label/tigl-dev
-        
-    - name: Install Matlab libs (windows)
-      if: contains(matrix.config.os, 'windows')
-      run: |
-          mkdir ${{ github.workspace }}\tigl-thirdparty
-          cd ${{ github.workspace }}\tigl-thirdparty
-          curl --verbose --retry 3 --max-time 900 --connect-timeout 60 -o matlab-libs-win.zip -SL https://sourceforge.net/projects/tigl/files/Thirdparty/matlab-libs-win.zip
-          unzip matlab-libs-win.zip -d matlab-libs-win
+        conda install tixi3${{ env.TIGL_TIXI3_VER }} oce-static${{ env.TIGL_OCE_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} qt${{ env.TIGL_QT_VER }} freetype-static=2.6 freeimageplus-static${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} matlab-libs${{ env.TIGL_MATLAB_LIBS }} -c dlr-sc -c dlr-sc/label/tigl-dev
 
     - name: Install ccache (ubuntu)
       run: |
@@ -203,7 +196,7 @@ jobs:
         
     - name: prepare cmake args (pythonocc directory and matlab libraries on windows)
       if: contains(matrix.config.os, 'windows')
-      run: echo "::set-env name=CMAKE_ARGS::${{ env.CMAKE_ARGS }} -DPythonOCC_SOURCE_DIR=C:\Miniconda\Library\src\pythonocc-core -DMATLAB_DIR=${{ github.workspace }}\tigl-thirdparty\matlab-libs-win"
+      run: echo "::set-env name=CMAKE_ARGS::${{ env.CMAKE_ARGS }} -DPythonOCC_SOURCE_DIR=C:\Miniconda\Library\src\pythonocc-core -DMATLAB_DIR=C:\Miniconda\Library\share\matlab"
     
     - name: prepare cmake args (enable coverage on ubuntu debug)
       if: matrix.config.name == 'Ubuntu-Debug'

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -99,10 +99,12 @@ jobs:
         command: |
           curl --retry 3 -o sshpass-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/sshpass-macOS.tar.gz
           curl --retry 3 -o doxygen-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/doxygen-macOS.tar.gz
+          curl --retry 3 -o matlab-libs-macos.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/matlab-libs-macos.tar.gz
           curl --retry 3 -o oce.0.17.2.macos_static.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/oce.0.17.2-1.macos_static.tar.gz
           curl --retry 3 -O -L https://github.com/DLR-SC/tixi/releases/download/v3.1.1/TIXI-3.1.1-Darwin.tar.gz
           tar xf sshpass-macOS.tar.gz -C /tmp
           tar xf doxygen-macOS.tar.gz -C /tmp
+          tar xf matlab-libs-macos.tar.gz -C /tmp
           tar xf oce.0.17.2.macos_static.tar.gz
           tar xf TIXI-3.1.1-Darwin.tar.gz
           echo "::add-path::/tmp"
@@ -193,6 +195,10 @@ jobs:
       if: contains(matrix.config.os, 'ubuntu') || contains(matrix.config.os, 'macos')
       shell: bash -l {0}
       run: echo "::set-env name=CMAKE_ARGS::${{ env.CMAKE_ARGS }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+      
+    - name: prepare cmake args (matlab-libs on macos)
+      if: contains(matrix.config.os, 'macos')
+      run: echo "::set-env name=CMAKE_ARGS::${{ env.CMAKE_ARGS }} -DMATLAB_DIR=/tmp/matlab-libs-macos"
         
     - name: prepare cmake args (pythonocc directory and matlab libraries on windows)
       if: contains(matrix.config.os, 'windows')

--- a/bindings/matlab/common.h
+++ b/bindings/matlab/common.h
@@ -290,7 +290,6 @@ bool isallinteger(const mxArray* arr) {
 #else
 		const double* pr = mxGetPr(arr);
 		const double* pi = mxGetPi(arr);
-		mwSize i;
 
 		if (pr == NULL) {
 			mexErrMsgIdAndTxt(__ARGTYPEMISMATCH__, "Operation supported only on numeric arrays.");


### PR DESCRIPTION
This PR:
 - Fixes the failing matlab libs download by using conda packages of the matlab libraries
 - Also builds the matlab bindings on macos
