### PR TITLE
allow zero-length wires in WireGetPointTangent

### DIFF
--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -207,19 +207,23 @@ void WireGetPointTangent(const TopoDS_Wire& wire, double alpha, gp_Pnt& point, g
     BRepAdaptor_CompCurve aCompoundCurve(wire, Standard_True);
 
     Standard_Real len =  GCPnts_AbscissaPoint::Length( aCompoundCurve );
-    if (len < Precision::Confusion()) {
-        throw tigl::CTiglError("WireGetPointTangent: Unable to compute tangent on zero length wire", TIGL_MATH_ERROR);
-    }
-    GCPnts_AbscissaPoint algo(aCompoundCurve, len*alpha, aCompoundCurve.FirstParameter());
-    if (algo.IsDone()) {
-        double par = algo.Parameter();
-        aCompoundCurve.D1( par, point, tangent );
-        // normalize tangent to length of the curve
-        tangent = len*tangent/tangent.Magnitude();
-    }
-    else {
-        throw tigl::CTiglError("WireGetPointTangent: Cannot compute point on curve.", TIGL_MATH_ERROR);
-    }
+     if (len < Precision::Confusion()) {
+         // wire length is zero, we can query at parameter 0 and accept zero length tangents
+         aCompoundCurve.D1(0., point, tangent);
+     }
+     else {
+         GCPnts_AbscissaPoint algo(aCompoundCurve, len*alpha, aCompoundCurve.FirstParameter());
+         if (algo.IsDone()) {
+             double par = algo.Parameter();
+             aCompoundCurve.D1( par, point, tangent );
+             // normalize tangent to length of the curve
+             tangent = len*tangent/tangent.Magnitude();
+          }
+          else {
+             throw tigl::CTiglError("WireGetPointTangent: Cannot compute point on curve.", TIGL_MATH_ERROR);
+          }
+     }
+
 }
 
 gp_Pnt EdgeGetPoint(const TopoDS_Edge& edge, double alpha)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, a zero-length wire would throw an exception in WireGetPointTangent. With this change, it doesnt, but a singular tangent is returned.

Addresses #819

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
No new tests were added for this refactor. All existing tests still work.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
