### PR TITLE
Fixed invalid cpacs after write

### DIFF
--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -109,8 +109,6 @@ void CCPACSFuselage::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::
     Cleanup();
 
     generated::CPACSFuselage::ReadCPACS(tixiHandle, fuselageXPath);
-
-    ConnectGuideCurveSegments();
 }
 
 // Returns the parent configuration
@@ -627,27 +625,6 @@ void CCPACSFuselage::BuildGuideCurves(TopoDS_Compound& cache) const
     // connect guide curve segments to a spline with given continuity conditions and tangents
     CTiglCurveConnector connector(roots, sectionParams);
     cache = connector.GetConnectedGuideCurves();
-}
-
-void CCPACSFuselage::ConnectGuideCurveSegments(void)
-{
-    for (int isegment = 1; isegment <= GetSegmentCount(); ++isegment) {
-        CCPACSFuselageSegment& segment = GetSegment(isegment);
-
-        if (!segment.GetGuideCurves()) {
-            continue;
-        }
-
-        CCPACSGuideCurves& curves = *segment.GetGuideCurves();
-        for (int icurve = 1; icurve <= curves.GetGuideCurveCount(); ++icurve) {
-            CCPACSGuideCurve& curve = curves.GetGuideCurve(icurve);
-            if (!curve.GetFromRelativeCircumference_choice2()) {
-                std::string fromUID = *curve.GetFromGuideCurveUID_choice1();
-                CCPACSGuideCurve& fromCurve = GetGuideCurveSegment(fromUID);
-                curve.SetFromRelativeCircumference_choice2(fromCurve.GetToRelativeCircumference());
-            }
-        }
-    }
 }
 
 TopoDS_Shape transformFuselageProfileGeometry(const CTiglTransformation& fuselTransform, const CTiglFuselageConnection& connection, const TopoDS_Shape& shape)

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -143,8 +143,6 @@ public:
 protected:
     void BuildGuideCurves(TopoDS_Compound& cache) const;
 
-    void ConnectGuideCurveSegments();
-
     // Cleanup routine
     void Cleanup();
 

--- a/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
+++ b/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
@@ -70,20 +70,8 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
     double outerScale = GetLength(outerChordLineWire);
 
 
-    double fromRelativeCircumference;
-    // check if fromRelativeCircumference is given in the current guide curve
-    if (guideCurve->GetFromRelativeCircumference_choice2()) {
-        fromRelativeCircumference = *guideCurve->GetFromRelativeCircumference_choice2();
-    }
-    // otherwise get relative circumference from neighboring segment guide curve
-    else {
-        // get neighboring guide curve UID
-        std::string neighborGuideCurveUID = *guideCurve->GetFromGuideCurveUID_choice1();
-        // get neighboring guide curve
-        const CCPACSGuideCurve& neighborGuideCurve = m_segment.GetFuselage().GetGuideCurveSegment(neighborGuideCurveUID);
-        // get relative circumference from neighboring guide curve
-        fromRelativeCircumference = neighborGuideCurve.GetToRelativeCircumference();
-    }
+    // get relative circumference of inner profile
+    double fromRelativeCircumference = guideCurve->GetFromRelativeCircumference();
 
     // get relative circumference of outer profile
     double toRelativeCircumference = guideCurve->GetToRelativeCircumference();

--- a/src/guide_curves/CCPACSGuideCurve.cpp
+++ b/src/guide_curves/CCPACSGuideCurve.cpp
@@ -61,6 +61,21 @@ CCPACSGuideCurve::FromDefinition CCPACSGuideCurve::GetFromDefinition() const {
     throw CTiglError("Logic error in FromDefinition detection");
 }
 
+
+double CCPACSGuideCurve::GetFromRelativeCircumference() const
+{
+    if ( GetFromGuideCurveUID_choice1() ) {
+        CCPACSGuideCurve& pred = m_uidMgr->ResolveObject<CCPACSGuideCurve>(*GetFromGuideCurveUID_choice1());
+        return pred.GetToRelativeCircumference();
+    }
+    else if (GetFromRelativeCircumference_choice2()) {
+        return *GetFromRelativeCircumference_choice2();
+    }
+    else {
+        throw CTiglError("CCPACSGuideCurve::GetFromRelativeCircumference(): Either a fromCircumference of a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
+    }
+}
+
 // Cleanup routine
 void CCPACSGuideCurve::Cleanup(void)
 {

--- a/src/guide_curves/CCPACSGuideCurve.h
+++ b/src/guide_curves/CCPACSGuideCurve.h
@@ -66,6 +66,10 @@ public:
 
     TIGL_EXPORT FromDefinition GetFromDefinition() const;
 
+    // Returns the relalive circumference
+    // If fromUID is set, the relativeCircumference is returned from the specified curve instead
+    TIGL_EXPORT double GetFromRelativeCircumference() const;
+
     TIGL_EXPORT std::vector<gp_Pnt> GetCurvePoints() const;
     TIGL_EXPORT TopoDS_Edge GetCurve() const;
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -169,29 +169,6 @@ void CCPACSWing::Cleanup()
     Invalidate();
 }
 
-void CCPACSWing::ConnectGuideCurveSegments(void)
-{
-    for (int isegment = 1; isegment <= GetSegmentCount(); ++isegment) {
-        CCPACSWingSegment& segment = GetSegment(isegment);
-
-        if (!segment.GetGuideCurves()) {
-            continue;
-        }
-
-        CCPACSGuideCurves& curves = *segment.GetGuideCurves();
-        for (int icurve = 1; icurve <= curves.GetGuideCurveCount(); ++icurve) {
-            CCPACSGuideCurve& curve = curves.GetGuideCurve(icurve);
-
-            if (!curve.GetFromRelativeCircumference_choice2()) {
-                std::string fromUID = *curve.GetFromGuideCurveUID_choice1();
-                CCPACSGuideCurve& fromCurve = GetGuideCurveSegment(fromUID);
-                curve.SetFromRelativeCircumference_choice2(fromCurve.GetToRelativeCircumference());
-                //TODO: also call curve->connect already
-            }
-        }
-    }
-}
-
 // Update internal wing data
 void CCPACSWing::Update()
 {
@@ -214,8 +191,6 @@ void CCPACSWing::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::stri
             m_parentUID = boost::none;
         }
     }
-
-    ConnectGuideCurveSegments();
 
     Update();
 }

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -193,8 +193,6 @@ protected:
     // Cleanup routine
     void Cleanup();
 
-    void ConnectGuideCurveSegments(void);
-
     // Update internal wing data
     void Update();
 

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -386,7 +386,7 @@ PNamedShape CCPACSWingSegment::BuildLoft() const
             std::multimap<double, const CCPACSGuideCurve*> guideMap;
             for (int iguide = 1; iguide <= curves.GetGuideCurveCount(); ++iguide) {
                 const CCPACSGuideCurve* curve = &curves.GetGuideCurve(iguide);
-                double value = *(curve->GetFromRelativeCircumference_choice2());
+                double value = curve->GetFromRelativeCircumference();
                 if (value >= 1. && !hasTrailingEdge) {
                     // this is a trailing edge profile, we should add it first
                     value = -1.;

--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -79,20 +79,8 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     double outerScale = GetLength(outerChordLineWire);
 
 
-    double fromRelativeCircumference;
-    // check if fromRelativeCircumference is given in the current guide curve
-    if (guideCurve->GetFromRelativeCircumference_choice2()) {
-        fromRelativeCircumference = *guideCurve->GetFromRelativeCircumference_choice2();
-    }
-    // otherwise get relative circumference from neighboring segment guide curve
-    else {
-        // get neighboring guide curve UID
-        std::string neighborGuideCurveUID = *guideCurve->GetFromGuideCurveUID_choice1();
-        // get neighboring guide curve
-        const CCPACSGuideCurve& neighborGuideCurve = m_segment.GetGuideCurves()->GetGuideCurve(neighborGuideCurveUID);
-        // get relative circumference from neighboring guide curve
-        fromRelativeCircumference = neighborGuideCurve.GetToRelativeCircumference();
-    }
+    // get relative circumference of inner profile
+    double fromRelativeCircumference = guideCurve->GetFromRelativeCircumference();
 
     // get relative circumference of outer profile
     double toRelativeCircumference = guideCurve->GetToRelativeCircumference();


### PR DESCRIPTION
## Description

Before, the guide curve fromCircumeferenceValue was set
by TiGL after connecting the guide curves. If a curve had set
fromGuideCurveUID, both values were written to XML, which
is not allowed.

Now, I added the method CCPACSGuideCurve::GetFromRelativeCircumference
such that an external code can ask for the circumference value, even
if fromGuideCurveUID is set. This was suggested by Roland.
There are many benefits by this approach:
 - More functional approach with less side effects
 - Fixed invalid xml
 - Simpler use of the guide curve. Simplifies calling code
 - Better code design that adheres better
    to the single responsibilty principle

  Closes #665

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

 I ran unit tests and loaded the guide curve example in TiGL Viewer.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
