### PR TITLE
Respect new dll loading policy of ctypes starting in Python 3.8

### DIFF
--- a/bindings/bindings_generator/python_generator.py
+++ b/bindings/bindings_generator/python_generator.py
@@ -51,7 +51,7 @@ class PythonGenerator(object):
         if self.license:
             string += self.license
         
-        string += 'import sys, ctypes\n\n'
+        string += 'import sys, ctypes, ctypes.util\n\n'
         for enumname, values in cparser.enums.items():
             string += self.create_enum(enumname, values) + '\n\n'
 
@@ -120,7 +120,8 @@ class PythonGenerator(object):
         
         string += indent + 'try:\n'
         string += indent + '    if sys.platform == \'win32\':\n'
-        string += indent + '        lib = ctypes.cdll.%s\n' % self.libname
+        string += indent + '        name = ctypes.util.find_library("%s")\n' % self.libname
+        string += indent + '        lib = ctypes.cdll.LoadLibrary(name)\n'
         string += indent + '    elif sys.platform == \'darwin\':\n'
         string += indent + '        lib = ctypes.CDLL("lib%s.dylib")\n' % self.libname
         string += indent + '    else:\n'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #842. Since ctypes changed it's dll loading policy in Python 3.8, we have to adapt our bindings generator.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested with a local conda build in a Python 3.8 environment.
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
