### PR TITLE
ControlDevices: Support referencing eta-xsi-coordinates relative to a segment

### DIFF
--- a/src/control_devices/CCPACSControlSurfaceBorderTrailingEdge.cpp
+++ b/src/control_devices/CCPACSControlSurfaceBorderTrailingEdge.cpp
@@ -20,6 +20,7 @@
 #include "CControlSurfaceBorderBuilder.h"
 #include "CCPACSControlSurfaceOuterShapeTrailingEdge.h"
 #include "CCPACSTrailingEdgeDevice.h"
+#include "tigletaxsifunctions.h"
 
 #include "CNamedShape.h"
 #include "Debugging.h"
@@ -106,8 +107,10 @@ TopoDS_Wire CCPACSControlSurfaceBorderTrailingEdge::GetAirfoilWire(CTiglControlS
 CTiglControlSurfaceBorderCoordinateSystem CCPACSControlSurfaceBorderTrailingEdge::GetCoordinateSystem(gp_Vec upDir) const
 {
     const auto& segment = ComponentSegment(*this);
-    gp_Pnt pLE = segment.GetPoint(getEtaLE(), getXsiLE());
-    gp_Pnt pTE = segment.GetPoint(getEtaTE(), getXsiTE());
+    auto& etaLE = GetEtaLE();
+    auto& etaTE = GetEtaTE().is_initialized()? GetEtaTE().value() : GetEtaLE();
+    gp_Pnt pLE = segment.GetPoint(transformEtaToCSOrTed(etaLE, *m_uidMgr), getXsiLE());
+    gp_Pnt pTE = segment.GetPoint(transformEtaToCSOrTed(etaTE, *m_uidMgr), getXsiTE());
 
     CTiglControlSurfaceBorderCoordinateSystem coords(pLE, pTE, upDir);
     return coords;

--- a/src/control_devices/CCPACSControlSurfaceWingCutOut.cpp
+++ b/src/control_devices/CCPACSControlSurfaceWingCutOut.cpp
@@ -24,6 +24,7 @@
 #include "Debugging.h"
 #include "generated/CPACSCutOutControlPoint.h"
 #include "CControlSurfaceBorderBuilder.h"
+#include "tigletaxsifunctions.h"
 
 #include <gp_Vec.hxx>
 #include <BRepOffsetAPI_ThruSections.hxx>
@@ -125,10 +126,10 @@ CCPACSControlSurfaceWingCutOut::GetCutoutCS(bool isInnerBorder, const CCPACSCont
         throw CTiglError("Cutout border of '" + GetParent()->GetUID() + "' requires etaLE and etaTE values to proceed.");
     }
 
-    double lEta = cutOutBorder->GetEtaLE_choice2().value().GetEta();
-    double lXsi = outerShapeBorder->getXsiLE();
-    double tEta = cutOutBorder->GetEtaTE_choice2().value().GetEta();
-    double tXsi = outerShapeBorder->getXsiTE();
+    double lEta = transformEtaToCSOrTed(cutOutBorder->GetEtaLE_choice2().value(), *m_uidMgr);
+    double lXsi = transformXsiToCSOrTed(outerShapeBorder->GetXsiLE(), *m_uidMgr);
+    double tEta = transformEtaToCSOrTed(cutOutBorder->GetEtaTE_choice2().value(), *m_uidMgr);
+    double tXsi = outerShapeBorder->getXsiTE(); // this is always 1.0
 
     const auto& segment = ComponentSegment(*this);
     gp_Pnt pLE = segment.GetPoint(lEta, lXsi);

--- a/tests/unittests/TestData/simpletest-flaps.cpacs.xml
+++ b/tests/unittests/TestData/simpletest-flaps.cpacs.xml
@@ -484,8 +484,8 @@
                 </structure>
                 <controlSurfaces>
                   <trailingEdgeDevices>
-                    <trailingEdgeDevice uID="Flap">
-                      <name>Flap</name>
+                    <trailingEdgeDevice uID="FlapInner">
+                      <name>FlapInner</name>
                       <parentUID>Wing_CS1</parentUID>
                       <outerShape>
                         <innerBorder>
@@ -558,6 +558,88 @@
                               <z>-0.1</z>
                             </innerHingeTranslation>
                             <outerHingeTranslation uID="Flap_outerHingeTranslation2">
+                              <x>0.1</x>
+                              <z>-0.1</z>
+                            </outerHingeTranslation>
+                            <hingeLineRotation>30</hingeLineRotation>
+                          </step>
+                        </steps>
+                      </path>
+                    </trailingEdgeDevice>
+                    <trailingEdgeDevice uID="FlapOuter">
+                      <name>FlapOuter</name>
+                      <parentUID>Wing_CS1</parentUID>
+                      <outerShape>
+                        <innerBorder>
+                          <etaLE>
+                            <eta>0.25</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaLE>
+                          <etaTE>
+                            <eta>0.25</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaTE>
+                          <xsiLE>
+                            <xsi>0.75</xsi>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </xsiLE>
+                          <leadingEdgeShape>
+                            <relHeightLE>0.5</relHeightLE>
+                            <xsiUpperSkin>0.8</xsiUpperSkin>
+                            <xsiLowerSkin>0.8</xsiLowerSkin>
+                          </leadingEdgeShape>
+                        </innerBorder>
+                        <outerBorder>
+                          <etaLE>
+                            <eta>0.75</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaLE>
+                          <etaTE>
+                            <eta>0.75</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaTE>
+                          <xsiLE>
+                            <xsi>0.75</xsi>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </xsiLE>
+                          <leadingEdgeShape>
+                            <relHeightLE>0.5</relHeightLE>
+                            <xsiUpperSkin>0.8</xsiUpperSkin>
+                            <xsiLowerSkin>0.8</xsiLowerSkin>
+                          </leadingEdgeShape>
+                        </outerBorder>
+                      </outerShape>
+                      <path>
+                        <innerHingePoint>
+                          <hingeXsi>0.8</hingeXsi>
+                          <hingeRelHeight>0.5</hingeRelHeight>
+                        </innerHingePoint>
+                        <outerHingePoint>
+                          <hingeXsi>0.8</hingeXsi>
+                          <hingeRelHeight>0.5</hingeRelHeight>
+                        </outerHingePoint>
+                        <steps>
+                          <step>
+                            <controlParameter>0.0</controlParameter>
+                            <innerHingeTranslation uID="FlapOuter_innerHingeTranslation1">
+                              <x>0.0</x>
+                              <y>0.0</y>
+                              <z>0.0</z>
+                            </innerHingeTranslation>
+                            <outerHingeTranslation uID="FlapOuter_outerHingeTranslation1">
+                              <x>0.0</x>
+                              <z>0.0</z>
+                            </outerHingeTranslation>
+                            <hingeLineRotation>0.0</hingeLineRotation>
+                          </step>
+                          <step>
+                            <controlParameter>1</controlParameter>
+                            <innerHingeTranslation uID="FlapOuter_innerHingeTranslation2">
+                              <x>0.1</x>
+                              <y>0.0</y>
+                              <z>-0.1</z>
+                            </innerHingeTranslation>
+                            <outerHingeTranslation uID="FlapOuter_outerHingeTranslation2">
                               <x>0.1</x>
                               <z>-0.1</z>
                             </outerHingeTranslation>

--- a/tests/unittests/tiglControlSurfaceDevice.cpp
+++ b/tests/unittests/tiglControlSurfaceDevice.cpp
@@ -252,7 +252,8 @@ TEST_F(TiglControlSurfaceDeviceSimple, setControlParameterAndExport)
 
 TEST_F(TiglControlSurfaceDeviceSimple, bug_780_reference_segment)
 {
-    // a test for Github issue #780
+    // a test for Github issue #780, the flap should extend from eta 0.25
+    // to eta 0.75 relative to the outer segment, not the component segment
     auto& manager = tigl::CCPACSConfigurationManager::GetInstance();
     auto& config = manager.GetConfiguration(tiglHandle);
     auto& wing = config.GetWing(1);

--- a/tests/unittests/tiglControlSurfaceDevice.cpp
+++ b/tests/unittests/tiglControlSurfaceDevice.cpp
@@ -32,6 +32,8 @@
 #include "GeomLProp_SLProps.hxx"
 #include "gp_Pln.hxx"
 #include "Geom_Plane.hxx"
+#include "CNamedShape.h"
+#include "tiglcommonfunctions.h"
 
 using namespace std;
 
@@ -72,6 +74,41 @@ class TiglControlSurfaceDevice : public ::testing::Test {
 TixiDocumentHandle TiglControlSurfaceDevice::tixiHandle = 0;
 TiglCPACSConfigurationHandle TiglControlSurfaceDevice::tiglHandle = 0;
 
+
+class TiglControlSurfaceDeviceSimple : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+        const char* filename = "TestData/simpletest-flaps.cpacs.xml";
+        ReturnCode tixiRet;
+        TiglReturnCode tiglRet;
+
+        tiglHandle = -1;
+        tixiHandle = -1;
+
+        tixiRet = tixiOpenDocument(filename, &tixiHandle);
+        ASSERT_TRUE (tixiRet == SUCCESS);
+        tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "Cpacs2Test", &tiglHandle);
+        ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+  }
+
+  static void TearDownTestCase() {
+        ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglHandle) == TIGL_SUCCESS);
+        ASSERT_TRUE(tixiCloseDocument(tixiHandle) == SUCCESS);
+        tiglHandle = -1;
+        tixiHandle = -1;
+  }
+
+  virtual void SetUp() {}
+  virtual void TearDown() {}
+
+
+  static TixiDocumentHandle           tixiHandle;
+  static TiglCPACSConfigurationHandle tiglHandle;
+};
+
+
+TixiDocumentHandle TiglControlSurfaceDeviceSimple::tixiHandle = 0;
+TiglCPACSConfigurationHandle TiglControlSurfaceDeviceSimple::tiglHandle = 0;
 //#########################################################################################################
 
 TEST_F(TiglControlSurfaceDevice, tiglGetControlSurfaceCount)
@@ -207,9 +244,27 @@ TEST_F(TiglControlSurfaceDevice, CCPACSTrailingEdgeDevices)
     ASSERT_THROW(devices.GetTrailingEdgeDevice("WrongUID"), tigl::CTiglError);
 }
 
-TEST(TiglControlSurfaceDeviceSimple, setControlParameterAndExport)
+TEST_F(TiglControlSurfaceDeviceSimple, setControlParameterAndExport)
 {
-    TiglHandleWrapper handle("TestData/simpletest-flaps.cpacs.xml", "");
-    ASSERT_EQ(TIGL_SUCCESS, tiglControlSurfaceSetControlParameter(handle, "Flap", 1.0));
-    tiglExportConfiguration(handle, "TestData/export/simpletest-flaps.stp", TIGL_TRUE, 0.0);
+    ASSERT_EQ(TIGL_SUCCESS, tiglControlSurfaceSetControlParameter(tiglHandle, "FlapInner", 1.0));
+    tiglExportConfiguration(tiglHandle, "TestData/export/simpletest-flaps.stp", TIGL_TRUE, 0.0);
+}
+
+TEST_F(TiglControlSurfaceDeviceSimple, bug_780_reference_segment)
+{
+    // a test for Github issue #780
+    auto& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    auto& config = manager.GetConfiguration(tiglHandle);
+    auto& wing = config.GetWing(1);
+    auto& componentSegment = static_cast<tigl::CCPACSWingComponentSegment&>(wing.GetComponentSegment(1));
+    auto& devices = *componentSegment.GetControlSurfaces()->GetTrailingEdgeDevices();
+    auto& outer_flap = devices.GetTrailingEdgeDevice(2);
+    auto flap_shape = outer_flap.GetFlapShape()->Shape();
+
+    //To Do: With OpenCascade 7.x we can calculate a tight bounding box, instead of checking for
+    //the extremal points along the y-axis
+    gp_Pnt min, max;
+    GetMinMaxPoint(flap_shape, gp_Vec(0., 1., 0.), min, max);
+    EXPECT_NEAR(min.Y(), 1.25, 1e-2);
+    EXPECT_NEAR(max.Y(), 1.75, 1e-2);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes #780, see the issue description for details.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
A new unit test has been added.

## Screenshots, that help to understand the changes(if applicable):

Screenshots are provided in the issue description #780

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
