### PR TITLE
Fix cpack path

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -319,8 +319,8 @@ jobs:
       run: |
         cd build
         cmake --build . --target doc
-        cpack -G ZIP
-        cpack -G NSIS
+        "C:\Program Files\CMake\bin\cpack.exe" -G ZIP
+        "C:\Program Files\CMake\bin\cpack.exe" -G NSIS
       if: contains(matrix.config.os, 'windows')
       
     - name: Upload package as artifact (windows)

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -319,8 +319,8 @@ jobs:
       run: |
         cd build
         cmake --build . --target doc
-        "C:\Program Files\CMake\bin\cpack.exe" -G ZIP
-        "C:\Program Files\CMake\bin\cpack.exe" -G NSIS
+        & 'C:\Program Files\CMake\bin\cpack.exe' -G ZIP
+        & 'C:\Program Files\CMake\bin\cpack.exe' -G NSIS
       if: contains(matrix.config.os, 'windows')
       
     - name: Upload package as artifact (windows)


### PR DESCRIPTION
Fixes #845

<!--- Provide a general summary of your changes in the Title above -->

The CI failed to create cmake packages, as chocolateys "cpack.exe" was used instead of cmakes executable.

This should fix this by providing the full path to cpack.


