### PR TITLE
Use OCCT 7.4.0 for ci

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -103,18 +103,18 @@ jobs:
           curl --retry 3 -o sshpass-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/sshpass-macOS.tar.gz
           curl --retry 3 -o doxygen-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/doxygen-macOS.tar.gz
           curl --retry 3 -o matlab-libs-macos.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/matlab-libs-macos.tar.gz
-          curl --retry 3 -o oce.0.17.2.macos_static.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/oce.0.17.2-1.macos_static.tar.gz
+          curl --retry 3 -o oce.0.17.2.macos_static.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/occt.7.4.0.macos_static.tar.gz
           curl --retry 3 -O -L https://github.com/DLR-SC/tixi/releases/download/v3.1.1/TIXI-3.1.1-Darwin.tar.gz
           tar xf sshpass-macOS.tar.gz -C /tmp
           tar xf doxygen-macOS.tar.gz -C /tmp
           tar xf matlab-libs-macos.tar.gz -C /tmp
-          tar xf oce.0.17.2.macos_static.tar.gz
+          tar xf occt.7.4.0.macos_static.tar.gz
           tar xf TIXI-3.1.1-Darwin.tar.gz
           echo "/tmp" >> $GITHUB_PATH
           echo "/tmp/doxygen" >> $GITHUB_PATH
           echo "DYLD_LIBRARY_PATH=${{ github.workspace }}/TIXI-3.1.1-Darwin/lib" >> $GITHUB_ENV
-          echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/TIXI-3.1.1-Darwin:${{ github.workspace }}/oce.0.17.2.macos_static:/usr/local/opt/qt/" >> $GITHUB_ENV
-          brew install qt
+          echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/TIXI-3.1.1-Darwin:${{ github.workspace }}/occt.7.4.0.macos_static:/usr/local/opt/qt@5/" >> $GITHUB_ENV
+          brew install qt@5
           
     - name: Setup conda (windows)
       if: contains(matrix.config.os, 'windows')

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -103,7 +103,7 @@ jobs:
           curl --retry 3 -o sshpass-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/sshpass-macOS.tar.gz
           curl --retry 3 -o doxygen-macOS.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/doxygen-macOS.tar.gz
           curl --retry 3 -o matlab-libs-macos.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/matlab-libs-macos.tar.gz
-          curl --retry 3 -o oce.0.17.2.macos_static.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/occt.7.4.0.macos_static.tar.gz
+          curl --retry 3 -o occt.7.4.0.macos_static.tar.gz -L https://sourceforge.net/projects/tigl/files/Thirdparty/occt.7.4.0.macos_static.tar.gz
           curl --retry 3 -O -L https://github.com/DLR-SC/tixi/releases/download/v3.1.1/TIXI-3.1.1-Darwin.tar.gz
           tar xf sshpass-macOS.tar.gz -C /tmp
           tar xf doxygen-macOS.tar.gz -C /tmp

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -24,6 +24,7 @@ env:
   TIGL_DOXYGEN_VER: "=1.8.15"
   TIGL_SWIG_VER: ">=3.0.11"
   TIGL_OCE_VER: "=0.17.2"
+  TIGL_OPENCASCADE_VER: ="7.4.0"
   TIGL_FREEIMAGEPLUS_VER: ""
   TIGL_NINJA_VER: ""
   TIGL_MATLAB_LIBS: ""
@@ -90,7 +91,7 @@ jobs:
           curl http://download.opensuse.org/repositories/science:/dlr/xUbuntu_18.04/Release.key | sudo apt-key add -
           echo "deb http://download.opensuse.org/repositories/science:/dlr/xUbuntu_18.04/ /" | sudo tee -a /etc/apt/sources.list 
           sudo apt-get update -qq
-          sudo apt-get install -y lcov gcovr  libtixi3-dev liboce-dev doxygen cmake cmake-data sshpass
+          sudo apt-get install -y lcov gcovr  libtixi3-dev libocct-ocaf-dev libtbb-dev occt-misc libxi-dev libocct-draw-dev libocct-data-exchange-dev tk-dev tcl-dev doxygen cmake cmake-data sshpass
         
     - name: Install dependencies (macos)
       if: contains(matrix.config.os, 'macos')
@@ -133,7 +134,7 @@ jobs:
     - name: Install dependencies using Miniconda (static, windows)
       if: matrix.config.link_type == 'static' && contains(matrix.config.os, 'windows')
       run: |
-        conda install pip python${{ env.TIGL_PYTHON_VER }} tixi3${{ env.TIGL_TIXI3_VER }} oce-static${{ env.TIGL_OCE_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} qt${{ env.TIGL_QT_VER }} freetype-static=2.6 freeimageplus-static${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} matlab-libs${{ env.TIGL_MATLAB_LIBS }} -c dlr-sc -c dlr-sc/label/tigl-dev
+        conda install pip python${{ env.TIGL_PYTHON_VER }} tixi3${{ env.TIGL_TIXI3_VER }} opencascade-static${{ env.TIGL_OPENCASCADE_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} qt${{ env.TIGL_QT_VER }} freetype-static=2.6 freeimageplus-static${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} matlab-libs${{ env.TIGL_MATLAB_LIBS }} -c dlr-sc -c dlr-sc/label/tigl-dev
 
     - name: Install ccache (ubuntu)
       run: |

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -114,6 +114,7 @@ jobs:
           echo "/tmp/doxygen" >> $GITHUB_PATH
           echo "DYLD_LIBRARY_PATH=${{ github.workspace }}/TIXI-3.1.1-Darwin/lib" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/TIXI-3.1.1-Darwin:${{ github.workspace }}/occt.7.4.0.macos_static:/usr/local/opt/qt@5/" >> $GITHUB_ENV
+          echo "CXXFLAGS=-fvisibility-inlines-hidden" >> $GITHUB_ENV
           brew install qt@5
           
     - name: Setup conda (windows)

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Install dependencies using Miniconda (static, windows)
       if: matrix.config.link_type == 'static' && contains(matrix.config.os, 'windows')
       run: |
-        conda install pip python${{ env.TIGL_PYTHON_VER }} tixi3${{ env.TIGL_TIXI3_VER }} opencascade-static${{ env.TIGL_OPENCASCADE_VER }} doxygen${{ env.TIGL_DOXYGEN_VER }} qt${{ env.TIGL_QT_VER }} freetype-static=2.6 freeimageplus-static${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} matlab-libs${{ env.TIGL_MATLAB_LIBS }} -c dlr-sc -c dlr-sc/label/tigl-dev
+        conda install pip python${{ env.TIGL_PYTHON_VER }} tixi3${{ env.TIGL_TIXI3_VER }} opencascade-static${{ env.TIGL_OPENCASCADE_VER }} tbb-devel doxygen${{ env.TIGL_DOXYGEN_VER }} qt${{ env.TIGL_QT_VER }} freetype-static=2.6 freeimageplus-static${{ env.TIGL_FREEIMAGEPLUS_VER }} ninja${{ env.TIGL_NINJA_VER }} matlab-libs${{ env.TIGL_MATLAB_LIBS }} -c dlr-sc -c dlr-sc/label/tigl-dev
 
     - name: Install ccache (ubuntu)
       run: |

--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -196,16 +196,19 @@ add_executable(${PROGNAME} ${TYPE}
 set_target_properties(${PROGNAME} PROPERTIES AUTOMOC TRUE)
 set_target_properties(${PROGNAME} PROPERTIES AUTOUIC TRUE)
 
-# opengl
-target_include_directories(${PROGNAME} PRIVATE ${OPENGL_INCLUDE_DIR})
 # include path for ui files
 target_include_directories(${PROGNAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# workaround: on macos, the file glext.h should be loaded from occt/include instead from the system dir
+# This is a "Bug" in the occt header files which use <> instead of "" for include
+# hence, we must explicitly inlude the occt dir before all other includes!
+target_include_directories(${PROGNAME} BEFORE PRIVATE  ${OpenCASCADE_INCLUDE_DIR}) 
 
 target_link_libraries(${PROGNAME} PRIVATE
   tigl3_static tigl3_cpp
   ${CMake_QT_LIBRARIES} 
-  OpenGL::GL
   ${OpenCASCADE_LIBRARIES} 
+  OpenGL::GL
   ${EXTRA_LIBRARIES} 
 )
 

--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -204,7 +204,7 @@ target_include_directories(${PROGNAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMA
 target_link_libraries(${PROGNAME} PRIVATE
   tigl3_static tigl3_cpp
   ${CMake_QT_LIBRARIES} 
-  ${OPENGL_LIBRARIES} 
+  OpenGL::GL
   ${OpenCASCADE_LIBRARIES} 
   ${EXTRA_LIBRARIES} 
 )

--- a/cmake/UseOpenCASCADE.cmake
+++ b/cmake/UseOpenCASCADE.cmake
@@ -83,6 +83,11 @@ else(OCE_FOUND)
       set_property(TARGET TKService APPEND PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES freetype)
   endif()
 
+  if (APPLE)
+    find_library (Appkit_LIB NAMES AppKit)
+    set_property(TARGET TKOpenGl APPEND PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${Appkit_LIB})
+  endif(APPLE)
+
 endif(OCE_FOUND)
 
 set_property(TARGET TKernel APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS "Standard_EXPORT=")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updated OCE 0.17 to OCCT 7.4.0 for continous integration. All platforms compile fine and use our OCCT 7.4.0 patched binaries.


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Unit tests and manuel TiGL Viewer tests.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
