### PR TITLE
fix surface factories curve list arguments

### DIFF
--- a/bindings/python_internal/tigl3/surface_factories.py
+++ b/bindings/python_internal/tigl3/surface_factories.py
@@ -1,4 +1,5 @@
 from tigl3.geometry import CTiglCurvesToSurface, CTiglInterpolateCurveNetwork
+from tigl3.occ_helpers.containers import geomcurve_vector
 
 
 def interpolate_curves(curve_list, params=None, degree=3, close_continuous=False):
@@ -14,13 +15,15 @@ def interpolate_curves(curve_list, params=None, degree=3, close_continuous=False
                              the loft is c2 continuous at the junction between first and last curve.
     :return: The final surface (Handle to Geom_BSplineSurface)
     """
-
+    curve_vector = geomcurve_vector(curve_list)
     if params is None:
-        surface_builder = CTiglCurvesToSurface(curve_list, close_continuous)
+        surface_builder = CTiglCurvesToSurface(curve_vector, close_continuous)
     else:
         if len(params) != len(curve_list):
             raise RuntimeError("Number of parameters don't match number of curves")
-        surface_builder = CTiglCurvesToSurface(curve_list, params, close_continuous)
+        surface_builder = CTiglCurvesToSurface(curve_vector,
+                                               params,
+                                               close_continuous)
 
     surface_builder.set_max_degree(degree)
     surface = surface_builder.surface()
@@ -43,5 +46,7 @@ def interpolate_curve_network(profiles, guides, tolerance=1e-4):
                      (in theory they must intersect and the distance is zero)
     :return: The final surface (Handle to Geom_BSplineSurface)
     """
-    interpolator = CTiglInterpolateCurveNetwork(profiles, guides, tolerance)
+    interpolator = CTiglInterpolateCurveNetwork(geomcurve_vector(profiles),
+                                                geomcurve_vector(guides),
+                                                tolerance)
     return interpolator.surface()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After the update to OpenCascade 7.4 the TiGL Curve factories did not work anymore. The problem was, that a python list of swig wrapped `Geom_Curve` instances could not be converted to a `std::vector` of `Handle(Geom_Curve)` automatically. This is now done using the helper function `tigl3.occ_helpers.containers.geomcurve_vector`

Fixes #823.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

The following code, taken from this [TiGL example](https://github.com/rainman110/tigl-workshop/blob/master/Exercises/solutions/Exercise3_Geometry-solution.ipynb) fails without the fix:
<details>
<summary>Click to expand Python Code</summary>

```python
import tigl3.curve_factories
import tigl3.surface_factories
from tigl3.geometry import CurveList, BSplineCurveList
from OCC.Core.gp import gp_Pnt
from OCC.Display.SimpleGui import init_display
import numpy as np

# list of points on NACA2412 profile
px = [1.000084, 0.975825, 0.905287, 0.795069, 0.655665, 0.500588, 0.34468, 0.203313, 0.091996, 0.022051, 0.0, 0.026892, 0.098987, 0.208902, 0.346303, 0.499412, 0.653352, 0.792716, 0.90373, 0.975232, 0.999916]
py = [0.001257, 0.006231, 0.019752, 0.03826, 0.057302, 0.072381, 0.079198, 0.072947, 0.054325, 0.028152, 0.0, -0.023408, -0.037507, -0.042346, -0.039941, -0.033493, -0.0245, -0.015499, -0.008033, -0.003035, -0.001257]
points_c1 = np.array([pnt for pnt in zip(px, [0.]*len(px), py)]) * 2.
points_c2 = np.array([pnt for pnt in zip(px, [0]*len(px), py)])
points_c3 = np.array([pnt for pnt in zip(px, py, [0.]*len(px))]) * 0.2

# shift sections to their correct position
# second curve at y = 7
points_c2 += np.array([1.0, 7, 0])

# third curve at y = 7.5
points_c3[:, 1] *= -1
points_c3 += np.array([1.7, 7.8, 1.0])

curve1 = tigl3.curve_factories.interpolate_points(points_c1)
curve2 = tigl3.curve_factories.interpolate_points(points_c2)
curve3 = tigl3.curve_factories.interpolate_points(points_c3)


surface = tigl3.surface_factories.interpolate_curves([curve1, curve2, curve3])

points_c1[:,0]+=3
points_c2[:,0]+=3
points_c3[:,0]+=3

# interpolate the three point sets to new profile curves
profile1 = tigl3.curve_factories.interpolate_points(points_c1)
profile2 = tigl3.curve_factories.interpolate_points(points_c2)
profile3 = tigl3.curve_factories.interpolate_points(points_c3)


# upper trailing edge points
te_up_points = np.array([points_c1[0,:], points_c2[0,:], points_c3[0,:]])

# leading edge points.
le_points = np.array([
    points_c1[10,:],    # First profile LE

    [3.35, 2., -0.1],# Additional point to control LE shape
    [3.7, 5., -0.2], # Additional point to control LE shape

    points_c2[10,:],   # Second profile LE
    points_c3[10,:], # Third profile LE
])


# lower trailing edge points
te_lo_points = np.array([points_c1[-1,:], points_c2[-1,:], points_c3[-1,:]])

te_up = tigl3.curve_factories.interpolate_points(te_up_points, [0, 0.65, 1.])
le = tigl3.curve_factories.interpolate_points(le_points, [0., 0.25, 0.55, 0.8, 1.0])
te_lo = tigl3.curve_factories.interpolate_points(te_lo_points, [0, 0.65, 1.])

surface2 = tigl3.surface_factories.interpolate_curve_network([profile1, profile2, profile3],
                                                             [te_up, le, te_lo])

# start up the gui
display, start_display, add_menu, add_function_to_menu = init_display()

# make tesselation more accurate
display.Context.SetDeviationCoefficient(0.0001)

# draw the points
for point in points_c1:
    display.DisplayShape(gp_Pnt(*point), update=False)

for point in points_c2:
    display.DisplayShape(gp_Pnt(*point), update=False)

for point in points_c3:
    display.DisplayShape(gp_Pnt(*point), update=False)

# draw the curves
display.DisplayShape(curve1)
display.DisplayShape(curve2)
display.DisplayShape(curve3)

display.DisplayShape(surface)

# draw the profiles
display.DisplayShape(profile1)
display.DisplayShape(profile2)
display.DisplayShape(profile3)

# draw the guide curves
display.DisplayShape(te_up)
display.DisplayShape(le)
display.DisplayShape(te_lo)

# also draw the guide curve points
for point in le_points:
    display.DisplayShape(gp_Pnt(*point), update=False)
for point in te_up_points:
    display.DisplayShape(gp_Pnt(*point), update=False)
for point in te_lo_points:
    display.DisplayShape(gp_Pnt(*point), update=False)

display.DisplayShape(surface2, color="green")


# match content to screen and start the event loop
display.FitAll()

# uncomment the following line to enter the event loop
start_display()
```

</details>

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
