### PR TITLE
Fixed incorrect computation of wing aspect ratio

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,16 +8,18 @@ xx/11/2021
 - Highlights / General changes:
 
   - Added support for canard style flaps. This allows to position the hinge points
-    outside of the wing by providing an additional translation vector.
+    outside of the wing by providing an additional translation vector (issue #816).
 
 - Fixes:
 
-  - Fixed CPACS versions header not correctly parsed, if the version number contained a patch version.
-  - Fixed multiple errors that occured during the computation of wing cells.
+  - Fixed CPACS versions header not correctly parsed, if the version number contained a patch version (issue #830).
+  - Fixed multiple errors that occured during the computation of wing cells (issues #815, #829, #840).
+  - Fixed computation of the wing aspect ratio (issue #827).
 
 - Bindings:
   - Added python 3.9 conda packages 
-  - Fixed loading python bindings with python 3.8 due to a changed DLL loading policy.
+  - Fixed loading python bindings with python 3.8 due to a changed DLL loading policy (issue #842).
+  - Fixed a crash in the python bindings due to wrong memory handling (issue #823).
 
 Version 3.2.1
 -------------

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -148,6 +148,20 @@ typedef enum TiglBoolean TiglBoolean;
 
 /**
  \ingroup Enums
+  Definition of Axis used in TIGL.
+*/
+enum TiglAxis
+{
+    TIGL_NO_AXIS = 0,
+    TIGL_X_AXIS = 1,
+    TIGL_Y_AXIS = 2,
+    TIGL_Z_AXIS = 3
+};
+
+typedef enum TiglAxis TiglAxis;
+
+/**
+ \ingroup Enums
   Definition of Symmetry Axis used in TIGL.
 */
 enum TiglSymmetryAxis

--- a/src/geometry/CTiglAbstractGeometricComponent.cpp
+++ b/src/geometry/CTiglAbstractGeometricComponent.cpp
@@ -60,7 +60,7 @@ Bnd_Box const& CTiglAbstractGeometricComponent::GetBoundingBox() const
     return *bounding_box;
 }
 
-PNamedShape CTiglAbstractGeometricComponent::GetMirroredLoft()
+PNamedShape CTiglAbstractGeometricComponent::GetMirroredLoft() const
 {
     const TiglSymmetryAxis& symmetryAxis = GetSymmetryAxis();
     if (symmetryAxis == TIGL_NO_SYMMETRY) {
@@ -89,7 +89,7 @@ PNamedShape CTiglAbstractGeometricComponent::GetMirroredLoft()
     return mirroredShape;
 }
 
-bool CTiglAbstractGeometricComponent::GetIsOn(const gp_Pnt& pnt) 
+bool CTiglAbstractGeometricComponent::GetIsOn(const gp_Pnt& pnt) const
 {
     const TopoDS_Shape segmentShape = GetLoft()->Shape();
 
@@ -120,7 +120,7 @@ bool CTiglAbstractGeometricComponent::GetIsOn(const gp_Pnt& pnt)
     }
 }
 
-bool CTiglAbstractGeometricComponent::GetIsOnMirrored(const gp_Pnt& pnt) 
+bool CTiglAbstractGeometricComponent::GetIsOnMirrored(const gp_Pnt& pnt) const
 {
     const TiglSymmetryAxis& symmetryAxis = GetSymmetryAxis();
     if (symmetryAxis == TIGL_NO_SYMMETRY) {

--- a/src/geometry/CTiglAbstractGeometricComponent.h
+++ b/src/geometry/CTiglAbstractGeometricComponent.h
@@ -49,14 +49,14 @@ public:
     TIGL_EXPORT PNamedShape GetLoft() const override;
 
     // Get the loft mirrored at the mirror plane
-    TIGL_EXPORT virtual PNamedShape GetMirroredLoft();
+    TIGL_EXPORT virtual PNamedShape GetMirroredLoft() const;
 
     // return if pnt lies on the loft
-    TIGL_EXPORT virtual bool GetIsOn(const gp_Pnt &pnt);
+    TIGL_EXPORT virtual bool GetIsOn(const gp_Pnt &pnt) const;
     
     // return if pnt lies on the mirrored loft
     // if the loft as no symmetry, false is returned
-    TIGL_EXPORT bool GetIsOnMirrored(const gp_Pnt &pnt);
+    TIGL_EXPORT bool GetIsOnMirrored(const gp_Pnt &pnt) const;
 
     // returns the bounding box of this component's loft
     TIGL_EXPORT Bnd_Box const& GetBoundingBox() const;

--- a/src/math/tiglmathfunctions.cpp
+++ b/src/math/tiglmathfunctions.cpp
@@ -452,4 +452,9 @@ double Interpolate(const std::vector<double>& xdata, const std::vector<double>& 
     return y;
 }
 
+bool isNear(double a, double b, double epsilon)
+{
+    return (fabs(a - b) <= epsilon);
+}
+
 } // namespace tigl

--- a/src/math/tiglmathfunctions.h
+++ b/src/math/tiglmathfunctions.h
@@ -23,6 +23,7 @@
 #include "tigl_internal.h"
 #include <vector>
 #include <math_Vector.hxx>
+#include <Precision.hxx>
 #include "tiglMatrix.h"
 
 namespace tigl 
@@ -127,6 +128,14 @@ TIGL_EXPORT double cstcurve(const double& N1, const double& N2, const std::vecto
  */
 TIGL_EXPORT double cstcurve_deriv(const double& N1, const double& N2, const std::vector<double>& B, const double& T, const int& n, const double& x);
 
+/**
+ * Return true if the value of a is similar to b
+ * @param a
+ * @param b
+ * @param epsilon
+ * @return
+ */
+TIGL_EXPORT bool isNear(double a, double b, double epsilon = Precision::Confusion());
 
 /**
  * 1D Function interface accepting one parameter t and returning

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -539,8 +539,8 @@ double CCPACSWing::GetReferenceArea(TiglSymmetryAxis symPlane) const
 
 double CCPACSWing::GetReferenceArea() const
 {
-    TiglAxis spanDir = winghelper::GetMajorDirection(*this);
-    TiglAxis deepDir = winghelper::GetDeepDirection(*this);
+    TiglAxis spanDir = winghelper::GetWingSpanAxis(*this);
+    TiglAxis deepDir = winghelper::GetWingDepthAxis(*this);
 
     if (spanDir == TIGL_Y_AXIS && deepDir == TIGL_X_AXIS) {
         return GetReferenceArea(TIGL_X_Y_PLANE);

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -536,7 +536,7 @@ double CCPACSWing::GetSurfaceArea()
 
 // Returns the reference area of the wing by taking account the quadrilateral portions
 // of each wing segment by projecting the wing segments into the plane defined by the user
-double CCPACSWing::GetReferenceArea(TiglSymmetryAxis symPlane)
+double CCPACSWing::GetReferenceArea(TiglSymmetryAxis symPlane) const
 {
     double refArea = 0.0;
 
@@ -547,7 +547,7 @@ double CCPACSWing::GetReferenceArea(TiglSymmetryAxis symPlane)
 }
 
 
-double CCPACSWing::GetWettedArea(TopoDS_Shape parent)
+double CCPACSWing::GetWettedArea(TopoDS_Shape parent) const
 {
     const TopoDS_Shape loft = GetLoft()->Shape();
 
@@ -572,7 +572,7 @@ Handle(Geom_Surface) CCPACSWing::GetUpperSegmentSurface(int index)
     return m_segments.GetSegment(index).GetUpperSurface();
 }
 
-double CCPACSWing::GetWingspan()
+double CCPACSWing::GetWingspan() const
 {
     Bnd_Box boundingBox;
     if (GetSymmetryAxis() == TIGL_NO_SYMMETRY) {
@@ -590,7 +590,7 @@ double CCPACSWing::GetWingspan()
         gp_XYZ cumulatedSpanDirection(0, 0, 0);
         gp_XYZ cumulatedDepthDirection(0, 0, 0);
         for (int i = 1; i <= GetSegmentCount(); ++i) {
-            CCPACSWingSegment& segment = m_segments.GetSegment(i);
+            const CCPACSWingSegment& segment = m_segments.GetSegment(i);
             const TopoDS_Shape segmentShape = segment.GetLoft()->Shape();
             BRepBndLib::Add(segmentShape, boundingBox);
 
@@ -601,7 +601,7 @@ double CCPACSWing::GetWingspan()
             cumulatedSpanDirection += dirSpan;
             cumulatedDepthDirection += dirDepth;
         }
-        CCPACSWingSegment& outerSegment = m_segments.GetSegment(GetSegmentCount());
+        const CCPACSWingSegment& outerSegment = m_segments.GetSegment(GetSegmentCount());
         gp_XYZ dirDepth = outerSegment.GetChordPoint(1,1).XYZ() - outerSegment.GetChordPoint(1,0).XYZ();
         dirDepth = gp_XYZ(fabs(dirDepth.X()), fabs(dirDepth.Y()), fabs(dirDepth.Z()));
         cumulatedDepthDirection += dirDepth;
@@ -631,7 +631,7 @@ double CCPACSWing::GetWingspan()
     }
     else {
         for (int i = 1; i <= GetSegmentCount(); ++i) {
-            CCPACSWingSegment& segment = GetSegment(i);
+            const CCPACSWingSegment& segment = GetSegment(i);
             TopoDS_Shape segmentShape = segment.GetLoft()->Shape();
             BRepBndLib::Add(segmentShape, boundingBox);
             TopoDS_Shape segmentMirroredShape = segment.GetMirroredLoft()->Shape();
@@ -660,7 +660,7 @@ double CCPACSWing::GetWingspan()
 // Returns the aspect ratio of a wing: AR=b**2/A=((2s)**2)/(2A_half)
 //     b: full span; A: Reference area of full wing (wing + symmetrical wing)
 //     s: half span; A_half: Reference area of wing without symmetrical wing
-double CCPACSWing::GetAspectRatio()
+double CCPACSWing::GetAspectRatio() const
 {
     return 2.0*(pow_int(GetWingspan(),2)/GetReferenceArea(GetSymmetryAxis()));
 }
@@ -673,7 +673,7 @@ double CCPACSWing::GetAspectRatio()
     * But the effect of insidance angle is neglected. These values should coincide
     * with the values found with tornado tool.
     */
-void  CCPACSWing::GetWingMAC(double& mac_chord, double& mac_x, double& mac_y, double& mac_z)
+void  CCPACSWing::GetWingMAC(double& mac_chord, double& mac_x, double& mac_y, double& mac_z) const
 {
     double A_sum = 0.;
     double cc_mac_sum=0.;

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -125,6 +125,9 @@ public:
     // of each wing segment by projecting the wing segments into the plane defined by the user
     TIGL_EXPORT double GetReferenceArea(TiglSymmetryAxis symPlane) const;
 
+    // Returns the reference area of the wing in the plane normal to the major direction
+    TIGL_EXPORT double GetReferenceArea() const;
+
     // Returns wetted Area
     TIGL_EXPORT double GetWettedArea(TopoDS_Shape parent) const;
 

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -123,19 +123,19 @@ public:
 
     // Returns the reference area of the wing by taking account the drilateral portions
     // of each wing segment by projecting the wing segments into the plane defined by the user
-    TIGL_EXPORT double GetReferenceArea(TiglSymmetryAxis symPlane);
+    TIGL_EXPORT double GetReferenceArea(TiglSymmetryAxis symPlane) const;
 
     // Returns wetted Area
-    TIGL_EXPORT double GetWettedArea(TopoDS_Shape parent);
+    TIGL_EXPORT double GetWettedArea(TopoDS_Shape parent) const;
 
     // Returns the wingspan of the wing
-    TIGL_EXPORT double GetWingspan();
+    TIGL_EXPORT double GetWingspan() const;
 
     // Returns the aspect ratio of the wing
-    TIGL_EXPORT double GetAspectRatio();
+    TIGL_EXPORT double GetAspectRatio() const;
 
     // Returns the mean aerodynamic chord of the wing
-    TIGL_EXPORT void  GetWingMAC(double& mac_chord, double& mac_x, double& mac_y, double& mac_z);
+    TIGL_EXPORT void  GetWingMAC(double& mac_chord, double& mac_x, double& mac_y, double& mac_z) const;
 
     // Calculates the segment coordinates from global (x,y,z) coordinates
     // Returns the segment index of the according segment

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -985,7 +985,7 @@ bool CCPACSWingSegment::GetIsOnTop(gp_Pnt pnt) const
 }
 
 
-bool CCPACSWingSegment::GetIsOn(const gp_Pnt& pnt)
+bool CCPACSWingSegment::GetIsOn(const gp_Pnt& pnt) const
 {
     bool isOnLoft = CTiglAbstractSegment<CCPACSWingSegment>::GetIsOn(pnt);
 

--- a/src/wing/CCPACSWingSegment.h
+++ b/src/wing/CCPACSWingSegment.h
@@ -164,7 +164,7 @@ public:
     TIGL_EXPORT bool GetIsOnTop(gp_Pnt pnt) const;
 
     // return if pnt lies on the loft or on the segment chord face
-    TIGL_EXPORT bool GetIsOn(const gp_Pnt &pnt) override;
+    TIGL_EXPORT bool GetIsOn(const gp_Pnt &pnt) const override;
 
     // Returns the reference area of the quadrilateral portion of the wing segment
     // by projecting the wing segment into the plane defined by the user

--- a/src/wing/TiglWingHelperFunctions.cpp
+++ b/src/wing/TiglWingHelperFunctions.cpp
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2019 CFS Engineering
+ *
+ * Created: 2019 Malo Drougard <malo.drougard@protonmail.com>
+ * Author: Malo Drougard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 #include "TiglWingHelperFunctions.h"
 
 #include "tigl.h"

--- a/src/wing/TiglWingHelperFunctions.cpp
+++ b/src/wing/TiglWingHelperFunctions.cpp
@@ -1,0 +1,118 @@
+#include "TiglWingHelperFunctions.h"
+
+#include "tigl.h"
+#include "CCPACSWingSegment.h"
+
+namespace tigl
+{
+
+namespace winghelper
+{
+
+bool HasShape(const tigl::CCPACSWing& wing)
+{
+    return wing.GetSegmentCount() > 0;
+
+}
+
+TiglAxis GetDeepDirection(const tigl::CCPACSWing& wing)
+{
+    if (!HasShape(wing)) {
+        LOG(WARNING) << "CTiglWingHelper::GetDeepDirection: This wing has no shape -> impossible to determine the "
+                        "direction properly. The default direction will be returned";
+        return TIGL_X_AXIS;
+    }
+
+    gp_XYZ cumulatedDepthDirection(0, 0, 0);
+    for (int i = 1; i <= wing.GetSegmentCount(); ++i) {
+        const CCPACSWingSegment& segment = wing.GetSegment(i);
+        gp_XYZ dirDepth                  = segment.GetChordPoint(0, 1).XYZ() - segment.GetChordPoint(0, 0).XYZ();
+        dirDepth                         = gp_XYZ(fabs(dirDepth.X()), fabs(dirDepth.Y()), fabs(dirDepth.Z()));
+        cumulatedDepthDirection += dirDepth;
+    }
+    const CCPACSWingSegment& outerSegment = wing.GetSegment(wing.GetSegmentCount());
+    gp_XYZ dirDepth = outerSegment.GetChordPoint(1, 1).XYZ() - outerSegment.GetChordPoint(1, 0).XYZ();
+    dirDepth        = gp_XYZ(fabs(dirDepth.X()), fabs(dirDepth.Y()), fabs(dirDepth.Z()));
+    cumulatedDepthDirection += dirDepth;
+
+    switch (GetMajorDirection(wing)) {
+    case TIGL_Y_AXIS:
+        return cumulatedDepthDirection.X() >= cumulatedDepthDirection.Z() ? TiglAxis::TIGL_X_AXIS
+                                                                          : TiglAxis::TIGL_Z_AXIS;
+    case TIGL_Z_AXIS:
+        return cumulatedDepthDirection.X() >= cumulatedDepthDirection.Y() ? TiglAxis::TIGL_X_AXIS
+                                                                          : TiglAxis::TIGL_Y_AXIS;
+    case TIGL_X_AXIS:
+        return cumulatedDepthDirection.Z() >= cumulatedDepthDirection.Y() ? TiglAxis::TIGL_Z_AXIS
+                                                                          : TiglAxis::TIGL_Y_AXIS;
+    default:
+        return TiglAxis ::TIGL_X_AXIS;
+    }
+}
+
+TiglAxis GetMajorDirection(const CCPACSWing& wing)
+{
+    if (!HasShape(wing)) {
+        LOG(WARNING) << "CTiglWingHelper::GetMajorDirection: This wing has no shape -> impossible to determine the "
+                        "direction properly. The default direction will be returned";
+        return TIGL_Y_AXIS;
+    }
+
+    switch (wing.GetSymmetryAxis()) {
+    case TIGL_X_Y_PLANE:
+        return TiglAxis::TIGL_Z_AXIS;
+    case TIGL_X_Z_PLANE:
+        return TiglAxis::TIGL_Y_AXIS;
+    case TIGL_Y_Z_PLANE:
+        return TiglAxis ::TIGL_X_AXIS;
+    default:
+        // heuristic to find the best major axis
+        // first find the deep axis , then chose the major axis between the two left axis
+        gp_XYZ cumulatedSpanDirection(0, 0, 0);
+        gp_XYZ cumulatedDepthDirection(0, 0, 0);
+        for (int i = 1; i <= wing.GetSegmentCount(); ++i) {
+            const CCPACSWingSegment& segment = wing.GetSegment(i);
+            gp_XYZ dirSpan                   = segment.GetChordPoint(1, 0).XYZ() - segment.GetChordPoint(0, 0).XYZ();
+            gp_XYZ dirDepth                  = segment.GetChordPoint(0, 1).XYZ() - segment.GetChordPoint(0, 0).XYZ();
+            dirSpan  = gp_XYZ(fabs(dirSpan.X()), fabs(dirSpan.Y()), fabs(dirSpan.Z())); // why we use abs value?
+            dirDepth = gp_XYZ(fabs(dirDepth.X()), fabs(dirDepth.Y()), fabs(dirDepth.Z()));
+            cumulatedSpanDirection += dirSpan;
+            cumulatedDepthDirection += dirDepth;
+        }
+        const CCPACSWingSegment& outerSegment = wing.GetSegment(wing.GetSegmentCount());
+        gp_XYZ dirDepth = outerSegment.GetChordPoint(1, 1).XYZ() - outerSegment.GetChordPoint(1, 0).XYZ();
+        dirDepth        = gp_XYZ(fabs(dirDepth.X()), fabs(dirDepth.Y()), fabs(dirDepth.Z()));
+        cumulatedDepthDirection += dirDepth;
+
+        int depthIndex = 0;
+        if (cumulatedDepthDirection.X() >= cumulatedDepthDirection.Y() &&
+            cumulatedDepthDirection.X() >= cumulatedDepthDirection.Z()) {
+            depthIndex = 0;
+        }
+        else if (cumulatedDepthDirection.Y() >= cumulatedDepthDirection.X() &&
+                 cumulatedDepthDirection.Y() >= cumulatedDepthDirection.Z()) {
+            depthIndex = 1;
+        }
+        else {
+            depthIndex = 2;
+        }
+
+        switch (depthIndex) {
+        case 0:
+            return cumulatedSpanDirection.Y() >= cumulatedSpanDirection.Z() ? TiglAxis::TIGL_Y_AXIS
+                                                                            : TiglAxis::TIGL_Z_AXIS;
+        case 1:
+            return cumulatedSpanDirection.X() >= cumulatedSpanDirection.Z() ? TiglAxis::TIGL_X_AXIS
+                                                                            : TiglAxis::TIGL_Z_AXIS;
+        case 2:
+            return cumulatedSpanDirection.X() >= cumulatedSpanDirection.Y() ? TiglAxis::TIGL_X_AXIS
+                                                                            : TiglAxis::TIGL_Y_AXIS;
+        default:
+            return TiglAxis ::TIGL_Y_AXIS;
+        }
+    }
+}
+
+} // namespace winghelper
+
+} // namespace tigl

--- a/src/wing/TiglWingHelperFunctions.h
+++ b/src/wing/TiglWingHelperFunctions.h
@@ -29,13 +29,30 @@ namespace tigl
 namespace winghelper
 {
 
- // Returns the deep direction of the wing
-TiglAxis GetDeepDirection(const tigl::CCPACSWing& wing);
+/**
+ * Returns the depth direction of the wing
+ *
+ * Note: this is a heuristic that is determined by the wing shape
+ * and its position in 3D space.
+ *
+ * TODO: In future we need do define on the cpacs basis the projection
+ * plane of the wing
+ */
+TiglAxis GetWingDepthAxis(const tigl::CCPACSWing& wing);
 
-// Returns the major direction of the wing (correspond to the span direction)
-// @Details: If a symmetry plan is set, the major direction is normal to the symmetry plan,
-// otherwise, an heuristic is used to find out the best span axis candidate.
-TiglAxis GetMajorDirection(const tigl::CCPACSWing& wing);
+/**
+ * Returns the major direction of the wing (correspond to the span direction)
+ *
+ * @Details: If a symmetry plan is set, the major direction is normal to the symmetry plan,
+ * otherwise, an heuristic is used to find out the best span axis candidate.
+ *
+ * Note: this is a heuristic that is determined by the wing shape
+ * and its position in 3D space.
+ *
+ * TODO: In future we need do define on the cpacs basis the projection
+ * plane of the wing
+ */
+TiglAxis GetWingSpanAxis(const tigl::CCPACSWing& wing);
 
 } // namespace winghelper
 

--- a/src/wing/TiglWingHelperFunctions.h
+++ b/src/wing/TiglWingHelperFunctions.h
@@ -1,0 +1,24 @@
+#ifndef TIGLWINGHELPERFUNCTIONS_H
+#define TIGLWINGHELPERFUNCTIONS_H
+
+#include <CCPACSWing.h>
+
+namespace tigl
+{
+
+namespace winghelper
+{
+
+ // Returns the deep direction of the wing
+TiglAxis GetDeepDirection(const tigl::CCPACSWing& wing);
+
+// Returns the major direction of the wing (correspond to the span direction)
+// @Details: If a symmetry plan is set, the major direction is normal to the symmetry plan,
+// otherwise, an heuristic is used to find out the best span axis candidate.
+TiglAxis GetMajorDirection(const tigl::CCPACSWing& wing);
+
+} // namespace winghelper
+
+} // namespace tigl
+
+#endif // TIGLWINGHELPERFUNCTIONS_H

--- a/src/wing/TiglWingHelperFunctions.h
+++ b/src/wing/TiglWingHelperFunctions.h
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2019 CFS Engineering
+ *
+ * Created: 2019 Malo Drougard <malo.drougard@protonmail.com>
+ * Author: Malo Drougard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 #ifndef TIGLWINGHELPERFUNCTIONS_H
 #define TIGLWINGHELPERFUNCTIONS_H
 

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -358,6 +358,9 @@ TEST_F(TiglWing, spanDirection)
     axis = tigl::winghelper::GetWingSpanAxis(vtp);
     EXPECT_EQ(TIGL_Z_AXIS, axis);
 
+    auto wingSymAx = wing.GetSymmetryAxis();
+    auto vtpSymAx = vtp.GetSymmetryAxis();
+
     wing.SetSymmetryAxis(TIGL_NO_SYMMETRY);
     vtp.SetSymmetryAxis(TIGL_X_Y_PLANE);
 
@@ -366,6 +369,11 @@ TEST_F(TiglWing, spanDirection)
 
     axis = tigl::winghelper::GetWingSpanAxis(vtp);
     EXPECT_EQ(TIGL_Z_AXIS, axis);
+
+    // we need to reset the axes, since the cpacs handle
+    // is static for all tests
+    wing.SetSymmetryAxis(wingSymAx);
+    vtp.SetSymmetryAxis(vtpSymAx);
 }
 
 TEST_F(TiglWing, depthDirection)
@@ -383,6 +391,9 @@ TEST_F(TiglWing, depthDirection)
     axis = tigl::winghelper::GetWingDepthAxis(vtp);
     EXPECT_EQ(TIGL_X_AXIS, axis);
 
+    auto wingSymAx = wing.GetSymmetryAxis();
+    auto vtpSymAx = vtp.GetSymmetryAxis();
+
     wing.SetSymmetryAxis(TIGL_NO_SYMMETRY);
     vtp.SetSymmetryAxis(TIGL_X_Y_PLANE);
 
@@ -391,6 +402,11 @@ TEST_F(TiglWing, depthDirection)
 
     axis = tigl::winghelper::GetWingDepthAxis(vtp);
     EXPECT_EQ(TIGL_X_AXIS, axis);
+
+    // we need to reset the axes, since the cpacs handle
+    // is static for all tests
+    wing.SetSymmetryAxis(wingSymAx);
+    vtp.SetSymmetryAxis(vtpSymAx);
 }
 
 TEST_F(WingSimple, wingGetMAC_success)

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -334,6 +334,12 @@ TEST_F(TiglWing, tiglGetAspectRatio)
     // The exact value also depends on the opencascade version
     // used so we are using a pretty large tolerance here
     EXPECT_NEAR(9.4031, wing.GetAspectRatio(), 1e-2);
+
+    const auto& vtp = config.GetWing(3);
+
+    // This value was roughly estimated
+    EXPECT_NEAR(3.2, vtp.GetAspectRatio(), 1e-1);
+
 }
 
 TEST_F(WingSimple, wingGetMAC_success)

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -24,7 +24,6 @@
 #include <string.h>
 #include <CCPACSConfigurationManager.h>
 
-
 /******************************************************************************/
 
 class TiglWing : public ::testing::Test 
@@ -282,14 +281,16 @@ TEST_F(TiglWing, tiglWingGetSegmentIndex_nullPtr)
     ASSERT_TRUE(tiglWingGetSegmentIndex(tiglHandle, "D150_VAMP_W1_Seg1", &segmentIndex, NULL) == TIGL_NULL_POINTER);
 }
 
-TEST_F(TiglWing, tiglWingGetSegmentIndex_wrongHandle){
+TEST_F(TiglWing, tiglWingGetSegmentIndex_wrongHandle)
+{
     TiglCPACSConfigurationHandle myWrongHandle = -1234;
     int segmentIndex = 0;
     int wingIndex = 0;
     ASSERT_TRUE(tiglWingGetSegmentIndex(myWrongHandle, "D150_VAMP_W1_Seg1", &segmentIndex, &wingIndex) == TIGL_NOT_FOUND);
 }
 
-TEST_F(TiglWing, tiglWingGetSpanVTP){
+TEST_F(TiglWing, tiglWingGetSpanVTP)
+{
     double span = 0.;
     tiglWingGetSpan(tiglHandle, "D150_VAMP_SL1", &span);
     ASSERT_LT(span, 5.9);
@@ -301,6 +302,7 @@ TEST_F(TiglWing, tiglWingGetSpanVTP){
  * behaviour while invalidating the wing
  */
 TEST_F(TiglWing, bug849)
+
 {
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
@@ -318,6 +320,16 @@ TEST_F(TiglWing, bug849)
 
     auto span = vtp.GetWingspan();
     EXPECT_NEAR(5.9, span, 0.1); // the reported wing span is 0.62 instead of 5.4
+}
+
+TEST_F(TiglWing, tiglGetAspectRatio)
+{
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
+
+    const auto& wing = config.GetWing(1);
+    auto ar = wing.GetAspectRatio();
+    EXPECT_NEAR(9.4, ar, 0.1);
 }
 
 

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -23,6 +23,7 @@
 #include "tigl.h"
 #include <string.h>
 #include <CCPACSConfigurationManager.h>
+#include <TiglWingHelperFunctions.h>
 
 /******************************************************************************/
 
@@ -340,6 +341,56 @@ TEST_F(TiglWing, tiglGetAspectRatio)
     // This value was roughly estimated
     EXPECT_NEAR(3.2, vtp.GetAspectRatio(), 1e-1);
 
+}
+
+TEST_F(TiglWing, spanDirection)
+{
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
+
+    auto& wing = config.GetWing(1);
+    auto& vtp = config.GetWing(3);
+
+    auto axis = tigl::winghelper::GetWingSpanAxis(wing);
+    EXPECT_EQ(TIGL_Y_AXIS, axis);
+
+
+    axis = tigl::winghelper::GetWingSpanAxis(vtp);
+    EXPECT_EQ(TIGL_Z_AXIS, axis);
+
+    wing.SetSymmetryAxis(TIGL_NO_SYMMETRY);
+    vtp.SetSymmetryAxis(TIGL_X_Y_PLANE);
+
+    axis = tigl::winghelper::GetWingSpanAxis(wing);
+    EXPECT_EQ(TIGL_Y_AXIS, axis);
+
+    axis = tigl::winghelper::GetWingSpanAxis(vtp);
+    EXPECT_EQ(TIGL_Z_AXIS, axis);
+}
+
+TEST_F(TiglWing, depthDirection)
+{
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
+
+    auto& wing = config.GetWing(1);
+    auto& vtp = config.GetWing(3);
+
+    auto axis = tigl::winghelper::GetWingDepthAxis(wing);
+    EXPECT_EQ(TIGL_X_AXIS, axis);
+
+
+    axis = tigl::winghelper::GetWingDepthAxis(vtp);
+    EXPECT_EQ(TIGL_X_AXIS, axis);
+
+    wing.SetSymmetryAxis(TIGL_NO_SYMMETRY);
+    vtp.SetSymmetryAxis(TIGL_X_Y_PLANE);
+
+    axis = tigl::winghelper::GetWingDepthAxis(wing);
+    EXPECT_EQ(TIGL_X_AXIS, axis);
+
+    axis = tigl::winghelper::GetWingDepthAxis(vtp);
+    EXPECT_EQ(TIGL_X_AXIS, axis);
 }
 
 TEST_F(WingSimple, wingGetMAC_success)

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -331,7 +331,9 @@ TEST_F(TiglWing, tiglGetAspectRatio)
     const auto& wing = config.GetWing(1);
 
     // The expected value was provided by the issue report
-    EXPECT_NEAR(9.4031, wing.GetAspectRatio(), 1e-4);
+    // The exact value also depends on the opencascade version
+    // used so we are using a pretty large tolerance here
+    EXPECT_NEAR(9.4031, wing.GetAspectRatio(), 1e-2);
 }
 
 TEST_F(WingSimple, wingGetMAC_success)

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -322,16 +322,17 @@ TEST_F(TiglWing, bug849)
     EXPECT_NEAR(5.9, span, 0.1); // the reported wing span is 0.62 instead of 5.4
 }
 
+/// Regression reported by issue #827
 TEST_F(TiglWing, tiglGetAspectRatio)
 {
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
 
     const auto& wing = config.GetWing(1);
-    auto ar = wing.GetAspectRatio();
-    EXPECT_NEAR(9.4, ar, 0.1);
-}
 
+    // The expected value was provided by the issue report
+    EXPECT_NEAR(9.4031, wing.GetAspectRatio(), 1e-4);
+}
 
 TEST_F(WingSimple, wingGetMAC_success)
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The computation of  the aspect ratio need to project the wing to a planform . The plane to be projected is typically the x-y plane. In cpacs however, users have the freedom to build the aircraft in another (rotated) way, so using the x-y plane is too restrictive.

The bug occured, because a wrong projection plane was selected. This led to a very small wing surface area and hence a large aspect ratio. 

This code change fixes the issue by improving the selection of the projection plane. The code was back-ported from CPACS Creator, were the issue was already fixed before.

Closes #827 

## How Has This Been Tested?
A system test was added checking roughly the correct AR value.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.

