### PR TITLE
Properly expose trailing edge devices in python bindings

### DIFF
--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -512,7 +512,8 @@ class CCPACSWingRibsPositioning;
          tigl::CCPACSWingCell,
          tigl::CCPACSWingRibsDefinition,
          tigl::CCPACSWingSparSegment,
-         tigl::CCPACSEnginePylon
+         tigl::CCPACSEnginePylon,
+         tigl::CCPACSTrailingEdgeDevice
 );
 
 namespace tigl

--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -225,7 +225,7 @@ namespace tigl {
 %boost_optional(tigl::generated::CPACSLeadingEdgeHollow)
 %boost_optional(tigl::generated::CPACSCutOutControlPoints)
 %boost_optional(tigl::generated::CPACSControlSurfaceSkinCutOutBorder)
-%boost_optional(tigl::generated::CPACSTrailingEdgeDevices)
+%boost_optional(tigl::CCPACSTrailingEdgeDevices)
 %boost_optional(tigl::CCPACSControlSurfaces)
 %boost_optional(tigl::CPACSControlSurfaceWingCutOut)
 %boost_optional(tigl::generated::CPACSControlSurfaceTracks)
@@ -273,6 +273,7 @@ namespace tigl
 %ignore ComponentSegment(CCPACSTrailingEdgeDevice&);
 %include "CCPACSTrailingEdgeDevice.h"
 %include "generated/CPACSTrailingEdgeDevices.h"
+%include "CCPACSTrailingEdgeDevices.h"
 %include "generated/CPACSControlSurfaces.h"
 %include "CCPACSControlSurfaces.h"
 

--- a/cpacs_gen_input/CustomTypes.txt
+++ b/cpacs_gen_input/CustomTypes.txt
@@ -122,6 +122,7 @@ CPACSWalls                                CCPACSWalls
 // control surfaces
 CPACSControlSurfaces                      CCPACSControlSurfaces
 CPACSControlSurfaceBorderTrailingEdge     CCPACSControlSurfaceBorderTrailingEdge
+CPACSTrailingEdgeDevices                  CCPACSTrailingEdgeDevices
 CPACSTrailingEdgeDevice                   CCPACSTrailingEdgeDevice
 CPACSControlSurfaceOuterShapeTrailingEdge CCPACSControlSurfaceOuterShapeTrailingEdge
 CPACSControlSurfaceWingCutOut             CCPACSControlSurfaceWingCutOut

--- a/src/control_devices/CCPACSTrailingEdgeDevices.cpp
+++ b/src/control_devices/CCPACSTrailingEdgeDevices.cpp
@@ -1,0 +1,68 @@
+/*
+* Copyright (C) 2007-2021 German Aerospace Center (DLR/SC)
+*
+* Created: 2021-02-05 Jan Kleinert <Jan.Kleinert@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/**
+* @file
+* @brief  Implementation of CPACS trailing edge devices
+*/
+
+#include "CTiglError.h"
+#include "CCPACSTrailingEdgeDevice.h"
+#include "CCPACSTrailingEdgeDevices.h"
+
+namespace tigl {
+
+CCPACSTrailingEdgeDevices::CCPACSTrailingEdgeDevices(CCPACSControlSurfaces* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSTrailingEdgeDevices(parent, uidMgr) {}
+
+// Returns the total count of trailing edge devices in a configuration
+int CCPACSTrailingEdgeDevices::GetTrailingEdgeDeviceCount() const
+{
+    return static_cast<int>(m_trailingEdgeDevices.size());
+}
+
+// Returns the trailing edge device for a given index.
+CCPACSTrailingEdgeDevice& CCPACSTrailingEdgeDevices::GetTrailingEdgeDevice(int index) const
+{
+    index --;
+    if (index < 0 || index >= GetTrailingEdgeDeviceCount()) {
+        throw CTiglError("Invalid index in CCPACSTrailingEdgeDevices::GetTrailingEdgeDevice", TIGL_INDEX_ERROR);
+    }
+    return *m_trailingEdgeDevices[index];
+}
+
+// Returns the trailing edge device for a given UID.
+CCPACSTrailingEdgeDevice& CCPACSTrailingEdgeDevices::GetTrailingEdgeDevice(const std::string& UID) const
+{
+    return *m_trailingEdgeDevices[GetTrailingEdgeDeviceIndex(UID)-1];
+}
+
+// Returns the trailing edge device index for a given UID.
+int CCPACSTrailingEdgeDevices::GetTrailingEdgeDeviceIndex(const std::string& UID) const
+{
+    for (int i=0; i < GetTrailingEdgeDeviceCount(); i++) {
+        const std::string tmpUID(m_trailingEdgeDevices[i]->GetUID());
+        if (tmpUID == UID) {
+            return i+1;
+        }
+    }
+
+    // UID not there
+    throw CTiglError("Invalid UID in CCPACSTrailingEdgeDevices::GetTrailingEdgeDeviceIndex", TIGL_UID_ERROR);
+}
+
+} // namespace tigl

--- a/src/control_devices/CCPACSTrailingEdgeDevices.h
+++ b/src/control_devices/CCPACSTrailingEdgeDevices.h
@@ -1,0 +1,50 @@
+/*
+* Copyright (C) 2007-2021 German Aerospace Center (DLR/SC)
+*
+* Created: 2021-02-05 Jan Kleinert <Jan.Kleinert@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/**
+* @file
+* @brief  Implementation of CPACS trailing edge devices
+*/
+
+#ifndef CCPACSTRAILINGEDGEDEVICES_H
+#define CCPACSTRAILINGEDGEDEVICES_H
+
+#include "generated/CPACSTrailingEdgeDevices.h"
+
+namespace tigl {
+
+class CCPACSTrailingEdgeDevices : public generated::CPACSTrailingEdgeDevices
+{
+public:
+    TIGL_EXPORT CCPACSTrailingEdgeDevices(CCPACSControlSurfaces* parent, CTiglUIDManager* uidMgr);
+
+    // Returns the total count of trailing edge devices in a configuration
+    TIGL_EXPORT int GetTrailingEdgeDeviceCount() const;
+
+    // Returns the trailing edge device for a given index.
+    TIGL_EXPORT CCPACSTrailingEdgeDevice& GetTrailingEdgeDevice(int index) const;
+
+    // Returns the trailing edge device for a given UID.
+    TIGL_EXPORT CCPACSTrailingEdgeDevice& GetTrailingEdgeDevice(const std::string& UID) const;
+
+    // Returns the trailing edge device index for a given UID.
+    TIGL_EXPORT int GetTrailingEdgeDeviceIndex(const std::string& UID) const;
+};
+
+} // namespace tigl
+
+#endif

--- a/src/generated/CPACSControlSurfaces.cpp
+++ b/src/generated/CPACSControlSurfaces.cpp
@@ -99,17 +99,17 @@ namespace generated
 
     }
 
-    const boost::optional<CPACSTrailingEdgeDevices>& CPACSControlSurfaces::GetTrailingEdgeDevices() const
+    const boost::optional<CCPACSTrailingEdgeDevices>& CPACSControlSurfaces::GetTrailingEdgeDevices() const
     {
         return m_trailingEdgeDevices;
     }
 
-    boost::optional<CPACSTrailingEdgeDevices>& CPACSControlSurfaces::GetTrailingEdgeDevices()
+    boost::optional<CCPACSTrailingEdgeDevices>& CPACSControlSurfaces::GetTrailingEdgeDevices()
     {
         return m_trailingEdgeDevices;
     }
 
-    CPACSTrailingEdgeDevices& CPACSControlSurfaces::GetTrailingEdgeDevices(CreateIfNotExistsTag)
+    CCPACSTrailingEdgeDevices& CPACSControlSurfaces::GetTrailingEdgeDevices(CreateIfNotExistsTag)
     {
         if (!m_trailingEdgeDevices)
             m_trailingEdgeDevices = boost::in_place(reinterpret_cast<CCPACSControlSurfaces*>(this), m_uidMgr);

--- a/src/generated/CPACSControlSurfaces.h
+++ b/src/generated/CPACSControlSurfaces.h
@@ -19,9 +19,9 @@
 
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+#include <CCPACSTrailingEdgeDevices.h>
 #include <string>
 #include <tixi.h>
-#include "CPACSTrailingEdgeDevices.h"
 #include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
@@ -62,10 +62,10 @@ namespace generated
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
 
-        TIGL_EXPORT virtual const boost::optional<CPACSTrailingEdgeDevices>& GetTrailingEdgeDevices() const;
-        TIGL_EXPORT virtual boost::optional<CPACSTrailingEdgeDevices>& GetTrailingEdgeDevices();
+        TIGL_EXPORT virtual const boost::optional<CCPACSTrailingEdgeDevices>& GetTrailingEdgeDevices() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSTrailingEdgeDevices>& GetTrailingEdgeDevices();
 
-        TIGL_EXPORT virtual CPACSTrailingEdgeDevices& GetTrailingEdgeDevices(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual CCPACSTrailingEdgeDevices& GetTrailingEdgeDevices(CreateIfNotExistsTag);
         TIGL_EXPORT virtual void RemoveTrailingEdgeDevices();
 
     protected:
@@ -73,7 +73,7 @@ namespace generated
 
         CTiglUIDManager* m_uidMgr;
 
-        boost::optional<CPACSTrailingEdgeDevices> m_trailingEdgeDevices;
+        boost::optional<CCPACSTrailingEdgeDevices> m_trailingEdgeDevices;
 
     private:
         CPACSControlSurfaces(const CPACSControlSurfaces&) = delete;

--- a/src/generated/CPACSTrailingEdgeDevice.cpp
+++ b/src/generated/CPACSTrailingEdgeDevice.cpp
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 #include <cassert>
+#include "CCPACSTrailingEdgeDevices.h"
 #include "CPACSTrailingEdgeDevice.h"
-#include "CPACSTrailingEdgeDevices.h"
 #include "CTiglError.h"
 #include "CTiglLogging.h"
 #include "CTiglUIDManager.h"
@@ -27,7 +27,7 @@ namespace tigl
 {
 namespace generated
 {
-    CPACSTrailingEdgeDevice::CPACSTrailingEdgeDevice(CPACSTrailingEdgeDevices* parent, CTiglUIDManager* uidMgr)
+    CPACSTrailingEdgeDevice::CPACSTrailingEdgeDevice(CCPACSTrailingEdgeDevices* parent, CTiglUIDManager* uidMgr)
         : m_uidMgr(uidMgr)
         , m_outerShape(reinterpret_cast<CCPACSTrailingEdgeDevice*>(this), m_uidMgr)
         , m_path(reinterpret_cast<CCPACSTrailingEdgeDevice*>(this), m_uidMgr)
@@ -44,12 +44,12 @@ namespace generated
         }
     }
 
-    const CPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent() const
+    const CCPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent() const
     {
         return m_parent;
     }
 
-    CPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent()
+    CCPACSTrailingEdgeDevices* CPACSTrailingEdgeDevice::GetParent()
     {
         return m_parent;
     }

--- a/src/generated/CPACSTrailingEdgeDevice.h
+++ b/src/generated/CPACSTrailingEdgeDevice.h
@@ -34,11 +34,10 @@
 namespace tigl
 {
 class CTiglUIDManager;
+class CCPACSTrailingEdgeDevices;
 
 namespace generated
 {
-    class CPACSTrailingEdgeDevices;
-
     // This class is used in:
     // CPACSTrailingEdgeDevices
 
@@ -64,13 +63,13 @@ namespace generated
     class CPACSTrailingEdgeDevice : public CTiglReqUIDObject, public ITiglUIDRefObject
     {
     public:
-        TIGL_EXPORT CPACSTrailingEdgeDevice(CPACSTrailingEdgeDevices* parent, CTiglUIDManager* uidMgr);
+        TIGL_EXPORT CPACSTrailingEdgeDevice(CCPACSTrailingEdgeDevices* parent, CTiglUIDManager* uidMgr);
 
         TIGL_EXPORT virtual ~CPACSTrailingEdgeDevice();
 
-        TIGL_EXPORT CPACSTrailingEdgeDevices* GetParent();
+        TIGL_EXPORT CCPACSTrailingEdgeDevices* GetParent();
 
-        TIGL_EXPORT const CPACSTrailingEdgeDevices* GetParent() const;
+        TIGL_EXPORT const CCPACSTrailingEdgeDevices* GetParent() const;
 
         TIGL_EXPORT virtual CTiglUIDObject* GetNextUIDParent();
         TIGL_EXPORT virtual const CTiglUIDObject* GetNextUIDParent() const;
@@ -118,7 +117,7 @@ namespace generated
         TIGL_EXPORT virtual void RemoveTracks();
 
     protected:
-        CPACSTrailingEdgeDevices* m_parent;
+        CCPACSTrailingEdgeDevices* m_parent;
 
         CTiglUIDManager* m_uidMgr;
 
@@ -160,7 +159,4 @@ namespace generated
 } // namespace generated
 
 // CPACSTrailingEdgeDevice is customized, use type CCPACSTrailingEdgeDevice directly
-
-// Aliases in tigl namespace
-using CCPACSTrailingEdgeDevices = generated::CPACSTrailingEdgeDevices;
 } // namespace tigl

--- a/src/generated/CPACSTrailingEdgeDevices.cpp
+++ b/src/generated/CPACSTrailingEdgeDevices.cpp
@@ -80,7 +80,7 @@ namespace generated
     {
         // read element trailingEdgeDevice
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/trailingEdgeDevice")) {
-            tixi::TixiReadElements(tixiHandle, xpath + "/trailingEdgeDevice", m_trailingEdgeDevices, 1, tixi::xsdUnbounded, this, m_uidMgr);
+            tixi::TixiReadElements(tixiHandle, xpath + "/trailingEdgeDevice", m_trailingEdgeDevices, 1, tixi::xsdUnbounded, reinterpret_cast<CCPACSTrailingEdgeDevices*>(this), m_uidMgr);
         }
 
     }
@@ -104,7 +104,7 @@ namespace generated
 
     CCPACSTrailingEdgeDevice& CPACSTrailingEdgeDevices::AddTrailingEdgeDevice()
     {
-        m_trailingEdgeDevices.push_back(make_unique<CCPACSTrailingEdgeDevice>(this, m_uidMgr));
+        m_trailingEdgeDevices.push_back(make_unique<CCPACSTrailingEdgeDevice>(reinterpret_cast<CCPACSTrailingEdgeDevices*>(this), m_uidMgr));
         return *m_trailingEdgeDevices.back();
     }
 

--- a/src/generated/CPACSTrailingEdgeDevices.h
+++ b/src/generated/CPACSTrailingEdgeDevices.h
@@ -81,6 +81,5 @@ namespace generated
     };
 } // namespace generated
 
-// Aliases in tigl namespace
-using CCPACSTrailingEdgeDevices = generated::CPACSTrailingEdgeDevices;
+// CPACSTrailingEdgeDevices is customized, use type CCPACSTrailingEdgeDevices directly
 } // namespace tigl

--- a/tests/unittests/tiglControlSurfaceDevice.cpp
+++ b/tests/unittests/tiglControlSurfaceDevice.cpp
@@ -21,7 +21,7 @@
 #include "CCPACSWing.h"
 #include "CCPACSWingComponentSegment.h"
 #include "CCPACSConfigurationManager.h"
-
+#include "CCPACSConfiguration.h"
 
 #include "TopoDS_Face.hxx"
 #include "TopExp_Explorer.hxx"
@@ -174,6 +174,37 @@ TEST_F(TiglControlSurfaceDevice, tiglControlSurfaceGetAndSetControlParameter)
     ASSERT_EQ(TIGL_SUCCESS     , tiglControlSurfaceGetControlParameter(tiglHandle, "D150_VAMP_W1_CompSeg1_innerFlap", &controlParm ) );
     ASSERT_NEAR(0.33, controlParm, 1e-10);
 
+}
+
+TEST_F(TiglControlSurfaceDevice, CCPACSTrailingEdgeDevices)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+    tigl::CCPACSWingComponentSegment& componentSegment = static_cast<tigl::CCPACSWingComponentSegment&>(wing.GetComponentSegment(1));
+    tigl::CCPACSTrailingEdgeDevices& devices = *componentSegment.GetControlSurfaces()->GetTrailingEdgeDevices();
+
+    // trailing edge device count
+    ASSERT_EQ(devices.GetTrailingEdgeDeviceCount(), 3);
+
+    // get trailing edge device by index
+    ASSERT_EQ(devices.GetTrailingEdgeDevice(1).GetUID(), "D150_VAMP_W1_CompSeg1_innerFlap");
+    ASSERT_EQ(devices.GetTrailingEdgeDevice(2).GetUID(), "D150_VAMP_W1_CompSeg1_outerFlap");
+    ASSERT_EQ(devices.GetTrailingEdgeDevice(3).GetUID(), "D150_VAMP_W1_CompSeg1_aileron");
+    ASSERT_THROW(devices.GetTrailingEdgeDevice(-1), tigl::CTiglError);
+    ASSERT_THROW(devices.GetTrailingEdgeDevice(4), tigl::CTiglError);
+
+    // get index of trailing edge device by uid
+    ASSERT_EQ(devices.GetTrailingEdgeDeviceIndex("D150_VAMP_W1_CompSeg1_innerFlap"), 1);
+    ASSERT_EQ(devices.GetTrailingEdgeDeviceIndex("D150_VAMP_W1_CompSeg1_outerFlap"), 2);
+    ASSERT_EQ(devices.GetTrailingEdgeDeviceIndex("D150_VAMP_W1_CompSeg1_aileron"), 3);
+    ASSERT_THROW(devices.GetTrailingEdgeDeviceIndex("WrongUID"), tigl::CTiglError);
+
+    // get trailing edge device by uid
+    ASSERT_EQ(devices.GetTrailingEdgeDevice("D150_VAMP_W1_CompSeg1_innerFlap").GetName(), devices.GetTrailingEdgeDevice(1).GetName());
+    ASSERT_EQ(devices.GetTrailingEdgeDevice("D150_VAMP_W1_CompSeg1_outerFlap").GetName(), devices.GetTrailingEdgeDevice(2).GetName());
+    ASSERT_EQ(devices.GetTrailingEdgeDevice("D150_VAMP_W1_CompSeg1_aileron").GetName(), devices.GetTrailingEdgeDevice(3).GetName());
+    ASSERT_THROW(devices.GetTrailingEdgeDevice("WrongUID"), tigl::CTiglError);
 }
 
 TEST(TiglControlSurfaceDeviceSimple, setControlParameterAndExport)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #759 

This PR properly exposes `CCPACSTrailingEdgeDevices` to the python bindings.

 - `CCPACSTrailingEdgeDevice` is retrievable using the uid manager from python
 - `CCPACSTrailingEdgeDevice` is retrievable via CPACS traversal and the new `CCPACSTrailingEdgeDevices` getters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Tested with the following python code, that previously did not work *(see issue description)*:

```python
from tixi3 import tixi3wrapper
from tigl3 import tigl3wrapper
from tigl3.configuration import CCPACSConfigurationManager_get_instance, CCPACSTrailingEdgeDevice

# open the CPACS file
tixi_handle = tixi3wrapper.Tixi3()
tixi_handle.open("D150_v30.xml")
tigl3 = tigl3wrapper.Tigl3()
tigl3.open(tixi_handle, '')

config = CCPACSConfigurationManager_get_instance().get_configuration(tigl3._handle.value)

# get trailing edge device by uid
uid_mgr = config.get_uidmanager()
inner_flap = uid_mgr.get_geometric_component("D150_InnerFlap")
print(type(inner_flap))

# get trailing edge by CPACS tree traversal starting at wing
wing = uid_mgr.get_geometric_component("D150_wing_1ID")
cpacs_te_devices = wing.get_component_segment(1).get_control_surfaces().get_trailing_edge_devices()
help(cpacs_te_devices)

te_device1 = cpacs_te_devices.get_trailing_edge_device(1)
help(te_device1)

te_device2 = cpacs_te_devices.get_trailing_edge_device("D150_InnerFlap")
help(te_device2)
```

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [x] New classes have been added to the Python interface.
- [x] API changes were documented properly in tigl.h.
