### PR TITLE
Prevent hard crash with guide curves

### DIFF
--- a/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
+++ b/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
@@ -94,6 +94,13 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
     CCPACSConfiguration& config = m_segment.GetFuselage().GetConfiguration();
     CCPACSGuideCurveProfile& guideCurveProfile = config.GetGuideCurveProfile(guideCurveProfileUID);
 
+    if( guideCurveProfile.GetGuideCurveProfilePoints()[0].y  < 1e-14) {
+        throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
+    }
+    if( guideCurveProfile.GetGuideCurveProfilePoints().back().y  > 1 - 1e-14) {
+        throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
+    }
+
     // get local x-direction for the guide curve
     gp_Dir rxDir = gp_Dir(0., 0., 1.);
     if (guideCurve->GetRXDirection()) {

--- a/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
+++ b/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
@@ -94,10 +94,10 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
     CCPACSConfiguration& config = m_segment.GetFuselage().GetConfiguration();
     CCPACSGuideCurveProfile& guideCurveProfile = config.GetGuideCurveProfile(guideCurveProfileUID);
 
-    if( guideCurveProfile.GetGuideCurveProfilePoints()[0].y  < 1e-14) {
+    if (guideCurveProfile.GetGuideCurveProfilePoints()[0].y < 1e-14) {
         throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
     }
-    if( guideCurveProfile.GetGuideCurveProfilePoints().back().y  > 1 - 1e-14) {
+    if (guideCurveProfile.GetGuideCurveProfilePoints().back().y > 1 - 1e-14) {
         throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
     }
 

--- a/src/guide_curves/CCPACSGuideCurveProfile.cpp
+++ b/src/guide_curves/CCPACSGuideCurveProfile.cpp
@@ -29,6 +29,13 @@ CCPACSGuideCurveProfile::CCPACSGuideCurveProfile(CCPACSGuideCurveProfiles* paren
     : generated::CPACSGuideCurveProfileGeometry(parent, uidMgr) {}
 
 const std::vector<CTiglPoint>& CCPACSGuideCurveProfile::GetGuideCurveProfilePoints() {
-    return m_pointList.AsVector();
+    const std::vector<CTiglPoint>& ret = m_pointList.AsVector();
+    if( ret[0].y  < 1e-14) {
+        throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
+    }
+    if( ret.back().y  > 1 - 1e-14) {
+        throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
+    }
+    return ret;
 }
 } // end namespace tigl

--- a/src/guide_curves/CCPACSGuideCurveProfile.cpp
+++ b/src/guide_curves/CCPACSGuideCurveProfile.cpp
@@ -29,13 +29,6 @@ CCPACSGuideCurveProfile::CCPACSGuideCurveProfile(CCPACSGuideCurveProfiles* paren
     : generated::CPACSGuideCurveProfileGeometry(parent, uidMgr) {}
 
 const std::vector<CTiglPoint>& CCPACSGuideCurveProfile::GetGuideCurveProfilePoints() {
-    const std::vector<CTiglPoint>& ret = m_pointList.AsVector();
-    if( ret[0].y  < 1e-14) {
-        throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
-    }
-    if( ret.back().y  > 1 - 1e-14) {
-        throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
-    }
-    return ret;
+    return m_pointList.AsVector();
 }
 } // end namespace tigl

--- a/src/guide_curves/CTiglCurveConnector.cpp
+++ b/src/guide_curves/CTiglCurveConnector.cpp
@@ -323,7 +323,12 @@ void CTiglCurveConnector::InterpolateGuideCurvePart(guideCurveConnected& connect
 
     GeomAPI_Interpolate interpol(hpoints, hparams, Standard_False, Precision::Confusion());
     interpol.Load(htangents, htangentFlags, false);
-    interpol.Perform();
+    try {
+        interpol.Perform();
+    } catch(...)
+    {
+        throw CTiglError("Error interpolating guide curve points.");
+    }
     Handle(Geom_BSplineCurve) hcurve = interpol.Curve();
     curvePart.localCurve = BRepBuilderAPI_MakeEdge(hcurve);
 }

--- a/src/guide_curves/CTiglCurveConnector.cpp
+++ b/src/guide_curves/CTiglCurveConnector.cpp
@@ -325,8 +325,8 @@ void CTiglCurveConnector::InterpolateGuideCurvePart(guideCurveConnected& connect
     interpol.Load(htangents, htangentFlags, false);
     try {
         interpol.Perform();
-    } catch(...)
-    {
+    }
+    catch(...) {
         throw CTiglError("Error interpolating guide curve points.");
     }
     Handle(Geom_BSplineCurve) hcurve = interpol.Curve();

--- a/src/guide_curves/CTiglCurveConnector.cpp
+++ b/src/guide_curves/CTiglCurveConnector.cpp
@@ -326,7 +326,7 @@ void CTiglCurveConnector::InterpolateGuideCurvePart(guideCurveConnected& connect
     try {
         interpol.Perform();
     }
-    catch(...) {
+    catch(const Standard_Failure&) {
         throw CTiglError("Error interpolating guide curve points.");
     }
     Handle(Geom_BSplineCurve) hcurve = interpol.Curve();

--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -103,10 +103,10 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     // get guide curve profile
     CCPACSGuideCurveProfile& guideCurveProfile = m_segment.GetUIDManager().ResolveObject<CCPACSGuideCurveProfile>(guideCurveProfileUID);
 
-    if( guideCurveProfile.GetGuideCurveProfilePoints()[0].y  < 1e-14) {
+    if (guideCurveProfile.GetGuideCurveProfilePoints()[0].y < 1e-14) {
         throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
     }
-    if( guideCurveProfile.GetGuideCurveProfilePoints().back().y  > 1 - 1e-14) {
+    if (guideCurveProfile.GetGuideCurveProfilePoints().back().y > 1 - 1e-14) {
         throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
     }
 

--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -103,6 +103,13 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     // get guide curve profile
     CCPACSGuideCurveProfile& guideCurveProfile = m_segment.GetUIDManager().ResolveObject<CCPACSGuideCurveProfile>(guideCurveProfileUID);
 
+    if( guideCurveProfile.GetGuideCurveProfilePoints()[0].y  < 1e-14) {
+        throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
+    }
+    if( guideCurveProfile.GetGuideCurveProfilePoints().back().y  > 1 - 1e-14) {
+        throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
+    }
+
     // get local x-direction for the guide curve
     gp_Dir rxDir = gp_Dir(1., 0., 0.);
     if (guideCurve->GetRXDirection()) {

--- a/tests/unittests/TestData/bugs/766/simple_test_guide_curves.xml
+++ b/tests/unittests/TestData/bugs/766/simple_test_guide_curves.xml
@@ -1,0 +1,745 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<cpacs xmlns:NS0="http://www.w3.org/2001/XMLSchema-instance" NS0:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>GuideCurveModel Test</name>
+    <description>Simple Test Model for Guide Curve Unit Testing</description>
+    <creator>Tobias Stollenwerk</creator>
+    <timestamp>2014-02-10T14:28:00</timestamp>
+    <version>1.4.0</version>
+    <cpacsVersion>3.1</cpacsVersion>
+    <updates>
+      <update>
+        <modification>Converted to cpacs 3.0 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2018-06-13T18:42:16</timestamp>
+        <version>1.2</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Fixed order of wing profiles.</modification>
+        <creator>fix_errors.py</creator>
+        <timestamp>2019-04-29T20:48:27</timestamp>
+        <version>1.3.0</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Converted to CPACS 3.1 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2020-04-26T02:01:34</timestamp>
+        <version>1.4.0</version>
+        <cpacsVersion>3.1</cpacsVersion>
+      </update>
+    </updates>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="GuideCurveModel">
+        <name>GuideCurveModel</name>
+        <fuselages>
+          <fuselage uID="Fuselage" symmetry="x-z-plane">
+            <name>Fuselage</name>
+            <description>This fuselage has been generated using CATIA2CPACS.</description>
+            <transformation uID="Fuselage_transformation1">
+              <scaling uID="Fuselage_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Fuselage_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Fuselage_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="GuideCurveModel_Fuselage_Sec1">
+                <name>GuideCurveModel - Fuselage Section 1</name>
+                <description>GuideCurveModel - Fuselage Section 1</description>
+                <transformation uID="GuideCurveModel_Fuselage_Sec1_transformation1">
+                  <scaling uID="GuideCurveModel_Fuselage_Sec1_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Fuselage_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Fuselage_Sec1_El1">
+                    <name>GuideCurveModel - Fuselage Section 1 Main Element</name>
+                    <description>GuideCurveModel - Fuselage Section 1 Main Element</description>
+                    <profileUID>GuideCurveModel_Fuselage_Sec1_El1_Pro</profileUID>
+                    <transformation uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0.0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Fuselage_Sec2">
+                <name>GuideCurveModel - Fuselage Section 6</name>
+                <description>GuideCurveModel - Fuselage Section 6</description>
+                <transformation uID="GuideCurveModel_Fuselage_Sec2_transformation1">
+                  <scaling uID="GuideCurveModel_Fuselage_Sec2_transformation1_scaling1">
+                    <x>2</x>
+                    <y>2</y>
+                    <z>2</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Fuselage_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Fuselage_Sec2_El1">
+                    <name>GuideCurveModel - Fuselage Section 6 Main Element</name>
+                    <description>GuideCurveModel - Fuselage Section 6 Main Element</description>
+                    <profileUID>GuideCurveModel_Fuselage_Sec2_El1_Pro</profileUID>
+                    <transformation uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Fuselage_Sec3">
+                <name>GuideCurveModel - Fuselage Section 9</name>
+                <description>GuideCurveModel - Fuselage Section 9</description>
+                <transformation uID="GuideCurveModel_Fuselage_Sec3_transformation1">
+                  <scaling uID="GuideCurveModel_Fuselage_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Fuselage_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Fuselage_Sec3_El1">
+                    <name>GuideCurveModel - Fuselage Section 9 Main Element</name>
+                    <description>GuideCurveModel - Fuselage Section 9 Main Element</description>
+                    <profileUID>GuideCurveModel_Fuselage_Sec3_El1_Pro</profileUID>
+                    <transformation uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="LamAiR_Jig_Shape_Fuselage_Sec1_Positioning">
+                <name>GuideCurveModel - Fuselage Section 1 Positioning</name>
+                <description>GuideCurveModel - Fuselage Section 1 Positioning</description>
+                <length>-10</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>GuideCurveModel_Fuselage_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Fuselage_Sec2_Positioning">
+                <name>GuideCurveModel - Fuselage Section 6 Positioning</name>
+                <description>GuideCurveModel - Fuselage Section 6 Positioning</description>
+                <length>10</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Fuselage_Sec1</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Fuselage_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Fuselage_Sec3_Positioning">
+                <name>GuideCurveModel - Fuselage Section 9 Positioning</name>
+                <description>GuideCurveModel - Fuselage Section 9 Positioning</description>
+                <length>10</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Fuselage_Sec2</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Fuselage_Sec3</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="GuideCurveModel_Fuselage_Seg_1_6">
+                <name>Segment from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element</name>
+                <description>Segment from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element</description>
+                <fromElementUID>GuideCurveModel_Fuselage_Sec1_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Fuselage_Sec2_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Lower">
+                    <name>Lower GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </name>
+                    <description>Lower GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Lower_Linear</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Middle">
+                    <name>Middle GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </name>
+                    <description>Middle GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.5</fromRelativeCircumference>
+                    <toRelativeCircumference>0.5</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Upper">
+                    <name>Upper GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </name>
+                    <description>Upper GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Upper_Linear</guideCurveProfileUID>
+                    <fromRelativeCircumference>1.0</fromRelativeCircumference>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="GuideCurveModel_Fuselage_Seg_6_9">
+                <name>Segment from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element</name>
+                <description>Segment from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element</description>
+                <fromElementUID>GuideCurveModel_Fuselage_Sec2_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Fuselage_Sec3_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_6_9_GuideCurve_Lower">
+                    <name>Lower GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </name>
+                    <description>Lower GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Lower_Linear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Lower</fromGuideCurveUID>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_6_9_GuideCurve_Middle">
+                    <name>Middle GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </name>
+                    <description>Middle GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Middle</fromGuideCurveUID>
+                    <toRelativeCircumference>0.5</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_6_9_GuideCurve_Upper">
+                    <name>Upper GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </name>
+                    <description>Upper GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Upper_Linear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Upper</fromGuideCurveUID>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+            </segments>
+          </fuselage>
+        </fuselages>
+        <wings>
+          <wing uID="Wing" symmetry="x-z-plane">
+            <name>Wing</name>
+            <description>This wing has been generated using CATIA2CPACS.</description>
+            <parentUID>Fuselage</parentUID>
+            <transformation uID="Wing_transformation1">
+              <scaling uID="Wing_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Wing_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Wing_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="GuideCurveModel_Wing_Sec1">
+                <name>GuideCurveModel - Wing Section 1</name>
+                <description>GuideCurveModel - Wing Section 1</description>
+                <transformation uID="GuideCurveModel_Wing_Sec1_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec1_transformation1_scaling1">
+                    <x>2</x>
+                    <y>2</y>
+                    <z>2</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec1_El1">
+                    <name>GuideCurveModel - Wing Section 1 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 1 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec1_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec1_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Wing_Sec2">
+                <name>GuideCurveModel - Wing Section 2</name>
+                <description>GuideCurveModel - Wing Section 2</description>
+                <transformation uID="GuideCurveModel_Wing_Sec2_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec2_transformation1_scaling1">
+                    <x>2</x>
+                    <y>2</y>
+                    <z>2</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec2_El1">
+                    <name>GuideCurveModel - Wing Section 2 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 2 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec2_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec2_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Wing_Sec3">
+                <name>GuideCurveModel - Wing Section 3</name>
+                <description>GuideCurveModel - Wing Section 3</description>
+                <transformation uID="GuideCurveModel_Wing_Sec3_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec3_El1">
+                    <name>GuideCurveModel - Wing Section 3 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 3 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec3_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec3_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec3_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec3_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Wing_Sec4">
+                <name>GuideCurveModel - Wing Section 4</name>
+                <description>GuideCurveModel - Wing Section 4</description>
+                <transformation uID="GuideCurveModel_Wing_Sec4_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec4_transformation1_scaling1">
+                    <x>0.5</x>
+                    <y>0.5</y>
+                    <z>0.5</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec4_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec4_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec4_El1">
+                    <name>GuideCurveModel - Wing Section 4 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 4 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec3_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec4_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec4_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec4_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec4_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec1_Positioning">
+                <name>GuideCurveModel - Wing Section 1 Positioning</name>
+                <description>GuideCurveModel - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>GuideCurveModel_Wing_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec2_Positioning">
+                <name>GuideCurveModel - Wing Section 2 Positioning</name>
+                <description>GuideCurveModel - Wing Section 2 Positioning</description>
+                <length>5</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Wing_Sec1</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Wing_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec3_Positioning">
+                <name>GuideCurveModel - Wing Section 3 Positioning</name>
+                <description>GuideCurveModel - Wing Section 3 Positioning</description>
+                <length>7</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Wing_Sec2</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Wing_Sec3</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec4_Positioning">
+                <name>GuideCurveModel - Wing Section 4 Positioning</name>
+                <description>GuideCurveModel - Wing Section 4 Positioning</description>
+                <length>2</length>
+                <sweepAngle>-30</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Wing_Sec3</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Wing_Sec4</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="GuideCurveModel_Wing_Seg_1_2">
+                <name>Segment from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element</name>
+                <description>Segment from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element</description>
+                <fromElementUID>GuideCurveModel_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Wing_Sec2_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower">
+                    <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                    <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>-1.0</fromRelativeCircumference>
+                    <toRelativeCircumference>-1.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_1_2_GuideCurve_LeadingEdge_NonLinear">
+                    <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                    <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper">
+                    <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                    <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>1.0</fromRelativeCircumference>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="GuideCurveModel_Wing_Seg_2_3">
+                <name>Segment from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element</name>
+                <description>Segment from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element</description>
+                <fromElementUID>GuideCurveModel_Wing_Sec2_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Wing_Sec3_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeLower">
+                    <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                    <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
+                    <continuity>C1 from previous</continuity>
+                    <toRelativeCircumference>-1.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_2_3_GuideCurve_LeadingEdge">
+                    <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                    <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_1_2_GuideCurve_LeadingEdge_NonLinear</fromGuideCurveUID>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeUpper">
+                    <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                    <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper</fromGuideCurveUID>
+                    <continuity>C1 from previous</continuity>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="GuideCurveModel_Wing_Seg_3_4">
+                <name>Segment from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element</name>
+                <description>Segment from GuideCurveModel - Wing Section 4 Main Element to GuideCurveModel - Wing Section 4 Main Element</description>
+                <fromElementUID>GuideCurveModel_Wing_Sec3_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Wing_Sec4_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_3_4_GuideCurve_TrailingEdgeLower">
+                    <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </name>
+                    <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
+                    <continuity>C2 from previous</continuity>
+                    <toRelativeCircumference>-1.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_3_4_GuideCurve_LeadingEdge">
+                    <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </name>
+                    <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_2_3_GuideCurve_LeadingEdge</fromGuideCurveUID>
+                    <continuity>C2 to previous</continuity>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_3_4_GuideCurve_TrailingEdgeUpper">
+                    <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </name>
+                    <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeUpper</fromGuideCurveUID>
+                    <continuity>C2 from previous</continuity>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+            </segments>
+          </wing>
+        </wings>
+      </model>
+    </aircraft>
+    <profiles>
+      <fuselageProfiles>
+        <fuselageProfile uID="GuideCurveModel_Fuselage_Sec1_El1_Pro">
+          <name>Profile for GuideCurveModel - Fuselage Section 1 Main Element</name>
+          <description>Profile for GuideCurveModel - Fuselage Section 1 Main Element</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0;0;0;0;0</x>
+            <y mapType="vector">0.0; 0.19134171618254; 0.353553390593273; 0.461939766255643; 0.5; 0.461939766255643; 0.353553390593273; 0.19134171618254; 0.0</y>
+            <z mapType="vector">-0.5; -0.461939766255643; -0.353553390593273; -0.191341716182545; 0.0; 0.191341716182545; 0.353553390593273; 0.461939766255643; 0.5</z>
+          </pointList>
+          <symmetry>half</symmetry>
+        </fuselageProfile>
+        <fuselageProfile uID="GuideCurveModel_Fuselage_Sec2_El1_Pro">
+          <name>Profile for GuideCurveModel - Fuselage Section 2 Main Element</name>
+          <description>Profile for GuideCurveModel - Fuselage Section 2 Main Element</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0;0;0;0;0</x>
+            <y mapType="vector">0.0; 0.19134171618254; 0.353553390593273; 0.461939766255643; 0.5; 0.461939766255643; 0.353553390593273; 0.19134171618254; 0.0</y>
+            <z mapType="vector">-0.5; -0.461939766255643; -0.353553390593273; -0.191341716182545; 0.0; 0.191341716182545; 0.353553390593273; 0.461939766255643; 0.5</z>
+          </pointList>
+          <symmetry>half</symmetry>
+        </fuselageProfile>
+        <fuselageProfile uID="GuideCurveModel_Fuselage_Sec3_El1_Pro">
+          <name>Profile for GuideCurveModel - Fuselage Section 3 Main Element</name>
+          <description>Profile for GuideCurveModel - Fuselage Section 3 Main Element</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0;0;0;0;0</x>
+            <y mapType="vector">0;.223860653;.432603294;.466631663;.499998888;.450157118;.311391445;.111113597;0</y>
+            <z mapType="vector">-.5;-.494434471;-.437105114;-.218786464;.001054491;.21762024;.391197352;.487497455;.487497455</z>
+          </pointList>
+          <symmetry>half</symmetry>
+        </fuselageProfile>
+      </fuselageProfiles>
+      <wingAirfoils>
+        <wingAirfoil uID="GuideCurveModel_Wing_Sec1_El1_Pro">
+          <name>Profile for GuideCurveModel - Wing Section 1 Main Element</name>
+          <description>Profile for GuideCurveModel - Wing Section 1 Main Element</description>
+          <pointList>
+            <x mapType="vector">.9999784;.968197388;.936349495;.904498754;.872660752;.84086439;.809165804;.777645373;.746369023;.715327073;.684414824;.653483715;.622409173;.59111906;.559609072;.527933591;.496162223;.464342346;.432498701;.400647422;.368800249;.336965189;.305148159;.273355754;.241594009;.209870517;.178197675;.146592625;.115081309;.083709634;.052577631;.022177734;0;.023262645;.053669824;.084769499;.116134169;.147647044;.179256233;.210921895;.242623663;.274356232;.306115173;.337894939;.369696476;.4015238;.433375739;.465267654;.497209966;.52916707;.56111429;.593048555;.624956577;.656807267;.688555686;.720154156;.751577886;.782831714;.813937486;.844909731;.875819929;.906731848;.937735348;.96884951;1.0000216</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">-.002501412;-.000514511;-.000066798;-.0002723;-.00118397;-.003037171;-.006133111;-.010694648;-.016709644;-.023842525;-.031521748;-.039124261;-.046113721;-.052058933;-.056696263;-.060026157;-.062272019;-.063681794;-.064384418;-.064427803;-.063891726;-.062868004;-.061383465;-.059441838;-.057050692;-.054196812;-.050827075;-.046874166;-.042233362;-.036731081;-.030013513;-.020616799;0;.019568135;.029342082;.036687505;.042814443;.048130166;.05284177;.057158942;.061202889;.06499762;.068565072;.071942056;.075106683;.078000774;.080609248;.082660055;.083617993;.083440607;.08259259;.081348039;.079559524;.076948121;.07330212;.068528372;.062711588;.056040221;.048707905;.040829923;.032710837;.024598326;.016844694;.00954676;.002501412</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="GuideCurveModel_Wing_Sec2_El1_Pro">
+          <name>Profile for GuideCurveModel - Wing Section 2 Main Element</name>
+          <description>Profile for GuideCurveModel - Wing Section 2 Main Element</description>
+          <pointList>
+            <x mapType="vector">.9999784;.968197367;.936349494;.904498765;.872660738;.840864376;.809165819;.777645367;.746368991;.715327071;.684414772;.65348374;.62240919;.591119061;.559609062;.527933678;.496162246;.46434231;.432498733;.400647404;.368800354;.336965189;.305148172;.273355781;.24159402;.209870542;.178197756;.146592645;.115081404;.083709644;.052577646;.022177748;0;.023262651;.053669828;.0847695;.116134159;.147647051;.179256214;.210921894;.24262364;.274356223;.306115158;.337894927;.369696505;.401523834;.433375785;.46526771;.497210025;.529167135;.561114345;.593048616;.624956639;.656807329;.688555755;.720154271;.751577946;.782831781;.813937535;.844909748;.875819947;.906731858;.937735354;.968849524;1.0000216</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">-.002501412;-.000514511;-.000066798;-.0002723;-.00118397;-.003037173;-.006133109;-.010694649;-.016709651;-.023842525;-.031521761;-.039124255;-.046113718;-.052058933;-.056696264;-.06002615;-.062272017;-.063681796;-.064384417;-.064427803;-.063891728;-.062868004;-.061383466;-.05944184;-.057050693;-.054196814;-.050827085;-.046874169;-.042233377;-.036731083;-.030013517;-.020616805;0;.019568138;.029342083;.036687505;.042814441;.048130167;.052841767;.057158942;.061202886;.064997619;.06856507;.071942054;.075106685;.078000777;.080609251;.082660058;.083617993;.083440606;.082592589;.081348037;.07955952;.076948115;.073302111;.068528353;.062711576;.056040206;.048707893;.040829919;.032710832;.024598324;.016844692;.009546757;.002501412</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="GuideCurveModel_Wing_Sec3_El1_Pro">
+          <name>Profile for GuideCurveModel - Wing Section 3 Main Element</name>
+          <description>Profile for GuideCurveModel - Wing Section 3 Main Element</description>
+          <pointList>
+            <x mapType="vector">1.00;0.975;0.9625;0.95;0.9375;0.925;0.9125;0.9;0.8875;0.875;0.8625;0.85;0.8375;0.825;0.8125;0.8;0.7875;0.775;0.7625;0.75;0.7375;0.725;0.7125;0.7;0.6875;0.675;0.6625;0.65;0.6375;0.625;0.6125;0.6;0.5875;0.575;0.5625;0.55;0.5375;0.525;0.5125;0.5;0.4875;0.475;0.4625;0.45;0.4375;0.425;0.4125;0.4;0.3875;0.375;0.3625;0.35;0.3375;0.325;0.3125;0.3;0.2875;0.275;0.2625;0.25;0.2375;0.225;0.2125;0.2;0.1875;0.175;0.1625;0.15;0.1375;0.125;0.1125;0.1;0.0875;0.075;0.0625;0.05;0.0375;0.025;0.0125;0.0;0.0125;0.025;0.0375;0.05;0.0625;0.075;0.0875;0.1;0.1125;0.125;0.1375;0.15;0.1625;0.175;0.1875;0.2;0.2125;0.225;0.2375;0.25;0.2625;0.275;0.2875;0.3;0.3125;0.325;0.3375;0.35;0.3625;0.375;0.3875;0.4;0.4125;0.425;0.4375;0.45;0.4625;0.475;0.4875;0.5;0.5125;0.525;0.5375;0.55;0.5625;0.575;0.5875;0.6;0.6125;0.625;0.6375;0.65;0.6625;0.675;0.6875;0.7;0.7125;0.725;0.7375;0.75;0.7625;0.775;0.7875;0.8;0.8125;0.825;0.8375;0.85;0.8625;0.875;0.8875;0.9;0.9125;0.925;0.9375;0.95;0.9625;0.975;0.9875;1.0</x>
+            <y mapType="vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+            <z mapType="vector">-0.003;-0.00471438572941;-0.00640256842113;-0.00806559133343;-0.00970403933653;-0.0113184567357;-0.0129093470398;-0.0144771727147;-0.0160223549226;-0.0175452732434;-0.0190462653789;-0.0205256268372;-0.0219836105968;-0.0234204267471;-0.024836242105;-0.0262311798047;-0.0276053188583;-0.0289586936852;-0.0302912936071;-0.0316030623052;-0.0328938972373;-0.0341636490097;-0.0354121207001;-0.0366390671268;-0.0378441940595;-0.0390271573644;-0.0401875620783;-0.0413249614032;-0.042438855614;-0.043528690869;-0.0445938579126;-0.0456336906587;-0.04664746464;-0.0476343953088;-0.0485936361694;-0.0495242767241;-0.0504253402064;-0.0512957810767;-0.0521344822472;-0.0529402520006;-0.0537118205596;-0.0544478362583;-0.0551468612564;-0.0558073667285;-0.0564277274483;-0.0570062156697;-0.0575409941929;-0.0580301084765;-0.0584714776309;-0.0588628840933;-0.059201961739;-0.0594861821311;-0.0597128385384;-0.059879027262;-0.0599816256958;-0.060017266394;-0.059982306219;-0.05987278938;-0.0596844028137;-0.059412421875;-0.059051643633;-0.0585963041308;-0.0580399746271;-0.0573754299024;-0.0565944788455;-0.0556877432118;-0.054644363746;-0.0534516022043;-0.0520942903127;-0.0505540468987;-0.0488081315259;-0.0468277042382;-0.0445750655553;-0.0419990347204;-0.0390266537476;-0.0355468568262;-0.0313738751622;-0.0261471986426;-0.0189390266528;0.0;0.0189390266528;0.0261471986426;0.0313738751622;0.0355468568262;0.0390266537476;0.0419990347204;0.0445750655553;0.0468277042382;0.0488081315259;0.0505540468987;0.0520942903127;0.0534516022043;0.054644363746;0.0556877432118;0.0565944788455;0.0573754299024;0.0580399746271;0.0585963041308;0.059051643633;0.059412421875;0.0596844028137;0.05987278938;0.059982306219;0.060017266394;0.0599816256958;0.059879027262;0.0597128385384;0.0594861821311;0.059201961739;0.0588628840933;0.0584714776309;0.0580301084765;0.0575409941929;0.0570062156697;0.0564277274483;0.0558073667285;0.0551468612564;0.0544478362583;0.0537118205596;0.0529402520006;0.0521344822472;0.0512957810767;0.0504253402064;0.0495242767241;0.0485936361694;0.0476343953088;0.04664746464;0.0456336906587;0.0445938579126;0.043528690869;0.042438855614;0.0413249614032;0.0401875620783;0.0390271573644;0.0378441940595;0.0366390671268;0.0354121207001;0.0341636490097;0.0328938972373;0.0316030623052;0.0302912936071;0.0289586936852;0.0276053188583;0.0262311798047;0.024836242105;0.0234204267471;0.0219836105968;0.0205256268372;0.0190462653789;0.0175452732434;0.0160223549226;0.0144771727147;0.0129093470398;0.0113184567357;0.00970403933653;0.00806559133343;0.00640256842113;0.00471438572941;0.0030004180415;0.00126</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+      <guideCurves>
+        <guideCurveProfile uID="GuideCurveModel_Fuselage_GuideCurveProfile_Lower_Linear">
+          <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0;0;0</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear">
+          <name>NonLinear Middle Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>NonLinear Middle Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0.;0;0;0;0;0;0;0;0</rX>
+            <rY mapType="vector">0.;0.2;0.3;0.4;0.5;0.6;0.7;0.8;0.9</rY>
+            <rZ mapType="vector">0.;0.012;0.037;0.110;0.098;0.086;0.073;0.024;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Fuselage_GuideCurveProfile_Upper_Linear">
+          <name>Linear Upper Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>Linear Upper Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0;0;0</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear">
+          <name>Linear Lower Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</name>
+          <description>Linear Lower Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</description>
+          <pointList>
+            <rX mapType="vector">0.001;0.01;0.001</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear">
+          <name>NonLinear Leading Edge Guide Curve Profile for GuideCurveModel - Wing</name>
+          <description>NonLinear Leading Edge Guide Curve Profile for GuideCurveModel - Wing</description>
+          <pointList>
+            <rX mapType="vector">0;-0.01;-0.03;-0.09;-0.08;-0.07;-0.06;-0.02;0</rX>
+            <rY mapType="vector">0.1;0.2;0.3;0.4;0.5;0.6;0.7;0.8;1.0</rY>
+            <rZ mapType="vector">0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear">
+          <name>Linear Upper Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</name>
+          <description>Linear Upper Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</description>
+          <pointList>
+            <rX mapType="vector">0.0;0.01;0.001</rX>
+            <rY mapType="vector">0.0;0.5;0.9</rY>
+            <rZ mapType="vector">0.0;0.0;0.0</rZ>
+          </pointList>
+        </guideCurveProfile>
+      </guideCurves>
+    </profiles>
+  </vehicles>
+</cpacs>

--- a/tests/unittests/tiglFuselageGuideCurves.cpp
+++ b/tests/unittests/tiglFuselageGuideCurves.cpp
@@ -479,3 +479,30 @@ TEST_F(FuselageGuideCurve2, bug747)
     EXPECT_TRUE(minz > -1.);
     EXPECT_TRUE(maxz < 1.);
 }
+
+
+TEST(FuselageGuideCurve_bug, 766)
+{
+    // https://github.com/DLR-SC/tigl/issues/766
+    const char* filename = "TestData/bugs/766/simple_test_guide_curves.xml";
+    ReturnCode tixiRet;
+    TiglReturnCode tiglRet;
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    TixiDocumentHandle tixiHandle = -1;
+
+    tixiRet = tixiOpenDocument(filename, &tixiHandle);
+    ASSERT_TRUE(tixiRet == SUCCESS);
+    tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "GuideCurveModel", &tiglHandle);
+    ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglHandle);
+
+    tigl::CCPACSFuselage& fuselage = config.GetFuselage(1);
+    EXPECT_THROW(fuselage.GetLoft()->Shape(), tigl::CTiglError);
+
+    tigl::CCPACSWing& wing = config.GetWing(1);
+    EXPECT_THROW(wing.GetLoft()->Shape(), tigl::CTiglError);
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes #766. I did not add an `assert` to CTiglPointToBSpline as mentioned in the issue description, because 
 - checking for uniqueness up to floating point precision is not super trivial, especially since the class takes a `Handle(TColgp_HArray1OfPnt)` and not an `std::vector`
 - It's not really related to the issue
 - The assert would only help in debug mode and uncover a fringe case of misuse.

## How Has This Been Tested?

I added a new unit test dedicated to #766.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- ~~[ ] New classes have been added to the Python interface.~~
- ~~[ ] API changes were documented properly in tigl.h.~~
