### PR TITLE
Implement tiglCrossSectionArea

### DIFF
--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -4477,6 +4477,40 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetSegmentVolume(TiglCPACSConfigur
 /*@{*/
 
 /**
+ * @brief tiglGetCrossSectionArea returns the area of the intersection of the fused aircraft with a plane.
+ * Thi function can be used for the surface rule. If no intersections are found, the resulting area is
+ * is zero. No warning or error is thrwon in this case. If more than one intersection is found, the returned area
+ * is the some of the areas of the intersections. No warning or error is thrown.
+ *
+ * @param[in]  cpacsHandle      Handle for the CPACS configuration
+ * @param[in]  origin_x         x-component of the origin of the plane
+ * @param[in]  origin_y         y-component of the origin of the plane
+ * @param[in]  origin_z         z-component of the origin of the plane
+ * @param[in]  normal_x         x-direction of the normal of the plane
+ * @param[in]  normal_y         y-direction of the normal of the plane
+ * @param[in]  normal_z         z-direction of the normal of the plane
+ * @param[in]  fuse_result_mode An integer denoting the fusing mode. Can be
+ *                              HALF_PLANE = 0,
+ *                              FULL_PLANE = 1,
+ *                              HALF_PLANE_TRIMMED_FF = 2,
+ *                              FULL_PLANE_TRIMMED_FF = 3
+ *                              This option is forwarded to the fusing algorithum
+ * @param[out] area             The area of the intersection of the aircraft with the plane
+ * @return
+ *   - TIGL_SUCCESS if no error occurred
+ *   - TIGL_MATH_ERROR if the normal of the plane is zero
+ *   - TIGL_INDEX_ERROR if the fuse_result_mode is not between 0 and 3.
+ *   - TIGL_ERROR if some other error occurred
+ */
+TIGL_COMMON_EXPORT TiglReturnCode tiglGetCrossSectionArea(TiglCPACSConfigurationHandle cpacsHandle,
+                                                          double origin_x, double origin_y, double origin_z,
+                                                          double normal_x, double normal_y, double normal_z,
+                                                          int fuse_result_mode,
+                                                          double* area
+                                                          );
+
+
+/**
 * @brief Returns the surface area of the wing. Currently, the area includes also the faces
 * on the wing symmetry plane (in case of a symmetric wing). In coming releases, these faces will
 * not belong anymore to the surface area calculation.

--- a/tests/unittests/tiglGetCrossSectionArea.cpp
+++ b/tests/unittests/tiglGetCrossSectionArea.cpp
@@ -1,0 +1,105 @@
+/*
+* Copyright (C) 2021 German Aerospace Center
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h"
+#include "tigl.h"
+
+class GetCrossSectionAreaSimple : public ::testing::Test
+{
+protected:
+    static void SetUpTestCase()
+    {
+        const char* filename = "TestData/simpletest.cpacs.xml";
+        ReturnCode tixiRet;
+        TiglReturnCode tiglRet;
+
+        tiglHandle = -1;
+        tixiHandle = -1;
+
+        tixiRet = tixiOpenDocument(filename, &tixiHandle);
+        ASSERT_TRUE (tixiRet == SUCCESS);
+        tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle);
+        ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+    }
+
+    static void TearDownTestCase()
+    {
+        ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglHandle) == TIGL_SUCCESS);
+        ASSERT_TRUE(tixiCloseDocument(tixiHandle) == SUCCESS);
+        tiglHandle = -1;
+        tixiHandle = -1;
+    }
+
+    void SetUp() override {}
+    void TearDown() override {}
+
+
+    static TixiDocumentHandle           tixiHandle;
+    static TiglCPACSConfigurationHandle tiglHandle;
+};
+
+
+TixiDocumentHandle  GetCrossSectionAreaSimple::tixiHandle = 0;
+TiglCPACSConfigurationHandle  GetCrossSectionAreaSimple::tiglHandle = 0;
+
+TEST_F(GetCrossSectionAreaSimple, error_handle_invalid)
+{
+    double area;
+    EXPECT_EQ(tiglGetCrossSectionArea(-1, 0., 0., 0., 1., 0., 0., 0, &area), TIGL_NOT_FOUND);
+}
+
+TEST_F(GetCrossSectionAreaSimple, fuse_result_mode_invalid)
+{
+    double area;
+    EXPECT_EQ(tiglGetCrossSectionArea(-1, 0., 0., 0., 1., 0., 0., -1, &area), TIGL_INDEX_ERROR);
+    EXPECT_EQ(tiglGetCrossSectionArea(-1, 0., 0., 0., 1., 0., 0.,  4, &area), TIGL_INDEX_ERROR);
+}
+
+TEST_F(GetCrossSectionAreaSimple, error_zero_normal)
+{
+    double area;
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, 0., 0., 0., 0., 0., 0., 0, &area), TIGL_MATH_ERROR);
+}
+
+
+TEST_F(GetCrossSectionAreaSimple, sanity_values)
+{
+    double area_half, area_full, area;
+
+    // in x-direction at x=0.75
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, -1, 0., 0., 1., 0., 0., 0, &area), TIGL_SUCCESS);
+    EXPECT_EQ(area, 0.);
+
+    // in x-direction
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, -0.25, 0., 0., 1., 0., 0., 1, &area), TIGL_SUCCESS);
+    EXPECT_NEAR(area, 3.1416*0.25, 0.05);
+
+    // reversed normal
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, -0.25, 0., 0., -1., 0., 0., 1, &area_full), TIGL_SUCCESS);
+    EXPECT_EQ(area_full, area);
+
+    // in z-direction at z=0
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, 0., 0., 0., 0., 0., 1., 0, &area_half), TIGL_SUCCESS);
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, 0., 0., 0., 0., 0., 1., 1, &area_full), TIGL_SUCCESS);
+    EXPECT_NEAR(area_half, 2 +   1.25, 0.1);  // full fuselage, one wing
+    EXPECT_NEAR(area_full, 2 + 2*1.25, 0.01); // full fuselage, two wings
+
+    // non-uniqe intersection (should not throw error and should be larger than zero
+    EXPECT_EQ(tiglGetCrossSectionArea(tiglHandle, 1.25, -0.5, 0., 1., -1., 0., 1, &area), TIGL_SUCCESS);
+    EXPECT_GE(area, 0.);
+
+}
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #763 

## Description

The new function calcuates the intersection wires of the fused aircraft with the plane and sums the area of each closed wire in the intersection. There are some cases where this might fail:
 - If a cross section cuts an engine nacelles in the y-z-plane this will return a wrong result: The intersection result would contain two concentric circles for the fan and core cowl and one circle for the center cowl.
 - If the airplane has inlets or "dimples". 
To work correctly, we would need to calculate not intersection wires, but intersection faces from cutting a solid with a plane.

## How Has This Been Tested?

New unit tests have been added

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [ ] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [x] API changes were documented properly in tigl.h.
