### PR TITLE
WIP: Updates to using opencascade head at b0b7668

### DIFF
--- a/TIGLViewer/src/ISession_Direction.cpp
+++ b/TIGLViewer/src/ISession_Direction.cpp
@@ -106,10 +106,10 @@ void ISession_Direction::Compute (const Handle(PrsMgr_PresentationManager3d)& /*
     Handle(Graphic3d_ArrayOfSegments) aPrims = new Graphic3d_ArrayOfSegments (2);
     aPrims->AddVertex (myPnt);
     aPrims->AddVertex (aLastPoint);
-    Prs3d_Root::CurrentGroup (aPresentation)->SetPrimitivesAspect (myDrawer->LineAspect()->Aspect());
-    Prs3d_Root::CurrentGroup (aPresentation)->AddPrimitiveArray (aPrims);
+    aPresentation->CurrentGroup()->SetPrimitivesAspect (myDrawer->LineAspect()->Aspect());
+    aPresentation->CurrentGroup()->AddPrimitiveArray (aPrims);
     // Draw arrow
-    Prs3d_Arrow::Draw (aPresentation,
+    Prs3d_Arrow::Draw (aPresentation->CurrentGroup(),
                        aLastPoint,
                        myDir,
                        anArrowAspect->Angle(),
@@ -118,7 +118,7 @@ void ISession_Direction::Compute (const Handle(PrsMgr_PresentationManager3d)& /*
     // Draw text
     if (myText.Length() != 0) {
         gp_Pnt aTextPosition = aLastPoint;
-        Prs3d_Text::Draw (aPresentation,
+        Prs3d_Text::Draw (aPresentation->CurrentGroup(),
                           myDrawer->TextAspect(),
                           myText,
                           aTextPosition);
@@ -126,10 +126,10 @@ void ISession_Direction::Compute (const Handle(PrsMgr_PresentationManager3d)& /*
 }
 
 
-void ISession_Direction::Compute (const Handle(Prs3d_Projector)& /*aProjector*/,
-                                  const Handle(Prs3d_Presentation)& /*aPresentation*/)
-{
-}
+// void ISession_Direction::Compute (const Handle(Prs3d_Projector)& /*aProjector*/,
+//                                   const Handle(Prs3d_Presentation)& /*aPresentation*/)
+// {
+// }
 
 void ISession_Direction::ComputeSelection (const Handle(SelectMgr_Selection)& /*aSelection*/,
                                            const Standard_Integer /*aMode*/)

--- a/TIGLViewer/src/ISession_Direction.h
+++ b/TIGLViewer/src/ISession_Direction.h
@@ -51,8 +51,8 @@ private:
     void Compute         (const Handle(PrsMgr_PresentationManager3d)& aPresentationManager,
                           const Handle(Prs3d_Presentation)& aPresentation,
                           const Standard_Integer aMode) override;
-    void Compute         (const Handle(Prs3d_Projector)& aProjector,
-                          const Handle(Prs3d_Presentation)& aPresentation) override;
+    // void Compute         (const Handle(Prs3d_Projector)& aProjector,
+    //                       const Handle(Prs3d_Presentation)& aPresentation) override;
     void ComputeSelection(const Handle(SelectMgr_Selection)& aSelection,const Standard_Integer aMode) override;
 
     gp_Pnt myPnt;

--- a/TIGLViewer/src/ISession_Point.cpp
+++ b/TIGLViewer/src/ISession_Point.cpp
@@ -68,10 +68,10 @@ void ISession_Point::Compute(const Handle(PrsMgr_PresentationManager3d)& /*aPres
 }
 
 
-void ISession_Point::Compute(const Handle(Prs3d_Projector)& /*aProjector*/,
-                             const Handle(Prs3d_Presentation)& /*aPresentation*/)
-{
-}
+// void ISession_Point::Compute(const Handle(Prs3d_Projector)& /*aProjector*/,
+//                              const Handle(Prs3d_Presentation)& /*aPresentation*/)
+// {
+// }
 
 #if 0
 void ISession_Point::Compute(const Handle(PrsMgr_PresentationManager2d)& /*aPresentationManager*/,

--- a/TIGLViewer/src/ISession_Point.h
+++ b/TIGLViewer/src/ISession_Point.h
@@ -51,8 +51,8 @@ private :
      void Compute          (const Handle(PrsMgr_PresentationManager3d)& aPresentationManager,
                             const Handle(Prs3d_Presentation)& aPresentation,
                             const Standard_Integer aMode) override;
-     void Compute          (const Handle(Prs3d_Projector)& aProjector,
-                            const Handle(Prs3d_Presentation)& aPresentation) override;
+    //  void Compute          (const Handle(Prs3d_Projector)& aProjector,
+    //                         const Handle(Prs3d_Presentation)& aPresentation) override;
      #if 0
      void Compute          (const Handle(PrsMgr_PresentationManager2d)& aPresentationManager,
                             const Handle(Graphic2d_GraphicObject)& aGrObj,

--- a/TIGLViewer/src/ISession_Text.cpp
+++ b/TIGLViewer/src/ISession_Text.cpp
@@ -54,11 +54,11 @@ ISession_Text::ISession_Text
                   const Standard_Real            anX ,        // = 0
                   const Standard_Real            anY ,        // = 0
                   const Standard_Real            aZ  ,        // = 0
-                  const Quantity_PlaneAngle      anAngle,     // = 0.0
+                  const Standard_Real            anAngle,     // = 0.0
                   const Standard_Real            aslant,      // = 0.0
                   const Standard_Integer         aColorIndex, // = 0
                   const Standard_Integer         aFontIndex,  // = 1
-                  const Quantity_Factor          aScale)      // = 1
+                  const Standard_Real            aScale)      // = 1
                   :AIS_InteractiveObject(),MyText(aText),MyX(anX),MyY(anY),MyZ(aZ),
                   MyAngle(anAngle),MySlant(aslant),
                   MyColorIndex(aColorIndex), MyFontIndex(aFontIndex), MyScale(aScale)
@@ -67,11 +67,11 @@ ISession_Text::ISession_Text
 ISession_Text::ISession_Text
                  (const TCollection_AsciiString& aText, 
                   gp_Pnt&                        aPoint,
-                  const Quantity_PlaneAngle      anAngle,     // = 0.0
+                  const Standard_Real            anAngle,     // = 0.0
                   const Standard_Real            aslant,      // = 0.0
                   const Standard_Integer         aColorIndex, // = 0
                   const Standard_Integer         aFontIndex,  // = 1
-                  const Quantity_Factor          aScale)      // = 1
+                  const Standard_Real            aScale)      // = 1
                   :AIS_InteractiveObject(),MyText(aText),MyX(aPoint.X()),MyY(aPoint.Y()),MyZ(aPoint.Z()),
                   MyAngle(anAngle),MySlant(aslant),
                   MyColorIndex(aColorIndex), MyFontIndex(aFontIndex), MyScale(aScale)
@@ -88,20 +88,24 @@ void ISession_Text::Compute(const Handle(PrsMgr_PresentationManager3d)& mgr,
                             const Standard_Integer /*aMode*/)
 {
 
-#if OCC_VERSION_HEX >= 0x070100
+#if OCC_VERSION_HEX >= 0x070200
+    Handle(Prs3d_Drawer) greenStyle = new Prs3d_Drawer();
+    greenStyle->SetColor(Quantity_NOC_GREEN);
+    mgr->Color(this, greenStyle);
+#elif OCC_VERSION_HEX >= 0x070100
     Handle(Graphic3d_HighlightStyle) greenStyle = new Graphic3d_HighlightStyle();
     greenStyle->SetColor(Quantity_NOC_GREEN);
     mgr->Color(this, greenStyle);
 #else
     mgr->Color(this, Quantity_NOC_GREEN);
 #endif
-    Prs3d_Text::Draw(aPresentation,myDrawer,MyText,gp_Pnt(  MyX ,MyY,MyZ ));
+    Prs3d_Text::Draw(aPresentation->CurrentGroup(),myDrawer->TextAspect(),MyText,gp_Pnt(  MyX ,MyY,MyZ ));
 }
 
-void ISession_Text::Compute(const Handle(Prs3d_Projector)& ,
-                            const Handle(Prs3d_Presentation)& )
-{
-}
+// void ISession_Text::Compute(const Handle(Prs3d_Projector)& ,
+//                             const Handle(Prs3d_Presentation)& )
+// {
+// }
 
 void ISession_Text::ComputeSelection(const Handle(SelectMgr_Selection)& /*aSelection*/,
                                      const Standard_Integer /*unMode*/)

--- a/TIGLViewer/src/ISession_Text.h
+++ b/TIGLViewer/src/ISession_Text.h
@@ -11,8 +11,8 @@
 #include <TCollection_AsciiString.hxx>
 #include <Standard_Real.hxx>
 #include <Standard_Integer.hxx>
-#include <Quantity_Factor.hxx>
-#include <Quantity_PlaneAngle.hxx>
+// #include <Quantity_Factor.hxx>
+// #include <Quantity_PlaneAngle.hxx>
 #include <Standard_OStream.hxx>
 #include <Standard_IStream.hxx>
 #include <Standard_CString.hxx>
@@ -34,19 +34,19 @@ public:
                              const Standard_Real            anX         = 0   ,
                              const Standard_Real            anY         = 0   ,
                              const Standard_Real            aZ          = 0   ,
-                             const Quantity_PlaneAngle      anAngle     = 0.0 ,
+                             const Standard_Real            anAngle     = 0.0 ,
                              const Standard_Real            aSlant      = 0.0 ,
                              const Standard_Integer         aColorIndex = 1   ,
                              const Standard_Integer         aFontIndex  = 1   ,
-                             const Quantity_Factor          aScale      = 0.1   );
+                             const Standard_Real            aScale      = 0.1   );
     ISession_Text
                             (const TCollection_AsciiString& aText, 
                              gp_Pnt&                        aPoint,
-                             const Quantity_PlaneAngle      anAngle     = 0.0 ,
+                             const Standard_Real            anAngle     = 0.0 ,
                              const Standard_Real            aSlant      = 0.0 ,
                              const Standard_Integer         aColorIndex = 1   ,
                              const Standard_Integer         aFontIndex  = 1   ,
-                             const Quantity_Factor          aScale      = 0.1   );
+                             const Standard_Real            aScale      = 0.1   );
 
     ~ISession_Text() override;
 
@@ -67,8 +67,8 @@ public:
     inline   void                    SetColorIndex(const Standard_Integer aNewColorIndex) ;
     inline   Standard_Integer        GetFontIndex() const;
     inline   void                    SetFontIndex(const Standard_Integer aNewFontIndex) ;
-    inline   Quantity_Factor         GetScale() const;
-    inline   void                    SetScale  (const Quantity_Factor aNewScale) ;
+    inline   Standard_Real           GetScale() const;
+    inline   void                    SetScale  (const Standard_Real aNewScale) ;
 
 
 DEFINE_STANDARD_RTTIEXT(ISession_Text,AIS_InteractiveObject)
@@ -78,8 +78,8 @@ private:
     void Compute          (const Handle(PrsMgr_PresentationManager3d)& aPresentationManager,
                            const Handle(Prs3d_Presentation)& aPresentation,
                            const Standard_Integer aMode) override;
-    void Compute          (const Handle(Prs3d_Projector)& aProjector,
-                           const Handle(Prs3d_Presentation)& aPresentation) override;
+    // void Compute          (const Handle(Prs3d_Projector)& aProjector,
+    //                        const Handle(Prs3d_Presentation)& aPresentation) override;
     void ComputeSelection (const Handle(SelectMgr_Selection)& aSelection,
                            const Standard_Integer unMode) override;
 
@@ -94,7 +94,7 @@ Standard_Real           MyAngle      ;
 Standard_Real           MySlant      ;
 Standard_Integer        MyColorIndex ;
 Standard_Integer        MyFontIndex  ;
-Quantity_Factor         MyScale      ;
+Standard_Real           MyScale      ;
 
 };
 
@@ -167,12 +167,12 @@ inline void ISession_Text::SetFontIndex(const Standard_Integer aNewFontIndex)
     MyFontIndex = aNewFontIndex; 
 }
 
-inline Quantity_Factor ISession_Text::GetScale() const 
+inline Standard_Real ISession_Text::GetScale() const 
 {  
     return MyScale; 
 }
 
-inline void ISession_Text::SetScale(const Quantity_Factor aNewScale)
+inline void ISession_Text::SetScale(const Standard_Real aNewScale)
 {
     MyScale  = aNewScale; 
 }

--- a/TIGLViewer/src/TIGLAISTriangulation.cpp
+++ b/TIGLViewer/src/TIGLAISTriangulation.cpp
@@ -96,7 +96,7 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
                                    const Standard_Integer aMode)
 {
     aPresentation->Clear();
-    Handle(Graphic3d_Group) TheGroup = Prs3d_Root::CurrentGroup(aPresentation);
+    Handle(Graphic3d_Group) TheGroup = aPresentation->CurrentGroup();
     TheGroup->Clear();
 
     switch (aMode) {

--- a/TIGLViewer/src/TIGLQAspectWindow.cpp
+++ b/TIGLViewer/src/TIGLQAspectWindow.cpp
@@ -103,7 +103,7 @@ void TIGLQAspectWindow::Unmap() const
 // function : DoResize
 // purpose  :
 // =======================================================================
-Aspect_TypeOfResize TIGLQAspectWindow::DoResize() const
+Aspect_TypeOfResize TIGLQAspectWindow::DoResize()
 {
     int                 aMask = 0;
     Aspect_TypeOfResize aMode = Aspect_TOR_UNKNOWN;

--- a/TIGLViewer/src/TIGLQAspectWindow.h
+++ b/TIGLViewer/src/TIGLQAspectWindow.h
@@ -73,7 +73,7 @@ public:
     Aspect_Drawable NativeParentHandle() const override;
     
     //! Applies the resizing to the window <me>
-    Aspect_TypeOfResize DoResize() const override;
+    Aspect_TypeOfResize DoResize() override;
     
     //! Returns True if the window <me> is opened
     //! and False if the window is closed.

--- a/TIGLViewer/src/TIGLViewer.h
+++ b/TIGLViewer/src/TIGLViewer.h
@@ -30,8 +30,8 @@
 #include <Aspect_GridDrawMode.hxx>
 #include <Aspect_GridType.hxx>
 #include <Standard_TypeDef.hxx>
-#include <Quantity_Factor.hxx>
-#include <Quantity_Length.hxx>
+#include <Standard_Real.hxx>
+// #include <Quantity_Length.hxx>
 #include <Quantity_NameOfColor.hxx>
 #include <V3d_Coordinate.hxx>
 

--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -88,7 +88,11 @@ TIGLViewerContext::TIGLViewerContext(QUndoStack* stack)
     myGridColor      = Quantity_NOC_RED4;
     myGridTenthColor = Quantity_NOC_GRAY90;
 
-#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,1,0)
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,2,0)
+    Handle(Prs3d_Drawer) whiteStyle = new Prs3d_Drawer();
+    whiteStyle->SetColor(Quantity_NOC_WHITE);
+    myContext->SetHighlightStyle(whiteStyle);
+#elif OCC_VERSION_HEX >= VERSION_HEX_CODE(7,1,0)
     Handle(Graphic3d_HighlightStyle) whiteStyle = new Graphic3d_HighlightStyle;
     whiteStyle->SetColor(Quantity_NOC_WHITE);
     myContext->SetHighlightStyle(whiteStyle);
@@ -163,6 +167,7 @@ Handle(V3d_Viewer) TIGLViewerContext::createViewer( const Standard_ExtString aNa
       deviceHandle = new OpenGl_GraphicDriver (aDisplayConnection);
     }
 
+#if OCC_VERSION_HEX < VERSION_HEX_CODE(7,4,0)
     return new V3d_Viewer(  deviceHandle,
                             aName,
                             aDomain,
@@ -171,11 +176,15 @@ Handle(V3d_Viewer) TIGLViewerContext::createViewer( const Standard_ExtString aNa
                             Quantity_NOC_BLACK,
                             V3d_ZBUFFER,
                             V3d_GOURAUD
-#if OCC_VERSION_HEX < VERSION_HEX_CODE(7,2,0)
+  #if OCC_VERSION_HEX < VERSION_HEX_CODE(7,2,0)
                             , V3d_WAIT
-#endif
+  #endif
                          );
+#else
+    return new V3d_Viewer( deviceHandle );
+#endif
 }
+
 /*! 
 \brief    Deletes all objects.
 
@@ -292,22 +301,22 @@ void TIGLViewerContext::selectAll()
     if (!myContext.IsNull()) {
         AIS_ListOfInteractive aList;
         // deselect all
-        myContext->ClearCurrents(Standard_False);
+        myContext->ClearSelected(Standard_False);
         myContext->DisplayedObjects( aList );
         AIS_ListIteratorOfListOfInteractive aListIterator;
         for ( aListIterator.Initialize( aList ); aListIterator.More(); aListIterator.Next() ) {
             // add to selection
-            myContext->AddOrRemoveCurrentObject(aListIterator.Value(), Standard_False);
+            myContext->AddOrRemoveSelected(aListIterator.Value(), Standard_False);
         }
         myContext->UpdateCurrentViewer();
     }
 }
 
-void TIGLViewerContext::setGridOffset (Quantity_Length offset)
+void TIGLViewerContext::setGridOffset (Standard_Real offset)
 {
-    Quantity_Length radius;
-    Quantity_Length xSize, ySize;
-    Quantity_Length oldOffset;
+    Standard_Real radius;
+    Standard_Real xSize, ySize;
+    Standard_Real oldOffset;
     
     myViewer->CircularGridGraphicValues( radius, oldOffset );
     myViewer->SetCircularGridGraphicValues( radius, offset);
@@ -444,8 +453,8 @@ bool TIGLViewerContext::hasSelectedShapes() const
     }
 
     bool hasSelectedShapes = false;
-    for (myContext->InitCurrent(); myContext->MoreCurrent (); myContext->NextCurrent ()) {
-        if (myContext->IsDisplayed(myContext->Current())) {
+    for (myContext->InitSelected(); myContext->MoreSelected (); myContext->NextSelected ()) {
+        if (myContext->IsDisplayed(myContext->SelectedInteractive())) {
             hasSelectedShapes = true;
         }
     }
@@ -470,8 +479,8 @@ std::vector<Handle(AIS_InteractiveObject)> TIGLViewerContext::selected()
 {
     std::vector<Handle(AIS_InteractiveObject)> objects;
     if (!myContext.IsNull()) {
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-            objects.push_back(myContext->Current());
+        for (myContext->InitSelected(); myContext->MoreSelected(); myContext->NextSelected()) {
+            objects.push_back(myContext->SelectedInteractive());
         }
     }
     return objects;
@@ -494,8 +503,8 @@ void TIGLViewerContext::setTransparency(int tr)
     transparency = tr * 0.01;
 
     if (!myContext.IsNull()) {
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-            myContext->SetTransparency(myContext->Current(), transparency, Standard_True);
+        for (myContext->InitSelected(); myContext->MoreSelected(); myContext->NextSelected()) {
+            myContext->SetTransparency(myContext->SelectedInteractive(), transparency, Standard_True);
         }
     }
 }
@@ -503,8 +512,8 @@ void TIGLViewerContext::setTransparency(int tr)
 void TIGLViewerContext::setObjectsWireframe()
 {
     if (!myContext.IsNull()) {
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-            myContext->SetDisplayMode(myContext->Current(), 0, true);
+        for (myContext->InitSelected(); myContext->MoreSelected(); myContext->NextSelected()) {
+            myContext->SetDisplayMode(myContext->SelectedInteractive(), 0, true);
         }
     }
 }
@@ -512,8 +521,8 @@ void TIGLViewerContext::setObjectsWireframe()
 void TIGLViewerContext::setObjectsShading()
 {
     if (!myContext.IsNull()) {
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-            myContext->SetDisplayMode(myContext->Current(), 1, true);
+        for (myContext->InitSelected(); myContext->MoreSelected(); myContext->NextSelected()) {
+            myContext->SetDisplayMode(myContext->SelectedInteractive(), 1, true);
         }
     }
 }
@@ -521,8 +530,8 @@ void TIGLViewerContext::setObjectsShading()
 void TIGLViewerContext::setObjectsMaterial(Graphic3d_NameOfMaterial material)
 {
     if (!myContext.IsNull()) {
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-             myContext->SetMaterial (myContext->Current(),  material, true);
+        for (myContext->InitSelected(); myContext->MoreSelected(); myContext->NextSelected()) {
+             myContext->SetMaterial (myContext->SelectedInteractive(),  material, true);
         }
     }
 }
@@ -532,8 +541,8 @@ void TIGLViewerContext::setObjectsTexture(const QString &filename)
     if (!myContext.IsNull()) {
         QApplication::setOverrideCursor( Qt::WaitCursor );
         QApplication::processEvents();
-        for (myContext->InitCurrent(); myContext->MoreCurrent(); myContext->NextCurrent()) {
-             Handle(AIS_TexturedShape) shape = Handle(AIS_TexturedShape)::DownCast(myContext->Current());
+        for (myContext->InitSelected(); myContext->MoreSelected(); myContext->NextSelected()) {
+             Handle(AIS_TexturedShape) shape = Handle(AIS_TexturedShape)::DownCast(myContext->SelectedInteractive());
              if (!shape.IsNull()) {
                  shape->SetTextureFileName(filename.toStdString().c_str());
                  shape->SetTextureMapOn();

--- a/TIGLViewer/src/TIGLViewerContext.h
+++ b/TIGLViewer/src/TIGLViewerContext.h
@@ -59,7 +59,7 @@ public:
                                      const Standard_CString aDomain,
                                      const Standard_Real ViewSize );
 
-    void setGridOffset (Quantity_Length offset);
+    void setGridOffset (Standard_Real offset);
     
     void displayPoint(const gp_Pnt& aPoint,
                       const char*   aText,

--- a/TIGLViewer/src/TIGLViewerInputoutput.cpp
+++ b/TIGLViewer/src/TIGLViewerInputoutput.cpp
@@ -184,8 +184,8 @@ Handle(TopTools_HSequenceOfShape) TIGLViewerInputOutput::getShapes( const Handle
     Handle(TopTools_HSequenceOfShape) aSequence;
     Handle(AIS_InteractiveObject) picked;
     // export selected objects
-    for ( ic->InitCurrent(); ic->MoreCurrent(); ic->NextCurrent() ) {
-        Handle(AIS_InteractiveObject) obj = ic->Current();
+    for ( ic->InitSelected(); ic->MoreSelected(); ic->NextSelected() ) {
+        Handle(AIS_InteractiveObject) obj = ic->SelectedInteractive();
         if ( obj->IsKind( STANDARD_TYPE( AIS_Shape ) ) ) {
             TopoDS_Shape shape = Handle(AIS_Shape)::DownCast(obj)->Shape();
             if ( aSequence.IsNull() ) {

--- a/TIGLViewer/src/TIGLViewerInternal.h
+++ b/TIGLViewer/src/TIGLViewerInternal.h
@@ -111,13 +111,13 @@
 #include <Precision.hxx>
 #include <Prs3d_IsoAspect.hxx>
 #include <Prs3d_LineAspect.hxx>
-#include <Prs3d_Projector.hxx>
+// #include <Prs3d_Projector.hxx>
 #include <Prs3d_Text.hxx>
-#include <Quantity_Factor.hxx>
-#include <Quantity_Length.hxx>
+// #include <Quantity_Factor.hxx>
+// #include <Quantity_Length.hxx>
 #include <Quantity_NameOfColor.hxx>
 #include <Quantity_PhysicalQuantity.hxx>
-#include <Quantity_PlaneAngle.hxx>
+// #include <Quantity_PlaneAngle.hxx>
 #include <Quantity_TypeOfColor.hxx>
 #include <SelectMgr_EntityOwner.hxx>
 #include <SelectMgr_SelectableObject.hxx>

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -184,7 +184,7 @@ private: // members
     Standard_Boolean                myViewResized;
     Standard_Boolean                myViewInitialized;
     CurrentAction3d                 myMode;
-    Quantity_Factor                 myCurZoom;
+    Standard_Real                   myCurZoom;
     Standard_Boolean                myGridSnap;
     AIS_StatusOfDetection           myDetection;
 

--- a/examples/c_demo/CMakeLists.txt
+++ b/examples/c_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
 # tigl demo cmake project
 # author: Martin Siggel
@@ -9,7 +9,7 @@ if (NOT TARGET tigl3)
 endif()
 
 add_executable(c_demo c_demo.c)
-target_link_libraries(c_demo tigl3)
+target_link_libraries(c_demo tigl3 ${OpenCASCADE_LIBRARIES})
 
 install(FILES 
     c_demo.c

--- a/src/boolean_operations/CBopCommon.cpp
+++ b/src/boolean_operations/CBopCommon.cpp
@@ -61,7 +61,7 @@ void CBopCommon::PrepareFiller()
     }
 
     if (!_dsfiller) {
-        BOPCol_ListOfShape aLS;
+        TopTools_ListOfShape aLS;
         aLS.Append(_tool->Shape());
         aLS.Append(_source->Shape());
 

--- a/src/configuration/CCPACSConfiguration.cpp
+++ b/src/configuration/CCPACSConfiguration.cpp
@@ -34,7 +34,7 @@
 #include "TopoDS_Compound.hxx"
 #include "BRepFeat_Gluer.hxx"
 #include "BRep_Builder.hxx"
-#include "BRepMesh.hxx"
+// #include "BRepMesh.hxx"
 #include "IGESControl_Controller.hxx"
 #include "IGESControl_Writer.hxx"
 #include "StlAPI_Writer.hxx"

--- a/src/exports/CTiglExportVtk.cpp
+++ b/src/exports/CTiglExportVtk.cpp
@@ -39,7 +39,7 @@
 #include "CTiglTypeRegistry.h"
 
 // algorithms
-#include "BRepMesh.hxx"
+// #include "BRepMesh.hxx"
 
 
 #include "CTiglPolyData.h"

--- a/src/fuselage/CCPACSFuselageSegment.cpp
+++ b/src/fuselage/CCPACSFuselageSegment.cpp
@@ -65,7 +65,7 @@
 #include "BRepBuilderAPI_MakeEdge.hxx"
 #include "BRepBuilderAPI_MakeWire.hxx"
 #include "BRepBuilderAPI_MakeFace.hxx"
-#include "BRepMesh.hxx"
+// #include "BRepMesh.hxx"
 #include "BRepTools.hxx"
 #include "BRepBuilderAPI_MakePolygon.hxx"
 #include "Bnd_Box.hxx"

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -73,7 +73,7 @@
 #include "BRepBuilderAPI_MakeEdge.hxx"
 #include "BRepBuilderAPI_MakeWire.hxx"
 #include "BRepBuilderAPI_MakeFace.hxx"
-#include "BRepMesh.hxx"
+// #include "BRepMesh.hxx"
 #include "BRepTools.hxx"
 #include "BRepLib.hxx"
 #include "BRepBndLib.hxx"

--- a/tests/unittests/testUtils.h
+++ b/tests/unittests/testUtils.h
@@ -26,7 +26,7 @@
 #include<fstream>
 
 #include <Geom_BSplineCurve.hxx>
-class TColgp_Array1OfPnt;
+// class TColgp_Array1OfPnt;
 
 // save x-y data
 void outputXY(const int & i, const double& x, const double&y, const std::string& filename);

--- a/tests/unittests/tiglPolydata.cpp
+++ b/tests/unittests/tiglPolydata.cpp
@@ -32,7 +32,7 @@
 #include "CTiglExportVtk.h"
 #include "CNamedShape.h"
 
-#include <BRepMesh.hxx>
+// #include <BRepMesh.hxx>
 #include <TopoDS_CompSolid.hxx>
 
 #include <ctime>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
commented out  deprecated `BRepMesh.hxx`
replaced deprecated commands with equivalent non-deprecated functionality
e.g. Prs3d_Arrow::Draw, Quantity_Factor, Quantity_PlaneAngle, Quantity_Length, InitCurrent, MoreCurrent, NextCurrent, Current, 

commented out deprecated `Compute` sections, include Prs3d_Projector.hxx
remove constness of `DoResize()`

modified the FindOpenCascade to look near the include directory for non-standard install locations.
modified the c_demo to link the opencascade libraries

BOPCol_ListOfShape deprecated


this may be able to fix  #679
It appears so far that there is an issue with the resize within in the viewer. but haven't debugged further hence it is a WIP.

## How Has This Been Tested?
executed the unit tests, currently two tests fail
```
[  PASSED  ] 627 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] TiglBSplineAlgorithms/GordonSurface.testFromBRep/9, where GetParam() = "fuselage1"
[  FAILED  ] TiglBSplineAlgorithms/GordonSurface.testFromBRep/10, where GetParam() = "fuselage2"

 2 FAILED TESTS
  YOU HAVE 1 DISABLED TEST
```
## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] A test for the new functionality was added.  -->
<!--- - [ ] New classes have been added to the Python interface.  -->
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] API changes were documented properly in tigl.h. 
