### PR TITLE
Fix java tixi local

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -1,7 +1,7 @@
 option(TIGL_BINDINGS_JAVA "Build the java bindings of tigl (requires java)" OFF)
 
 if (TIGL_BINDINGS_JAVA)
-    find_package(Java 1.7.0 COMPONENTS Development REQUIRED)
+    find_package(Java COMPONENTS Development REQUIRED)
 endif(TIGL_BINDINGS_JAVA)
 
 if (TIGL_BINDINGS_JAVA)

--- a/examples/java_demo/CMakeLists.txt
+++ b/examples/java_demo/CMakeLists.txt
@@ -7,22 +7,20 @@ install(FILES
     COMPONENT docu
 )
 
-get_target_property(TIXI_DLL tixi3 LOCATION)
-get_filename_component(TIXI_LIB_PATH ${TIXI_DLL} PATH)
-
 if (TIGL_BINDINGS_JAVA)
-	SET(TIGL_JAR "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/tigl-${TIGL_VERSION}.jar")
+    set (TIGL_JAR "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/tigl-${TIGL_VERSION}.jar")
 
-	set(TIGL_LIB_PATH ${PROJECT_BINARY_DIR}/lib)
-	
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/build.gradle.in ${CMAKE_CURRENT_BINARY_DIR}/build.gradle)
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gradle.properties ${CMAKE_CURRENT_BINARY_DIR}/gradle.properties COPYONLY )
-	
-	ADD_CUSTOM_TARGET(
-		tigl-java-demo 
-		DEPENDS ${TIGL_JAR}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		COMMAND   ${Java_JAVA_EXECUTABLE} -classpath ${PROJECT_SOURCE_DIR}/bindings/java/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain build run
-	)
+    string(RANDOM TEMP_STR)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/build.gradle.in ${CMAKE_CURRENT_BINARY_DIR}/build.gradle.in.${TEMP_STR} )
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gradle.properties ${CMAKE_CURRENT_BINARY_DIR}/gradle.properties COPYONLY )
+
+    file(GENERATE  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/build.gradle" INPUT "${CMAKE_CURRENT_BINARY_DIR}/build.gradle.in.${TEMP_STR}")
+
+    add_custom_target(
+        tigl-java-demo 
+        DEPENDS ${TIGL_JAR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND   ${Java_JAVA_EXECUTABLE} -classpath ${PROJECT_SOURCE_DIR}/bindings/java/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain build run
+    )
 
 endif()

--- a/examples/java_demo/build.gradle.in
+++ b/examples/java_demo/build.gradle.in
@@ -20,14 +20,14 @@ dependencies {
     compile group: 'commons-logging', name: 'commons-logging', version: '1.2'
     compile group: 'net.java.dev.jna', name: 'jna', version: '4.1.0'
 
-    compile fileTree(dir: '@TIGL_LIB_PATH@', include: ['tigl-@TIGL_VERSION@.jar'])
+    compile fileTree(dir: '$<TARGET_FILE_DIR:tigl3>', include: ['tigl-@TIGL_VERSION@.jar'])
 }
 
 run {
     args += '@PROJECT_SOURCE_DIR@/tests/unittests/TestData/simpletest.cpacs.xml'
-    classpath  'java.library.path','@TIGL_LIB_PATH@','@TIGL_LIB_PATH@/Release','@TIGL_LIB_PATH@/Debug'
-    environment 'DYLD_LIBRARY_PATH', '@OpenCASCADE_DLL_DIRECTORY@:@TIXI_LIB_PATH@'
-    environment 'LD_LIBRARY_PATH', '@OpenCASCADE_DLL_DIRECTORY@:@TIXI_LIB_PATH@'
-    environment 'PATH', '@OpenCASCADE_DLL_DIRECTORY@;@TIXI_LIB_PATH@'
+    classpath  'java.library.path','$<TARGET_FILE_DIR:tigl3>'
+    environment 'DYLD_LIBRARY_PATH', '$<TARGET_FILE_DIR:tixi3>:@OpenCASCADE_DLL_DIRECTORY@'
+    environment 'LD_LIBRARY_PATH', '$<TARGET_FILE_DIR:tixi3>:@OpenCASCADE_DLL_DIRECTORY@'
+    environment 'PATH', '$<TARGET_FILE_DIR:tixi3>;@OpenCASCADE_DLL_DIRECTORY@'
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improved building of java bindings, if tixi is added as a submodule.

For #736 , I simply removed the version argument for find_package.

For #737, I  am now using generator expressions.

Fixes #737  and fixes #736 