### PR TITLE
Fix failing unittests if shuffled

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -257,7 +257,7 @@ jobs:
       run: |
         cd build
         cd tests/unittests/
-        ./TiGL-unittests --gtest_output=xml:test_results.xml
+        ./TiGL-unittests --gtest_shuffle --gtest_output=xml:test_results.xml
       if: contains(matrix.config.name, 'Ubuntu-Release') || contains(matrix.config.os, 'macos')
       
     - name: Run unit tests (windows)
@@ -267,7 +267,7 @@ jobs:
         cd build
         cmake --build . --target tigl-java-demo
         cd tests\unittests
-        .\TiGL-unittests.exe --gtest_output=xml:test_results.xml
+        .\TiGL-unittests.exe --gtest_shuffle --gtest_output=xml:test_results.xml
       if: contains(matrix.config.os, 'windows')
     
     - name: Create coverage report (ubuntu debug)

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -77,8 +77,8 @@ TiglCPACSConfigurationHandle WingSegment::tiglHandle = 0;
 class WingSegmentSimple : public ::testing::Test 
 {
 protected:
-    static void SetUpTestCase() 
-    {
+
+    void SetUp() override {
         const char* filename = "TestData/simpletest.cpacs.xml";
         ReturnCode tixiRet;
         TiglReturnCode tiglRet;
@@ -92,17 +92,12 @@ protected:
         tiglRet = tiglOpenCPACSConfiguration(tixiSimpleHandle, "Cpacs2Test", &tiglSimpleHandle);
         ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
     }
-
-    static void TearDownTestCase() 
-    {
+    void TearDown() override {
         ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglSimpleHandle) == TIGL_SUCCESS);
         ASSERT_TRUE(tixiCloseDocument(tixiSimpleHandle) == SUCCESS);
         tiglSimpleHandle = -1;
         tixiSimpleHandle = -1;
     }
-
-    void SetUp() override {}
-    void TearDown() override {}
 
 
     static TixiDocumentHandle           tixiSimpleHandle;
@@ -886,6 +881,9 @@ TEST_F(WingSegmentSimple, getIsOnTop_performance)
 
 TEST_F(WingSegmentSimple, trafo_Consistency)
 {
+    TiglReturnCode tiglRet = tiglWingSetGetPointBehavior(tiglSimpleHandle, onLinearLoft);
+    ASSERT_EQ(tiglRet, SUCCESS);
+
     // we transform eta, xsi to x,y,z and perform the back transform
     // we check if we get the the same eta xsi as before
     int segIndex = 1;
@@ -964,6 +962,9 @@ TEST_F(WingSegmentSimple, getEtaXsi_Performance)
 // @todo: test of failures, outliers etc...
 TEST_F(WingSegmentSimple, wingGetEtaXsi)
 {  
+    TiglReturnCode tiglRet = tiglWingSetGetPointBehavior(tiglSimpleHandle, onLinearLoft);
+    ASSERT_EQ(tiglRet, SUCCESS);
+
     double x = 0., y = 0., z = 0.;
     ASSERT_TRUE(tiglWingGetUpperPoint(tiglSimpleHandle, 1, 1, 0.5, 0.5, &x, &y, &z) == TIGL_SUCCESS);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #772. This makes sure that the text fixtures for `WingSegmentSimple` get properly set up and torn down. Also, `--gtest_shuffle` is enabled in CI to catch this issue in the future. 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
