### PR TITLE
747 fuselage guidecurve bug

### DIFF
--- a/src/fuselage/CCPACSFuselageProfile.cpp
+++ b/src/fuselage/CCPACSFuselageProfile.cpp
@@ -65,56 +65,57 @@
 
 namespace
 {
-    // In case of a half profile, we have to compute the symmetric points and parameters
-    void SymmetrizeFuselageProfile(std::vector<tigl::CTiglPoint>& points, tigl::ParamMap& params, std::vector<unsigned int>& kinks)
-    {
-        size_t n_points = points.size();
+// In case of a half profile, we have to compute the symmetric points and parameters
+void SymmetrizeFuselageProfile(std::vector<tigl::CTiglPoint>& points, tigl::ParamMap& params,
+                               std::vector<unsigned int>& kinks)
+{
+    size_t n_points = points.size();
 
-        if (n_points == 0) {
-            return;
-        }
-
-        if (fabs(points[0].y) > 1e-6) {
-            throw tigl::CTiglError("Cannot create a symmetric fuselage profile. Y-Coordinate not zero!");
-        }
-
-        auto get_param_or = [&params](unsigned int idx, double def_value) -> double {
-            const auto& it = params.find(idx);
-            return it != params.end() ? it->second : def_value;
-        };
-
-        double umin = get_param_or(0, 0.);
-        double umax = umin + 2. * (get_param_or(static_cast<unsigned int>(n_points - 1), 0.5)  - umin);
-
-        // y is already ~ 0, make it really zero!
-        points[0].y = 0.;
-
-        // mirror each point at x-z plane i.e. mirror y coordinate to close the profile
-        // and skip first point
-        for (size_t i = n_points - 1; i > 0; i--) {
-            auto curP = points[i];
-            if (i == n_points - 1 && std::abs(curP.y) < 1e-6) {
-                // do not add the same points twice
-                continue;
-            }
-            curP.y = -curP.y;
-            unsigned int currentIdx = static_cast<unsigned int>(points.size());
-            if (std::find(std::begin(kinks), std::end(kinks), i) != std::end(kinks)) {
-                kinks.push_back(currentIdx);
-            }
-            auto parm_it = params.find(static_cast<unsigned int>(i));
-            if (parm_it != params.end()) {
-                double param_new = umax + umin - parm_it->second;
-                params[currentIdx] = param_new;
-            }
-            points.push_back(curP);
-        }
-
-        points.push_back(points[0]);
-        params[0] = umin;
-        params[static_cast<unsigned int>(points.size() - 1)] = umax;
+    if (n_points == 0) {
+        return;
     }
+
+    if (fabs(points[0].y) > 1e-6) {
+        throw tigl::CTiglError("Cannot create a symmetric fuselage profile. Y-Coordinate not zero!");
+    }
+
+    auto get_param_or = [&params](unsigned int idx, double def_value) -> double {
+        const auto& it = params.find(idx);
+        return it != params.end() ? it->second : def_value;
+    };
+
+    double umin = get_param_or(0, 0.);
+    double umax = umin + 2. * (get_param_or(static_cast<unsigned int>(n_points - 1), 0.5) - umin);
+
+    // y is already ~ 0, make it really zero!
+    points[0].y = 0.;
+
+    // mirror each point at x-z plane i.e. mirror y coordinate to close the profile
+    // and skip first point
+    for (size_t i = n_points - 1; i > 0; i--) {
+        auto curP = points[i];
+        if (i == n_points - 1 && std::abs(curP.y) < 1e-6) {
+            // do not add the same points twice
+            continue;
+        }
+        curP.y                  = -curP.y;
+        unsigned int currentIdx = static_cast<unsigned int>(points.size());
+        if (std::find(std::begin(kinks), std::end(kinks), i) != std::end(kinks)) {
+            kinks.push_back(currentIdx);
+        }
+        auto parm_it = params.find(static_cast<unsigned int>(i));
+        if (parm_it != params.end()) {
+            double param_new   = umax + umin - parm_it->second;
+            params[currentIdx] = param_new;
+        }
+        points.push_back(curP);
+    }
+
+    points.push_back(points[0]);
+    params[0]                                            = umin;
+    params[static_cast<unsigned int>(points.size() - 1)] = umax;
 }
+} // namespace
 
 namespace tigl
 {
@@ -128,7 +129,9 @@ CCPACSFuselageProfile::CCPACSFuselageProfile(CCPACSFuselageProfiles* parent, CTi
 {
 }
 
-CCPACSFuselageProfile::~CCPACSFuselageProfile() {}
+CCPACSFuselageProfile::~CCPACSFuselageProfile()
+{
+}
 
 // Read fuselage profile file
 void CCPACSFuselageProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
@@ -142,7 +145,7 @@ void CCPACSFuselageProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, cons
     }
 }
 
-const int CCPACSFuselageProfile::GetNumPoints() const 
+const int CCPACSFuselageProfile::GetNumPoints() const
 {
     if (!m_pointList_choice1)
         return 0;
@@ -182,7 +185,6 @@ bool CCPACSFuselageProfile::checkSamePoints(gp_Pnt pointA, gp_Pnt pointB) const
     }
 }
 
-
 // Builds the fuselage profile wire. The returned wire is already transformed by the
 // fuselage profile element transformation.
 void CCPACSFuselageProfile::BuildWires(WireCache& cache) const
@@ -195,7 +197,7 @@ void CCPACSFuselageProfile::BuildWires(WireCache& cache) const
 
     auto points = m_pointList_choice1->AsVector();
     auto params = m_pointList_choice1->GetParamsAsMap();
-    auto kinks = m_pointList_choice1->GetKinksAsVector();
+    auto kinks  = m_pointList_choice1->GetKinksAsVector();
     if (mirrorSymmetry) {
         SymmetrizeFuselageProfile(points, params, kinks);
     }
@@ -208,9 +210,7 @@ void CCPACSFuselageProfile::BuildWires(WireCache& cache) const
     if (mirrorSymmetry) {
         double umin = spline->FirstParameter();
         double umax = spline->LastParameter();
-        spline = CTiglBSplineAlgorithms::trimCurve(spline,
-                                                   umin,
-                                                   0.5*(umin + umax));
+        spline      = CTiglBSplineAlgorithms::trimCurve(spline, umin, 0.5 * (umin + umax));
         CTiglBSplineAlgorithms::reparametrizeBSpline(*spline, umin, umax);
     }
 
@@ -227,7 +227,7 @@ void CCPACSFuselageProfile::BuildWires(WireCache& cache) const
     if (!spline->IsClosed()) {
         builder2.Add(BRepBuilderAPI_MakeEdge(spline->EndPoint(), spline->StartPoint()));
     }
-    TopoDS_Wire tempWireClosed   = builder2.Wire();
+    TopoDS_Wire tempWireClosed = builder2.Wire();
     if (tempWireClosed.IsNull() == Standard_True || tempWireOriginal.IsNull() == Standard_True) {
         throw CTiglError("TopoDS_Wire is null in CCPACSFuselageProfile::BuildWire", TIGL_ERROR);
     }
@@ -249,7 +249,8 @@ gp_Pnt CCPACSFuselageProfile::TransformPoint(const gp_Pnt& aPoint) const
 gp_Pnt CCPACSFuselageProfile::GetPoint(double zeta) const
 {
     if (zeta < 0.0 || zeta > 1.0) {
-        throw CTiglError("Parameter zeta not in the range 0.0 <= zeta <= 1.0 in CCPACSFuselageProfile::GetPoint", TIGL_ERROR);
+        throw CTiglError("Parameter zeta not in the range 0.0 <= zeta <= 1.0 in CCPACSFuselageProfile::GetPoint",
+                         TIGL_ERROR);
     }
 
     // Get the first edge of the wire
@@ -259,14 +260,13 @@ gp_Pnt CCPACSFuselageProfile::GetPoint(double zeta) const
     }
 
     Standard_Real firstParam = 0.;
-    Standard_Real lastParam = 1.;
+    Standard_Real lastParam  = 1.;
     Handle(Geom_Curve) curve = BRep_Tool::Curve(wireExplorer.Current(), firstParam, lastParam);
 
-    gp_Pnt point = curve->Value(firstParam*(1-zeta) + lastParam*zeta);
+    gp_Pnt point = curve->Value(firstParam * (1 - zeta) + lastParam * zeta);
 
     return point;
 }
-
 
 void CCPACSFuselageProfile::BuildDiameterPoints(DiameterPointsCache& cache) const
 {
@@ -276,16 +276,16 @@ void CCPACSFuselageProfile::BuildDiameterPoints(DiameterPointsCache& cache) cons
 
     if (mirrorSymmetry) {
         cache.start = coordinates[0].Get_gp_Pnt();
-        cache.end = coordinates[coordinates.size() - 1].Get_gp_Pnt();
+        cache.end   = coordinates[coordinates.size() - 1].Get_gp_Pnt();
     }
     else {
         // compute starting diameter point
         gp_Pnt firstPnt = coordinates[0].Get_gp_Pnt();
         gp_Pnt lastPnt  = coordinates[coordinates.size() - 1].Get_gp_Pnt();
-        double x = (firstPnt.X() + lastPnt.X())/2.;
-        double y = (firstPnt.Y() + lastPnt.Y())/2.;
-        double z = (firstPnt.Z() + lastPnt.Z())/2.;
-        cache.start = gp_Pnt(x,y,z);
+        double x        = (firstPnt.X() + lastPnt.X()) / 2.;
+        double y        = (firstPnt.Y() + lastPnt.Y()) / 2.;
+        double z        = (firstPnt.Z() + lastPnt.Z()) / 2.;
+        cache.start     = gp_Pnt(x, y, z);
 
         // find the point with the max dist to starting point
         cache.end = cache.start;
@@ -295,19 +295,15 @@ void CCPACSFuselageProfile::BuildDiameterPoints(DiameterPointsCache& cache) cons
                 cache.end = point;
             }
         }
-        // project into x-z plane
-        cache.end.SetY(0.);
-        cache.start.SetY(0.);
     }
 }
 
 TopoDS_Wire CCPACSFuselageProfile::GetDiameterWire() const
 {
     Handle(Geom_TrimmedCurve) diameterCurve = GC_MakeSegment(diameterPointsCache->start, diameterPointsCache->end);
-    TopoDS_Edge diameterEdge = BRepBuilderAPI_MakeEdge(diameterCurve);
-    TopoDS_Wire diameterWire = BRepBuilderAPI_MakeWire(diameterEdge);
+    TopoDS_Edge diameterEdge                = BRepBuilderAPI_MakeEdge(diameterCurve);
+    TopoDS_Wire diameterWire                = BRepBuilderAPI_MakeWire(diameterEdge);
     return diameterWire;
 }
 
 } // end namespace tigl
-

--- a/src/fuselage/CCPACSFuselageProfile.cpp
+++ b/src/fuselage/CCPACSFuselageProfile.cpp
@@ -171,20 +171,6 @@ TopoDS_Wire CCPACSFuselageProfile::GetWire(bool forceClosed) const
     return forceClosed ? wireCache->closed : wireCache->original;
 }
 
-// check if the distance between two points are below a fixed value, so that
-// these point could be imaged as "equal".
-bool CCPACSFuselageProfile::checkSamePoints(gp_Pnt pointA, gp_Pnt pointB) const
-{
-    Standard_Real distance;
-    distance = pointA.Distance(pointB);
-    if (distance < 0.01) {
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-
 // Builds the fuselage profile wire. The returned wire is already transformed by the
 // fuselage profile element transformation.
 void CCPACSFuselageProfile::BuildWires(WireCache& cache) const

--- a/src/fuselage/CCPACSFuselageProfile.h
+++ b/src/fuselage/CCPACSFuselageProfile.h
@@ -90,28 +90,25 @@ private:
     // fuselage profile transformation.
     void BuildWires(WireCache& cache) const;
 
-    // Helper function to determine the "diameter" (the wing profile chord line equivalent) 
+    // Helper function to determine the "diameter" (the wing profile chord line equivalent)
     // which is defined as the line intersecting Point1 and Point2
-    // 
+    //
     // In the case of a non-mirror symmetric profile we have
     // Point1: The middle point between first and last point of the profile point list
     // Point2: The profile point list point with the largest distance to Point1
-    // 
+    //
     // In the case of a mirror symmetric profile we have
     // Point1: First point in the profile point list
     // Point2: Last point in the profile point list
     void BuildDiameterPoints(DiameterPointsCache& cache) const;
 
 private:
-    // Checks is two point are the same, or nearly the same.
-    bool checkSamePoints(gp_Pnt pointA, gp_Pnt pointB) const;
-
     // Invalidates internal wing profile state
     void InvalidateImpl(const boost::optional<std::string>& source) const override;
 
 private:
     bool mirrorSymmetry; /**< Mirror symmetry with repect to the x-z plane */
-    Cache<WireCache, CCPACSFuselageProfile> wireCache;   /**< Original and force closed fuselage profile wire */
+    Cache<WireCache, CCPACSFuselageProfile> wireCache; /**< Original and force closed fuselage profile wire */
     Cache<DiameterPointsCache, CCPACSFuselageProfile> diameterPointsCache;
     std::unique_ptr<ITiglWireAlgorithm> profileWireAlgo;
 };
@@ -119,4 +116,3 @@ private:
 } // end namespace tigl
 
 #endif // CCPACSFUSELAGEPROFILE_H
-

--- a/tests/unittests/TestData/bugs/747/simpletest_fuselage_guides.cpacs.xml
+++ b/tests/unittests/TestData/bugs/747/simpletest_fuselage_guides.cpacs.xml
@@ -1,0 +1,579 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Simple Wing for unit testing</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2012-10-09T15:12:47</timestamp>
+    <version>0.4.0</version>
+    <cpacsVersion>3.1</cpacsVersion>
+    <updates>
+      <update>
+        <modification>Converted to cpacs 3.0 using cpacs2to3 - does not include structure update</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2018-01-15T09:22:57</timestamp>
+        <version>0.2</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Added missing UIDs.</modification>
+        <creator>fix_errors.py</creator>
+        <timestamp>2019-04-29T20:48:26</timestamp>
+        <version>0.3.0</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Converted to CPACS 3.1 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2020-04-26T02:01:33</timestamp>
+        <version>0.4.0</version>
+        <cpacsVersion>3.1</cpacsVersion>
+      </update>
+    </updates>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="CpacsTest">
+        <name>CpacsTest</name>
+        <reference>
+          <area>1</area>
+          <length>1</length>
+          <point uID="Cpacs2Test_point1">
+            <x>0</x>
+            <y>0</y>
+            <z>0</z>
+          </point>
+        </reference>
+        <fuselages>
+          <fuselage uID="SimpleFuselage">
+            <name>name</name>
+            <description>description</description>
+            <transformation uID="SimpleFuselage_transformation1">
+              <scaling uID="SimpleFuselage_transformation1_scaling1">
+                <x>1.0</x>
+                <y>0.5</y>
+                <z>0.5</z>
+              </scaling>
+              <rotation uID="SimpleFuselage_transformation1_rotation1">
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+              </rotation>
+              <translation refType="absLocal" uID="SimpleFuselage_transformation1_translation1">
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="D150_Fuselage_1Section1ID">
+                <name>D150_Fuselage_1Section1</name>
+                <transformation uID="D150_Fuselage_1Section1ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section1ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section1ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section1ID_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section1IDElement1">
+                    <name>D150_Fuselage_1Section1</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section1IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section1IDElement1_transformation1_scaling1">
+                        <x>1.0</x>
+                        <y>1.0</y>
+                        <z>1.0</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section1IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section1IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section2ID">
+                <name>D150_Fuselage_1Section2</name>
+                <transformation uID="D150_Fuselage_1Section2ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section2ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section2ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section2ID_transformation1_translation1">
+                    <x>0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section2IDElement1">
+                    <name>D150_Fuselage_1Section2</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section2IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section2IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section2IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section2IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section3ID">
+                <name>D150_Fuselage_1Section3</name>
+                <transformation uID="D150_Fuselage_1Section3ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section3ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section3ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section3ID_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section3IDElement1">
+                    <name>D150_Fuselage_1Section3</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section3IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section3IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section3IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section3IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="D150_Fuselage_1Positioning1ID">
+                <name>D150_Fuselage_1Positioning1</name>
+                <length>-0.5</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>D150_Fuselage_1Section1ID</toSectionUID>
+              </positioning>
+              <positioning uID="D150_Fuselage_1Positioning3ID">
+                <name>D150_Fuselage_1Positioning3</name>
+                <length>2</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>D150_Fuselage_1Section1ID</fromSectionUID>
+                <toSectionUID>D150_Fuselage_1Section3ID</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="segmentD150_Fuselage_1Segment2ID">
+                <name>D150_Fuselage_1Segment2</name>
+                <fromElementUID>D150_Fuselage_1Section1IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section2IDElement1</toElementUID>
+                <guideCurves>
+                <guideCurve uID="simple_guide_curve_seg_1_1">
+                  <name>Simple Fuselage Guide Curve Segment 1 </name>
+                  <description>Simple Fuselage Guide Curve Segment 1 </description>
+                  <guideCurveProfileUID>simple_guide_curve</guideCurveProfileUID>
+                  <fromRelativeCircumference>0.</fromRelativeCircumference>
+                  <toRelativeCircumference>0.</toRelativeCircumference>
+                </guideCurve>
+                <guideCurve uID="simple_guide_curve_seg_1_2">
+                  <name>Simple Fuselage Guide Curve Segment 1 </name>
+                  <description>Simple Fuselage Guide Curve Segment 1 </description>
+                  <guideCurveProfileUID>simple_guide_curve</guideCurveProfileUID>
+                  <fromRelativeCircumference>0.5</fromRelativeCircumference>
+                  <toRelativeCircumference>0.5</toRelativeCircumference>
+                </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="segmentD150_Fuselage_1Segment3ID">
+                <name>D150_Fuselage_1Segment3</name>
+                <fromElementUID>D150_Fuselage_1Section2IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section3IDElement1</toElementUID>
+                <guideCurves>
+                <guideCurve uID="simple_guide_curve_seg_2_1">
+                  <name>Simple Fuselage Guide Curve Segment 2 </name>
+                  <description>Simple Fuselage Guide Curve Segment 2 </description>
+                  <guideCurveProfileUID>simple_guide_curve</guideCurveProfileUID>
+                  <fromGuideCurveUID>simple_guide_curve_seg_1_1</fromGuideCurveUID>
+                  <toRelativeCircumference>0.</toRelativeCircumference>
+                </guideCurve>
+                <guideCurve uID="simple_guide_curve_seg_2_2">
+                  <name>Simple Fuselage Guide Curve Segment 2 </name>
+                  <description>Simple Fuselage Guide Curve Segment 2 </description>
+                  <guideCurveProfileUID>simple_guide_curve</guideCurveProfileUID>
+                  <fromGuideCurveUID>simple_guide_curve_seg_1_2</fromGuideCurveUID>
+                  <toRelativeCircumference>0.5</toRelativeCircumference>
+                </guideCurve>
+                </guideCurves>
+              </segment>
+            </segments>
+          </fuselage>
+        </fuselages>
+        <wings>
+          <wing uID="Wing" symmetry="x-z-plane">
+            <name>Wing</name>
+            <parentUID>SimpleFuselage</parentUID>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation uID="Wing_transformation1">
+              <scaling uID="Wing_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Wing_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Wing_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation uID="Cpacs2Test_Wing_Sec1_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec1_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec1_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation uID="Cpacs2Test_Wing_Sec2_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec2_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec2_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec3">
+                <name>Cpacs2Test - Wing Section 3</name>
+                <description>Cpacs2Test - Wing Section 3</description>
+                <transformation uID="Cpacs2Test_Wing_Sec3_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec3_El1">
+                    <name>Cpacs2Test - Wing Section 3 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 3 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec3_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec3_El1_transformation1_scaling1">
+                        <x>0.5</x>
+                        <y>0.5</y>
+                        <z>0.5</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec3_El1_transformation1_translation1">
+                        <x>0.5</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="Wing_positioning1">
+                <name>Cpacs2Test - Wing Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="Wing_positioning2">
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="Wing_positioning3">
+                <name>Cpacs2Test - Wing Section 3 Positioning</name>
+                <description>Cpacs2Test - Wing Section 3 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec2</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec3</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec2_El1</toElementUID>
+              </segment>
+              <segment uID="Cpacs2Test_Wing_Seg_2_3">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 2 Main Element to Cpacs2Test - Wing Section 3 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 2 Main Element to Cpacs2Test - Wing Section 3 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec2_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
+              </segment>
+            </segments>
+            <componentSegments>
+              <componentSegment uID="WING_CS1">
+                <name>Wing_CS1</name>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
+                <structure>
+                  <upperShell uID="WING_CS1_upperShell1">
+                    <skin>
+                      <material>
+                        <materialUID>MySkinMat</materialUID>
+                        <thickness>0.0</thickness>
+                      </material>
+                    </skin>
+                    <cells>
+                      <cell uID="WING_CS1_CELL1">
+                        <skin>
+                          <material>
+                            <materialUID>MyCellMat</materialUID>
+                            <thickness>0.0</thickness>
+                          </material>
+                        </skin>
+                        <positioningLeadingEdge>
+                          <xsi1>0.8</xsi1>
+                          <xsi2>0.8</xsi2>
+                        </positioningLeadingEdge>
+                        <positioningTrailingEdge>
+                          <xsi1>1.0</xsi1>
+                          <xsi2>1.0</xsi2>
+                        </positioningTrailingEdge>
+                        <positioningInnerBorder>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
+                        </positioningInnerBorder>
+                        <positioningOuterBorder>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
+                        </positioningOuterBorder>
+                      </cell>
+                    </cells>
+                  </upperShell>
+                  <lowerShell uID="WING_CS1_lowerShell1">
+                    <skin>
+                      <material>
+                        <materialUID>MySkinMat</materialUID>
+                      </material>
+                    </skin>
+                  </lowerShell>
+                </structure>
+              </componentSegment>
+            </componentSegments>
+          </wing>
+        </wings>
+      </model>
+    </aircraft>
+    <profiles>
+      <wingAirfoils>
+        <wingAirfoil uID="NACA0012">
+          <name>NACA0.00.00.12</name>
+          <description>NACA 4 Series Profile</description>
+          <pointList>
+            <x mapType="vector">1.0;0.9875;0.975;0.9625;0.95;0.9375;0.925;0.9125;0.9;0.8875;0.875;0.8625;0.85;0.8375;0.825;0.8125;0.8;0.7875;0.775;0.7625;0.75;0.7375;0.725;0.7125;0.7;0.6875;0.675;0.6625;0.65;0.6375;0.625;0.6125;0.6;0.5875;0.575;0.5625;0.55;0.5375;0.525;0.5125;0.5;0.4875;0.475;0.4625;0.45;0.4375;0.425;0.4125;0.4;0.3875;0.375;0.3625;0.35;0.3375;0.325;0.3125;0.3;0.2875;0.275;0.2625;0.25;0.2375;0.225;0.2125;0.2;0.1875;0.175;0.1625;0.15;0.1375;0.125;0.1125;0.1;0.0875;0.075;0.0625;0.05;0.0375;0.025;0.0125;0.0;0.0125;0.025;0.0375;0.05;0.0625;0.075;0.0875;0.1;0.1125;0.125;0.1375;0.15;0.1625;0.175;0.1875;0.2;0.2125;0.225;0.2375;0.25;0.2625;0.275;0.2875;0.3;0.3125;0.325;0.3375;0.35;0.3625;0.375;0.3875;0.4;0.4125;0.425;0.4375;0.45;0.4625;0.475;0.4875;0.5;0.5125;0.525;0.5375;0.55;0.5625;0.575;0.5875;0.6;0.6125;0.625;0.6375;0.65;0.6625;0.675;0.6875;0.7;0.7125;0.725;0.7375;0.75;0.7625;0.775;0.7875;0.8;0.8125;0.825;0.8375;0.85;0.8625;0.875;0.8875;0.9;0.9125;0.925;0.9375;0.95;0.9625;0.975;0.9875;1.0</x>
+            <y mapType="vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+            <z mapType="vector">-0.00126;-0.0030004180415;-0.00471438572941;-0.00640256842113;-0.00806559133343;-0.00970403933653;-0.0113184567357;-0.0129093470398;-0.0144771727147;-0.0160223549226;-0.0175452732434;-0.0190462653789;-0.0205256268372;-0.0219836105968;-0.0234204267471;-0.024836242105;-0.0262311798047;-0.0276053188583;-0.0289586936852;-0.0302912936071;-0.0316030623052;-0.0328938972373;-0.0341636490097;-0.0354121207001;-0.0366390671268;-0.0378441940595;-0.0390271573644;-0.0401875620783;-0.0413249614032;-0.042438855614;-0.043528690869;-0.0445938579126;-0.0456336906587;-0.04664746464;-0.0476343953088;-0.0485936361694;-0.0495242767241;-0.0504253402064;-0.0512957810767;-0.0521344822472;-0.0529402520006;-0.0537118205596;-0.0544478362583;-0.0551468612564;-0.0558073667285;-0.0564277274483;-0.0570062156697;-0.0575409941929;-0.0580301084765;-0.0584714776309;-0.0588628840933;-0.059201961739;-0.0594861821311;-0.0597128385384;-0.059879027262;-0.0599816256958;-0.060017266394;-0.059982306219;-0.05987278938;-0.0596844028137;-0.059412421875;-0.059051643633;-0.0585963041308;-0.0580399746271;-0.0573754299024;-0.0565944788455;-0.0556877432118;-0.054644363746;-0.0534516022043;-0.0520942903127;-0.0505540468987;-0.0488081315259;-0.0468277042382;-0.0445750655553;-0.0419990347204;-0.0390266537476;-0.0355468568262;-0.0313738751622;-0.0261471986426;-0.0189390266528;0.0;0.0189390266528;0.0261471986426;0.0313738751622;0.0355468568262;0.0390266537476;0.0419990347204;0.0445750655553;0.0468277042382;0.0488081315259;0.0505540468987;0.0520942903127;0.0534516022043;0.054644363746;0.0556877432118;0.0565944788455;0.0573754299024;0.0580399746271;0.0585963041308;0.059051643633;0.059412421875;0.0596844028137;0.05987278938;0.059982306219;0.060017266394;0.0599816256958;0.059879027262;0.0597128385384;0.0594861821311;0.059201961739;0.0588628840933;0.0584714776309;0.0580301084765;0.0575409941929;0.0570062156697;0.0564277274483;0.0558073667285;0.0551468612564;0.0544478362583;0.0537118205596;0.0529402520006;0.0521344822472;0.0512957810767;0.0504253402064;0.0495242767241;0.0485936361694;0.0476343953088;0.04664746464;0.0456336906587;0.0445938579126;0.043528690869;0.042438855614;0.0413249614032;0.0401875620783;0.0390271573644;0.0378441940595;0.0366390671268;0.0354121207001;0.0341636490097;0.0328938972373;0.0316030623052;0.0302912936071;0.0289586936852;0.0276053188583;0.0262311798047;0.024836242105;0.0234204267471;0.0219836105968;0.0205256268372;0.0190462653789;0.0175452732434;0.0160223549226;0.0144771727147;0.0129093470398;0.0113184567357;0.00970403933653;0.00806559133343;0.00640256842113;0.00471438572941;0.0030004180415;0.00126</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+          <guideCurves>
+        <guideCurveProfile uID="simple_guide_curve">
+          <name>A simple fuselage guide curve</name>
+          <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0.0;-0.2</rX>
+            <rY mapType="vector">0.33;0.67</rY>
+            <rZ mapType="vector">0.2;0.0</rZ>
+          </pointList>
+        </guideCurveProfile>
+          </guideCurves>
+      <fuselageProfiles>
+        <fuselageProfile uID="fuselageCircleProfileuID">
+          <name>Circle</name>
+          <description>Profile build up from set of Points on Circle where may Dimensions are 1..-1</description>
+          <pointList>
+            <!-- start outside of symmetry plane -->
+            <x mapType="vector">0.0;0.0;0.0;0.0;0.0</x>
+            <y mapType="vector">-1.0;0.0;1.0;0.0;-1.0</y>
+            <z mapType="vector">0.0;1.0;0.0;-1.0;0.0</z>
+            <!--
+            <y mapType="vector">0.0;1.0;0.0;-1.0;0.0</y>
+            <z mapType="vector">1.0;0.0;-1.0;0.0;1.0</z>
+            -->
+          </pointList>
+        </fuselageProfile>
+      </fuselageProfiles>
+    </profiles>
+  </vehicles>
+  <toolspecific>
+    <cFD>
+      <farField>
+        <type>halfCube</type>
+        <referenceLength>10.0</referenceLength>
+        <multiplier>1.</multiplier>
+      </farField>
+    </cFD>
+  </toolspecific>
+</cpacs>

--- a/tests/unittests/tiglFuselageGuideCurves.cpp
+++ b/tests/unittests/tiglFuselageGuideCurves.cpp
@@ -44,6 +44,7 @@
 #include "CCPACSFuselageSegment.h"
 #include "CTiglLogging.h"
 #include "tiglcommonfunctions.h"
+#include "CNamedShape.h"
 
 using namespace std;
 
@@ -62,15 +63,15 @@ protected:
         tixiHandle = -1;
 
         tixiRet = tixiOpenDocument(filename, &tixiHandle);
-        ASSERT_TRUE (tixiRet == SUCCESS);
+        ASSERT_TRUE(tixiRet == SUCCESS);
         tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "GuideCurveModel", &tiglHandle);
         ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
 
         // constant values for the guide curve points
         const double tempy[] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
-        beta=std::vector<double>(tempy, tempy + sizeof(tempy) / sizeof(tempy[0]) );
+        beta                 = std::vector<double>(tempy, tempy + sizeof(tempy) / sizeof(tempy[0]));
         const double tempz[] = {0.0, 0.001, 0.003, 0.009, 0.008, 0.007, 0.006, 0.002, 0.0};
-        gamma=std::vector<double>(tempz, tempz + sizeof(tempz) / sizeof(tempz[0]) );
+        gamma                = std::vector<double>(tempz, tempz + sizeof(tempz) / sizeof(tempz[0]));
     }
 
     void TearDown() override
@@ -85,29 +86,30 @@ protected:
     void outputXY(const int& i, const double& x, const double& y, const std::string& filename)
     {
         ofstream out;
-        if (i>0) {
+        if (i > 0) {
             out.open(filename.c_str(), ios::app);
         }
         else {
             out.open(filename.c_str());
         }
-        out << setprecision(17) << std::scientific  << x << "\t" << y << endl;
+        out << setprecision(17) << std::scientific << x << "\t" << y << endl;
         out.close();
     }
-    void outputXYVector(const int& i, const double& x, const double& y, const double& vx, const double& vy, const std::string& filename)
+    void outputXYVector(const int& i, const double& x, const double& y, const double& vx, const double& vy,
+                        const std::string& filename)
     {
         ofstream out;
-        if (i>0) {
+        if (i > 0) {
             out.open(filename.c_str(), ios::app);
         }
         else {
             out.open(filename.c_str());
         }
-        out << setprecision(17) << std::scientific  << x << "\t" << y << "\t" << vx << "\t" << vy << "\t" << endl;
+        out << setprecision(17) << std::scientific << x << "\t" << y << "\t" << vx << "\t" << vy << "\t" << endl;
         out.close();
     }
 
-    TixiDocumentHandle           tixiHandle;
+    TixiDocumentHandle tixiHandle;
     TiglCPACSConfigurationHandle tiglHandle;
     //tigl::CCPACSGuideCurve guideCurve;
     std::vector<double> alpha;
@@ -115,6 +117,35 @@ protected:
     std::vector<double> gamma;
 };
 
+class FuselageGuideCurve2 : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        const char* filename = "TestData/bugs/747/simpletest_fuselage_guides.cpacs.xml";
+        ReturnCode tixiRet;
+        TiglReturnCode tiglRet;
+
+        tiglHandle = -1;
+        tixiHandle = -1;
+
+        tixiRet = tixiOpenDocument(filename, &tixiHandle);
+        ASSERT_TRUE(tixiRet == SUCCESS);
+        tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "CpacsTest", &tiglHandle);
+        ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglHandle) == TIGL_SUCCESS);
+        ASSERT_TRUE(tixiCloseDocument(tixiHandle) == SUCCESS);
+        tiglHandle = -1;
+        tixiHandle = -1;
+    }
+
+    TixiDocumentHandle tixiHandle;
+    TiglCPACSConfigurationHandle tiglHandle;
+};
 
 /******************************************************************************/
 
@@ -136,7 +167,8 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSGuideCurveProfiles)
     tigl::CCPACSGuideCurveProfiles guideCurves(NULL, NULL);
     guideCurves.ReadCPACS(tixiHandle, "/cpacs/vehicles/profiles/guideCurves");
     ASSERT_EQ(guideCurves.GetGuideCurveProfileCount(), 6);
-    tigl::CCPACSGuideCurveProfile& guideCurve = guideCurves.GetGuideCurveProfile("GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear");
+    tigl::CCPACSGuideCurveProfile& guideCurve =
+        guideCurves.GetGuideCurveProfile("GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear");
     ASSERT_EQ(guideCurve.GetUID(), "GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear");
     ASSERT_EQ(guideCurve.GetName(), "NonLinear Middle Guide Curve Profile for GuideCurveModel - Fuselage");
 }
@@ -146,17 +178,17 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSGuideCurveProfiles)
 */
 TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointAlgoOnCircle)
 {
-    double radius1=1.0;
-    gp_Pnt location1(radius1, 0.0,  0.0);
+    double radius1 = 1.0;
+    gp_Pnt location1(radius1, 0.0, 0.0);
     gp_Ax2 circlePosition1(location1, gp::DY(), gp::DX());
     Handle(Geom_Circle) circle1 = new Geom_Circle(circlePosition1, radius1);
 
     // convert to edge
-    double start=0.0;
-    double end=2*M_PI;
+    double start          = 0.0;
+    double end            = 2 * M_PI;
     TopoDS_Edge innerEdge = BRepBuilderAPI_MakeEdge(circle1, start, end);
 
-    // convert to wires 
+    // convert to wires
     TopoDS_Wire innerWire = BRepBuilderAPI_MakeWire(innerEdge);
 
     // put wire into container for getPointAlgo
@@ -171,12 +203,13 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointA
     // plot points and tangents
     int N = 20;
     int M = 2;
-    for (int i=0; i<=N+2*M; i++) {
-        double da = 1.0/double(N);
-        double alpha = -M*da + da*i;
+    for (int i = 0; i <= N + 2 * M; i++) {
+        double da    = 1.0 / double(N);
+        double alpha = -M * da + da * i;
         getPointAlgo.GetPointTangent(alpha, point, tangent);
         outputXY(i, point.X(), point.Z(), "./TestData/analysis/tiglFuselageGuideCurve_circleSamplePoints_points.dat");
-        outputXYVector(i, point.X(), point.Z(), tangent.X(), tangent.Z(), "./TestData/analysis/tiglFuselageGuideCurve_circleSamplePoints_tangents.dat");
+        outputXYVector(i, point.X(), point.Z(), tangent.X(), tangent.Z(),
+                       "./TestData/analysis/tiglFuselageGuideCurve_circleSamplePoints_tangents.dat");
         // plot points and tangents with gnuplot by:
         // echo "plot 'TestData/analysis/tiglFuselageGuideCurve_circleSamplePoints_tangents.dat' u 1:2:3:4 with vectors filled head lw 2, 'TestData/analysis/tiglFuselageGuideCurve_circleSamplePoints_points.dat' w linespoints lw 2" | gnuplot -persist
     }
@@ -188,16 +221,16 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointA
     ASSERT_NEAR(point.Z(), 0.0, 1E-10);
     ASSERT_NEAR(tangent.X(), 0.0, 1E-10);
     ASSERT_NEAR(tangent.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(tangent.Z(), -2*M_PI, 1E-10);
+    ASSERT_NEAR(tangent.Z(), -2 * M_PI, 1E-10);
 
     // end: Tangent must be in negative z-direction has to be of length pi
     getPointAlgo.GetPointTangent(-1.0, point, tangent);
     ASSERT_NEAR(point.X(), 2.0, 1E-10);
     ASSERT_NEAR(point.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(point.Z(), 2*M_PI, 1E-10);
+    ASSERT_NEAR(point.Z(), 2 * M_PI, 1E-10);
     ASSERT_NEAR(tangent.X(), 0.0, 1E-10);
     ASSERT_NEAR(tangent.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(tangent.Z(), -2*M_PI, 1E-10);
+    ASSERT_NEAR(tangent.Z(), -2 * M_PI, 1E-10);
 
     // check points and tangents for alpha > 1
     gp_Pnt point2;
@@ -206,28 +239,28 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointA
     getPointAlgo.GetPointTangent(2.0, point2, tangent2);
     ASSERT_NEAR(point2.X(), 2.0, 1E-10);
     ASSERT_NEAR(point2.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(point2.Z(), -2*M_PI, 1E-10);
+    ASSERT_NEAR(point2.Z(), -2 * M_PI, 1E-10);
     ASSERT_NEAR(tangent2.X(), 0.0, 1E-10);
     ASSERT_NEAR(tangent2.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(tangent2.Z(), -2*M_PI, 1E-10);
+    ASSERT_NEAR(tangent2.Z(), -2 * M_PI, 1E-10);
     ASSERT_EQ(tangent.X(), tangent2.X());
     ASSERT_EQ(tangent.Y(), tangent2.Y());
     ASSERT_EQ(tangent.Z(), tangent2.Z());
-    ASSERT_NEAR(point.Distance(point2), 2*M_PI, 1E-10);
+    ASSERT_NEAR(point.Distance(point2), 2 * M_PI, 1E-10);
 
     // check if tangent is constant for alpha < 0
     getPointAlgo.GetPointTangent(0.0, point, tangent);
     getPointAlgo.GetPointTangent(-1.0, point2, tangent2);
     ASSERT_NEAR(point2.X(), 2.0, 1E-10);
     ASSERT_NEAR(point2.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(point2.Z(), 2*M_PI, 1E-10);
+    ASSERT_NEAR(point2.Z(), 2 * M_PI, 1E-10);
     ASSERT_NEAR(tangent2.X(), 0.0, 1E-10);
     ASSERT_NEAR(tangent2.Y(), 0.0, 1E-10);
-    ASSERT_NEAR(tangent2.Z(), -2*M_PI, 1E-10);
+    ASSERT_NEAR(tangent2.Z(), -2 * M_PI, 1E-10);
     ASSERT_EQ(tangent.X(), tangent2.X());
     ASSERT_EQ(tangent.Y(), tangent2.Y());
     ASSERT_EQ(tangent.Z(), tangent2.Z());
-    ASSERT_NEAR(point.Distance(point2), 2*M_PI, 1E-10);
+    ASSERT_NEAR(point.Distance(point2), 2 * M_PI, 1E-10);
 }
 /**
 * * Tests CCPACSFuselageProfileGetPointAlgo class
@@ -236,11 +269,11 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointA
 {
     // read configuration
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
-    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglHandle);
 
     // get upper and lower fuselage profile
     tigl::CCPACSFuselageProfile& profile = config.GetFuselageProfile("GuideCurveModel_Fuselage_Sec3_El1_Pro");
-    TopoDS_Wire wire = profile.GetWire();
+    TopoDS_Wire wire                     = profile.GetWire();
 
     // pack wire container for get point algo
     TopTools_SequenceOfShape wireContainer;
@@ -253,12 +286,13 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointA
     // plot points and tangents
     int N = 20;
     int M = 2;
-    for (int i=0; i<=N+2*M; i++) {
-        double da = 1.0/double(N);
-        double alpha = -M*da + da*i;
+    for (int i = 0; i <= N + 2 * M; i++) {
+        double da    = 1.0 / double(N);
+        double alpha = -M * da + da * i;
         getPointAlgo.GetPointTangent(alpha, point, tangent);
         outputXY(i, point.Y(), point.Z(), "./TestData/analysis/tiglFuselageGuideCurve_profileSamplePoints_points.dat");
-        outputXYVector(i, point.Y(), point.Z(), tangent.Y(), tangent.Z(), "./TestData/analysis/tiglFuselageGuideCurve_profileSamplePoints_tangents.dat");
+        outputXYVector(i, point.Y(), point.Z(), tangent.Y(), tangent.Z(),
+                       "./TestData/analysis/tiglFuselageGuideCurve_profileSamplePoints_tangents.dat");
         // plot points and tangents with gnuplot by:
         // echo "plot 'TestData/analysis/tiglFuselageGuideCurve_profileSamplePoints_tangents.dat' u 1:2:3:4 with vectors filled head lw 2, 'TestData/analysis/tiglFuselageGuideCurve_profileSamplePoints_points.dat' w linespoints lw 2" | gnuplot -persist
     }
@@ -297,9 +331,9 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageProfileGetPointA
 TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSGuideCurveAlgo)
 {
     // create two circles
-    double radius1=1.0;
-    double radius2=2.0;
-    double distance=4.0;
+    double radius1  = 1.0;
+    double radius2  = 2.0;
+    double distance = 4.0;
     gp_Pnt location1(0.0, -radius1, 0.0);
     gp_Ax2 circlePosition1(location1, gp::DX(), gp::DZ());
     Handle(Geom_Circle) circle1 = new Geom_Circle(circlePosition1, radius1);
@@ -308,9 +342,9 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSGuideCurveAlgo)
     Handle(Geom_Circle) circle2 = new Geom_Circle(circlePosition2, radius2);
 
     // convert to wires and consider only half circles starting at the bottom
-    double start=M_PI;
-    TopoDS_Edge edge1 = BRepBuilderAPI_MakeEdge(circle1, start, start+M_PI);
-    TopoDS_Edge edge2 = BRepBuilderAPI_MakeEdge(circle2, start, start+M_PI);
+    double start      = M_PI;
+    TopoDS_Edge edge1 = BRepBuilderAPI_MakeEdge(circle1, start, start + M_PI);
+    TopoDS_Edge edge2 = BRepBuilderAPI_MakeEdge(circle2, start, start + M_PI);
     TopoDS_Wire wire1 = BRepBuilderAPI_MakeWire(edge1);
     TopoDS_Wire wire2 = BRepBuilderAPI_MakeWire(edge2);
 
@@ -326,29 +360,30 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSGuideCurveAlgo)
 
     std::vector<gp_Pnt> guideCurvePnts;
     // instantiate guideCurveAlgo
-    guideCurvePnts = tigl::CCPACSGuideCurveAlgo<tigl::CCPACSFuselageProfileGetPointAlgo> (wireContainer1, wireContainer2, 0.5, 0.5, 2*radius1, 2*radius2, gp_Dir(0.0, 0.0, 1.0), guideCurveProfile);
+    guideCurvePnts = tigl::CCPACSGuideCurveAlgo<tigl::CCPACSFuselageProfileGetPointAlgo>(
+        wireContainer1, wireContainer2, 0.5, 0.5, 2 * radius1, 2 * radius2, gp_Dir(0.0, 0.0, 1.0), guideCurveProfile);
     TopoDS_Edge guideCurveEdge = EdgeSplineFromPoints(guideCurvePnts);
 
     // check if guide curve runs through sample points
     // get curve
     Standard_Real u1, u2;
-    Handle(Geom_Curve) curve =  BRep_Tool::Curve(guideCurveEdge, u1, u2);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(guideCurveEdge, u1, u2);
     // set predicted sample points from cpacs file
     const double temp[] = {0, 0, 0.012, 0.037, 0.110, 0.098, 0.086, 0.073, 0.024, 0, 0};
-    std::vector<double> predictedSamplePointsY (temp, temp + sizeof(temp) / sizeof(temp[0]) );
+    std::vector<double> predictedSamplePointsY(temp, temp + sizeof(temp) / sizeof(temp[0]));
     for (unsigned int i = 0; i <= 10; ++i) {
         // get intersection point of the guide curve with planes parallel to the y-z plane located at a
-        double a = i/double(10);
-        Handle(Geom_Plane) plane = new Geom_Plane(gp_Pnt(a*distance, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0));
-        GeomAPI_IntCS intersection (curve, plane);
+        double a                 = i / double(10);
+        Handle(Geom_Plane) plane = new Geom_Plane(gp_Pnt(a * distance, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0));
+        GeomAPI_IntCS intersection(curve, plane);
         ASSERT_EQ(Standard_True, intersection.IsDone());
         ASSERT_EQ(intersection.NbPoints(), 1);
         gp_Pnt point = intersection.Point(1);
 
         // scale sample points since 2nd profile is scaled by a factor 2
-        predictedSamplePointsY[i]*=(2*radius1+(2*radius2-2*radius1)*a);
+        predictedSamplePointsY[i] *= (2 * radius1 + (2 * radius2 - 2 * radius1) * a);
         // check is guide curve runs through the predicted sample points
-        ASSERT_NEAR(a*distance, point.X(), 1E-14);
+        ASSERT_NEAR(a * distance, point.X(), 1E-14);
         ASSERT_NEAR(predictedSamplePointsY[i], point.Y(), 1E-14);
         ASSERT_NEAR(0.0, point.Z(), 1E-14);
     }
@@ -360,61 +395,87 @@ TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSGuideCurveAlgo)
 TEST_F(FuselageGuideCurve, tiglFuselageGuideCurve_CCPACSFuselageSegment)
 {
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
-    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
-    tigl::CCPACSFuselage& fuselage = config.GetFuselage(1);
+    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSFuselage& fuselage            = config.GetFuselage(1);
 
-    ASSERT_EQ(fuselage.GetSegmentCount(),2);
-    tigl::CCPACSFuselageSegment& segment1 = (tigl::CCPACSFuselageSegment&) fuselage.GetSegment(1);
+    ASSERT_EQ(fuselage.GetSegmentCount(), 2);
+    tigl::CCPACSFuselageSegment& segment1 = (tigl::CCPACSFuselageSegment&)fuselage.GetSegment(1);
 
     ASSERT_TRUE(segment1.GetGuideCurves().get_ptr() != NULL);
     tigl::CCPACSGuideCurves& guides = *segment1.GetGuideCurves();
     ASSERT_EQ(guides.GetGuideCurveCount(), 3);
 
-    // obtain leading edge guide curve 
+    // obtain leading edge guide curve
     TopoDS_Edge guideCurveWire = guides.GetGuideCurve(2).GetCurve();
 
     // check if guide curve runs through sample points
     // get curve
     Standard_Real u1, u2;
-    Handle(Geom_Curve) curve =  BRep_Tool::Curve(guideCurveWire, u1, u2);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(guideCurveWire, u1, u2);
     // gamma values of cpacs data points
     const double temp[] = {0, 0, 0.012, 0.037, 0.110, 0.098, 0.086, 0.073, 0.024, 0, 0};
-    std::vector<double> gammaDeviation (temp, temp + sizeof(temp) / sizeof(temp[0]) );
+    std::vector<double> gammaDeviation(temp, temp + sizeof(temp) / sizeof(temp[0]));
     // number of sample points
-    unsigned int N=10;
+    unsigned int N = 10;
     // segment length
-    double length=10.0;
+    double length = 10.0;
     // segment position
-    double position=-10.0;
+    double position = -10.0;
     // start profile scale factor
-    double startScale=1.0;
+    double startScale = 1.0;
     // end profile scale factor
-    double endScale=2.0;
+    double endScale = 2.0;
     for (unsigned int i = 0; i <= N; ++i) {
         // get intersection point of the guide curve with planes parallel to the y-z-direction
         // located at a
-        double a = length*i/double(N);
-        gp_Pnt planeLocation = gp_Pnt(a+position, 0.5*startScale + 0.5*(endScale-startScale) / length * a, 0.0);
-        gp_Vec dirVec(gp_Pnt(position, 0.5*startScale, 0.0),gp_Pnt(0.0, 0.5*endScale, 0.0));
+        double a             = length * i / double(N);
+        gp_Pnt planeLocation = gp_Pnt(a + position, 0.5 * startScale + 0.5 * (endScale - startScale) / length * a, 0.0);
+        gp_Vec dirVec(gp_Pnt(position, 0.5 * startScale, 0.0), gp_Pnt(0.0, 0.5 * endScale, 0.0));
         Handle(Geom_Plane) plane = new Geom_Plane(planeLocation, gp_Dir(dirVec));
-        GeomAPI_IntCS intersection (curve, plane);
+        GeomAPI_IntCS intersection(curve, plane);
         ASSERT_EQ(intersection.NbPoints(), 1);
         gp_Pnt point = intersection.Point(1);
 
         // start at segment minimal x position
         gp_Vec predictedPoint(position, 0.0, 0.0);
         // go along the fuselage segment maximal y edge
-        predictedPoint += gp_Vec(0.0, 0.5*startScale + 0.5*(endScale-startScale) / length * a  ,  0.0);
+        predictedPoint += gp_Vec(0.0, 0.5 * startScale + 0.5 * (endScale - startScale) / length * a, 0.0);
         predictedPoint += gp_Vec(a, 0.0, 0.0);
         // scale sample points since outer profile's diameter is greater by a factor of 2
-        double s=(startScale+(endScale-startScale)*i/double(N));
+        double s = (startScale + (endScale - startScale) * i / double(N));
         // go along direction perpendicular to the leading edge in the x-y plane
-        double angle=atan2(0.5*(endScale-startScale), length);
-        predictedPoint += gp_Vec(-sin(angle)*gammaDeviation[i]*s, cos(angle)*gammaDeviation[i]*s, 0.0);
+        double angle = atan2(0.5 * (endScale - startScale), length);
+        predictedPoint += gp_Vec(-sin(angle) * gammaDeviation[i] * s, cos(angle) * gammaDeviation[i] * s, 0.0);
 
         // check is guide curve runs through the predicted sample points
         ASSERT_NEAR(predictedPoint.X(), point.X(), 1E-10);
         ASSERT_NEAR(predictedPoint.Y(), point.Y(), 1E-10);
         ASSERT_NEAR(predictedPoint.Z(), point.Z(), 1E-14);
     }
+}
+
+TEST_F(FuselageGuideCurve2, bug747)
+{
+    // https://github.com/DLR-SC/tigl/issues/747
+
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSFuselage& fuselage            = config.GetFuselage(1);
+
+    tigl::CCPACSFuselageProfile& startProfile = fuselage.GetSegment(1).GetStartConnection().GetProfile();
+    TopoDS_Wire diameter                      = startProfile.GetDiameterWire();
+
+    // Can be calculate the correct diameter?
+    EXPECT_NEAR(GetLength(diameter), 2., 1e-3);
+
+    // Can we build the loft? Is the result reasonable?
+    PNamedShape loft = fuselage.GetLoft();
+    double minx, maxx, miny, maxy, minz, maxz;
+    GetShapeExtension(loft->Shape(), minx, maxx, miny, maxy, minz, maxz);
+    EXPECT_TRUE(minx > -1.5);
+    EXPECT_TRUE(maxx < 2.);
+    EXPECT_TRUE(miny > -1.);
+    EXPECT_TRUE(maxy < 1.);
+    EXPECT_TRUE(minz > -1.);
+    EXPECT_TRUE(maxz < 1.);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the Lofter crashes in case of fuselage profiles that don't have a start and end-point at the relative circumenference of 0.25 and 0.75 respectively.
This fixes #747 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I added a new unit test.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide. **<-- Sorry, my autoformatter reformated the code. I actually just deleted three lines from `CCPACSFuselageProfile.cpp`, all other changes are code format chagnes**
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
