### PR TITLE
Fixed parsing of CPACS versions

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -91,6 +91,11 @@ public:
             return false;
         }
 
+        // pre-release version is always lower than release version
+        if (!vLabel().empty() && other.vLabel().empty()) {
+            return true;
+        }
+
         // we don't compare build or pre-release right now
         // is there any sane way to do it???
         return false;

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,0 +1,133 @@
+/*
+* Copyright (C) 2021 German Aerospace Center (DLR/SC)
+*
+* Created: 2021-11-02 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef VERSION_H
+#define VERSION_H
+
+#include <string>
+#include <regex>
+#include <exception>
+
+/**
+ * @brief A class to parse and compare version strings
+ */
+class Version
+{
+public:
+    explicit Version(const std::string& str)
+        : m_major(0),
+          m_minor(0),
+          m_patch(0)
+    {
+        parse(str);
+    }
+
+    int vMajor() const
+    {
+        return m_major;
+    }
+
+    int vMinor() const
+    {
+        return m_minor;
+    }
+
+    int vPatch() const
+    {
+        return m_patch;
+    }
+
+    std::string vLabel() const
+    {
+        return m_label;
+    }
+
+    std::string vBuild() const
+    {
+        return m_build;
+    }
+
+    bool operator< (const Version& other) const
+    {
+        if (vMajor() < other.vMajor()) {
+            return true;
+        }
+        else if (vMajor() > other.vMajor()) {
+            return false;
+        }
+
+        // major Versions are same
+        if (vMinor() < other.vMinor()) {
+            return true;
+        }
+        else if (vMinor() > other.vMinor()) {
+            return false;
+        }
+
+        // major and minor are same
+        if (vPatch() < other.vPatch()) {
+            return true;
+        }
+        else if (vPatch() > other.vPatch()) {
+            return false;
+        }
+
+        // we don't compare build or pre-release right now
+        // is there any sane way to do it???
+
+
+        return false;
+
+    }
+
+    bool operator> (const Version& other) const
+    {
+        return other < *this;
+    }
+
+    bool operator== (const Version& other) const
+    {
+        return !(*this < other) && !(*this > other);
+    }
+
+private:
+
+    int m_major, m_minor, m_patch;
+    std::string m_label, m_build;
+
+    void parse(const std::string& str)
+    {
+        const auto expr = std::regex("([0-9]+)\\.([0-9]+)(\\.([0-9]+))?(?:-(\\w+(\\.\\w*)?)(\\+(.*))?|\\+(.*))?");
+        auto results = std::match_results<std::string::const_iterator>();
+
+        if (std::regex_search(str, results, expr)) {
+            m_major = atof(results[1].str().c_str());
+            m_minor = atof(results[2].str().c_str());
+            m_patch = atof(results[4].str().c_str());
+            m_label = results[5];
+            m_build = results[8] != "" ? results[8] : results[9];
+        }
+        else {
+            throw std::invalid_argument("Invalid format of version string '" + str + "'." );
+        }
+    }
+
+
+};
+
+#endif // VERSION_H

--- a/src/Version.h
+++ b/src/Version.h
@@ -95,13 +95,10 @@ public:
         if (comparePreleases(vLabel(), other.vLabel())) {
             return true;
         }
-        else if (comparePreleases(other.vLabel(), vLabel())) {
+        else {
+            // Build string must be ignored by definition
             return false;
         }
-
-        // TODO: compare builds right now
-
-        return false;
     }
 
     bool operator> (const Version& other) const

--- a/tests/unittests/TestData/testversion_good.xml
+++ b/tests/unittests/TestData/testversion_good.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Test file to check versioning</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2021-11-02T15:12:00</timestamp>
+    <version>1.0.0</version>
+    <cpacsVersion>3.2.1</cpacsVersion>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="LoggingTestModel"/>
+    </aircraft>
+  </vehicles>
+
+</cpacs>

--- a/tests/unittests/TestData/testversion_no_cpacs_version.xml
+++ b/tests/unittests/TestData/testversion_no_cpacs_version.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Test file to check versioning</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2021-11-02T15:12:00</timestamp>
+    <version>1.0.0</version>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="LoggingTestModel"/>
+    </aircraft>
+  </vehicles>
+
+</cpacs>

--- a/tests/unittests/TestData/testversion_too_old.xml
+++ b/tests/unittests/TestData/testversion_too_old.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Test file to check versioning</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2021-11-02T15:12:00</timestamp>
+    <version>1.0.0</version>
+    <cpacsVersion>2.1.3</cpacsVersion>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="LoggingTestModel"/>
+    </aircraft>
+  </vehicles>
+
+</cpacs>

--- a/tests/unittests/testCpacsVersion.cpp
+++ b/tests/unittests/testCpacsVersion.cpp
@@ -1,0 +1,62 @@
+/*
+* Copyright (C) 2021 German Aerospace Center (DLR/SC)
+*
+* Created: 2021-11-02 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h"
+
+#include "tigl.h"
+
+
+TEST(CPACSVersion, success1)
+{
+    TixiHandleWrapper tixihandle("TestData/testversion_good.xml");
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    EXPECT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
+
+    tiglCloseCPACSConfiguration(tiglHandle);
+}
+
+TEST(CPACSVersion, success2)
+{
+    TixiHandleWrapper tixihandle("TestData/simpletest.cpacs.xml");
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    EXPECT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
+
+    tiglCloseCPACSConfiguration(tiglHandle);
+}
+
+TEST(CPACSVersion, versionTooOld)
+{
+    TixiHandleWrapper tixihandle("TestData/testversion_too_old.xml");
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    EXPECT_EQ(TIGL_WRONG_CPACS_VERSION, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
+
+    tiglCloseCPACSConfiguration(tiglHandle);
+}
+
+TEST(CPACSVersion, noCPACSVersion)
+{
+    TixiHandleWrapper tixihandle("TestData/testversion_no_cpacs_version.xml");
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    EXPECT_EQ(TIGL_WRONG_CPACS_VERSION, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
+
+    tiglCloseCPACSConfiguration(tiglHandle);
+}

--- a/tests/unittests/testVersion.cpp
+++ b/tests/unittests/testVersion.cpp
@@ -77,6 +77,16 @@ TEST(Version, MajorMinorBuild)
     EXPECT_STREQ("4", version.vBuild().c_str());
 }
 
+TEST(Version, MajorMinorPatchLabelBuild_Complicated)
+{
+    const auto version = Version("1.2.3----RC-SNAPSHOT.12.9.1--.12+788");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(3, version.vPatch());
+    EXPECT_STREQ("---RC-SNAPSHOT.12.9.1--.12", version.vLabel().c_str());
+    EXPECT_STREQ("788", version.vBuild().c_str());
+}
+
 TEST(Version, Compare)
 {
     EXPECT_TRUE(Version("1.2.3") < Version("2.2.3"));
@@ -96,8 +106,98 @@ TEST(Version, Compare)
     EXPECT_TRUE(Version("1.2.3-beta") == Version("1.2.3-alpha"));
 }
 
+/**
+ * Tests valid semver version strings
+ *
+ * From: https://regex101.com/r/vkijKf/1/
+ *
+ * Modified to allow omitting patch level
+ */
+TEST(Version, ValidFormat)
+{
+    EXPECT_NO_THROW(Version("0.0.4"));
+    EXPECT_NO_THROW(Version("1.2.3"));
+    EXPECT_NO_THROW(Version("10.20.30"));
+    EXPECT_NO_THROW(Version("1.1.2-prerelease+meta"));
+    EXPECT_NO_THROW(Version("1.1.2+meta"));
+    EXPECT_NO_THROW(Version("1.1.2+meta-valid"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha"));
+    EXPECT_NO_THROW(Version("1.0.0-beta"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha.beta"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha.beta.1"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha.1"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha0.valid"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha.0valid"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay"));
+    EXPECT_NO_THROW(Version("1.0.0-rc.1+build.1"));
+    EXPECT_NO_THROW(Version("2.0.0-rc.1+build.123"));
+    EXPECT_NO_THROW(Version("1.2.3-beta"));
+    EXPECT_NO_THROW(Version("10.2.3-DEV-SNAPSHOT"));
+    EXPECT_NO_THROW(Version("1.2.3-SNAPSHOT-123"));
+    EXPECT_NO_THROW(Version("1.0.0"));
+    EXPECT_NO_THROW(Version("2.0.0"));
+    EXPECT_NO_THROW(Version("1.1.7"));
+    EXPECT_NO_THROW(Version("2.0.0+build.1848"));
+    EXPECT_NO_THROW(Version("2.0.1-alpha.1227"));
+    EXPECT_NO_THROW(Version("1.0.0-alpha+beta"));
+    EXPECT_NO_THROW(Version("1.2.3----RC-SNAPSHOT.12.9.1--.12+788"));
+    EXPECT_NO_THROW(Version("1.2.3----R-S.12.9.1--.12+meta"));
+    EXPECT_NO_THROW(Version("1.2.3----RC-SNAPSHOT.12.9.1--.12"));
+    EXPECT_NO_THROW(Version("1.0.0+0.build.1-rc.10000aaa-kk-0.1"));
+    EXPECT_NO_THROW(Version("99999999999999999999999.999999999999999999.99999999999999999"));
+    EXPECT_NO_THROW(Version("1.0.0-0A.is.legal"));
+
+    // These are modifications from the actual semver 2.0.0 definition that allow omitting the patch version
+    EXPECT_NO_THROW(Version("1.2"));
+    EXPECT_NO_THROW(Version("1.2-SNAPSHOT"));
+    EXPECT_NO_THROW(Version("1.2-RC-SNAPSHOT"));
+}
+
+
+/**
+ * Tests invalid semver version strings
+ *
+ * From: https://regex101.com/r/vkijKf/1/
+ *
+ * Modified to allow omitting patch level
+ */
 TEST(Version, InvalidFormat)
 {
     EXPECT_THROW(Version("1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.2.3-0123"), std::invalid_argument);
+    EXPECT_THROW(Version("1.2.3-0123.0123"), std::invalid_argument);
+    EXPECT_THROW(Version("1.1.2+.123"), std::invalid_argument);
+    EXPECT_THROW(Version("+invalid"), std::invalid_argument);
+    EXPECT_THROW(Version("-invalid"), std::invalid_argument);
+    EXPECT_THROW(Version("-invalid+invalid"), std::invalid_argument);
+    EXPECT_THROW(Version("-invalid.01"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha.beta"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha.beta.1"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha.1"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha+beta"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha_beta"), std::invalid_argument);
+    EXPECT_THROW(Version("alpha."), std::invalid_argument);
+    EXPECT_THROW(Version("alpha.."), std::invalid_argument);
+    EXPECT_THROW(Version("beta"), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha_beta"), std::invalid_argument);
+    EXPECT_THROW(Version("-alpha."), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha.."), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha..1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha...1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha....1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha.....1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha......1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.0.0-alpha.......1"), std::invalid_argument);
+    EXPECT_THROW(Version("01.1.1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.01.1"), std::invalid_argument);
+    EXPECT_THROW(Version("1.1.01"), std::invalid_argument);
+    EXPECT_THROW(Version("1.2.3.DEV"), std::invalid_argument);
+    EXPECT_THROW(Version("1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788"), std::invalid_argument);
+    EXPECT_THROW(Version("-1.0.3-gamma+b7718"), std::invalid_argument);
+    EXPECT_THROW(Version("+justmeta"), std::invalid_argument);
+    EXPECT_THROW(Version("9.8.7+meta+meta"), std::invalid_argument);
+    EXPECT_THROW(Version("9.8.7-whatever+meta+meta"), std::invalid_argument);
+    EXPECT_THROW(Version("99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12"), std::invalid_argument);
 }
 

--- a/tests/unittests/testVersion.cpp
+++ b/tests/unittests/testVersion.cpp
@@ -125,8 +125,10 @@ TEST(Version, Compare)
     EXPECT_FALSE(Version("1.0.0-beta.11") > Version("1.0.0-rc.1"));
     EXPECT_FALSE(Version("1.0.0-rc1") > Version("1.0.0"));
 
-    // we don't compare build versions yet
+    // Build Versions must be ignored
     EXPECT_TRUE(Version("1.2.3+1") == Version("1.2.3+2"));
+    EXPECT_TRUE(Version("1.2.3-alpha+1") == Version("1.2.3-alpha+2"));
+    EXPECT_TRUE(Version("1.2.3-alpha+2") < Version("1.2.3-beta+1"));
 }
 
 /**

--- a/tests/unittests/testVersion.cpp
+++ b/tests/unittests/testVersion.cpp
@@ -101,9 +101,13 @@ TEST(Version, Compare)
 
     EXPECT_TRUE(Version("1.2") < Version("1.2.3"));
 
+    // pre-release is always smaller than release version
+    EXPECT_TRUE(Version("1.2.3-alpha") < Version("1.2.3"));
+
     // we don't compare build or pre-release
     EXPECT_TRUE(Version("1.2.3+1") == Version("1.2.3+2"));
     EXPECT_TRUE(Version("1.2.3-beta") == Version("1.2.3-alpha"));
+
 }
 
 /**

--- a/tests/unittests/testVersion.cpp
+++ b/tests/unittests/testVersion.cpp
@@ -93,21 +93,40 @@ TEST(Version, Compare)
     EXPECT_TRUE(Version("2.2.3") > Version("1.2.3"));
     EXPECT_TRUE(Version("1.2.3") == Version("1.2.3"));
 
+    EXPECT_FALSE(Version("1.2.3") > Version("2.2.3"));
+    EXPECT_FALSE(Version("2.2.3") < Version("1.2.3"));
+
     // compare minor level
     EXPECT_TRUE(Version("1.2.3") < Version("1.3.0"));
+    EXPECT_FALSE(Version("1.2.3") > Version("1.3.0"));
 
     // compare patch level
     EXPECT_TRUE(Version("1.2.3") < Version("1.2.4"));
+    EXPECT_FALSE(Version("1.2.3") > Version("1.2.4"));
 
     EXPECT_TRUE(Version("1.2") < Version("1.2.3"));
+    EXPECT_FALSE(Version("1.2") > Version("1.2.3"));
 
-    // pre-release is always smaller than release version
-    EXPECT_TRUE(Version("1.2.3-alpha") < Version("1.2.3"));
+    // From https://semver.org/#spec-item-11:
+    // 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
+    EXPECT_TRUE(Version("1.0.0-alpha") < Version("1.0.0-alpha.1"));
+    EXPECT_TRUE(Version("1.0.0-alpha.1") < Version("1.0.0-alpha.beta"));
+    EXPECT_TRUE(Version("1.0.0-alpha.beta") < Version("1.0.0-beta"));
+    EXPECT_TRUE(Version("1.0.0-beta") < Version("1.0.0-beta.2"));
+    EXPECT_TRUE(Version("1.0.0-beta.2") < Version("1.0.0-beta.11"));
+    EXPECT_TRUE(Version("1.0.0-beta.11") < Version("1.0.0-rc.1"));
+    EXPECT_TRUE(Version("1.0.0-rc1") < Version("1.0.0"));
 
-    // we don't compare build or pre-release
+    EXPECT_FALSE(Version("1.0.0-alpha") > Version("1.0.0-alpha.1"));
+    EXPECT_FALSE(Version("1.0.0-alpha.1") > Version("1.0.0-alpha.beta"));
+    EXPECT_FALSE(Version("1.0.0-alpha.beta") > Version("1.0.0-beta"));
+    EXPECT_FALSE(Version("1.0.0-beta") > Version("1.0.0-beta.2"));
+    EXPECT_FALSE(Version("1.0.0-beta.2") > Version("1.0.0-beta.11"));
+    EXPECT_FALSE(Version("1.0.0-beta.11") > Version("1.0.0-rc.1"));
+    EXPECT_FALSE(Version("1.0.0-rc1") > Version("1.0.0"));
+
+    // we don't compare build versions yet
     EXPECT_TRUE(Version("1.2.3+1") == Version("1.2.3+2"));
-    EXPECT_TRUE(Version("1.2.3-beta") == Version("1.2.3-alpha"));
-
 }
 
 /**

--- a/tests/unittests/testVersion.cpp
+++ b/tests/unittests/testVersion.cpp
@@ -1,0 +1,103 @@
+/*
+* Copyright (C) 2021 German Aerospace Center (DLR/SC)
+*
+* Created: 2021-11-02 Martin Siggel <Martin.Siggel@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h"
+
+#include "Version.h"
+
+TEST(Version, MajorMinorPatch)
+{
+    const auto version = Version("1.2.3");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(3, version.vPatch());
+    EXPECT_STREQ("", version.vLabel().c_str());
+}
+
+TEST(Version, MajorMinor)
+{
+    const auto version = Version("1.2");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(0, version.vPatch());
+    EXPECT_STREQ("", version.vLabel().c_str());
+}
+
+TEST(Version, MajorMinorPatchLabel)
+{
+    const auto version = Version("1.2.3-beta");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(3, version.vPatch());
+    EXPECT_STREQ("beta", version.vLabel().c_str());
+}
+
+TEST(Version, MajorMinorPatchBuild)
+{
+    const auto version = Version("1.2.3+4");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(3, version.vPatch());
+    EXPECT_STREQ("", version.vLabel().c_str());
+    EXPECT_STREQ("4", version.vBuild().c_str());
+}
+
+TEST(Version, MajorMinorPatchLabelBuild)
+{
+    const auto version = Version("1.2.3-alpha+4");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(3, version.vPatch());
+    EXPECT_STREQ("alpha", version.vLabel().c_str());
+    EXPECT_STREQ("4", version.vBuild().c_str());
+}
+
+TEST(Version, MajorMinorBuild)
+{
+    const auto version = Version("1.2+4");
+    EXPECT_EQ(1, version.vMajor());
+    EXPECT_EQ(2, version.vMinor());
+    EXPECT_EQ(0, version.vPatch());
+    EXPECT_STREQ("", version.vLabel().c_str());
+    EXPECT_STREQ("4", version.vBuild().c_str());
+}
+
+TEST(Version, Compare)
+{
+    EXPECT_TRUE(Version("1.2.3") < Version("2.2.3"));
+    EXPECT_TRUE(Version("2.2.3") > Version("1.2.3"));
+    EXPECT_TRUE(Version("1.2.3") == Version("1.2.3"));
+
+    // compare minor level
+    EXPECT_TRUE(Version("1.2.3") < Version("1.3.0"));
+
+    // compare patch level
+    EXPECT_TRUE(Version("1.2.3") < Version("1.2.4"));
+
+    EXPECT_TRUE(Version("1.2") < Version("1.2.3"));
+
+    // we don't compare build or pre-release
+    EXPECT_TRUE(Version("1.2.3+1") == Version("1.2.3+2"));
+    EXPECT_TRUE(Version("1.2.3-beta") == Version("1.2.3-alpha"));
+}
+
+TEST(Version, InvalidFormat)
+{
+    EXPECT_THROW(Version("1"), std::invalid_argument);
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed parsing the cpacs version.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the cpacs version could not be parsed correctly, if a patch level version was included in the version string.

This PR adds proper semantic versioning. A new class for parsing semantic versions based on std::regex has been added. Tests have been added accordingly.

Fixes #830 

## How Has This Been Tested?

I added tests for the new semantic versioning class and tests that check opening the cpacs files with correct and incorrect cpacs versions.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.

