### PR TITLE
Respect PointBehaviour for tiglWingGetSegmentEtaXsi

### DIFF
--- a/TIGLViewer/scripts/globaldefs.js
+++ b/TIGLViewer/scripts/globaldefs.js
@@ -1,3 +1,12 @@
+function EtaXsi(eta, xsi) {
+    this.eta = eta;
+    this.xsi = xsi;
+}
+
+EtaXsi.prototype.toString = function() {
+    return '{\n  eta:' + this.eta + ',\n  xsi:' + this.xsi + '\n}';
+}
+
 function Point3d(x,y,z) {
     this.x = x;
     this.y = y;

--- a/TIGLViewer/src/TIGLScriptProxy.cpp
+++ b/TIGLViewer/src/TIGLScriptProxy.cpp
@@ -474,6 +474,50 @@ QScriptValue TIGLScriptProxy::controlSurfaceSetControlParameter(QString controlS
 }
 
 
+QScriptValue TIGLScriptProxy::wingSetGetPointBehaviour (int behaviour)
+{
+    TiglGetPointBehavior b = onLinearLoft;
+    if (behaviour == 0) {
+        b = asParameterOnSurface;
+    }
+    else {
+        b = onLinearLoft;
+    }
+
+    TiglReturnCode ret = ::tiglWingSetGetPointBehavior(getTiglHandle(), b);
+    if (ret != TIGL_SUCCESS) {
+        return context()->throwError(tiglGetErrorString(ret));
+    }
+    else {
+        return QScriptValue::UndefinedValue;
+    }
+}
+
+QScriptValue TIGLScriptProxy::wingGetSegmentEtaXsi(int wingIdx, double px, double py, double pz)
+{
+    double eta, xsi;
+    int segmentIndex, isOnTop;
+
+    TiglReturnCode ret = ::tiglWingGetSegmentEtaXsi(getTiglHandle(), wingIdx, px, py, pz, &segmentIndex, &eta, &xsi, &isOnTop);
+
+    if (ret != TIGL_SUCCESS) {
+        return context()->throwError(tiglGetErrorString(ret));
+    }
+    else {
+        QScriptValue EtaXsiCtor = engine()->globalObject().property("EtaXsi");
+        QScriptValue etaxsi = EtaXsiCtor.construct(QScriptValueList() << eta << xsi);
+
+        QScriptValue obj = engine()->newObject();
+
+        obj.setProperty("etaxsi", etaxsi);
+        obj.setProperty("isOnTop", isOnTop);
+        obj.setProperty("segmentIndex", segmentIndex);
+        return obj;
+    }
+
+}
+
+
 QScriptValue TIGLScriptProxy::getShape(QString uid)
 {
     if (!_app->getDocument()) {

--- a/TIGLViewer/src/TIGLScriptProxy.h
+++ b/TIGLViewer/src/TIGLScriptProxy.h
@@ -55,7 +55,7 @@ public slots:
     QScriptValue getWingCount();
     QString getVersion();
     QScriptValue componentGetHashCode (QString componentUID);
-    
+
     // exports
     QScriptValue exportComponent (QString uid, QString filename, double deflection);
     QScriptValue exportConfiguration (QString filename, bool fuseAllShapes, double deflection);
@@ -92,7 +92,10 @@ public slots:
     QScriptValue wingGetSpan(QString wingUID);
     QScriptValue wingGetSegmentVolume (int wingIndex, int segmentIndex);
     QScriptValue controlSurfaceSetControlParameter(QString controlSurfaceUID, double controlParameter);
-    
+    QScriptValue wingSetGetPointBehaviour (int behaviour);
+    QScriptValue wingGetSegmentEtaXsi(int wingIdx, double px, double py, double pz);
+
+
     QString      getErrorString(int errorCode);
     QScriptValue getShape(QString uid);
     

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -738,10 +738,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingSetGetPointBehavior(TiglCPACSConfigura
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         for(int wingIndex = 1; wingIndex <= config.GetWingCount(); ++wingIndex ) {
             tigl::CCPACSWing& wing = config.GetWing(wingIndex);
-            for (int segmentIndex = 1; segmentIndex <= wing.GetSegmentCount(); ++segmentIndex) {
-                tigl::CCPACSWingSegment& segment = wing.GetSegment(segmentIndex);
-                segment.SetGetPointBehavior(behavior);
-            }
+            wing.SetGetPointBehavior(behavior);
         }
 
         return TIGL_SUCCESS;

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -255,7 +255,8 @@ bool CTiglTriangularizer::writeWingSegmentMeta(tigl::ITiglGeometricComponent &se
         }
         
         double eta = 0., xsi = 0.;
-        segment.GetEtaXsi(baryCenter.Get_gp_Pnt(), eta, xsi);
+        gp_Pnt pDummy;
+        segment.GetEtaXsi(baryCenter.Get_gp_Pnt(), eta, xsi, pDummy, onLinearLoft);
         polys.currentObject().setPolyDataReal(iPoly, "eta", eta);
         polys.currentObject().setPolyDataReal(iPoly, "xsi", xsi);
         

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -496,13 +496,13 @@ CTiglTransformation CCPACSWing::GetPositioningTransformation(std::string section
 // Gets the upper point in absolute (world) coordinates for a given segment, eta, xsi
 gp_Pnt CCPACSWing::GetUpperPoint(int segmentIndex, double eta, double xsi)
 {
-    return ((CCPACSWingSegment &) GetSegment(segmentIndex)).GetUpperPoint(eta, xsi);
+    return ((CCPACSWingSegment &) GetSegment(segmentIndex)).GetUpperPoint(eta, xsi, getPointBehavior);
 }
 
 // Gets the upper point in absolute (world) coordinates for a given segment, eta, xsi
 gp_Pnt CCPACSWing::GetLowerPoint(int segmentIndex, double eta, double xsi)
 {
-    return  ((CCPACSWingSegment &) GetSegment(segmentIndex)).GetLowerPoint(eta, xsi);
+    return  ((CCPACSWingSegment &) GetSegment(segmentIndex)).GetLowerPoint(eta, xsi, getPointBehavior);
 }
 
 // Gets a point on the chord surface in absolute (world) coordinates for a given segment, eta, xsi
@@ -769,17 +769,9 @@ int CCPACSWing::GetSegmentEtaXsi(const gp_Pnt& point, double& eta, double& xsi, 
         CCPACSWingSegment& segment2 = (CCPACSWingSegment&) GetSegment(segmentFound+1);
 
         double eta1, eta2, xsi1, xsi2;
-        segment1.GetEtaXsi(point, eta1, xsi1);
-        segment2.GetEtaXsi(point, eta2, xsi2);
-
-        // Get the points on the chord face
-        double eta1p = max(0.0, min(1.0, eta1));
-        double eta2p = max(0.0, min(1.0, eta2));
-        double xsi1p = max(0.0, min(1.0, xsi1));
-        double xsi2p = max(0.0, min(1.0, xsi2));
-
-        gp_Pnt p1 = segment1.GetChordPoint(eta1p, xsi1p);
-        gp_Pnt p2 = segment2.GetChordPoint(eta2p, xsi2p);
+        gp_Pnt p1, p2;
+        segment1.GetEtaXsi(point, eta1, xsi1, p1, getPointBehavior);
+        segment2.GetEtaXsi(point, eta2, xsi2, p2, getPointBehavior);
 
         double d1 = p1.Distance(point);
         double d2 = p2.Distance(point);
@@ -807,7 +799,8 @@ int CCPACSWing::GetSegmentEtaXsi(const gp_Pnt& point, double& eta, double& xsi, 
     else {
 
         CCPACSWingSegment& segment = (CCPACSWingSegment&) GetSegment(segmentFound);
-        segment.GetEtaXsi(point, eta, xsi);
+        gp_Pnt pTmp;
+        segment.GetEtaXsi(point, eta, xsi, pTmp, getPointBehavior);
 
         // TODO: do we need that here?
         onTop = segment.GetIsOnTop(point);
@@ -983,6 +976,23 @@ PNamedShape CCPACSWing::GetWingCleanShape() const
     return *wingCleanShape;
 }
 
+// Sets the GetPoint behavior to asParameterOnSurface or onLinearLoft
+void CCPACSWing::SetGetPointBehavior(TiglGetPointBehavior behavior)
+{
+    getPointBehavior = behavior;
+}
+
+// Gets the getPointBehavior
+TiglGetPointBehavior const CCPACSWing::GetGetPointBehavior() const
+{
+    return getPointBehavior;
+}
+
+// Gets the getPointBehavior
+TiglGetPointBehavior CCPACSWing::GetGetPointBehavior()
+{
+    return getPointBehavior;
+}
 namespace
 {
 

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -174,6 +174,13 @@ public:
     // Returns the wing shape without any extended flaps
     TIGL_EXPORT PNamedShape GetWingCleanShape() const;
 
+    // Sets the getPointBehavior to asParameterOnSurface or onLinearLoft
+    TIGL_EXPORT void SetGetPointBehavior(TiglGetPointBehavior behavior = asParameterOnSurface);
+
+    // Gets the getPointBehavior
+    TIGL_EXPORT TiglGetPointBehavior const GetGetPointBehavior() const;
+    TIGL_EXPORT TiglGetPointBehavior GetGetPointBehavior();
+
 protected:
 
     struct LocatedGuideCurves
@@ -229,6 +236,9 @@ private:
     bool                           buildFlaps;               /**< Indicates if the wing's loft shall include flaps */
     FusedElementsContainerType     fusedElements;            /**< Stores already fused segments */
     double                         myVolume;                 /**< Volume of this Wing           */
+
+
+    TiglGetPointBehavior getPointBehavior {asParameterOnSurface};
 
     friend class CCPACSWingSegment;
     friend class CCPACSWingComponentSegment;

--- a/src/wing/CCPACSWingComponentSegment.cpp
+++ b/src/wing/CCPACSWingComponentSegment.cpp
@@ -958,13 +958,10 @@ const CCPACSWingSegment* CCPACSWingComponentSegment::findSegment(double x, doubl
     for (SegmentList::const_iterator segit = segments.begin(); segit != segments.end(); ++segit) {
         try {
             double eta, xsi;
-            (*segit)->GetEtaXsi(pnt, eta, xsi);
-            gp_Pnt pointProjected = (*segit)->GetChordPoint(eta, xsi);
+            gp_Pnt currentPoint;
+            (*segit)->GetEtaXsi(pnt, eta, xsi, currentPoint, onLinearLoft);
 
-            // Get nearest point on this segment
-            double nextEta = Clamp(eta, 0., 1.);
-            double nextXsi = Clamp(xsi, 0., 1.);
-            gp_Pnt currentPoint = (*segit)->GetChordPoint(nextEta, nextXsi);
+            gp_Pnt pointProjected = (*segit)->GetChordPoint(eta, xsi);
 
             double currentDist = currentPoint.Distance(pointProjected);
             if (currentDist < deviation) {

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -78,10 +78,10 @@ public:
     TIGL_EXPORT gp_Pnt GetOuterProfilePoint(double xsi) const;
 
     // Gets the upper point in relative wing coordinates for a given eta and xsi
-    TIGL_EXPORT gp_Pnt GetUpperPoint(double eta, double xsi) const;
+    TIGL_EXPORT gp_Pnt GetUpperPoint(double eta, double xsi, TiglGetPointBehavior getPointBehavior) const;
 
     // Gets the lower point in relative wing coordinates for a given eta and xsi
-    TIGL_EXPORT gp_Pnt GetLowerPoint(double eta, double xsi) const;
+    TIGL_EXPORT gp_Pnt GetLowerPoint(double eta, double xsi, TiglGetPointBehavior getPointBehavior) const;
 
     // Gets the point on the wing chord surface in relative wing coordinates for a given eta and xsi
     TIGL_EXPORT gp_Pnt GetChordPoint(double eta, double xsi, TiglCoordinateSystem referenceCS = GLOBAL_COORDINATE_SYSTEM) const;
@@ -157,7 +157,7 @@ public:
 
 
     // projects a point unto the wing and returns its coordinates
-    TIGL_EXPORT void GetEtaXsi(gp_Pnt pnt, double& eta, double& xsi) const;
+    TIGL_EXPORT void GetEtaXsi(gp_Pnt pnt, double& eta, double& xsi, gp_Pnt& projectedPoint, TiglGetPointBehavior behavior) const;
 
 
     // Returns if the given point is ont the Top of the wing or on the lower side.
@@ -221,12 +221,6 @@ public:
 
     TIGL_EXPORT CTiglTransformation GetParentTransformation() const;
 
-    // Sets the getPointBehavior to asParameterOnSurface or onLinearLoft
-    TIGL_EXPORT void SetGetPointBehavior(TiglGetPointBehavior behavior = asParameterOnSurface);
-
-    // Gets the getPointBehavior
-    TIGL_EXPORT TiglGetPointBehavior const GetGetPointBehavior() const;
-    TIGL_EXPORT TiglGetPointBehavior GetGetPointBehavior();
 
 protected:
     // Builds the loft between the two segment sections
@@ -269,6 +263,8 @@ private:
 
     // converts segment eta xsi coordinates to face uv coordinates
     void etaXsiToUV(bool isFromUpper, double eta, double xsi, double& u, double& v) const;
+    void uvToEtaXsi(bool isFromUpper, double u, double v, double& eta, double& xsi) const;
+
 
     CTiglWingConnection  innerConnection;      /**< Inner segment connection (root)         */
     CTiglWingConnection  outerConnection;      /**< Outer segment connection (tip)          */
@@ -284,8 +280,6 @@ private:
     Cache<double, CCPACSWingSegment>            volumeCache;
 
     std::unique_ptr<IGuideCurveBuilder> m_guideCurveBuilder;
-
-    TiglGetPointBehavior getPointBehavior {asParameterOnSurface};
 };
 
 } // end namespace tigl


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I had to change the class structure / method signature slightly
to allow to pass, how GetEtaXsi is evaluated.

Unfortunately, GetEtaXsi on the paramter surfaces is almost
a factor of thousand slower, which could be a problem for the
VTK export with metadata. Therefore I decided to use the old
eta / xsi interpretation for the exports for now.



closes #808

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

To validate, I changed the consistency test, added a performance
test and added a function to tiglviewer to play around with
the function.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
