### PR TITLE
hotfix for #767

### DIFF
--- a/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
+++ b/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
@@ -82,10 +82,11 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
     CCPACSConfiguration& config = m_segment.GetFuselage().GetConfiguration();
     CCPACSGuideCurveProfile& guideCurveProfile = config.GetGuideCurveProfile(guideCurveProfileUID);
 
-    if (guideCurveProfile.GetGuideCurveProfilePoints()[0].y < 1e-14) {
+    auto& profilePoints = guideCurveProfile.GetGuideCurveProfilePoints();
+    if (profilePoints.size() > 0 && profilePoints[0].y < 1e-14) {
         throw CTiglError("Wrong CPACS Definition: First guidecurve profile points should have a y component > 0.\n.");
     }
-    if (guideCurveProfile.GetGuideCurveProfilePoints().back().y > 1 - 1e-14) {
+    if (profilePoints.size() > 0 && profilePoints.back().y > 1 - 1e-14) {
         throw CTiglError("Wrong CPACS Definition: Last guidecurve profile points should have a y component < 1.\n.");
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #793

Fixes a small bug introduced in https://github.com/DLR-SC/tigl/commit/2164b67f8fe7857f179c111caf6e804dbdc836d9 where I check for the first and last element of a vector that is allowed to be empty.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
