### PR TITLE
run CI on external PRs only, remove branch restriction

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -4,10 +4,9 @@ on:
   schedule:
     - cron: "40 2 * * *"
   push:
-  pull_request_target:
-  create:
     tags:
       - v*
+  pull_request_target:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/compiler-cache
@@ -180,7 +179,7 @@ jobs:
         restore-keys: ${{ matrix.config.name }}-compiler-cache
         
     - name: prepare cmake args (disable nightly flag and src concatenation for release builds)
-      if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
         echo "::set-env name=TIGL_NIGHTLY::OFF"
         echo "::set-env name=TIGL_CONCAT_GENERATED_FILES::OFF"
@@ -319,7 +318,7 @@ jobs:
         
   deploy:
    
-    if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest     
     needs: build-and-test
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -4,12 +4,7 @@ on:
   schedule:
     - cron: "40 2 * * *"
   push:
-  pull_request:
-    branches:
-      - master
   pull_request_target:
-    branches:
-      - master
   create:
     tags:
       - v*


### PR DESCRIPTION
Changes in this PR:

 - Since we start the CI builds on push, there is no need to run them on an (internal) PR, so the `on: pull_request` is removed.
 - It should be safer to run all CI builds from external forks also for other branches than PRs onto master, so this restriction is changed as well.

Oh and also this PR tests if the builds are started for PRs from external forks at all.