### PR TITLE
Added support for canard style flaps

### DIFF
--- a/cpacs_gen_input/cpacs_schema.xsd
+++ b/cpacs_gen_input/cpacs_schema.xsd
@@ -6969,6 +6969,12 @@ marko.alder@dlr.de
                                 Reference is the parent airfoil height.</xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
+                    <xsd:element minOccurs="0" name="translation" type="pointType">
+                        <xsd:annotation>
+                            <xsd:documentation>Optional absolute translation of the hinge point.
+                                This can be used to move the hinge points outside of the wing shape.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
                 </xsd:all>
             </xsd:extension>
         </xsd:complexContent>

--- a/src/CCPACSPoint.cpp
+++ b/src/CCPACSPoint.cpp
@@ -26,6 +26,11 @@ CCPACSPoint::CCPACSPoint(CCPACSControlSurfaceStep* parent, CTiglUIDManager* uidM
 {
 }
 
+CCPACSPoint::CCPACSPoint(CCPACSControlSurfaceHingePoint* parent, CTiglUIDManager* uidMgr)
+    : generated::CPACSPoint(parent, uidMgr)
+{
+}
+
 CCPACSPoint::CCPACSPoint(CCPACSPointList* parent, CTiglUIDManager* uidMgr)
     : generated::CPACSPoint(parent, uidMgr)
 {

--- a/src/CCPACSPoint.h
+++ b/src/CCPACSPoint.h
@@ -25,6 +25,7 @@ class CCPACSPoint : public generated::CPACSPoint
 {
 public:
     TIGL_EXPORT CCPACSPoint(CCPACSControlSurfaceStep* parent, CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSPoint(CCPACSControlSurfaceHingePoint* parent, CTiglUIDManager* uidMgr);
     TIGL_EXPORT CCPACSPoint(CCPACSPointList* parent, CTiglUIDManager* uidMgr);
     TIGL_EXPORT CCPACSPoint(CCPACSSeatModule* parent, CTiglUIDManager* uidMgr);
     TIGL_EXPORT CCPACSPoint(CCPACSTransformation* parent, CTiglUIDManager* uidMgr);

--- a/src/control_devices/CCPACSControlSurfaceBorderTrailingEdge.cpp
+++ b/src/control_devices/CCPACSControlSurfaceBorderTrailingEdge.cpp
@@ -46,7 +46,10 @@ TopoDS_Wire CCPACSControlSurfaceBorderTrailingEdge::GetWire(PNamedShape wingShap
 
 
     TopoDS_Wire wire;
-    if (GetLeadingEdgeShape().is_initialized()) {
+    if (getXsiLE() < 1e-3) {
+        wire = builder.wholeWingBorder();
+    }
+    else if (GetLeadingEdgeShape().is_initialized()) {
         wire = builder.borderWithLEShape(GetLeadingEdgeShape()->GetRelHeightLE(), 1.0,
                                           GetLeadingEdgeShape()->GetXsiUpperSkin(),
                                           GetLeadingEdgeShape()->GetXsiLowerSkin());

--- a/src/control_devices/CCPACSTrailingEdgeDevice.cpp
+++ b/src/control_devices/CCPACSTrailingEdgeDevice.cpp
@@ -225,6 +225,7 @@ void CCPACSTrailingEdgeDevice::ComputeHingePoints(CCPACSTrailingEdgeDevice::Hing
             cSegment.GetPoint(transformEtaToCSOrTed(border.GetEtaLE(), *m_uidMgr), hingeXsi[i], WING_COORDINATE_SYSTEM);
         gp_Vec midplaneNormal = cSegment.GetMidplaneNormal(transformEtaToCSOrTed(border.GetEtaLE(), *m_uidMgr));
 
+
         // Project point on the inner and outer face of the Wing loft
         gp_Pnt upper, lower;
         upper = ProjectPointOnShape(wsr.GetUpperShape(WING_COORDINATE_SYSTEM), myHingePoint, midplaneNormal);
@@ -233,6 +234,12 @@ void CCPACSTrailingEdgeDevice::ComputeHingePoints(CCPACSTrailingEdgeDevice::Hing
         gp_Vec delta(lower, upper);
         delta *= relHingeHeight[i];
         lower.Translate(delta);
+
+        // do we have to translate the point?
+        auto translation = (i == 0? GetPath().GetInnerHingePoint().GetTranslation() : GetPath().GetOuterHingePoint().GetTranslation());
+        if (translation) {
+            lower = lower.XYZ() + translation.value().AsPoint().Get_gp_Pnt().XYZ();
+        }
 
         points[i] = lower;
     }

--- a/src/control_devices/CControlSurfaceBorderBuilder.h
+++ b/src/control_devices/CControlSurfaceBorderBuilder.h
@@ -70,6 +70,12 @@ public:
      */
     TopoDS_Wire borderSimple(double xsiUpper, double xsiLower);
 
+    /**
+     * @brief Computes a border that spans the whole wing, i.e. for canard style flaps
+     * @return
+     */
+    TopoDS_Wire wholeWingBorder();
+
     gp_Pnt2d upperPoint();
     gp_Pnt2d lowerPoint();
 

--- a/src/generated/CPACSControlSurfaceHingePoint.h
+++ b/src/generated/CPACSControlSurfaceHingePoint.h
@@ -17,12 +17,17 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
+#include <CCPACSPoint.h>
 #include <string>
 #include <tixi.h>
+#include "CreateIfNotExists.h"
 #include "tigl_internal.h"
 
 namespace tigl
 {
+class CTiglUIDManager;
 class CTiglUIDObject;
 
 namespace generated
@@ -47,7 +52,7 @@ namespace generated
     class CPACSControlSurfaceHingePoint
     {
     public:
-        TIGL_EXPORT CPACSControlSurfaceHingePoint(CPACSControlSurfacePath* parent);
+        TIGL_EXPORT CPACSControlSurfaceHingePoint(CPACSControlSurfacePath* parent, CTiglUIDManager* uidMgr);
 
         TIGL_EXPORT virtual ~CPACSControlSurfaceHingePoint();
 
@@ -58,6 +63,9 @@ namespace generated
         TIGL_EXPORT virtual CTiglUIDObject* GetNextUIDParent();
         TIGL_EXPORT virtual const CTiglUIDObject* GetNextUIDParent() const;
 
+        TIGL_EXPORT CTiglUIDManager& GetUIDManager();
+        TIGL_EXPORT const CTiglUIDManager& GetUIDManager() const;
+
         TIGL_EXPORT virtual void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
         TIGL_EXPORT virtual void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
 
@@ -67,16 +75,27 @@ namespace generated
         TIGL_EXPORT virtual const double& GetHingeRelHeight() const;
         TIGL_EXPORT virtual void SetHingeRelHeight(const double& value);
 
+        TIGL_EXPORT virtual const boost::optional<CCPACSPoint>& GetTranslation() const;
+        TIGL_EXPORT virtual boost::optional<CCPACSPoint>& GetTranslation();
+
+        TIGL_EXPORT virtual CCPACSPoint& GetTranslation(CreateIfNotExistsTag);
+        TIGL_EXPORT virtual void RemoveTranslation();
+
     protected:
         CPACSControlSurfacePath* m_parent;
 
+        CTiglUIDManager* m_uidMgr;
+
         /// Relative chordwise coordinate (xsi) of the
         /// hinge line point. Reference is the parent chord.
-        double m_hingeXsi;
+        double                       m_hingeXsi;
 
         /// Relative height of the hinge line point.
         /// Reference is the parent airfoil height.
-        double m_hingeRelHeight;
+        double                       m_hingeRelHeight;
+
+        /// Optional absolute translation of the hinge point
+        boost::optional<CCPACSPoint> m_translation;
 
     private:
         CPACSControlSurfaceHingePoint(const CPACSControlSurfaceHingePoint&) = delete;

--- a/src/generated/CPACSControlSurfacePath.cpp
+++ b/src/generated/CPACSControlSurfacePath.cpp
@@ -30,8 +30,8 @@ namespace generated
 {
     CPACSControlSurfacePath::CPACSControlSurfacePath(CCPACSTrailingEdgeDevice* parent, CTiglUIDManager* uidMgr)
         : m_uidMgr(uidMgr)
-        , m_innerHingePoint(this)
-        , m_outerHingePoint(this)
+        , m_innerHingePoint(this, m_uidMgr)
+        , m_outerHingePoint(this, m_uidMgr)
         , m_steps(this, m_uidMgr)
     {
         //assert(parent != NULL);

--- a/src/generated/CPACSPoint.cpp
+++ b/src/generated/CPACSPoint.cpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include "CCPACSTransformation.h"
+#include "CPACSControlSurfaceHingePoint.h"
 #include "CPACSControlSurfaceStep.h"
 #include "CPACSPoint.h"
 #include "CPACSPointList.h"
@@ -30,6 +31,14 @@ namespace tigl
 {
 namespace generated
 {
+    CPACSPoint::CPACSPoint(CPACSControlSurfaceHingePoint* parent, CTiglUIDManager* uidMgr)
+        : m_uidMgr(uidMgr)
+    {
+        //assert(parent != NULL);
+        m_parent = parent;
+        m_parentType = &typeid(CPACSControlSurfaceHingePoint);
+    }
+
     CPACSPoint::CPACSPoint(CPACSControlSurfaceStep* parent, CTiglUIDManager* uidMgr)
         : m_uidMgr(uidMgr)
     {
@@ -70,6 +79,9 @@ namespace generated
     const CTiglUIDObject* CPACSPoint::GetNextUIDParent() const
     {
         if (m_parent) {
+            if (IsParent<CPACSControlSurfaceHingePoint>()) {
+                return GetParent<CPACSControlSurfaceHingePoint>()->GetNextUIDParent();
+            }
             if (IsParent<CPACSControlSurfaceStep>()) {
                 return GetParent<CPACSControlSurfaceStep>()->GetNextUIDParent();
             }
@@ -92,6 +104,9 @@ namespace generated
     CTiglUIDObject* CPACSPoint::GetNextUIDParent()
     {
         if (m_parent) {
+            if (IsParent<CPACSControlSurfaceHingePoint>()) {
+                return GetParent<CPACSControlSurfaceHingePoint>()->GetNextUIDParent();
+            }
             if (IsParent<CPACSControlSurfaceStep>()) {
                 return GetParent<CPACSControlSurfaceStep>()->GetNextUIDParent();
             }

--- a/src/generated/CPACSPoint.h
+++ b/src/generated/CPACSPoint.h
@@ -33,11 +33,13 @@ class CCPACSTransformation;
 
 namespace generated
 {
+    class CPACSControlSurfaceHingePoint;
     class CPACSControlSurfaceStep;
     class CPACSPointList;
     class CPACSSeatModule;
 
     // This class is used in:
+    // CPACSControlSurfaceHingePoint
     // CPACSControlSurfaceStep
     // CPACSPointList
     // CPACSSeatModule
@@ -50,6 +52,7 @@ namespace generated
     class CPACSPoint : public CTiglOptUIDObject
     {
     public:
+        TIGL_EXPORT CPACSPoint(CPACSControlSurfaceHingePoint* parent, CTiglUIDManager* uidMgr);
         TIGL_EXPORT CPACSPoint(CPACSControlSurfaceStep* parent, CTiglUIDManager* uidMgr);
         TIGL_EXPORT CPACSPoint(CPACSPointList* parent, CTiglUIDManager* uidMgr);
         TIGL_EXPORT CPACSPoint(CPACSSeatModule* parent, CTiglUIDManager* uidMgr);
@@ -67,7 +70,7 @@ namespace generated
         P* GetParent()
         {
 #ifdef HAVE_STDIS_SAME
-            static_assert(std::is_same<P, CPACSControlSurfaceStep>::value || std::is_same<P, CPACSPointList>::value || std::is_same<P, CPACSSeatModule>::value || std::is_same<P, CCPACSTransformation>::value, "template argument for P is not a parent class of CPACSPoint");
+            static_assert(std::is_same<P, CPACSControlSurfaceHingePoint>::value || std::is_same<P, CPACSControlSurfaceStep>::value || std::is_same<P, CPACSPointList>::value || std::is_same<P, CPACSSeatModule>::value || std::is_same<P, CCPACSTransformation>::value, "template argument for P is not a parent class of CPACSPoint");
 #endif
             if (!IsParent<P>()) {
                 throw CTiglError("bad parent");
@@ -79,7 +82,7 @@ namespace generated
         const P* GetParent() const
         {
 #ifdef HAVE_STDIS_SAME
-            static_assert(std::is_same<P, CPACSControlSurfaceStep>::value || std::is_same<P, CPACSPointList>::value || std::is_same<P, CPACSSeatModule>::value || std::is_same<P, CCPACSTransformation>::value, "template argument for P is not a parent class of CPACSPoint");
+            static_assert(std::is_same<P, CPACSControlSurfaceHingePoint>::value || std::is_same<P, CPACSControlSurfaceStep>::value || std::is_same<P, CPACSPointList>::value || std::is_same<P, CPACSSeatModule>::value || std::is_same<P, CCPACSTransformation>::value, "template argument for P is not a parent class of CPACSPoint");
 #endif
             if (!IsParent<P>()) {
                 throw CTiglError("bad parent");
@@ -137,6 +140,7 @@ namespace generated
 // CPACSPoint is customized, use type CCPACSPoint directly
 
 // Aliases in tigl namespace
+using CCPACSControlSurfaceHingePoint = generated::CPACSControlSurfaceHingePoint;
 using CCPACSControlSurfaceStep = generated::CPACSControlSurfaceStep;
 using CCPACSPointList = generated::CPACSPointList;
 using CCPACSSeatModule = generated::CPACSSeatModule;

--- a/tests/unittests/TestData/canards.xml
+++ b/tests/unittests/TestData/canards.xml
@@ -1,0 +1,609 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Simple Wing for unit testing</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2012-10-09T15:12:47</timestamp>
+    <version>0.3.0</version>
+    <cpacsVersion>3.2</cpacsVersion>
+    <updates>
+      <update>
+        <modification>Converted to cpacs 3.0 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2019-12-27T10:20:36</timestamp>
+        <version>0.1.0</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Converted to CPACS 3.1 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2020-04-26T02:01:33</timestamp>
+        <version>0.2.0</version>
+        <cpacsVersion>3.1</cpacsVersion>
+      </update>
+      <update>
+        <modification>Converted to CPACS 3.2 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2021-04-23T18:02:01</timestamp>
+        <version>0.3.0</version>
+        <cpacsVersion>3.2</cpacsVersion>
+      </update>
+    </updates>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="Cpacs2Test">
+        <name>Cpacs2Test</name>
+        <description/>
+        <reference>
+          <area>1</area>
+          <length>1</length>
+          <point uID="Cpacs2Test_point1">
+            <x>0</x>
+            <y>0</y>
+            <z>0</z>
+          </point>
+        </reference>
+        <fuselages>
+          <fuselage uID="SimpleFuselage">
+            <name>name</name>
+            <description>description</description>
+            <transformation uID="SimpleFuselage_transformation1">
+              <scaling uID="SimpleFuselage_transformation1_scaling1">
+                <x>1.0</x>
+                <y>0.5</y>
+                <z>0.5</z>
+              </scaling>
+              <rotation uID="SimpleFuselage_transformation1_rotation1">
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+              </rotation>
+              <translation refType="absLocal" uID="SimpleFuselage_transformation1_translation1">
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="D150_Fuselage_1Section1ID">
+                <name>D150_Fuselage_1Section1</name>
+                <transformation uID="D150_Fuselage_1Section1ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section1ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section1ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section1ID_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section1IDElement1">
+                    <name>D150_Fuselage_1Section1</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section1IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section1IDElement1_transformation1_scaling1">
+                        <x>1.0</x>
+                        <y>1.0</y>
+                        <z>1.0</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section1IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section1IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section2ID">
+                <name>D150_Fuselage_1Section2</name>
+                <transformation uID="D150_Fuselage_1Section2ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section2ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section2ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section2ID_transformation1_translation1">
+                    <x>0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section2IDElement1">
+                    <name>D150_Fuselage_1Section2</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section2IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section2IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section2IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section2IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section3ID">
+                <name>D150_Fuselage_1Section3</name>
+                <transformation uID="D150_Fuselage_1Section3ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section3ID_transformation1_scaling1">
+                    <x>1.0</x>
+                    <y>1.0</y>
+                    <z>1.0</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section3ID_transformation1_rotation1">
+                    <x>0.0</x>
+                    <y>0.0</y>
+                    <z>0.0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section3ID_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section3IDElement1">
+                    <name>D150_Fuselage_1Section3</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section3IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section3IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section3IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section3IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="D150_Fuselage_1Positioning1ID">
+                <name>D150_Fuselage_1Positioning1</name>
+                <length>-0.5</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>D150_Fuselage_1Section1ID</toSectionUID>
+              </positioning>
+              <positioning uID="D150_Fuselage_1Positioning3ID">
+                <name>D150_Fuselage_1Positioning3</name>
+                <length>2</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>D150_Fuselage_1Section1ID</fromSectionUID>
+                <toSectionUID>D150_Fuselage_1Section3ID</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="segmentD150_Fuselage_1Segment2ID">
+                <name>D150_Fuselage_1Segment2</name>
+                <fromElementUID>D150_Fuselage_1Section1IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section2IDElement1</toElementUID>
+              </segment>
+              <segment uID="segmentD150_Fuselage_1Segment3ID">
+                <name>D150_Fuselage_1Segment3</name>
+                <fromElementUID>D150_Fuselage_1Section2IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section3IDElement1</toElementUID>
+              </segment>
+            </segments>
+          </fuselage>
+        </fuselages>
+        <wings>
+          <wing uID="Wing" symmetry="x-z-plane">
+            <name>Wing</name>
+            <parentUID>SimpleFuselage</parentUID>
+            <description>This wing has been generated to test CATIA2CPACS.</description>
+            <transformation uID="Wing_transformation1">
+              <scaling uID="Wing_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Wing_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Wing_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="Cpacs2Test_Wing_Sec1">
+                <name>Cpacs2Test - Wing Section 1</name>
+                <description>Cpacs2Test - Wing Section 1</description>
+                <transformation uID="Cpacs2Test_Wing_Sec1_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec1_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec1_El1">
+                    <name>Cpacs2Test - Wing Section 1 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 1 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec1_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec2">
+                <name>Cpacs2Test - Wing Section 2</name>
+                <description>Cpacs2Test - Wing Section 2</description>
+                <transformation uID="Cpacs2Test_Wing_Sec2_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec2_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec2_El1">
+                    <name>Cpacs2Test - Wing Section 2 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 2 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec2_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="Cpacs2Test_Wing_Sec3">
+                <name>Cpacs2Test - Wing Section 3</name>
+                <description>Cpacs2Test - Wing Section 3</description>
+                <transformation uID="Cpacs2Test_Wing_Sec3_transformation1">
+                  <scaling uID="Cpacs2Test_Wing_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="Cpacs2Test_Wing_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="Cpacs2Test_Wing_Sec3_El1">
+                    <name>Cpacs2Test - Wing Section 3 Main Element</name>
+                    <description>Cpacs2Test - Wing Section 3 Main Element</description>
+                    <airfoilUID>NACA0012</airfoilUID>
+                    <transformation uID="Cpacs2Test_Wing_Sec3_El1_transformation1">
+                      <scaling uID="Cpacs2Test_Wing_Sec3_El1_transformation1_scaling1">
+                        <x>0.3</x>
+                        <y>0.3</y>
+                        <z>0.3</z>
+                      </scaling>
+                      <rotation uID="Cpacs2Test_Wing_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="Cpacs2Test_Wing_Sec3_El1_transformation1_translation1">
+                        <x>0.65</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="Wing_positioning1">
+                <name>Cpacs2Test - Wing Section 1 Positioning</name>
+                <description>Cpacs2Test - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>Cpacs2Test_Wing_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="Wing_positioning2">
+                <name>Cpacs2Test - Wing Section 2 Positioning</name>
+                <description>Cpacs2Test - Wing Section 2 Positioning</description>
+                <length>0.501</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec1</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="Wing_positioning3">
+                <name>Cpacs2Test - Wing Section 3 Positioning</name>
+                <description>Cpacs2Test - Wing Section 3 Positioning</description>
+                <length>1</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>Cpacs2Test_Wing_Sec2</fromSectionUID>
+                <toSectionUID>Cpacs2Test_Wing_Sec3</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="Cpacs2Test_Wing_Seg_1_2">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 1 Main Element to Cpacs2Test - Wing Section 2 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec2_El1</toElementUID>
+              </segment>
+              <segment uID="Cpacs2Test_Wing_Seg_2_3">
+                <name>Fuselage Segment from Cpacs2Test - Wing Section 2 Main Element to Cpacs2Test - Wing Section 3 Main Element</name>
+                <description>Fuselage Segment from Cpacs2Test - Wing Section 2 Main Element to Cpacs2Test - Wing Section 3 Main Element</description>
+                <fromElementUID>Cpacs2Test_Wing_Sec2_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
+              </segment>
+            </segments>
+            <componentSegments>
+              <componentSegment uID="WING_CS1">
+                <name>Wing_CS1</name>
+                <fromElementUID>Cpacs2Test_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>Cpacs2Test_Wing_Sec3_El1</toElementUID>
+                <structure>
+                  <upperShell uID="WING_CS1_upperShell1">
+                    <skin>
+                      <material>
+                        <materialUID>MySkinMat</materialUID>
+                        <thickness>0.0</thickness>
+                      </material>
+                    </skin>
+                    <cells>
+                      <cell uID="WING_CS1_CELL1">
+                        <skin>
+                          <material>
+                            <materialUID>MyCellMat</materialUID>
+                            <thickness>0.0</thickness>
+                          </material>
+                        </skin>
+                        <positioningLeadingEdge>
+                          <xsi1>0.8</xsi1>
+                          <xsi2>0.8</xsi2>
+                        </positioningLeadingEdge>
+                        <positioningTrailingEdge>
+                          <xsi1>1.0</xsi1>
+                          <xsi2>1.0</xsi2>
+                        </positioningTrailingEdge>
+                        <positioningInnerBorder>
+                          <eta1>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
+                        </positioningInnerBorder>
+                        <positioningOuterBorder>
+                          <eta1>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta1>
+                          <eta2>
+                            <eta>0.5</eta>
+                            <referenceUID>WING_CS1</referenceUID>
+                          </eta2>
+                        </positioningOuterBorder>
+                      </cell>
+                    </cells>
+                  </upperShell>
+                  <lowerShell uID="WING_CS1_lowerShell1">
+                    <skin>
+                      <material>
+                        <materialUID>MySkinMat</materialUID>
+                      </material>
+                    </skin>
+                  </lowerShell>
+                </structure>
+                <controlSurfaces>
+                  <trailingEdgeDevices>
+                    <trailingEdgeDevice uID="FlapOuter">
+                      <name>FlapOuter</name>
+                      <parentUID>Wing_CS1</parentUID>
+                      <outerShape>
+                        <innerBorder>
+                          <etaLE>
+                            <eta>0.0</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaLE>
+                          <etaTE>
+                            <eta>0.0</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaTE>
+                          <xsiLE>
+                            <xsi>0.0</xsi>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </xsiLE>
+                        </innerBorder>
+                        <outerBorder>
+                          <etaLE>
+                            <eta>1.0</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaLE>
+                          <etaTE>
+                            <eta>1.0</eta>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </etaTE>
+                          <xsiLE>
+                            <xsi>0.0</xsi>
+                            <referenceUID>Cpacs2Test_Wing_Seg_2_3</referenceUID>
+                          </xsiLE>
+
+                        </outerBorder>
+                      </outerShape>
+                      <path>
+                        <innerHingePoint>
+                          <hingeXsi>0.8</hingeXsi>
+                          <hingeRelHeight>0.5</hingeRelHeight>
+                        </innerHingePoint>
+                        <outerHingePoint>
+                          <hingeXsi>0.8</hingeXsi>
+                          <hingeRelHeight>0.5</hingeRelHeight>
+                        </outerHingePoint>
+                        <steps>
+                          <step>
+                            <controlParameter>0.0</controlParameter>
+                            <innerHingeTranslation uID="FlapOuter_innerHingeTranslation1">
+                              <x>0.0</x>
+                              <y>0.0</y>
+                              <z>0.0</z>
+                            </innerHingeTranslation>
+                            <outerHingeTranslation uID="FlapOuter_outerHingeTranslation1">
+                              <x>0.0</x>
+                              <z>0.0</z>
+                            </outerHingeTranslation>
+                            <hingeLineRotation>0.0</hingeLineRotation>
+                          </step>
+                          <step>
+                            <controlParameter>1</controlParameter>
+                            <innerHingeTranslation uID="FlapOuter_innerHingeTranslation2">
+                              <x>0.1</x>
+                              <y>0.0</y>
+                              <z>-0.1</z>
+                            </innerHingeTranslation>
+                            <outerHingeTranslation uID="FlapOuter_outerHingeTranslation2">
+                              <x>0.1</x>
+                              <z>-0.1</z>
+                            </outerHingeTranslation>
+                            <hingeLineRotation>30</hingeLineRotation>
+                          </step>
+                        </steps>
+                      </path>
+                    </trailingEdgeDevice>
+                  </trailingEdgeDevices>
+                </controlSurfaces>
+              </componentSegment>
+            </componentSegments>
+          </wing>
+        </wings>
+      </model>
+    </aircraft>
+    <profiles>
+      <wingAirfoils>
+        <wingAirfoil uID="NACA0012">
+          <name>NACA0.00.00.12</name>
+          <description>NACA 4 Series Profile</description>
+          <pointList>
+            <x mapType="vector">1.0;0.9875;0.975;0.9625;0.95;0.9375;0.925;0.9125;0.9;0.8875;0.875;0.8625;0.85;0.8375;0.825;0.8125;0.8;0.7875;0.775;0.7625;0.75;0.7375;0.725;0.7125;0.7;0.6875;0.675;0.6625;0.65;0.6375;0.625;0.6125;0.6;0.5875;0.575;0.5625;0.55;0.5375;0.525;0.5125;0.5;0.4875;0.475;0.4625;0.45;0.4375;0.425;0.4125;0.4;0.3875;0.375;0.3625;0.35;0.3375;0.325;0.3125;0.3;0.2875;0.275;0.2625;0.25;0.2375;0.225;0.2125;0.2;0.1875;0.175;0.1625;0.15;0.1375;0.125;0.1125;0.1;0.0875;0.075;0.0625;0.05;0.0375;0.025;0.0125;0.0;0.0125;0.025;0.0375;0.05;0.0625;0.075;0.0875;0.1;0.1125;0.125;0.1375;0.15;0.1625;0.175;0.1875;0.2;0.2125;0.225;0.2375;0.25;0.2625;0.275;0.2875;0.3;0.3125;0.325;0.3375;0.35;0.3625;0.375;0.3875;0.4;0.4125;0.425;0.4375;0.45;0.4625;0.475;0.4875;0.5;0.5125;0.525;0.5375;0.55;0.5625;0.575;0.5875;0.6;0.6125;0.625;0.6375;0.65;0.6625;0.675;0.6875;0.7;0.7125;0.725;0.7375;0.75;0.7625;0.775;0.7875;0.8;0.8125;0.825;0.8375;0.85;0.8625;0.875;0.8875;0.9;0.9125;0.925;0.9375;0.95;0.9625;0.975;0.9875;1.0</x>
+            <y mapType="vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+            <z mapType="vector">-0.00126;-0.0030004180415;-0.00471438572941;-0.00640256842113;-0.00806559133343;-0.00970403933653;-0.0113184567357;-0.0129093470398;-0.0144771727147;-0.0160223549226;-0.0175452732434;-0.0190462653789;-0.0205256268372;-0.0219836105968;-0.0234204267471;-0.024836242105;-0.0262311798047;-0.0276053188583;-0.0289586936852;-0.0302912936071;-0.0316030623052;-0.0328938972373;-0.0341636490097;-0.0354121207001;-0.0366390671268;-0.0378441940595;-0.0390271573644;-0.0401875620783;-0.0413249614032;-0.042438855614;-0.043528690869;-0.0445938579126;-0.0456336906587;-0.04664746464;-0.0476343953088;-0.0485936361694;-0.0495242767241;-0.0504253402064;-0.0512957810767;-0.0521344822472;-0.0529402520006;-0.0537118205596;-0.0544478362583;-0.0551468612564;-0.0558073667285;-0.0564277274483;-0.0570062156697;-0.0575409941929;-0.0580301084765;-0.0584714776309;-0.0588628840933;-0.059201961739;-0.0594861821311;-0.0597128385384;-0.059879027262;-0.0599816256958;-0.060017266394;-0.059982306219;-0.05987278938;-0.0596844028137;-0.059412421875;-0.059051643633;-0.0585963041308;-0.0580399746271;-0.0573754299024;-0.0565944788455;-0.0556877432118;-0.054644363746;-0.0534516022043;-0.0520942903127;-0.0505540468987;-0.0488081315259;-0.0468277042382;-0.0445750655553;-0.0419990347204;-0.0390266537476;-0.0355468568262;-0.0313738751622;-0.0261471986426;-0.0189390266528;0.0;0.0189390266528;0.0261471986426;0.0313738751622;0.0355468568262;0.0390266537476;0.0419990347204;0.0445750655553;0.0468277042382;0.0488081315259;0.0505540468987;0.0520942903127;0.0534516022043;0.054644363746;0.0556877432118;0.0565944788455;0.0573754299024;0.0580399746271;0.0585963041308;0.059051643633;0.059412421875;0.0596844028137;0.05987278938;0.059982306219;0.060017266394;0.0599816256958;0.059879027262;0.0597128385384;0.0594861821311;0.059201961739;0.0588628840933;0.0584714776309;0.0580301084765;0.0575409941929;0.0570062156697;0.0564277274483;0.0558073667285;0.0551468612564;0.0544478362583;0.0537118205596;0.0529402520006;0.0521344822472;0.0512957810767;0.0504253402064;0.0495242767241;0.0485936361694;0.0476343953088;0.04664746464;0.0456336906587;0.0445938579126;0.043528690869;0.042438855614;0.0413249614032;0.0401875620783;0.0390271573644;0.0378441940595;0.0366390671268;0.0354121207001;0.0341636490097;0.0328938972373;0.0316030623052;0.0302912936071;0.0289586936852;0.0276053188583;0.0262311798047;0.024836242105;0.0234204267471;0.0219836105968;0.0205256268372;0.0190462653789;0.0175452732434;0.0160223549226;0.0144771727147;0.0129093470398;0.0113184567357;0.00970403933653;0.00806559133343;0.00640256842113;0.00471438572941;0.0030004180415;0.00126</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+      <fuselageProfiles>
+        <fuselageProfile uID="fuselageCircleProfileuID">
+          <name>Circle</name>
+          <description>Profile build up from set of Points on Circle where may Dimensions are 1..-1</description>
+          <pointList>
+            <x mapType="vector">0.0;0.0;0.0;0.0;0.0</x>
+            <y mapType="vector">0.0;1.0;0.0;-1.0;0.0</y>
+            <z mapType="vector">1.0;0.0;-1.0;0.0;1.0</z>
+          </pointList>
+        </fuselageProfile>
+      </fuselageProfiles>
+    </profiles>
+  </vehicles>
+  <toolspecific>
+    <cFD>
+      <farField>
+        <type>halfCube</type>
+        <referenceLength>10.0</referenceLength>
+        <multiplier>1.</multiplier>
+      </farField>
+    </cFD>
+  </toolspecific>
+</cpacs>

--- a/tests/unittests/TestData/canards.xml
+++ b/tests/unittests/TestData/canards.xml
@@ -491,8 +491,8 @@
                 </structure>
                 <controlSurfaces>
                   <trailingEdgeDevices>
-                    <trailingEdgeDevice uID="FlapOuter">
-                      <name>FlapOuter</name>
+                    <trailingEdgeDevice uID="Canard">
+                      <name>Canard</name>
                       <parentUID>Wing_CS1</parentUID>
                       <outerShape>
                         <innerBorder>
@@ -527,38 +527,34 @@
                       </outerShape>
                       <path>
                         <innerHingePoint>
-                          <hingeXsi>0.8</hingeXsi>
+                          <hingeXsi>0.0</hingeXsi>
                           <hingeRelHeight>0.5</hingeRelHeight>
+                          <translation>
+                            <x>0.5</x>
+                            <y>0</y>
+                            <z>0</z>
+                          </translation>
                         </innerHingePoint>
                         <outerHingePoint>
-                          <hingeXsi>0.8</hingeXsi>
+                          <hingeXsi>0.0</hingeXsi>
                           <hingeRelHeight>0.5</hingeRelHeight>
+                          <translation>
+                            <x>-0.15</x>
+                            <y>0</y>
+                            <z>0</z>
+                          </translation>
                         </outerHingePoint>
                         <steps>
                           <step>
+                            <controlParameter>-1.0</controlParameter>
+                            <hingeLineRotation>-30.0</hingeLineRotation>
+                          </step>
+                          <step>
                             <controlParameter>0.0</controlParameter>
-                            <innerHingeTranslation uID="FlapOuter_innerHingeTranslation1">
-                              <x>0.0</x>
-                              <y>0.0</y>
-                              <z>0.0</z>
-                            </innerHingeTranslation>
-                            <outerHingeTranslation uID="FlapOuter_outerHingeTranslation1">
-                              <x>0.0</x>
-                              <z>0.0</z>
-                            </outerHingeTranslation>
                             <hingeLineRotation>0.0</hingeLineRotation>
                           </step>
                           <step>
                             <controlParameter>1</controlParameter>
-                            <innerHingeTranslation uID="FlapOuter_innerHingeTranslation2">
-                              <x>0.1</x>
-                              <y>0.0</y>
-                              <z>-0.1</z>
-                            </innerHingeTranslation>
-                            <outerHingeTranslation uID="FlapOuter_outerHingeTranslation2">
-                              <x>0.1</x>
-                              <z>-0.1</z>
-                            </outerHingeTranslation>
                             <hingeLineRotation>30</hingeLineRotation>
                           </step>
                         </steps>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

To support canard style flaps, the following changes had to be implemented:
 - Create wing cutouts / flap pofiles that can include also the leading edge of the wing
 - To allow placing the hinge points outside the wing, I implemented an absolute translation. This required an extension of the cpacs schema, which now includes an optional "translation" node for hinge points

Closes #816 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested different settings with TiGL Viewer. The canard flap can now be either some part of the wing or the whole wing at once.

## Screenshots, that help to understand the changes(if applicable):

![canards](https://user-images.githubusercontent.com/3213107/125610739-72414a91-c874-4459-9656-170a8db95dc1.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [x] New classes have been added to the Python interface.
- [x] API changes were documented properly in tigl.h.
