### PR TITLE
Resolve: Enable to use more than 3 wing guide curves

### DIFF
--- a/TIGLViewer/src/TIGLScriptEngine.cpp
+++ b/TIGLViewer/src/TIGLScriptEngine.cpp
@@ -1,5 +1,3 @@
-#include <utility>
-
 /*
 * Copyright (C) 2007-2013 German Aerospace Center (DLR/SC)
 *

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -1969,16 +1969,7 @@ void TIGLViewerDocument::drawWingComponentSegment()
         return;
     }
 
-    for (int i = 1; i <= GetConfiguration().GetWingCount();++i) {
-        tigl::CCPACSWing& wing = GetConfiguration().GetWing(i);
-        for (int j = 1; j <= wing.GetComponentSegmentCount();++j) {
-            auto& segment = static_cast<tigl::CCPACSWingComponentSegment&>(wing.GetComponentSegment(j));
-            if (segment.GetUID() == csUid.toStdString()) {
-                drawWingComponentSegment(segment);
-                break;
-            }
-        }
-    }
+    drawComponentByUID(csUid);
 }
 
 void TIGLViewerDocument::drawWingComponentSegmentPoints()

--- a/bindings/python_internal/geometry.i
+++ b/bindings/python_internal/geometry.i
@@ -70,6 +70,7 @@
 #include "CTiglInterpolatePointsWithKinks.h"
 #include "CTiglApproxResult.h"
 #include "SurfTools.hxx"
+#include "CTiglConcatSurfaces.h"
 %}
 
 
@@ -92,6 +93,7 @@
 %boost_optional(tigl::generated::CPACSPointX)
 %boost_optional(tigl::generated::CPACSPointXYZ)
 
+%include "CTiglConcatSurfaces.h"
 %include "SurfTools.hxx"
 %include "CTiglApproxResult.h"
 %include "CTiglIntersectBSplines.h"

--- a/bindings/python_internal/geometry.i
+++ b/bindings/python_internal/geometry.i
@@ -69,6 +69,7 @@
 #include "CTiglIntersectBSplines.h"
 #include "CTiglInterpolatePointsWithKinks.h"
 #include "CTiglApproxResult.h"
+#include "SurfTools.hxx"
 %}
 
 
@@ -80,7 +81,9 @@
 
 %template(CPointContainer) std::vector<gp_Pnt>;
 %template(BSplineCurveList) std::vector<Handle_Geom_BSplineCurve>;
+%template(BSplineSurfaceList) std::vector<Handle_Geom_BSplineSurface>;
 %template(CurveList) std::vector<Handle_Geom_Curve>;
+%template(SurfaceList) std::vector<Handle_Geom_Surface>;
 %template(CurveIntersectionResultList) std::vector<tigl::CurveIntersectionResult>;
 
 %boost_optional(tigl::CCPACSPointAbsRel)
@@ -89,6 +92,7 @@
 %boost_optional(tigl::generated::CPACSPointX)
 %boost_optional(tigl::generated::CPACSPointXYZ)
 
+%include "SurfTools.hxx"
 %include "CTiglApproxResult.h"
 %include "CTiglIntersectBSplines.h"
 %include "CTiglPointsToBSplineInterpolation.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ endforeach()
 
 # object library containing just the compiled sources
 add_library(tigl3_objects OBJECT ${TIGL_SRC})
+target_compile_features(tigl3_objects PRIVATE cxx_std_11)
 set_property(TARGET tigl3_objects PROPERTY POSITION_INDEPENDENT_CODE ON) # needed for shared libraries
 
 target_include_directories(tigl3_objects
@@ -207,6 +208,7 @@ target_include_directories(tigl3_cpp INTERFACE
 )
 
 target_link_libraries(tigl3_cpp INTERFACE ${OpenCASCADE_LIBRARIES} Boost::boost Boost::disable_autolinking)
+target_compile_features(tigl3_cpp INTERFACE cxx_std_11)
 
 if (TARGET glog::glog)
   target_link_libraries (tigl3_cpp INTERFACE glog::glog)

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -324,6 +324,14 @@ size_t IndexFromUid(const std::vector<std::unique_ptr<T> >& vectorOfPointers, co
     return found - vectorOfPointers.begin();
 }
 
+/**
+ * @brief Searches for a entry in a range and returns its index
+ *
+ * This function can be used with std::arrays, std::vectors
+ * and also possible other containers supported by std::distance
+ *
+ * If the index is not found, the size of the range will be returned instead
+ */
 template <typename ForwardIter, typename Compare>
 size_t FindIndex(ForwardIter begin, ForwardIter end, Compare comp)
 {
@@ -336,6 +344,14 @@ size_t FindIndex(ForwardIter begin, ForwardIter end, Compare comp)
     }
 }
 
+/**
+ * @brief Checks, whether an array contains a value or not
+ *
+ * @param array The array to be searched in
+ * @param val The value to be saerched for
+ * @param tolerance This functions is typically used with floating point values. The tolerance allows
+ *                  to search for a value within the specified tolerance.
+ */
 template <typename ArrayLike, typename ValueType>
 bool Contains(const ArrayLike& array, ValueType val, ValueType tolerance)
 {

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -324,6 +324,28 @@ size_t IndexFromUid(const std::vector<std::unique_ptr<T> >& vectorOfPointers, co
     return found - vectorOfPointers.begin();
 }
 
+template <typename ForwardIter, typename Compare>
+size_t FindIndex(ForwardIter begin, ForwardIter end, Compare comp)
+{
+    const auto it = std::find_if(begin, end, comp);
+    if (it != end) {
+        return std::distance(begin, it);
+    }
+    else {
+        return std::distance(begin, end);
+    }
+}
+
+template <typename ArrayLike, typename ValueType>
+bool Contains(const ArrayLike& array, ValueType val, ValueType tolerance)
+{
+    auto idx = FindIndex(std::begin(array), std::end(array), [val, tolerance](const typename ArrayLike::value_type& cval) {
+        return fabs(cval - val) < tolerance;
+    });
+
+    return idx < array.size();
+}
+
 template <class ArrayType, typename BinaryPredicate, typename BinaryMerge>
 void ReplaceAdjacentWithMerged(ArrayType& list, BinaryPredicate is_adjacent, BinaryMerge merged)
 {

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -1188,4 +1188,112 @@ Handle(Geom_BSplineCurve) CTiglBSplineAlgorithms::concatCurves(std::vector<Handl
     return result;
 }
 
+Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::concatSurfacesUDir(Handle(Geom_BSplineSurface) bspl1,
+                                                                       Handle(Geom_BSplineSurface) bspl2,
+                                                                       double space_tol)
+{
+
+    // the surfaces must not be periodic in u direction
+    assert (bspl1->IsUPeriodic() == false);
+    assert (bspl2->IsUPeriodic() == false);
+
+    // we dont have nurbs implemented right now
+    assert (bspl1->IsURational() == false);
+    assert (bspl2->IsURational() == false);
+    assert (bspl1->IsVRational() == false);
+    assert (bspl2->IsVRational() == false);
+
+    double param_tol = 1e-15;
+
+    // check that surfaces are following parametrically
+    double umin1, umax1, vmin1, vmax1;
+    bspl1->Bounds(umin1, umax1, vmin1, vmax1);
+    double umin2, umax2, vmin2, vmax2;
+    bspl2->Bounds(umin2, umax2, vmin2, vmax2);
+
+    if (std::abs(umax1 - umin2) > param_tol) {
+        std::stringstream str;
+        str << "Surfaces do not follow in u-parametric direction in CTiglBSplineAlgorithms::concatSurfacesUDir. ";
+        str << "Surface 1 ends at " << umax1 << ", Surface 2 begins at " << umin2 << "!";
+        throw CTiglError(str.str(), TIGL_MATH_ERROR);
+    }
+
+    bspl1->SetVNotPeriodic();
+    bspl2->SetVNotPeriodic();
+
+    auto u_degree = std::max(bspl1->UDegree(), bspl2->UDegree());
+    auto v_degree = std::max(bspl1->VDegree(), bspl2->VDegree());
+
+    bspl1->IncreaseDegree(u_degree, v_degree);
+    bspl2->IncreaseDegree(u_degree, v_degree);
+
+    // check that corner points match
+    auto leftCornerDist = bspl1->Value(umax1, vmin1).Distance(bspl2->Value(umin2, vmin2));
+    auto rightCornerDist = bspl1->Value(umax1, vmax1).Distance(bspl2->Value(umin2, vmax2)) ;
+    if (leftCornerDist > space_tol || rightCornerDist > space_tol) {
+        throw CTiglError("Surfaces don't match within tolerances in CTiglBSplineAlgorithms::concatSurfacesUDir.", TIGL_MATH_ERROR);
+    }
+
+    auto spl_vec = CTiglBSplineAlgorithms::createCommonVKnotsVectorSurface({bspl1, bspl2});
+    bspl1 = spl_vec[0];
+    bspl2 = spl_vec[1];
+
+    assert(bspl1->NbVPoles() == bspl2->NbVPoles());
+
+    // concat control points
+    TColgp_Array2OfPnt cpsNew(1, bspl1->NbUPoles() + bspl2->NbUPoles() - 1, 1, bspl1->NbVPoles());
+    for (int iv = 0; iv < bspl1->NbVPoles(); ++iv) {
+        for (int iu = 0; iu < bspl1->NbUPoles() - 1; ++iu) {
+            cpsNew.SetValue(iu+1, iv+1, bspl1->Pole(iu+1, iv+1));
+        }
+        auto offset = bspl1->NbUPoles();
+        for (int iu = 0; iu < bspl2->NbUPoles(); ++iu) {
+            cpsNew.SetValue(iu + offset, iv+1, bspl2->Pole(iu+1, iv+1));
+        }
+    }
+
+    // concat knots and mults
+    TColStd_Array1OfReal uknots_new(1, bspl1->NbUKnots() + bspl2->NbUKnots() - 1);
+    TColStd_Array1OfInteger umults_new(1, bspl1->NbUKnots() + bspl2->NbUKnots() - 1);
+
+    for (int i = 0; i < bspl1->NbUKnots()-1; ++i) {
+        uknots_new.SetValue(i+1, bspl1->UKnot(i+1));
+        umults_new.SetValue(i+1, bspl1->UMultiplicity(i+1));
+    }
+
+    int middleIdx = bspl1->NbUKnots();
+    uknots_new.SetValue(middleIdx, 0.5 * (bspl1->UKnot(middleIdx) + bspl2->UKnot(1)));
+    umults_new.SetValue(middleIdx, bspl1->UMultiplicity(middleIdx) - 1);
+
+    for (int i = 1; i < bspl2->NbUKnots(); ++i) {
+        uknots_new.SetValue(i + middleIdx, bspl2->UKnot(i+1));
+        umults_new.SetValue(i + middleIdx, bspl2->UMultiplicity(i+1));
+    }
+
+    // we simply take the v-knots of the first spline
+    TColStd_Array1OfReal vknots_new(1, bspl1->NbVKnots());
+    TColStd_Array1OfInteger vmults_new(1, bspl1->NbVKnots());
+    bspl1->VKnots(vknots_new);
+    bspl1->VMultiplicities(vmults_new);
+
+#ifdef DEBUG
+    int sum_umults = 0;
+    for (int i = umults_new.Lower(); i <= umults_new.Upper(); ++i) {
+        sum_umults += umults_new.Value(i);
+    }
+
+    int sum_vmults = 0;
+    for (int i = vmults_new.Lower(); i <= vmults_new.Upper(); ++i) {
+        sum_vmults += vmults_new.Value(i);
+    }
+
+    assert(cpsNew.ColLength() + u_degree + 1 == sum_umults);
+    assert(cpsNew.RowLength() + v_degree + 1 == sum_vmults);
+#endif
+
+    return new Geom_BSplineSurface(cpsNew, uknots_new, vknots_new,
+                                   umults_new, vmults_new,
+                                   u_degree, v_degree, false, false);
+}
+
 } // namespace tigl

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -1301,7 +1301,7 @@ Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::concatSurfacesUDir(Handle(Ge
                                    u_degree, v_degree, false, false);
 }
 
-Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::approxSurface(Handle(Geom_BSplineSurface) surf, unsigned int nseg_u, unsigned int nseg_v)
+Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::makeKnotsUniform(Handle(Geom_BSplineSurface) surf, unsigned int nseg_u, unsigned int nseg_v)
 {
     double u1, u2, v1, v2;
     surf->Bounds(u1, u2, v1, v2);

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -25,6 +25,7 @@
 #include "CTiglPointsToBSplineInterpolation.h"
 #include "to_string.h"
 #include "tiglcommonfunctions.h"
+#include "Debugging.h"
 
 #include <Standard_Version.hxx>
 #include <Geom2d_BSplineCurve.hxx>
@@ -1192,6 +1193,10 @@ Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::concatSurfacesUDir(Handle(Ge
                                                                        Handle(Geom_BSplineSurface) bspl2,
                                                                        double space_tol)
 {
+
+    DEBUG_SCOPE(debug);
+    debug.addShape(BRepBuilderAPI_MakeFace(bspl1, 1e-6).Face(), "surf1");
+    debug.addShape(BRepBuilderAPI_MakeFace(bspl2, 1e-6).Face(), "surf2");
 
     // the surfaces must not be periodic in u direction
     assert (bspl1->IsUPeriodic() == false);

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -535,56 +535,24 @@ std::vector<Handle(Geom_BSplineCurve)> CTiglBSplineAlgorithms::createCommonKnots
     return std::vector<Handle(Geom_BSplineCurve)>(splines_adapter.begin(), splines_adapter.end());
 }
 
-std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface) >& old_surfaces_vector)
+std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface) >& old_surfaces_vector, SurfaceDirection dir)
 {
-    // all B-spline surfaces must have the same parameter range in u- and v-direction
-    // TODO: Match parameter range
-
     // Create a copy that we can modify
     std::vector<SurfAdapterView> adapterSplines;
     for (size_t i = 0; i < old_surfaces_vector.size(); ++i) {
         adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), udir));
     }
 
-    // first in u direction
-    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
-
-    for (size_t i = 0; i < old_surfaces_vector.size(); ++i) adapterSplines[i].setDir(vdir);
-
-    // now in v direction
-    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
-
-    return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
-}
-
-std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonUKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface) >& old_surfaces_vector)
-{
-    // all B-spline surfaces must have the same parameter range in u- and v-direction
-    // TODO: Match parameter range
-
-    // Create a copy that we can modify
-    std::vector<SurfAdapterView> adapterSplines;
-    for (size_t i = 0; i < old_surfaces_vector.size(); ++i) {
-        adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), udir));
+    if (dir == SurfaceDirection::u || dir == SurfaceDirection::both) {
+        // first in u direction
+        makeGeometryCompatibleImpl(adapterSplines, 1e-14);
     }
 
-    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
-
-    return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
-}
-
-std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonVKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface) >& old_surfaces_vector)
-{
-    // all B-spline surfaces must have the same parameter range in u- and v-direction
-    // TODO: Match parameter range
-
-    // Create a copy that we can modify
-    std::vector<SurfAdapterView> adapterSplines;
-    for (size_t i = 0; i < old_surfaces_vector.size(); ++i) {
-        adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), vdir));
+    if (dir == SurfaceDirection::v || dir == SurfaceDirection::both) {
+         // now in v direction
+        for (size_t i = 0; i < old_surfaces_vector.size(); ++i) adapterSplines[i].setDir(vdir);
+        makeGeometryCompatibleImpl(adapterSplines, 1e-14);
     }
-
-    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
 
     return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
 }
@@ -1239,7 +1207,7 @@ Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::concatSurfacesUDir(Handle(Ge
         throw CTiglError("Surfaces don't match within tolerances in CTiglBSplineAlgorithms::concatSurfacesUDir.", TIGL_MATH_ERROR);
     }
 
-    auto spl_vec = CTiglBSplineAlgorithms::createCommonVKnotsVectorSurface({bspl1, bspl2});
+    auto spl_vec = CTiglBSplineAlgorithms::createCommonKnotsVectorSurface({bspl1, bspl2}, SurfaceDirection::v);
     bspl1 = spl_vec[0];
     bspl2 = spl_vec[1];
 

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -546,12 +546,12 @@ std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonKn
     }
 
     // first in u direction
-    makeGeometryCompatibleImpl(adapterSplines, 1e-15);
+    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
 
     for (size_t i = 0; i < old_surfaces_vector.size(); ++i) adapterSplines[i].setDir(vdir);
 
     // now in v direction
-    makeGeometryCompatibleImpl(adapterSplines, 1e-15);
+    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
 
     return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
 }
@@ -567,7 +567,7 @@ std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonUK
         adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), udir));
     }
 
-    makeGeometryCompatibleImpl(adapterSplines, 1e-15);
+    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
 
     return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
 }
@@ -583,7 +583,7 @@ std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonVK
         adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), vdir));
     }
 
-    makeGeometryCompatibleImpl(adapterSplines, 1e-15);
+    makeGeometryCompatibleImpl(adapterSplines, 1e-14);
 
     return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
 }
@@ -847,6 +847,23 @@ void CTiglBSplineAlgorithms::reparametrizeBSpline(Geom_BSplineCurve& spline, dou
         spline.Knots (aKnots);
         BSplCLib::Reparametrize (umin, umax, aKnots);
         spline.SetKnots (aKnots);
+    }
+}
+
+void CTiglBSplineAlgorithms::reparametrizeBSpline(Geom_BSplineSurface& spline, double umin, double umax, double vmin, double vmax, double tol)
+{
+    if (std::abs(spline.UKnot(1) - umin) > tol || std::abs(spline.UKnot(spline.NbUKnots()) - umax) > tol) {
+        TColStd_Array1OfReal aKnots (1, spline.NbUKnots());
+        spline.UKnots (aKnots);
+        BSplCLib::Reparametrize (umin, umax, aKnots);
+        spline.SetUKnots (aKnots);
+    }
+
+    if (std::abs(spline.VKnot(1) - vmin) > tol || std::abs(spline.VKnot(spline.NbVKnots()) - vmax) > tol) {
+        TColStd_Array1OfReal aKnots (1, spline.NbVKnots());
+        spline.VKnots (aKnots);
+        BSplCLib::Reparametrize (vmin, vmax, aKnots);
+        spline.SetVKnots (aKnots);
     }
 }
 

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -556,6 +556,38 @@ std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonKn
     return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
 }
 
+std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonUKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface) >& old_surfaces_vector)
+{
+    // all B-spline surfaces must have the same parameter range in u- and v-direction
+    // TODO: Match parameter range
+
+    // Create a copy that we can modify
+    std::vector<SurfAdapterView> adapterSplines;
+    for (size_t i = 0; i < old_surfaces_vector.size(); ++i) {
+        adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), udir));
+    }
+
+    makeGeometryCompatibleImpl(adapterSplines, 1e-15);
+
+    return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
+}
+
+std::vector<Handle(Geom_BSplineSurface) > CTiglBSplineAlgorithms::createCommonVKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface) >& old_surfaces_vector)
+{
+    // all B-spline surfaces must have the same parameter range in u- and v-direction
+    // TODO: Match parameter range
+
+    // Create a copy that we can modify
+    std::vector<SurfAdapterView> adapterSplines;
+    for (size_t i = 0; i < old_surfaces_vector.size(); ++i) {
+        adapterSplines.push_back(SurfAdapterView(Handle(Geom_BSplineSurface)::DownCast(old_surfaces_vector[i]->Copy()), vdir));
+    }
+
+    makeGeometryCompatibleImpl(adapterSplines, 1e-15);
+
+    return std::vector<Handle(Geom_BSplineSurface)>(adapterSplines.begin(), adapterSplines.end());
+}
+
 void CTiglBSplineAlgorithms::matchParameterRange(std::vector<Handle(Geom_BSplineCurve)> const& bsplines, double tolerance)
 {
     Standard_Real umin = bsplines[0]->FirstParameter();

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -129,6 +129,31 @@ public:
     TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
 
     /**
+     * @brief createCommonUKnotsVectorSurface:
+     *          Creates a common knot vector in u-direction of the given vector of B-spline surfaces
+     *          The common knot vector contains all knots in u-direction of all surfaces with the highest multiplicity of all surfaces.
+     * @param old_surfaces_vector:
+     *          the given vector of B-spline surfaces that could have a different knot vector in u-direction
+     * @return
+     *          the given vector of B-spline surfaces, now with a common knot vector
+     *          The B-spline surface geometry remains the same.
+     */
+    TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonUKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
+
+    /**
+     * @brief createCommonVKnotsVectorSurface:
+     *          Creates a common knot vector in v-direction of the given vector of B-spline surfaces
+     *          The common knot vector contains all knots in v-direction of all surfaces with the highest multiplicity of all surfaces.
+     * @param old_surfaces_vector:
+     *          the given vector of B-spline surfaces that could have a different knot vector in v-direction
+     * @return
+     *          the given vector of B-spline surfaces, now with a common knot vector
+     *          The B-spline surface geometry remains the same.
+     */
+    TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonVKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
+
+
+    /**
      */
     TIGL_EXPORT static void reparametrizeBSpline(Geom_BSplineCurve& spline, double umin, double umax, double tol=1e-15);
 

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -310,19 +310,20 @@ public:
     TIGL_EXPORT static Handle(Geom_BSplineSurface) concatSurfacesUDir(Handle(Geom_BSplineSurface) bspl1, Handle(Geom_BSplineSurface) bspl2, double space_tol=1e-5);
 
     /**
-     * @ brief Approximates a surface by sampling it and interpolating it
-     * with a degree 3 b-spline surface
+     * @ brief Changes the knot sequence to be uniform after calling the function
      *
-     * The approximation error depends on the number of segments.
-     * The more segments are used, the better will be the result.
+     * Technically, this is done by approximating the surface with a new surface
+     * which also adds an approximation error.
+     * For the surface approximation, derivatives at the boundary are not taken into account yet.
      *
-     * Currently, derivatives at the boundary are not taken into account.
+     * The approximation error depends on the number of knot segments,
+     * the more segments are used, the better will be the result.
      *
      * @param surf Surface to approximate
      * @param nseg_u Number of knot segments in u direction
      * @param nseg_v Number of knot segments in v direction
     */
-    TIGL_EXPORT static Handle(Geom_BSplineSurface) approxSurface(Handle(Geom_BSplineSurface) surf, unsigned int nseg_u, unsigned int nseg_v);
+    TIGL_EXPORT static Handle(Geom_BSplineSurface) makeKnotsUniform(Handle(Geom_BSplineSurface) surf, unsigned int nseg_u, unsigned int nseg_v);
 };
 } // namespace tigl
 

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -152,10 +152,15 @@ public:
      */
     TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonVKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
 
-
     /**
+     * Changes the parameter range of the b-spline curve
      */
     TIGL_EXPORT static void reparametrizeBSpline(Geom_BSplineCurve& spline, double umin, double umax, double tol=1e-15);
+
+    /**
+     * Changes the parameter range of the b-spline surfae
+     */
+    TIGL_EXPORT static void reparametrizeBSpline(Geom_BSplineSurface& spline, double umin, double umax, double vmin, double vmax, double tol);
 
     /**
      * Reparametrizes the B-Spline such that the knot distribution is uniform and the number of

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -292,6 +292,22 @@ public:
     TIGL_EXPORT static Handle(Geom_BSplineCurve) concatCurves(std::vector<Handle(Geom_BSplineCurve)> curves,
                                                               bool parByLength=true, double tolerance = 1e-6);
 
+    /**
+     * @brief Concatenates two surfaces in u direction
+     *
+     * Note: This function has the following requirements
+     *   - s2 follows s1 in u direction and have a common boundary
+     *   - s2 follows s1 also in parametric domain
+     *   - both surfaces are non-rational!
+     *   - the surfaces a non-periodic in u direction
+     *
+     * The resulting surface might not C1 and C2 continuous.
+     * We still have geometric continuity.
+     *
+     * To achieve parametric continuity, the surfaces must be
+     * re-parametrized accordingly before
+     */
+    TIGL_EXPORT static Handle(Geom_BSplineSurface) concatSurfacesUDir(Handle(Geom_BSplineSurface) bspl1, Handle(Geom_BSplineSurface) bspl2, double space_tol=1e-5);
 };
 } // namespace tigl
 

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -308,6 +308,21 @@ public:
      * re-parametrized accordingly before
      */
     TIGL_EXPORT static Handle(Geom_BSplineSurface) concatSurfacesUDir(Handle(Geom_BSplineSurface) bspl1, Handle(Geom_BSplineSurface) bspl2, double space_tol=1e-5);
+
+    /**
+     * @ brief Approximates a surface by sampling it and interpolating it
+     * with a degree 3 b-spline surface
+     *
+     * The approximation error depends on the number of segments.
+     * The more segments are used, the better will be the result.
+     *
+     * Currently, derivatives at the boundary are not taken into account.
+     *
+     * @param surf Surface to approximate
+     * @param nseg_u Number of knot segments in u direction
+     * @param nseg_v Number of knot segments in v direction
+    */
+    TIGL_EXPORT static Handle(Geom_BSplineSurface) approxSurface(Handle(Geom_BSplineSurface) surf, unsigned int nseg_u, unsigned int nseg_v);
 };
 } // namespace tigl
 

--- a/src/geometry/CTiglBSplineAlgorithms.h
+++ b/src/geometry/CTiglBSplineAlgorithms.h
@@ -39,6 +39,14 @@
 namespace tigl
 {
 
+enum class SurfaceDirection
+{
+    u,
+    v,
+    both
+};
+
+
 class CTiglBSplineAlgorithms
 {
 public:
@@ -117,40 +125,20 @@ public:
 
     /**
      * @brief createCommonKnotsVectorSurface:
-     *          Creates a common knot vector in both u- and v-direction of the given vector of B-spline surfaces
+     *          Creates a common knot vector in both u- and / or v-direction of the given vector of B-spline surfaces
      *          The common knot vector contains all knots in u- and v-direction of all surfaces with the highest multiplicity of all surfaces.
-     *          !!! This method calls the method createCommonKnotsVectorSurfaceOneDir two times to create a common knot vector in both directions !!!
+     *
+     *          Note: the parameter range of the surfaces must match before calling this function.
+     *
      * @param old_surfaces_vector:
      *          the given vector of B-spline surfaces that could have a different knot vector in u- and v-direction
+     * @param dir:
+     *          Defines, which knot vector (u/v/both) is modified
      * @return
      *          the given vector of B-spline surfaces, now with a common knot vector
      *          The B-spline surface geometry remains the same.
      */
-    TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
-
-    /**
-     * @brief createCommonUKnotsVectorSurface:
-     *          Creates a common knot vector in u-direction of the given vector of B-spline surfaces
-     *          The common knot vector contains all knots in u-direction of all surfaces with the highest multiplicity of all surfaces.
-     * @param old_surfaces_vector:
-     *          the given vector of B-spline surfaces that could have a different knot vector in u-direction
-     * @return
-     *          the given vector of B-spline surfaces, now with a common knot vector
-     *          The B-spline surface geometry remains the same.
-     */
-    TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonUKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
-
-    /**
-     * @brief createCommonVKnotsVectorSurface:
-     *          Creates a common knot vector in v-direction of the given vector of B-spline surfaces
-     *          The common knot vector contains all knots in v-direction of all surfaces with the highest multiplicity of all surfaces.
-     * @param old_surfaces_vector:
-     *          the given vector of B-spline surfaces that could have a different knot vector in v-direction
-     * @return
-     *          the given vector of B-spline surfaces, now with a common knot vector
-     *          The B-spline surface geometry remains the same.
-     */
-    TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonVKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector);
+    TIGL_EXPORT static std::vector<Handle(Geom_BSplineSurface) > createCommonKnotsVectorSurface(const std::vector<Handle(Geom_BSplineSurface)>& old_surfaces_vector, SurfaceDirection dir);
 
     /**
      * Changes the parameter range of the b-spline curve

--- a/src/geometry/CTiglConcatSurfaces.cpp
+++ b/src/geometry/CTiglConcatSurfaces.cpp
@@ -1,0 +1,85 @@
+/*
+* Copyright (C) 2020 German Aerospace Center (DLR/SC)
+*
+* Created: 2020-09-10 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "CTiglConcatSurfaces.h"
+
+#include <CTiglBSplineAlgorithms.h>
+#include <CTiglError.h>
+
+#include <algorithm>
+
+namespace tigl
+{
+
+CTiglConcatSurfaces::CTiglConcatSurfaces(const std::vector<Handle(Geom_BSplineSurface)>& surfaces,
+                                         const std::vector<double>& surfaceParams, ConcatDir dir)
+    : m_surfaces(surfaces)
+    , m_params(surfaceParams)
+    , m_dir(dir)
+{
+
+    if (surfaces.size() + 1 != surfaceParams.size()) {
+        throw CTiglError("Surfaces dont match parameters: Number of parameters != number of surfaces + 1");
+    }
+
+    if (dir ==ConcatDir::v) {
+        throw CTiglError("CTiglConcatSurfaces in v-direction not yet implemented");
+    }
+
+    std::sort(m_params.begin(), m_params.end());
+}
+
+void CTiglConcatSurfaces::SetApproxInputSurfacesEnabled(unsigned int nUSeg, unsigned int nVSeg)
+{
+    if (nUSeg > 0 && nVSeg > 0) {
+        m_approxSegments.reset({nUSeg, nVSeg});
+    }
+    else {
+        m_approxSegments.reset();
+    }
+}
+
+Handle(Geom_BSplineSurface) CTiglConcatSurfaces::Surface() const
+{
+    // create a copy of all surfaces
+    std::vector<Handle(Geom_BSplineSurface)> surfaces;
+    std::transform(std::begin(m_surfaces), std::end(m_surfaces), std::back_inserter(surfaces),
+                   [](const Handle(Geom_BSplineSurface) & surf) {
+                       return Handle(Geom_BSplineSurface)::DownCast(surf->Copy());
+                   });
+
+    if (m_approxSegments) {
+        std::transform(
+            std::begin(surfaces), std::end(surfaces), std::begin(surfaces), [this](Handle(Geom_BSplineSurface) & surf) {
+                return CTiglBSplineAlgorithms::approxSurface(surf, m_approxSegments->nu, m_approxSegments->nv);
+            });
+    }
+
+    for (size_t surfIdx = 0; surfIdx < surfaces.size(); ++surfIdx) {
+        CTiglBSplineAlgorithms::reparametrizeBSpline(*surfaces[surfIdx], m_params[surfIdx], m_params[surfIdx + 1], 0.,
+                                                     1., 1e-10);
+    }
+
+    for (size_t surfIdx = 1; surfIdx < surfaces.size(); ++surfIdx) {
+        surfaces[0] = CTiglBSplineAlgorithms::concatSurfacesUDir(surfaces[0], surfaces[surfIdx]);
+    }
+
+    return surfaces[0];
+}
+
+} // namespace tigl

--- a/src/geometry/CTiglConcatSurfaces.cpp
+++ b/src/geometry/CTiglConcatSurfaces.cpp
@@ -44,7 +44,7 @@ CTiglConcatSurfaces::CTiglConcatSurfaces(const std::vector<Handle(Geom_BSplineSu
     std::sort(m_params.begin(), m_params.end());
 }
 
-void CTiglConcatSurfaces::SetApproxInputSurfacesEnabled(unsigned int nUSeg, unsigned int nVSeg)
+void CTiglConcatSurfaces::SetMakeKnotsUniformEnabled(unsigned int nUSeg, unsigned int nVSeg)
 {
     if (nUSeg > 0 && nVSeg > 0) {
         m_approxSegments.reset({nUSeg, nVSeg});
@@ -66,7 +66,7 @@ Handle(Geom_BSplineSurface) CTiglConcatSurfaces::Surface() const
     if (m_approxSegments) {
         std::transform(
             std::begin(surfaces), std::end(surfaces), std::begin(surfaces), [this](Handle(Geom_BSplineSurface) & surf) {
-                return CTiglBSplineAlgorithms::approxSurface(surf, m_approxSegments->nu, m_approxSegments->nv);
+                return CTiglBSplineAlgorithms::makeKnotsUniform(surf, m_approxSegments->nu, m_approxSegments->nv);
             });
     }
 

--- a/src/geometry/CTiglConcatSurfaces.h
+++ b/src/geometry/CTiglConcatSurfaces.h
@@ -1,0 +1,77 @@
+/*
+* Copyright (C) 2020 German Aerospace Center (DLR/SC)
+*
+* Created: 2020-09-10 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef CTIGLCONCATSURFACES_H
+#define CTIGLCONCATSURFACES_H
+
+#include "tigl_internal.h"
+#include <vector>
+#include <Geom_BSplineSurface.hxx>
+#include <boost/optional.hpp>
+
+namespace tigl
+{
+
+enum class ConcatDir
+{
+    u,
+    v
+};
+
+class CTiglConcatSurfaces
+{
+public:
+    /**
+     * @brief Concatenes multiple surfaces along the given directions
+     *
+     * Note: The surfaces must follow in the correct order in the specified direction
+     *
+     * @param surfaces      The surfaces to concatenate
+     * @param surfaceParams A vector of parameters that define the parameters at the final surface, at which
+     *                      the input surfaces are stitched.
+     * @param dir           Direction to concatenate
+     */
+    TIGL_EXPORT CTiglConcatSurfaces(const std::vector<Handle(Geom_BSplineSurface)>& surfaces,
+                                    const std::vector<double>& surfaceParams, ConcatDir dir);
+
+    /**
+     * @brief Enables the approximation of the input surfaces with the specified number of segments
+     * @param nUSeg Number of segments in u dir to approximate
+     * @param nVSeg Number of segments in v dir to approximate
+     */
+    TIGL_EXPORT void SetApproxInputSurfacesEnabled(unsigned int nUSeg, unsigned int nVSeg);
+
+    /**
+     + @brief Returns the final surface
+     */
+    TIGL_EXPORT Handle(Geom_BSplineSurface) Surface() const;
+
+private:
+    std::vector<Handle(Geom_BSplineSurface)> m_surfaces;
+    std::vector<double> m_params;
+    ConcatDir m_dir;
+
+    struct SegmentsSize {
+        unsigned int nu, nv;
+    };
+    boost::optional<SegmentsSize> m_approxSegments;
+};
+
+} // namespace tigl
+
+#endif // CTIGLCONCATSURFACES_H

--- a/src/geometry/CTiglConcatSurfaces.h
+++ b/src/geometry/CTiglConcatSurfaces.h
@@ -50,11 +50,17 @@ public:
                                     const std::vector<double>& surfaceParams, ConcatDir dir);
 
     /**
-     * @brief Enables the approximation of the input surfaces with the specified number of segments
-     * @param nUSeg Number of segments in u dir to approximate
-     * @param nVSeg Number of segments in v dir to approximate
+     * @brief This allows the algorithm to make the knot sequence of each input
+     * surface uniform.
+     *
+     * This might be useful, if the input surfaces have very different knot distributions
+     * leaving a resulting in a bad balanced knot vector of the final surfaces.
+     * This approximation comes however with an error.
+     *
+     * @param nUSeg Number of knot segments in u dir to approximate
+     * @param nVSeg Number of knot segments in v dir to approximate
      */
-    TIGL_EXPORT void SetApproxInputSurfacesEnabled(unsigned int nUSeg, unsigned int nVSeg);
+    TIGL_EXPORT void SetMakeKnotsUniformEnabled(unsigned int nUSeg, unsigned int nVSeg);
 
     /**
      + @brief Returns the final surface

--- a/src/geometry/CTiglGordonSurfaceBuilder.cpp
+++ b/src/geometry/CTiglGordonSurfaceBuilder.cpp
@@ -189,7 +189,8 @@ void CTiglGordonSurfaceBuilder::CreateGordonSurface(const std::vector<Handle(Geo
     surfaces_vector_unmod.push_back(tensorProdSurf);
 
     // create common knot vector for all three surfaces
-    std::vector<Handle(Geom_BSplineSurface)> surfaces_vector = CTiglBSplineAlgorithms::createCommonKnotsVectorSurface(surfaces_vector_unmod);
+    std::vector<Handle(Geom_BSplineSurface)> surfaces_vector = CTiglBSplineAlgorithms::createCommonKnotsVectorSurface(surfaces_vector_unmod,
+                                                                                                                      SurfaceDirection::both);
 
     assert(surfaces_vector.size() == 3);
 

--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -24,7 +24,10 @@
 #include "tigl.h"
 #include "BRepBuilderAPI_GTransform.hxx"
 #include "BRepBuilderAPI_Transform.hxx"
+#include "BRepBuilderAPI_MakeFace.hxx"
+#include "BRep_Tool.hxx"
 #include "gp_XYZ.hxx"
+#include "TopoDS_Face.hxx"
 #include "Standard_Version.hxx"
 #include "CNamedShape.h"
 
@@ -426,6 +429,21 @@ TopoDS_Shape CTiglTransformation::Transform(const TopoDS_Shape& shape) const
         const TopoDS_Shape& transformedShape = brepBuilderGTransform.Shape();
         return transformedShape;
     }
+}
+
+// Transforms a surface with the current transformation matrix and
+// returns the transformed point
+TIGL_EXPORT Handle(Geom_Surface) CTiglTransformation::Transform(const Handle(Geom_Surface)& surf) const
+{
+    auto surfCopy = Handle(Geom_Surface)::DownCast(surf->Copy());
+
+    TopoDS_Face tmpFace = BRepBuilderAPI_MakeFace(surfCopy, 1e-6);
+    tmpFace = TopoDS::Face(Transform(tmpFace));
+    TopLoc_Location L;
+    surfCopy = BRep_Tool::Surface(tmpFace, L);
+    surfCopy->Transform(L.Transformation());
+
+    return surfCopy;
 }
 
 PNamedShape tigl::CTiglTransformation::Transform(PNamedShape shape) const

--- a/src/geometry/CTiglTransformation.h
+++ b/src/geometry/CTiglTransformation.h
@@ -117,7 +117,7 @@ public:
     TIGL_EXPORT gp_Pnt Transform(const gp_Pnt& point) const;
 
     // Transforms a surface with the current transformation matrix and
-    // returns the transformed point
+    // returns the transformed surface
     TIGL_EXPORT Handle(Geom_Surface) Transform(const Handle(Geom_Surface)& surf) const;
 
     // Transforms a vector with the current transformation matrix and

--- a/src/geometry/CTiglTransformation.h
+++ b/src/geometry/CTiglTransformation.h
@@ -28,6 +28,7 @@
 #include "gp_GTrsf.hxx"
 #include "gp_Pnt.hxx"
 #include "TopoDS.hxx"
+#include "Geom_Surface.hxx"
 #include "PNamedShape.h"
 
 namespace tigl
@@ -114,6 +115,10 @@ public:
     // Transforms a point with the current transformation matrix and
     // returns the transformed point
     TIGL_EXPORT gp_Pnt Transform(const gp_Pnt& point) const;
+
+    // Transforms a surface with the current transformation matrix and
+    // returns the transformed point
+    TIGL_EXPORT Handle(Geom_Surface) Transform(const Handle(Geom_Surface)& surf) const;
 
     // Transforms a vector with the current transformation matrix and
     // returns the transformed vector

--- a/src/guide_curves/CCPACSGuideCurves.cpp
+++ b/src/guide_curves/CCPACSGuideCurves.cpp
@@ -101,11 +101,13 @@ std::vector<double> CCPACSGuideCurves::GetRelativeCircumferenceParameters() cons
         const CCPACSGuideCurve* root = GetGuideCurve(iguide).GetRootCurve();
         relCircs.push_back(*root->GetFromRelativeCircumference_choice2());
     }
-    if ( relCircs.back() < 1.0 ) {
-        relCircs.push_back(1.0);
-    }
 
     std::sort(relCircs.begin(), relCircs.end());
+
+    double eps = 1e-10;
+    if ( relCircs.back() < 1.0 - eps ) {
+        relCircs.push_back(1.0);
+    }
 
     return relCircs;
 }

--- a/src/guide_curves/CCPACSGuideCurves.cpp
+++ b/src/guide_curves/CCPACSGuideCurves.cpp
@@ -104,8 +104,7 @@ std::vector<double> CCPACSGuideCurves::GetRelativeCircumferenceParameters() cons
 
     std::sort(relCircs.begin(), relCircs.end());
 
-    double eps = 1e-10;
-    if ( relCircs.back() < 1.0 - eps ) {
+    if (std::abs(relCircs.back() - 1.0) >= 1e-3 ) {
         relCircs.push_back(1.0);
     }
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -865,11 +865,17 @@ TopoDS_Compound CCPACSWing::GetGuideCurveWires() const
 
 std::vector<double> CCPACSWing::GetGuideCurveStartParameters() const
 {
-    std::vector<double> res;
-    for (const auto& curve : guideCurves->curves) {
-        res.push_back(curve.fromRelCircumference);
+    if (GetSegmentCount() == 0) {
+        return {};
     }
-    return res;
+
+    const auto& segment = GetSegment(1);
+    const auto& guides = segment.GetGuideCurves();
+    if (!guides) {
+        return {};
+    }
+
+    return guides->GetRelativeCircumferenceParameters();
 }
 
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -960,8 +960,14 @@ void CCPACSWing::BuildGuideCurveWires(LocatedGuideCurves& cache) const
 
     auto rootIt = roots.begin();
     for (TopoDS_Iterator anIter(wires); anIter.More(); anIter.Next(), rootIt++) {
-        cache.curves.push_back(LocatedGuideCurves::LocatedGuideCurve(TopoDS::Wire(anIter.Value()), rootIt->first));
+        cache.curves.push_back({TopoDS::Wire(anIter.Value()), rootIt->first});
     }
+
+    // sort according to from location parameter
+    using LocCurve = LocatedGuideCurves::LocatedGuideCurve;
+    std::sort(std::begin(cache.curves), std::end(cache.curves), [](const LocCurve& c1, const LocCurve& c2) {
+        return c1.fromRelCircumference < c2.fromRelCircumference;
+    });
 }
 
 TopoDS_Shape transformWingProfileGeometry(const CTiglTransformation& wingTransform, const CTiglWingConnection& connection, const TopoDS_Shape& wire)

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -165,6 +165,9 @@ public:
     // Returns all guide curve wires as a compound
     TIGL_EXPORT TopoDS_Compound GetGuideCurveWires() const;
 
+    // Returns the "fromRelCirc" parameter for each guide curve wire
+    TIGL_EXPORT std::vector<double> GetGuideCurveStartParameters() const;
+
     // Adjust, whether the wing should be modeled with the flaps or not
     TIGL_EXPORT void SetBuildFlaps(bool enabled);
 
@@ -172,7 +175,24 @@ public:
     TIGL_EXPORT PNamedShape GetWingCleanShape() const;
 
 protected:
-    void BuildGuideCurveWires(TopoDS_Compound& cache) const;
+
+    struct LocatedGuideCurves
+    {
+        struct LocatedGuideCurve
+        {
+            LocatedGuideCurve(const TopoDS_Wire& w, double relCirc)
+                : wire(w), fromRelCircumference(relCirc)
+            {}
+
+            TopoDS_Wire wire;
+            double fromRelCircumference;
+        };
+
+        TopoDS_Compound wiresAsCompound;
+        std::vector<LocatedGuideCurve> curves;
+    };
+
+    void BuildGuideCurveWires(LocatedGuideCurves& cache) const;
 
     // Cleanup routine
     void Cleanup();
@@ -205,7 +225,8 @@ private:
     TopoDS_Shape                   fusedSegmentWithEdge;     /**< All Segments in one shape plus modelled leading edge */ 
     TopoDS_Shape                   upperShape;
     TopoDS_Shape                   lowerShape;
-    Cache<TopoDS_Compound, CCPACSWing> guideCurves;
+
+    Cache<LocatedGuideCurves, CCPACSWing> guideCurves;
 
     Cache<PNamedShape, CCPACSWing> wingShapeWithCutouts;     /**< Wing without flaps / flaps removed */
     Cache<PNamedShape, CCPACSWing> wingCleanShape;           /**< Clean wing surface without flaps cutout*/

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -180,10 +180,6 @@ protected:
     {
         struct LocatedGuideCurve
         {
-            LocatedGuideCurve(const TopoDS_Wire& w, double relCirc)
-                : wire(w), fromRelCircumference(relCirc)
-            {}
-
             TopoDS_Wire wire;
             double fromRelCircumference;
         };

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -954,6 +954,7 @@ void CCPACSWingSegment::MakeSurfaces(SurfaceCache& cache) const
     if (m_guideCurves) {
         auto params = m_guideCurves->GetRelativeCircumferenceParameters();
         auto it = std::find_if(std::begin(params), std::end(params), [](double val) {
+            // the leading edge is defined at parameter 0, we allow some tolerance
             return std::abs(val) < 1e-3;
         });
 
@@ -969,7 +970,7 @@ void CCPACSWingSegment::MakeSurfaces(SurfaceCache& cache) const
 
         auto concatSurfs = [](const TopoDS_Shape& shape, const std::vector<double>& parms) {
             if (GetNumberOfFaces(shape) == 1) {
-                return GeomConvert::SurfaceToBSplineSurface(BRep_Tool::Surface(TopoDS::Face(shape)));
+                return BRep_Tool::Surface(TopoDS::Face(shape));
             }
             else {
                 std::vector<Handle(Geom_BSplineSurface)> surfs;
@@ -981,7 +982,7 @@ void CCPACSWingSegment::MakeSurfaces(SurfaceCache& cache) const
                 }
 
                 CTiglConcatSurfaces concat(surfs, parms, ConcatDir::u);
-                return concat.Surface();
+                return Handle(Geom_Surface)(concat.Surface());
             }
         };
 

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -997,7 +997,7 @@ void CCPACSWingSegment::MakeSurfaces(SurfaceCache& cache) const
     }
 
     cache.lowerSurfaceLocal = globalToLocalTrsf.Transform(cache.lowerSurface);
-    cache.lowerSurfaceLocal = globalToLocalTrsf.Transform(cache.upperSurface);
+    cache.upperSurfaceLocal = globalToLocalTrsf.Transform(cache.upperSurface);
 
 }
 

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -454,8 +454,8 @@ PNamedShape CCPACSWingSegment::BuildLoft() const
     std::string loftShortName = GetShortShapeName();
     PNamedShape loft (new CNamedShape(loftShape, loftName.c_str(), loftShortName.c_str()));
     std::vector<double> guideCurveParams = {};
-    if (GetParent()->IsParent<tigl::CCPACSWing>()) {
-        guideCurveParams = GetParent()->GetParent<tigl::CCPACSWing>()->GetGuideCurveStartParameters();
+    if (GetGuideCurves()) {
+        guideCurveParams = GetGuideCurves()->GetRelativeCircumferenceParameters();
     }
     CTiglWingBuilder::SetFaceTraits(guideCurveParams,  GetUID(), loft, innerConnection.GetProfile().HasBluntTE());
     return loft;
@@ -954,7 +954,7 @@ void CCPACSWingSegment::MakeSurfaces(SurfaceCache& cache) const
     if (m_guideCurves) {
         auto params = m_guideCurves->GetRelativeCircumferenceParameters();
         auto it = std::find_if(std::begin(params), std::end(params), [](double val) {
-            return std::abs(val) < 1e-6;
+            return std::abs(val) < 1e-3;
         });
 
         if (it == params.end()) {

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -60,7 +60,7 @@ size_t find_index(ForwardIter begin, ForwardIter end, Compare comp)
 template <typename ArrayLike, typename ValueType>
 bool contains(const ArrayLike& array, ValueType val)
 {
-    auto idx = find_index(std::cbegin(array), std::cend(array), [val](const auto& cval) {
+    auto idx = find_index(std::begin(array), std::end(array), [val](const typename ArrayLike::value_type& cval) {
         return fabs(cval - val) < 1e-3;
     });
 

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -288,7 +288,6 @@ void CTiglWingBuilder::SetFaceTraits (const std::string& wingUID, PNamedShape lo
     assert(std::is_sorted(std::begin(params), std::end(params)));
 
     bool hasGuideCurves = params.size() > 0.;
-    LOG(ERROR) << "HasGuideCurves " << hasGuideCurves;
 
     size_t nFacesPerSegment = 2; // Without trailing edge
     size_t idx_leading_edge = 1;

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -41,8 +41,6 @@
 #include <cassert>
 #include <algorithm>
 
-#define NO_EXPLICIT_TE_MODELING
-
 namespace
 {
 template <typename ForwardIter, typename Compare>
@@ -78,208 +76,6 @@ CTiglWingBuilder::CTiglWingBuilder(const CCPACSWing& wing)
 {
 }
 
-#ifndef NO_EXPLICIT_TE_MODELING
-Standard_Boolean CreateSideCap(const TopoDS_Wire& W,
-                               const Standard_Real presPln,
-                               TopoDS_Face& theFace);
-
-PNamedShape CTiglWingBuilder::BuildShape()
-{
-    const CCPACSWingSegments& segments = _wing.m_segments;
-
-    // check whether we have a blunt TE or not
-    const CCPACSWingProfile& innerProfile = segments.GetSegment(1).GetInnerConnection().GetProfile();
-
-    TopoDS_Compound guideCurves = _wing.GetGuideCurveWires();
-
-    std::vector<TopoDS_Wire> guides;
-    for (TopoDS_Iterator anIter(guideCurves); anIter.More(); anIter.Next()) {
-        TopoDS_Wire aSh = TopoDS::Wire(anIter.Value());
-        guides.push_back(aSh);
-    }
-
-    // we assume, that all profiles of one wing are either blunt or not
-    // this is checked during cpacs loading of each wing segment
-    bool hasBluntTE = innerProfile.HasBluntTE();
-    bool hasGuideCurves = guides.size() > 0;
-
-
-    CTiglMakeLoft lofter;
-    lofter.setMakeSolid(false);
-
-    std::vector<gp_Pnt> upperTEPoints, lowerTEPoints;
-    for (int i=1; i <= segments.GetSegmentCount(); i++) {
-        const TopoDS_Wire& startWire = segments.GetSegment(i).GetInnerWire();
-
-        // extract trailing edge, in case of a blunt TE
-        // we assume, that the TE is the last edge of the wire
-        if (hasBluntTE) {
-            BRepBuilderAPI_MakeWire wireMaker;
-            TopTools_IndexedMapOfShape edgeMap;
-            TopExp::MapShapes(startWire, TopAbs_EDGE, edgeMap);
-            for (int i = 1; i <= edgeMap.Extent(); ++i) {
-                const TopoDS_Edge& e = TopoDS::Edge(edgeMap(i));
-                if (i < edgeMap.Extent()) {
-                    wireMaker.Add(e);
-                }
-            }
-            TopoDS_Wire aeroProfile = wireMaker.Wire();
-            lofter.addProfiles(aeroProfile);
-            upperTEPoints.push_back(GetLastPoint(aeroProfile));
-            lowerTEPoints.push_back(GetFirstPoint(aeroProfile));
-        }
-        else {
-            lofter.addProfiles(startWire);
-        }
-    }
-
-    TopoDS_Wire endWire =  segments.GetSegment(segments.GetSegmentCount()).GetOuterWire();
-    if (hasBluntTE) {
-        // extract the wire without the trailing edge
-
-        BRepBuilderAPI_MakeWire wireMaker;
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(endWire, TopAbs_EDGE, edgeMap);
-        for (int i = 1; i <= edgeMap.Extent(); ++i) {
-            const TopoDS_Edge& e = TopoDS::Edge(edgeMap(i));
-            if (i < edgeMap.Extent()) {
-                wireMaker.Add(e);
-            }
-        }
-        TopoDS_Wire aeroProfile = wireMaker.Wire();
-        lofter.addProfiles(aeroProfile);
-        upperTEPoints.push_back(GetLastPoint(aeroProfile));
-        lowerTEPoints.push_back(GetFirstPoint(aeroProfile));
-    }
-    else {
-        lofter.addProfiles(endWire);
-    }
-
-    // add guide curves
-    lofter.addGuides(guideCurves);
-
-    TopoDS_Shape aeroShape = lofter.Shape();
-    BRepBuilderAPI_Sewing sewingAlgo;
-    sewingAlgo.Add(aeroShape);
-
-    // If blunt trailing edge is available, model it explicitly
-    if (hasBluntTE) {
-
-        TopoDS_Wire upperTE, lowerTE;
-        if (hasGuideCurves) {
-            // The guide curves are sorted in the order of the relative starting coordinate
-            // at the innermost section
-            upperTE = guides.back();
-            lowerTE = guides.front();
-        }
-        else {
-            // model the edges by taking the first and last profile points
-
-            assert(lowerTEPoints.size() == upperTEPoints.size());
-            assert(lowerTEPoints.size() > 1);
-
-            // build upper edge
-            BRepBuilderAPI_MakeWire upperWireMaker, lowerWireMaker;
-            for (unsigned int i = 0; i < upperTEPoints.size() - 1; ++i) {
-                upperWireMaker.Add(BRepBuilderAPI_MakeEdge(upperTEPoints.at(i), upperTEPoints.at(i+1)));
-                lowerWireMaker.Add(BRepBuilderAPI_MakeEdge(lowerTEPoints.at(i), lowerTEPoints.at(i+1)));
-            }
-            upperTE = upperWireMaker.Wire();
-            lowerTE = lowerWireMaker.Wire();
-        }
-
-        // the TE is build using a ruled loft
-        BRepOffsetAPI_ThruSections trailingEdgeBuilder(Standard_False, Standard_True);
-        trailingEdgeBuilder.AddWire(upperTE);
-        trailingEdgeBuilder.AddWire(lowerTE);
-        trailingEdgeBuilder.Build();
-        TopoDS_Shape trailingEdge = trailingEdgeBuilder.Shape();
-        sewingAlgo.Add(trailingEdge);
-
-    } // hasBluntTE
-
-
-    // get the profiles
-    TopoDS_Wire innerWire = segments.GetSegment(1).GetInnerWire();
-    TopoDS_Wire outerWire = segments.GetSegment(segments.GetSegmentCount()).GetOuterWire();
-
-    TopoDS_Face innerFace, outerFace;
-    CreateSideCap(innerWire, 1e-6, innerFace);
-    CreateSideCap(outerWire, 1e-6, outerFace);
-
-    sewingAlgo.Add(innerFace);
-    sewingAlgo.Add(outerFace);
-
-    sewingAlgo.Perform();
-    TopoDS_Shape shellClosed  = sewingAlgo.SewedShape();
-    if (shellClosed.ShapeType() != TopAbs_SHELL)
-        throw CTiglError("Expected sewing algo to construct a shell when building wing loft");
-    shellClosed.Closed(Standard_True);
-
-    // make solid from shell
-    TopoDS_Solid solid;
-    BRep_Builder solidMaker;
-    solidMaker.MakeSolid(solid);
-    solidMaker.Add(solid, shellClosed);
-
-    // verify the orientation the solid
-    BRepClass3d_SolidClassifier clas3d(solid);
-    clas3d.PerformInfinitePoint(Precision::Confusion());
-    if (clas3d.State() == TopAbs_IN) {
-     solidMaker.MakeSolid(solid);
-        TopoDS_Shape aLocalShape = shellClosed.Reversed();
-        solidMaker.Add(solid, TopoDS::Shell(aLocalShape));
-    }
-
-    solid.Closed(Standard_True);
-    BRepLib::EncodeRegularity(solid);
-
-    std::string loftName = _wing.GetUID();
-    std::string loftShortName = _wing.GetShortShapeName();
-    PNamedShape loft(new CNamedShape(solid, loftName.c_str(), loftShortName.c_str()));
-    SetFaceTraits(_wing.GetUID(), loft, hasBluntTE);
-
-    return loft;
-}
-
-// creates the inside and outside cap of the wing
-Standard_Boolean CreateSideCap(const TopoDS_Wire& W,
-                               const Standard_Real presPln,
-                               TopoDS_Face& theFace)
-{
-    Standard_Boolean isDegen = Standard_True;
-    TopoDS_Iterator iter(W);
-    for (; iter.More(); iter.Next())
-    {
-        const TopoDS_Edge& anEdge = TopoDS::Edge(iter.Value());
-        if (!BRep_Tool::Degenerated(anEdge))
-            isDegen = Standard_False;
-    }
-    if (isDegen)
-        return Standard_True;
-
-    Standard_Boolean Ok = Standard_False;
-    if (!W.IsNull()) {
-        BRepBuilderAPI_FindPlane Searcher( W, presPln );
-        if (Searcher.Found()) {
-            theFace = BRepBuilderAPI_MakeFace(Searcher.Plane(), W);
-            Ok = Standard_True;
-        }
-        else {
-            // try to find another surface
-            BRepBuilderAPI_MakeFace MF( W );
-            if (MF.IsDone())
-            {
-                theFace = MF.Face();
-                Ok = Standard_True;
-            }
-        }
-    }
-
-    return Ok;
-}
-
-#else
 PNamedShape CTiglWingBuilder::BuildShape()
 {
     const CCPACSWingSegments& segments = _wing.GetSegments();
@@ -310,8 +106,6 @@ PNamedShape CTiglWingBuilder::BuildShape()
     SetFaceTraits(_wing.GetGuideCurveStartParameters(), _wing.GetUID(), loft, hasBluntTE);
     return loft;
 }
-#endif
-
 
 
 CTiglWingBuilder::operator PNamedShape()
@@ -380,32 +174,12 @@ void CTiglWingBuilder::SetFaceTraits (const std::vector<double>& guideCurveParam
         return;
     }
 
-#ifndef NO_EXPLICIT_TE_MODELING
-
-    unsigned int nTEFaces = hasBluntTE ? nSegments : 0;
-    unsigned int nAeroFaces = nFaces - nTEFaces - 2;
-
-    // assign "Top" and "Bottom" to face traits
-    for (unsigned int i = 0; i < nAeroFaces; i++) {
-        CFaceTraits traits = loft->GetFaceTraits(i);
-        traits.SetName(names[i%2].c_str());
-        loft->SetFaceTraits(i, traits);
-    }
-
-    // assign TE to face traits
-    for (unsigned int i = nAeroFaces; i < nAeroFaces + nTEFaces; ++i) {
-        CFaceTraits traits = loft->GetFaceTraits(i);
-        traits.SetName(names[2].c_str());
-        loft->SetFaceTraits(i, traits);
-    }
-#else
     // assign "Top" and "Bottom" to face traits
     for (unsigned int i = 0; i < nFaces-2; i++) {
         CFaceTraits traits = shape->GetFaceTraits(i);
         traits.SetName(names[i%names.size()]);
         shape->SetFaceTraits(i, traits);
     }
-#endif
 
     // assign "Inside" and "Outside" to face traits
     for (unsigned int i = nFaces-2; i < nFaces; i++) {

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -98,11 +98,11 @@ void CTiglWingBuilder::SetFaceTraits (const std::vector<double>& guideCurveParam
     size_t idx_leading_edge = 1;
     if (hasGuideCurves) {
         double tolerance = 1e-3;
-        if (!Contains(params, -1., tolerance)) {
+        if (std::abs(params.front() + 1.) > tolerance) {
             params.insert(params.begin(), -1.);
         }
 
-        if (!Contains(params, 1., tolerance)) {
+        if (std::abs(params.back() - 1.) > tolerance) {
             params.push_back(1.);
         }
 

--- a/src/wing/CTiglWingBuilder.cpp
+++ b/src/wing/CTiglWingBuilder.cpp
@@ -41,32 +41,6 @@
 #include <cassert>
 #include <algorithm>
 
-namespace
-{
-template <typename ForwardIter, typename Compare>
-size_t find_index(ForwardIter begin, ForwardIter end, Compare comp)
-{
-    const auto it = std::find_if(begin, end, comp);
-    if (it != end) {
-        return std::distance(begin, it);
-    }
-    else {
-        return std::distance(begin, end);
-    }
-}
-
-template <typename ArrayLike, typename ValueType>
-bool contains(const ArrayLike& array, ValueType val)
-{
-    auto idx = find_index(std::begin(array), std::end(array), [val](const typename ArrayLike::value_type& cval) {
-        return fabs(cval - val) < 1e-3;
-    });
-
-    return idx < array.size();
-}
-
-} // namespace
-
 namespace tigl
 {
 
@@ -123,17 +97,18 @@ void CTiglWingBuilder::SetFaceTraits (const std::vector<double>& guideCurveParam
     size_t nFacesPerSegment = 2; // Without trailing edge
     size_t idx_leading_edge = 1;
     if (hasGuideCurves) {
-        if (!contains(params, -1.)) {
+        double tolerance = 1e-3;
+        if (!Contains(params, -1., tolerance)) {
             params.insert(params.begin(), -1.);
         }
 
-        if (!contains(params, 1.)) {
+        if (!Contains(params, 1., tolerance)) {
             params.push_back(1.);
         }
 
         // find leading edge curve
-        idx_leading_edge = find_index(params.cbegin(), params.cend(), [] (double val) {
-            return fabs(val) < 1e-3;
+        idx_leading_edge = FindIndex(params.cbegin(), params.cend(), [tolerance] (double val) {
+            return fabs(val) < tolerance;
         });
 
         if (idx_leading_edge == params.size()) {

--- a/src/wing/CTiglWingBuilder.h
+++ b/src/wing/CTiglWingBuilder.h
@@ -35,8 +35,8 @@ public:
 
     PNamedShape BuildShape();
 
+    static void SetFaceTraits (const std::vector<double>& guideCurveParams, const std::string& shapeUid, PNamedShape shape, bool hasBluntTE);
 private:
-    void SetFaceTraits (const std::string& uid, PNamedShape loft, bool hasBluntTE);
 
     const CCPACSWing& _wing;
 };

--- a/tests/unittests/TestData/simpletest-with-guides.cpacs.xml
+++ b/tests/unittests/TestData/simpletest-with-guides.cpacs.xml
@@ -1,0 +1,644 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Simple Wing with 4 guide curves for testing</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2020-10-12T12:26:00</timestamp>
+    <version>0.4.0</version>
+    <cpacsVersion>3.1</cpacsVersion>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="Cpacs2Test">
+        <name>Cpacs2Test</name>
+        <reference>
+          <area>1</area>
+          <length>1</length>
+          <point uID="Cpacs2Test_point1">
+            <x>0</x>
+            <y>0</y>
+            <z>0</z>
+          </point>
+        </reference>
+        <fuselages>
+          <fuselage uID="SimpleFuselage">
+            <name>name</name>
+            <description>description</description>
+            <transformation uID="SimpleFuselage_transformation1">
+              <scaling uID="SimpleFuselage_transformation1_scaling1">
+                <x>1.0</x>
+                <y>0.5</y>
+                <z>0.5</z>
+              </scaling>
+              <rotation uID="SimpleFuselage_transformation1_rotation1">
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+              </rotation>
+              <translation refType="absLocal" uID="SimpleFuselage_transformation1_translation1">
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="D150_Fuselage_1Section1ID">
+                <name>D150_Fuselage_1Section1</name>
+                <transformation uID="D150_Fuselage_1Section1ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section1ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section1ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section1ID_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section1IDElement1">
+                    <name>D150_Fuselage_1Section1</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section1IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section1IDElement1_transformation1_scaling1">
+                        <x>1.0</x>
+                        <y>1.0</y>
+                        <z>1.0</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section1IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section1IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section2ID">
+                <name>D150_Fuselage_1Section2</name>
+                <transformation uID="D150_Fuselage_1Section2ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section2ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section2ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section2ID_transformation1_translation1">
+                    <x>0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section2IDElement1">
+                    <name>D150_Fuselage_1Section2</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section2IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section2IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section2IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section2IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section3ID">
+                <name>D150_Fuselage_1Section3</name>
+                <transformation uID="D150_Fuselage_1Section3ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section3ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section3ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section3ID_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section3IDElement1">
+                    <name>D150_Fuselage_1Section3</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section3IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section3IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section3IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section3IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="D150_Fuselage_1Positioning1ID">
+                <name>D150_Fuselage_1Positioning1</name>
+                <length>-0.5</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>D150_Fuselage_1Section1ID</toSectionUID>
+              </positioning>
+              <positioning uID="D150_Fuselage_1Positioning3ID">
+                <name>D150_Fuselage_1Positioning3</name>
+                <length>2</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>D150_Fuselage_1Section1ID</fromSectionUID>
+                <toSectionUID>D150_Fuselage_1Section3ID</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="segmentD150_Fuselage_1Segment2ID">
+                <name>D150_Fuselage_1Segment2</name>
+                <fromElementUID>D150_Fuselage_1Section1IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section2IDElement1</toElementUID>
+              </segment>
+              <segment uID="segmentD150_Fuselage_1Segment3ID">
+                <name>D150_Fuselage_1Segment3</name>
+                <fromElementUID>D150_Fuselage_1Section2IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section3IDElement1</toElementUID>
+              </segment>
+            </segments>
+          </fuselage>
+        </fuselages>
+        <wings>
+          <wing uID="Wing" symmetry="x-z-plane">
+            <name>Wing</name>
+            <parentUID>SimpleFuselage</parentUID>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation uID="Wing_transformation1">
+              <scaling uID="Wing_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Wing_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Wing_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation uID="Cpacs2Test_Wing_Sec1_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec1_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>2.5</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec1_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation uID="Cpacs2Test_Wing_Sec2_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec2_transformation1_scaling1">
+                    <x>1</x>
+                    <y>2</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec2_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec3">
+                <name>Cpacs2Test - Wing Section 3</name>
+                <description>Cpacs2Test - Wing Section 3</description>
+                <transformation uID="Cpacs2Test_Wing_Sec3_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>0.5</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec3_El1">
+                    <name>Cpacs2Test - Wing Section 3 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 3 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec3_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec3_El1_transformation1_scaling1">
+                        <x>0.5</x>
+                        <y>0.5</y>
+                        <z>0.5</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec3_El1_transformation1_translation1">
+                        <x>0.5</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="Wing_positioning1">
+                <name>Cpacs2Test - Wing Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="Wing_positioning2">
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>0.8</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="Wing_positioning3">
+                <name>Cpacs2Test - Wing Section 3 Positioning</name>
+                <description>Cpacs2Test - Wing Section 3 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec2</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec3</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec2_El1</toElementUID>
+                <guideCurves>
+                    <guideCurve uID="Wing_Seg_1_2_GuideCurve_TrailingEdgeLower">
+                      <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                      <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                      <guideCurveProfileUID>S1_TE_LOWER_GUIDE</guideCurveProfileUID>
+                      <fromRelativeCircumference>-1.0</fromRelativeCircumference>
+                      <toRelativeCircumference>-1.0</toRelativeCircumference>
+                    </guideCurve>
+                    <guideCurve uID="Wing_Seg_1_2_GuideCurve_LeadingEdge">
+                      <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                      <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                      <guideCurveProfileUID>S1_LE_GUIDE</guideCurveProfileUID>
+                      <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                      <toRelativeCircumference>0.0</toRelativeCircumference>
+                    </guideCurve>
+                    <guideCurve uID="Wing_Seg_1_2_GuideCurve_Upper">
+                        <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                        <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                        <guideCurveProfileUID>S1_UPPER_GUIDE</guideCurveProfileUID>
+                        <fromRelativeCircumference>0.5</fromRelativeCircumference>
+                        <toRelativeCircumference>0.5    </toRelativeCircumference>
+                    </guideCurve>
+                    <guideCurve uID="Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper">
+                      <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                      <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                      <guideCurveProfileUID>S1_TE_UPPER_GUIDE</guideCurveProfileUID>
+                      <fromRelativeCircumference>1.0</fromRelativeCircumference>
+                      <toRelativeCircumference>1.0</toRelativeCircumference>
+                    </guideCurve>
+                  </guideCurves>
+              </segment>
+              <segment uID="Cpacs2Test_Wing_Seg_2_3">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 2 Main Element to Cpacs2Test - Wing Section 3 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 2 Main Element to Cpacs2Test - Wing Section 3 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec2_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
+                <guideCurves>
+                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_TrailingEdgeLower">
+                      <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                      <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                      <guideCurveProfileUID>S2_TE_LOWER_GUIDE</guideCurveProfileUID>
+                      <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
+                      <toRelativeCircumference>-1.0</toRelativeCircumference>
+                    </guideCurve>
+                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_LeadingEdge">
+                      <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                      <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                      <guideCurveProfileUID>S2_LE_GUIDE</guideCurveProfileUID>
+                      <continuity>C1 from previous</continuity>
+                      <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_LeadingEdge</fromGuideCurveUID>
+                      <toRelativeCircumference>0.0</toRelativeCircumference>
+                    </guideCurve>
+                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_Upper">
+                        <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                        <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                        <guideCurveProfileUID>S2_UPPER_GUIDE</guideCurveProfileUID>
+                        <continuity>C1 from previous</continuity>
+                        <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_Upper</fromGuideCurveUID>
+                        <toRelativeCircumference>0.5</toRelativeCircumference>
+                    </guideCurve>
+                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_TrailingEdgeUpper">
+                      <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                      <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                      <guideCurveProfileUID>S2_TE_UPPER_GUIDE</guideCurveProfileUID>
+                      <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper</fromGuideCurveUID>
+                      <toRelativeCircumference>1.0</toRelativeCircumference>
+                    </guideCurve>
+                  </guideCurves>
+              </segment>
+            </segments>
+            <componentSegments>
+              <componentSegment uID="WING_CS1">
+                <name>Wing_CS1</name>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
+                <structure>
+                  <upperShell uID="WING_CS1_upperShell1">
+                    <skin>
+                      <material>
+                        <materialUID>MySkinMat</materialUID>
+                        <thickness>0.0</thickness>
+                      </material>
+                    </skin>
+                    <cells>
+                      <cell uID="WING_CS1_CELL1">
+                        <skin>
+                          <material>
+                            <materialUID>MyCellMat</materialUID>
+                            <thickness>0.0</thickness>
+                          </material>
+                        </skin>
+                        <positioningLeadingEdge>
+                          <xsi1>0.8</xsi1>
+                          <xsi2>0.8</xsi2>
+                        </positioningLeadingEdge>
+                        <positioningTrailingEdge>
+                          <xsi1>1.0</xsi1>
+                          <xsi2>1.0</xsi2>
+                        </positioningTrailingEdge>
+                        <positioningInnerBorder>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
+                        </positioningInnerBorder>
+                        <positioningOuterBorder>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
+                        </positioningOuterBorder>
+                      </cell>
+                    </cells>
+                  </upperShell>
+                  <lowerShell uID="WING_CS1_lowerShell1">
+                    <skin>
+                      <material>
+                        <materialUID>MySkinMat</materialUID>
+                      </material>
+                    </skin>
+                  </lowerShell>
+                </structure>
+              </componentSegment>
+            </componentSegments>
+          </wing>
+        </wings>
+      </model>
+    </aircraft>
+    <profiles>
+      <wingAirfoils>
+        <wingAirfoil uID="NACA0012">
+          <name>NACA0.00.00.12</name>
+          <description>NACA 4 Series Profile</description>
+          <pointList>
+            <x mapType="vector">1.0;0.9875;0.975;0.9625;0.95;0.9375;0.925;0.9125;0.9;0.8875;0.875;0.8625;0.85;0.8375;0.825;0.8125;0.8;0.7875;0.775;0.7625;0.75;0.7375;0.725;0.7125;0.7;0.6875;0.675;0.6625;0.65;0.6375;0.625;0.6125;0.6;0.5875;0.575;0.5625;0.55;0.5375;0.525;0.5125;0.5;0.4875;0.475;0.4625;0.45;0.4375;0.425;0.4125;0.4;0.3875;0.375;0.3625;0.35;0.3375;0.325;0.3125;0.3;0.2875;0.275;0.2625;0.25;0.2375;0.225;0.2125;0.2;0.1875;0.175;0.1625;0.15;0.1375;0.125;0.1125;0.1;0.0875;0.075;0.0625;0.05;0.0375;0.025;0.0125;0.0;0.0125;0.025;0.0375;0.05;0.0625;0.075;0.0875;0.1;0.1125;0.125;0.1375;0.15;0.1625;0.175;0.1875;0.2;0.2125;0.225;0.2375;0.25;0.2625;0.275;0.2875;0.3;0.3125;0.325;0.3375;0.35;0.3625;0.375;0.3875;0.4;0.4125;0.425;0.4375;0.45;0.4625;0.475;0.4875;0.5;0.5125;0.525;0.5375;0.55;0.5625;0.575;0.5875;0.6;0.6125;0.625;0.6375;0.65;0.6625;0.675;0.6875;0.7;0.7125;0.725;0.7375;0.75;0.7625;0.775;0.7875;0.8;0.8125;0.825;0.8375;0.85;0.8625;0.875;0.8875;0.9;0.9125;0.925;0.9375;0.95;0.9625;0.975;0.9875;1.0</x>
+            <y mapType="vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+            <z mapType="vector">-0.00126;-0.0030004180415;-0.00471438572941;-0.00640256842113;-0.00806559133343;-0.00970403933653;-0.0113184567357;-0.0129093470398;-0.0144771727147;-0.0160223549226;-0.0175452732434;-0.0190462653789;-0.0205256268372;-0.0219836105968;-0.0234204267471;-0.024836242105;-0.0262311798047;-0.0276053188583;-0.0289586936852;-0.0302912936071;-0.0316030623052;-0.0328938972373;-0.0341636490097;-0.0354121207001;-0.0366390671268;-0.0378441940595;-0.0390271573644;-0.0401875620783;-0.0413249614032;-0.042438855614;-0.043528690869;-0.0445938579126;-0.0456336906587;-0.04664746464;-0.0476343953088;-0.0485936361694;-0.0495242767241;-0.0504253402064;-0.0512957810767;-0.0521344822472;-0.0529402520006;-0.0537118205596;-0.0544478362583;-0.0551468612564;-0.0558073667285;-0.0564277274483;-0.0570062156697;-0.0575409941929;-0.0580301084765;-0.0584714776309;-0.0588628840933;-0.059201961739;-0.0594861821311;-0.0597128385384;-0.059879027262;-0.0599816256958;-0.060017266394;-0.059982306219;-0.05987278938;-0.0596844028137;-0.059412421875;-0.059051643633;-0.0585963041308;-0.0580399746271;-0.0573754299024;-0.0565944788455;-0.0556877432118;-0.054644363746;-0.0534516022043;-0.0520942903127;-0.0505540468987;-0.0488081315259;-0.0468277042382;-0.0445750655553;-0.0419990347204;-0.0390266537476;-0.0355468568262;-0.0313738751622;-0.0261471986426;-0.0189390266528;0.0;0.0189390266528;0.0261471986426;0.0313738751622;0.0355468568262;0.0390266537476;0.0419990347204;0.0445750655553;0.0468277042382;0.0488081315259;0.0505540468987;0.0520942903127;0.0534516022043;0.054644363746;0.0556877432118;0.0565944788455;0.0573754299024;0.0580399746271;0.0585963041308;0.059051643633;0.059412421875;0.0596844028137;0.05987278938;0.059982306219;0.060017266394;0.0599816256958;0.059879027262;0.0597128385384;0.0594861821311;0.059201961739;0.0588628840933;0.0584714776309;0.0580301084765;0.0575409941929;0.0570062156697;0.0564277274483;0.0558073667285;0.0551468612564;0.0544478362583;0.0537118205596;0.0529402520006;0.0521344822472;0.0512957810767;0.0504253402064;0.0495242767241;0.0485936361694;0.0476343953088;0.04664746464;0.0456336906587;0.0445938579126;0.043528690869;0.042438855614;0.0413249614032;0.0401875620783;0.0390271573644;0.0378441940595;0.0366390671268;0.0354121207001;0.0341636490097;0.0328938972373;0.0316030623052;0.0302912936071;0.0289586936852;0.0276053188583;0.0262311798047;0.024836242105;0.0234204267471;0.0219836105968;0.0205256268372;0.0190462653789;0.0175452732434;0.0160223549226;0.0144771727147;0.0129093470398;0.0113184567357;0.00970403933653;0.00806559133343;0.00640256842113;0.00471438572941;0.0030004180415;0.00126</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+      <fuselageProfiles>
+        <fuselageProfile uID="fuselageCircleProfileuID">
+          <name>Circle</name>
+          <description>Profile build up from set of Points on Circle where may Dimensions are 1..-1</description>
+          <pointList>
+            <x mapType="vector">0.0;0.0;0.0;0.0;0.0</x>
+            <y mapType="vector">0.0;1.0;0.0;-1.0;0.0</y>
+            <z mapType="vector">1.0;0.0;-1.0;0.0;1.0</z>
+          </pointList>
+        </fuselageProfile>
+      </fuselageProfiles>
+      <guideCurves>
+        <guideCurveProfile uID="S1_TE_LOWER_GUIDE">
+          <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0;0;0</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="S1_LE_GUIDE">
+            <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+            <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+            <pointList>
+              <rX mapType="vector">0</rX>
+              <rY mapType="vector">0.5</rY>
+              <rZ mapType="vector">0</rZ>
+            </pointList>
+          </guideCurveProfile>
+          <guideCurveProfile uID="S1_UPPER_GUIDE">
+            <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+            <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+            <pointList>
+              <rX mapType="vector">0</rX>
+              <rY mapType="vector">0.5</rY>
+              <rZ mapType="vector">0.01</rZ>
+            </pointList>
+          </guideCurveProfile>
+          <guideCurveProfile uID="S1_TE_UPPER_GUIDE">
+            <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+            <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+            <pointList>
+              <rX mapType="vector">0;0;0</rX>
+              <rY mapType="vector">0.1;0.5;0.9</rY>
+              <rZ mapType="vector">0;0;0</rZ>
+            </pointList>
+          </guideCurveProfile>
+          <guideCurveProfile uID="S2_TE_LOWER_GUIDE">
+            <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+            <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+            <pointList>
+              <rX mapType="vector">0;0;0</rX>
+              <rY mapType="vector">0.1;0.5;0.9</rY>
+              <rZ mapType="vector">0;0;0</rZ>
+            </pointList>
+          </guideCurveProfile>
+          <guideCurveProfile uID="S2_LE_GUIDE">
+              <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+              <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+              <pointList>
+                <rX mapType="vector">-0.2</rX>
+                <rY mapType="vector">0.5</rY>
+                <rZ mapType="vector">0</rZ>
+              </pointList>
+            </guideCurveProfile>
+            <guideCurveProfile uID="S2_UPPER_GUIDE">
+                <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+                <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+                <pointList>
+                  <rX mapType="vector">-0.05</rX>
+                  <rY mapType="vector">0.5</rY>
+                  <rZ mapType="vector"> -0.03</rZ>
+                </pointList>
+              </guideCurveProfile>
+            <guideCurveProfile uID="S2_TE_UPPER_GUIDE">
+              <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+              <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+              <pointList>
+                <rX mapType="vector">0;0;0</rX>
+                <rY mapType="vector">0.1;0.5;0.9</rY>
+                <rZ mapType="vector">0;0;0</rZ>
+              </pointList>
+            </guideCurveProfile>
+      </guideCurves>
+    </profiles>
+  </vehicles>
+  <toolspecific>
+    <cFD>
+      <farField>
+        <type>halfCube</type>
+        <referenceLength>10.0</referenceLength>
+        <multiplier>1.</multiplier>
+      </farField>
+    </cFD>
+  </toolspecific>
+</cpacs>

--- a/tests/unittests/TestData/simpletest-with-guides.cpacs.xml
+++ b/tests/unittests/TestData/simpletest-with-guides.cpacs.xml
@@ -398,6 +398,13 @@
                 <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
                 <toElementUID>Cpacs2Test_Wing_Sec2_El1</toElementUID>
                 <guideCurves>
+                    <guideCurve uID="Wing_Seg_1_2_GuideCurve_Upper">
+                        <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                        <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                        <guideCurveProfileUID>S1_UPPER_GUIDE</guideCurveProfileUID>
+                        <fromRelativeCircumference>0.5</fromRelativeCircumference>
+                        <toRelativeCircumference>0.5    </toRelativeCircumference>
+                    </guideCurve>
                     <guideCurve uID="Wing_Seg_1_2_GuideCurve_TrailingEdgeLower">
                       <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
                       <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
@@ -406,19 +413,12 @@
                       <toRelativeCircumference>-1.0</toRelativeCircumference>
                     </guideCurve>
                     <guideCurve uID="Wing_Seg_1_2_GuideCurve_LeadingEdge">
-                      <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
-                      <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
-                      <guideCurveProfileUID>S1_LE_GUIDE</guideCurveProfileUID>
-                      <fromRelativeCircumference>0.0</fromRelativeCircumference>
-                      <toRelativeCircumference>0.0</toRelativeCircumference>
-                    </guideCurve>
-                    <guideCurve uID="Wing_Seg_1_2_GuideCurve_Upper">
-                        <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
-                        <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
-                        <guideCurveProfileUID>S1_UPPER_GUIDE</guideCurveProfileUID>
-                        <fromRelativeCircumference>0.5</fromRelativeCircumference>
-                        <toRelativeCircumference>0.5    </toRelativeCircumference>
-                    </guideCurve>
+                        <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                        <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                        <guideCurveProfileUID>S1_LE_GUIDE</guideCurveProfileUID>
+                        <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                        <toRelativeCircumference>0.0</toRelativeCircumference>
+                      </guideCurve>
                     <guideCurve uID="Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper">
                       <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
                       <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
@@ -434,21 +434,6 @@
                 <fromElementUID>Cpacs2Test_Wing_Sec2_El1</fromElementUID>
                 <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
                 <guideCurves>
-                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_TrailingEdgeLower">
-                      <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
-                      <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
-                      <guideCurveProfileUID>S2_TE_LOWER_GUIDE</guideCurveProfileUID>
-                      <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
-                      <toRelativeCircumference>-1.0</toRelativeCircumference>
-                    </guideCurve>
-                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_LeadingEdge">
-                      <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
-                      <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
-                      <guideCurveProfileUID>S2_LE_GUIDE</guideCurveProfileUID>
-                      <continuity>C1 from previous</continuity>
-                      <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_LeadingEdge</fromGuideCurveUID>
-                      <toRelativeCircumference>0.0</toRelativeCircumference>
-                    </guideCurve>
                     <guideCurve uID="Wing_Seg_2_3_GuideCurve_Upper">
                         <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
                         <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
@@ -457,6 +442,13 @@
                         <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_Upper</fromGuideCurveUID>
                         <toRelativeCircumference>0.5</toRelativeCircumference>
                     </guideCurve>
+                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_TrailingEdgeLower">
+                        <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                        <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                        <guideCurveProfileUID>S2_TE_LOWER_GUIDE</guideCurveProfileUID>
+                        <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
+                        <toRelativeCircumference>-1.0</toRelativeCircumference>
+                      </guideCurve>
                     <guideCurve uID="Wing_Seg_2_3_GuideCurve_TrailingEdgeUpper">
                       <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
                       <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
@@ -464,6 +456,14 @@
                       <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper</fromGuideCurveUID>
                       <toRelativeCircumference>1.0</toRelativeCircumference>
                     </guideCurve>
+                    <guideCurve uID="Wing_Seg_2_3_GuideCurve_LeadingEdge">
+                        <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                        <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                        <guideCurveProfileUID>S2_LE_GUIDE</guideCurveProfileUID>
+                        <continuity>C1 from previous</continuity>
+                        <fromGuideCurveUID>Wing_Seg_1_2_GuideCurve_LeadingEdge</fromGuideCurveUID>
+                        <toRelativeCircumference>0.0</toRelativeCircumference>
+                      </guideCurve>
                   </guideCurves>
               </segment>
             </segments>

--- a/tests/unittests/testctiglbsplinealgorithms.cpp
+++ b/tests/unittests/testctiglbsplinealgorithms.cpp
@@ -1645,7 +1645,7 @@ TEST_F(ConcatSurfaces, concatWithParams)
 TEST_F(ConcatSurfaces, concatWithParamsApprox)
 {
     tigl::CTiglConcatSurfaces concatter({s1, s2}, {0., 2., 4.}, tigl::ConcatDir::u);
-    concatter.SetApproxInputSurfacesEnabled(3, 3);
+    concatter.SetMakeKnotsUniformEnabled(3, 3);
 
     auto result = concatter.Surface();
 
@@ -1675,7 +1675,7 @@ TEST(ApproxSurface, simple)
     pnts.SetValue(2, 1, gp_Pnt(1, 2, 0));
 
     auto surfOrig = tigl::CTiglBSplineAlgorithms::pointsToSurface(pnts, {0., 1.}, {0., 1.}, false, false);
-    auto surfApprox = tigl::CTiglBSplineAlgorithms::approxSurface(surfOrig, 4, 8);
+    auto surfApprox = tigl::CTiglBSplineAlgorithms::makeKnotsUniform(surfOrig, 4, 8);
 
     EXPECT_EQ(3, surfApprox->NbUKnots());
     EXPECT_EQ(7, surfApprox->NbVKnots());

--- a/tests/unittests/testctiglbsplinealgorithms.cpp
+++ b/tests/unittests/testctiglbsplinealgorithms.cpp
@@ -479,7 +479,7 @@ TEST(TiglBSplineAlgorithms, testCreateCommonKnotsVectorSurface)
     surfaces_vector.push_back(surface2);
     surfaces_vector.push_back(surface3);
 
-    std::vector<Handle(Geom_BSplineSurface) > modified_surfaces_vector = CTiglBSplineAlgorithms::createCommonKnotsVectorSurface(surfaces_vector);
+    std::vector<Handle(Geom_BSplineSurface) > modified_surfaces_vector = CTiglBSplineAlgorithms::createCommonKnotsVectorSurface(surfaces_vector, SurfaceDirection::both);
 
     TColStd_Array1OfReal computed_knot_vector_u(1, 6);
     modified_surfaces_vector[0]->UKnots(computed_knot_vector_u);

--- a/tests/unittests/testctiglbsplinealgorithms.cpp
+++ b/tests/unittests/testctiglbsplinealgorithms.cpp
@@ -19,6 +19,7 @@
 #include <CTiglInterpolateCurveNetwork.h>
 #include <CTiglGordonSurfaceBuilder.h>
 #include <CTiglCurvesToSurface.h>
+#include <CTiglConcatSurfaces.h>
 #include <tiglcommonfunctions.h>
 
 #include <BSplCLib.hxx>
@@ -1621,6 +1622,48 @@ TEST_F(ConcatSurfaces, error_notAdjacent)
     t.SetTranslation(gp_Vec(0, 0, 1));
     s2->Transform(t);
     ASSERT_THROW(tigl::CTiglBSplineAlgorithms::concatSurfacesUDir(s1, s2), tigl::CTiglError);
+}
+
+TEST_F(ConcatSurfaces, concatWithParams)
+{
+    tigl::CTiglConcatSurfaces concatter({s1, s2}, {0., 2., 4.}, tigl::ConcatDir::u);
+
+    auto result = concatter.Surface();
+
+    double u1, u2, v1, v2;
+    result->Bounds(u1, u2, v1, v2);
+
+    EXPECT_NEAR(0.0, u1, 1e-15);
+    EXPECT_NEAR(4.0, u2, 1e-15);
+    EXPECT_NEAR(0.0, v1, 1e-15);
+    EXPECT_NEAR(1.0, v2, 1e-15);
+
+    EXPECT_NEAR(0.0, s1->Value(0.5, 0.5).Distance(result->Value(1.0, 0.5)), 1e-10);
+    EXPECT_NEAR(0.0, s2->Value(1.3, 0.3).Distance(result->Value(2.6, 0.3)), 1e-10);
+}
+
+TEST_F(ConcatSurfaces, concatWithParamsApprox)
+{
+    tigl::CTiglConcatSurfaces concatter({s1, s2}, {0., 2., 4.}, tigl::ConcatDir::u);
+    concatter.SetApproxInputSurfacesEnabled(3, 3);
+
+    auto result = concatter.Surface();
+
+    double u1, u2, v1, v2;
+    result->Bounds(u1, u2, v1, v2);
+
+    EXPECT_NEAR(0.0, u1, 1e-15);
+    EXPECT_NEAR(4.0, u2, 1e-15);
+    EXPECT_NEAR(0.0, v1, 1e-15);
+    EXPECT_NEAR(1.0, v2, 1e-15);
+
+    EXPECT_NEAR(0.0, s1->Value(0.5, 0.5).Distance(result->Value(1.0, 0.5)), 1e-10);
+    EXPECT_NEAR(0.0, s2->Value(1.3, 0.3).Distance(result->Value(2.6, 0.3)), 1e-10);
+}
+
+TEST_F(ConcatSurfaces, concatToFewParams)
+{
+    ASSERT_THROW(tigl::CTiglConcatSurfaces({s1, s2}, {0., 2.}, tigl::ConcatDir::u), tigl::CTiglError);
 }
 
 TEST(ApproxSurface, simple)

--- a/tests/unittests/tiglCommonFunctions.cpp
+++ b/tests/unittests/tiglCommonFunctions.cpp
@@ -282,6 +282,30 @@ TEST(TiglCommonFunctions, normalizeAngleDeg)
     EXPECT_NEAR(45., NormalizeAngleDeg(405.), 1e-9);
 }
 
+TEST(TiglCommonFunctions, findIndex)
+{
+    std::array<float, 5> arr{0., 1.0, 2.0, 3.0, 4.0};
+
+    size_t idx = FindIndex(std::begin(arr), std::end(arr), [](float v) {
+        return v == 2.0;
+    });
+    EXPECT_EQ(2, idx);
+
+    idx = FindIndex(std::begin(arr), std::end(arr), [](float v) {
+        return v == -2.0;
+    });
+
+    EXPECT_EQ(5, idx);
+}
+
+TEST(TiglCommonFunctions, contains)
+{
+    std::array<float, 5> arr{0., 1.0, 2.0, 3.0, 4.0};
+    EXPECT_TRUE(Contains(arr, 1.00, 1e-15));
+    EXPECT_FALSE(Contains(arr, 1.01, 1e-15));
+    EXPECT_TRUE(Contains(arr, 1.01, 2e-2));
+}
+
 class TestBuildFace: public ::testing::TestWithParam<int>
 {
 protected:

--- a/tests/unittests/tiglTransformation.cpp
+++ b/tests/unittests/tiglTransformation.cpp
@@ -1,0 +1,66 @@
+/*
+* Copyright (C) 2020 German Aerospace Center (DLR/SC)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h"
+#include "tigl.h"
+
+#include "CTiglPointsToBSplineInterpolation.h"
+#include "CTiglCurvesToSurface.h"
+#include "tiglcommonfunctions.h"
+#include "CTiglTransformation.h"
+
+TEST(TiglTransformation, transformSurface)
+{
+    auto pnts1 = OccArray({
+        gp_Pnt(0., 0., 0.),
+        gp_Pnt(1., 0, 0.),
+    });
+
+    auto pnts2 = OccArray({
+        gp_Pnt(0., 1., 0.),
+        gp_Pnt(1., 1.0, 0.),
+    });
+
+    auto c1   = tigl::CTiglPointsToBSplineInterpolation(pnts1).Curve();
+    auto c2   = tigl::CTiglPointsToBSplineInterpolation(pnts2).Curve();
+    auto surf = tigl::CTiglCurvesToSurface({c1, c2}).Surface();
+
+    EXPECT_EQ(0.0, surf->Value(0., 0.).Distance(gp_Pnt(0., 0., 0.)));
+    EXPECT_EQ(0.0, surf->Value(1., 1.).Distance(gp_Pnt(1., 1., 0.)));
+
+    tigl::CTiglTransformation transl;
+    transl.AddTranslation(0, 0, 1.);
+
+    auto surfTrans = transl.Transform(surf);
+
+    EXPECT_NEAR(0.0, surfTrans->Value(0., 0.).Distance(gp_Pnt(0., 0., 1.)), 1e-12);
+    EXPECT_NEAR(0.0, surfTrans->Value(1., 1.).Distance(gp_Pnt(1., 1., 1.)), 1e-12);
+
+    tigl::CTiglTransformation rot;
+    rot.AddRotationZ(90.);
+
+    auto surfRot = rot.Transform(surf);
+    EXPECT_NEAR(0.0, surfRot->Value(0., 0.).Distance(gp_Pnt(0., 0., 0.)), 1e-12);
+    EXPECT_NEAR(0.0, surfRot->Value(1., 1.).Distance(gp_Pnt(-1., 1., 0.)), 1e-12);
+
+
+    tigl::CTiglTransformation scale;
+    scale.AddScaling(2, 0.5, 1.);
+
+    auto surfScale = scale.Transform(surf);
+    EXPECT_NEAR(0.0, surfScale->Value(0., 0.).Distance(gp_Pnt(0., 0., 0.)), 1e-12);
+    EXPECT_NEAR(0.0, surfScale->Value(1., 1.).Distance(gp_Pnt(2., 0.5, 0.)), 1e-12);
+}

--- a/tests/unittests/tiglWingGetPoint.cpp
+++ b/tests/unittests/tiglWingGetPoint.cpp
@@ -440,3 +440,30 @@ TEST(WingGetPointBugs, getPointDirection_Fuehrer)
     ASSERT_EQ(TIGL_SUCCESS, tiglWingGetUpperPointAtDirection(tiglHandle, 1, 1, 0.0, 1.0, dirx, diry, dirz, &px, &py, &pz, &distance));
     ASSERT_LT(distance, tolerance);
 }
+
+TEST(WingGetPointWithGuides, fourGuideCurves)
+{
+    TiglHandleWrapper handle("TestData/simpletest-with-guides.cpacs.xml", "");
+    double x, y, z;
+    tiglWingGetUpperPoint(handle, 1, 1, 1.0, 0.5, &x, &y, &z);
+
+    EXPECT_NEAR(0.053, z, 1e-3);
+    EXPECT_NEAR(0.8, y, 1e-10);
+    EXPECT_NEAR(0.5, x, 0.01);
+
+    tiglWingGetUpperPoint(handle, 1, 1, 1.0, 0.0, &x, &y, &z);
+
+    EXPECT_NEAR(0.0, z, 1e-3);
+    EXPECT_NEAR(0.8, y, 1e-10);
+    EXPECT_NEAR(0.0, x, 1e-10);
+
+    // check, that get point function succeed and do not crash
+    for (double eta = 0; eta <= 1.0; eta += 0.1) {
+        for (double xsi = 0; xsi <= 1.0; xsi += 0.1) {
+            EXPECT_EQ(TIGL_SUCCESS, tiglWingGetUpperPoint(handle, 1, 1, eta, xsi, &x, &y, &z));
+            EXPECT_EQ(TIGL_SUCCESS, tiglWingGetLowerPoint(handle, 1, 2, eta, xsi, &x, &y, &z));
+            EXPECT_EQ(TIGL_SUCCESS, tiglWingGetUpperPoint(handle, 1, 1, eta, xsi, &x, &y, &z));
+            EXPECT_EQ(TIGL_SUCCESS, tiglWingGetLowerPoint(handle, 1, 2, eta, xsi, &x, &y, &z));
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR enables to use more than 3 guide curves with TiGL.

## Description
Several issues had been addressed:
 - Correctly detect upper and lower wing surfaces
 - Added algorithm to concate surfaces
 - Concat all upper / lower surfaces of a wing segment, that is used for the get point methods and others as well.

## How Has This Been Tested?
TODO: We still need a test example.xml file, that demonstrates the functionality. We might use the FFD or another aircraft.

## Screenshots, that help to understand the changes(if applicable):
![GetPointMultipleGuideCurves](https://user-images.githubusercontent.com/3213107/95602722-9d26dd80-0a55-11eb-98c3-f2a7481052b3.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [x] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
