### PR TITLE
Fix strange invalidation side effect for wings

### DIFF
--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -141,7 +141,6 @@ void CCPACSWing::InvalidateImpl(const boost::optional<std::string>& source) cons
     rebuildShells = true;
     rebuildFusedSegWEdge = true;
 
-    Reset();
     loft.clear();
     guideCurves.clear();
     wingCleanShape.clear();

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -22,6 +22,7 @@
 #include "test.h" // Brings in the GTest framework
 #include "tigl.h"
 #include <string.h>
+#include <CCPACSConfigurationManager.h>
 
 
 /******************************************************************************/
@@ -293,6 +294,30 @@ TEST_F(TiglWing, tiglWingGetSpanVTP){
     tiglWingGetSpan(tiglHandle, "D150_VAMP_SL1", &span);
     ASSERT_LT(span, 5.9);
     ASSERT_GT(span, 5.8);
+}
+
+/**
+ * This test replicates issue 849, which showed a strange
+ * behaviour while invalidating the wing
+ */
+TEST_F(TiglWing, bug849)
+{
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
+
+    auto& vtp = config.GetWing(3);
+
+    // somehow, this generates something
+    // removing this line maade the test succeed
+    // otherwise, the test failed
+    vtp.GetWingspan();
+
+    // which is not correctly invalidated now
+    // note, that we actually don't change anything
+    vtp.SetSymmetryAxis(vtp.GetSymmetryAxis());
+
+    auto span = vtp.GetWingspan();
+    EXPECT_NEAR(5.9, span, 0.1); // the reported wing span is 0.62 instead of 5.4
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The wing invalidation logic contained a reset, which is simply wrong. Invalidation should only affect cached values and not change any other values. Removing Reset fixes the bug.

Fixes #849 

## How Has This Been Tested?
I added a unit test that should check this in future.




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.

