### PR TITLE
Improved robustness of CAD export

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,8 @@ xx/11/2021
   - Fixed multiple errors that occured during the computation of wing cells (issues #815, #829, #840).
   - Fixed computation of the wing aspect ratio (issue #827).
   - Fixed crashes in TiGL Viewer when displaying control surface devices (issue #851).
+  - Improved robustness of export functions. The export now tries to export as much as possible,
+    even if one component failed to built (issue #853).
 
 - Bindings:
   - Added python 3.9 conda packages 

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -111,6 +111,7 @@ double getAbsDeflection (const TopoDS_Shape& theShape, double relDeflection)
     return aDeflection;
 }
 
+
 TIGLViewerDocument::TIGLViewerDocument(TIGLViewerWindow *parentWidget)
     : QObject(parentWidget)
     , m_flapsDialog(new TIGLViewerSelectWingAndFlapStatusDialog(this, parentWidget))
@@ -134,6 +135,11 @@ void TIGLViewerDocument::writeToStatusBar(const QString& text)
 void TIGLViewerDocument::displayError(const QString& text, const QString& header)
 {
     app->displayErrorMessage(text, header);
+}
+
+void TIGLViewerDocument::displayTiglError(const QString& msg, TiglReturnCode ret)
+{
+    displayError(QString("%1 Error code: %2").arg(msg).arg(tiglGetErrorString(ret)), "TIGL Error");
 }
 
 
@@ -1231,7 +1237,7 @@ void TIGLViewerDocument::exportAsIges()
         START_COMMAND()
         TiglReturnCode err = tiglExportIGES(m_cpacsHandle, qstringToCstring(fileName));
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportIGES</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportIGES</u>", err);
         }
     }
 }
@@ -1252,7 +1258,7 @@ void TIGLViewerDocument::exportFusedAsIges()
         START_COMMAND()
         TiglReturnCode err = tiglExportFusedWingFuselageIGES(m_cpacsHandle, qstringToCstring(fileName));
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportFusedWingFuselageIGES</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportFusedWingFuselageIGES</u>.", err);
         }
     }
 }
@@ -1271,7 +1277,7 @@ void TIGLViewerDocument::exportAsStep()
         START_COMMAND()
         TiglReturnCode err = tiglExportSTEP(m_cpacsHandle, qstringToCstring(fileName));
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportSTEP</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportSTEP</u>.", err);
         }
     }
 }
@@ -1288,7 +1294,7 @@ void TIGLViewerDocument::exportAsStepFused()
         START_COMMAND()
         TiglReturnCode err = tiglExportFusedSTEP(m_cpacsHandle, qstringToCstring(fileName));
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportFusedSTEP</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportFusedSTEP</u>.", err);
         }
     }
 }
@@ -1313,7 +1319,7 @@ void TIGLViewerDocument::exportMeshedWingSTL()
         double deflection = wing.GetWingspan()/2. * TIGLViewerSettings::Instance().triangulationAccuracy();
         TiglReturnCode err = tiglExportMeshedWingSTLByUID(m_cpacsHandle, qstringToCstring(wingUid), qstringToCstring(fileName), deflection);
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportMeshedWingSTLByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportMeshedWingSTLByUID</u>.", err);
         }
     }
 }
@@ -1337,7 +1343,7 @@ void TIGLViewerDocument::exportMeshedFuselageSTL()
         START_COMMAND()
         TiglReturnCode err = tiglExportMeshedFuselageSTLByUID(m_cpacsHandle, qstringToCstring(fuselageUid), qstringToCstring(fileName), TIGLViewerSettings::Instance().triangulationAccuracy());
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportMeshedFuselageSTLByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportMeshedFuselageSTLByUID</u>.", err);
         }
     }
 }
@@ -1355,7 +1361,7 @@ void TIGLViewerDocument::exportMeshedConfigSTL()
         START_COMMAND()
         TiglReturnCode err = tiglExportMeshedGeometrySTL(m_cpacsHandle, qstringToCstring(fileName), TIGLViewerSettings::Instance().triangulationAccuracy());
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportMeshedGeometrySTL</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportMeshedGeometrySTL</u>.", err);
         }
     }
 }
@@ -1393,7 +1399,7 @@ void TIGLViewerDocument::exportMeshedWingVTK()
         START_COMMAND()
         TiglReturnCode err = tiglExportMeshedWingVTKByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), settings.getDeflection());
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportMeshedWingVTKByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportMeshedWingVTKByUID</u>.", err);
         }
     }
 }
@@ -1432,7 +1438,7 @@ void TIGLViewerDocument::exportMeshedWingVTKsimple()
         START_COMMAND()
         TiglReturnCode err = tiglExportMeshedWingVTKSimpleByUID(m_cpacsHandle, qstringToCstring(wingUid), qstringToCstring(fileName), deflection);
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportMeshedWingVTKSimpleByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportMeshedWingVTKSimpleByUID</u>.", err);
         }
     }
 }
@@ -1458,7 +1464,7 @@ void TIGLViewerDocument::exportWingCollada()
 
         TiglReturnCode err = tiglExportWingColladaByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), deflection);
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportWingColladaByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportWingColladaByUID</u>.", err);
         }
     }
 }
@@ -1479,7 +1485,7 @@ void TIGLViewerDocument::exportFuselageCollada()
                 * TIGLViewerSettings::Instance().triangulationAccuracy();
         TiglReturnCode err = tiglExportFuselageColladaByUID(m_cpacsHandle, qstringToCstring(fuselageUid), qstringToCstring(fileName), deflection);
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportFuselageColladaByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportFuselageColladaByUID</u>.", err);
         }
     }
 }
@@ -1495,10 +1501,10 @@ void TIGLViewerDocument::exportConfigCollada()
 
         tigl::CTiglExportCollada exporter;
         tigl::CCPACSConfiguration& config = GetConfiguration();
-        exporter.AddConfiguration(config, options);
+        bool okay = exporter.AddConfiguration(config, options);
 
         writeToStatusBar(tr("Meshing and writing COLLADA file ") + fileName + ".");
-        bool okay = exporter.Write(fileName.toStdString());
+        okay = exporter.Write(fileName.toStdString()) && okay;
         writeToStatusBar("");
         if (!okay) {
             displayError(QString("Error while exporting to COLLADA."), "TIGL Error");
@@ -1537,7 +1543,7 @@ void TIGLViewerDocument::exportMeshedFuselageVTK()
         START_COMMAND()
         TiglReturnCode err = tiglExportMeshedFuselageVTKByUID(m_cpacsHandle, wingUid.toStdString().c_str(), qstringToCstring(fileName), settings.getDeflection());
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportMeshedFuselageVTKByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportMeshedFuselageVTKByUID</u>.", err);
         }
     }
 }
@@ -1566,7 +1572,10 @@ void TIGLViewerDocument::exportMeshedConfigVTK()
         START_COMMAND()
         writeToStatusBar("Calculating fused airplane, this can take a while");
 
-        tiglExportMeshedGeometryVTK(m_cpacsHandle, fileName.toStdString().c_str(), settings.getDeflection());
+        TiglReturnCode err = tiglExportMeshedGeometryVTK(m_cpacsHandle, fileName.toStdString().c_str(), settings.getDeflection());
+        if (err != TIGL_SUCCESS) {
+            displayTiglError("Error in function <u>tiglExportMeshedGeometryVTK</u>.", err);
+        }
 
         writeToStatusBar("");
     }
@@ -1596,10 +1605,14 @@ void TIGLViewerDocument::exportMeshedConfigVTKNoFuse()
         writeToStatusBar("Writing meshed vtk file");
 
         tigl::CTiglExportVtk exporter;
-        exporter.AddConfiguration(GetConfiguration(), tigl::TriangulatedExportOptions(settings.getDeflection()));
+        bool okay = exporter.AddConfiguration(GetConfiguration(), tigl::TriangulatedExportOptions(settings.getDeflection()));
 
-        exporter.Write(fileName.toStdString());
+        okay = exporter.Write(fileName.toStdString()) && okay;
         writeToStatusBar("");
+
+        if (!okay) {
+            displayError(QString("Error while exporting to VTK."), "TIGL Error");
+        }
     }
 }
 
@@ -1619,7 +1632,8 @@ void TIGLViewerDocument::exportWingBRep()
         START_COMMAND()
         TiglReturnCode err = tiglExportWingBREPByUID(m_cpacsHandle, qstringToCstring(wingUid), qstringToCstring(fileName));
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportWingBREPByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>tiglExportWingBREPByUID</u>.", err);
+
             return;
         }
     }
@@ -1640,7 +1654,8 @@ void TIGLViewerDocument::exportFuselageBRep()
         START_COMMAND()
         TiglReturnCode err = tiglExportFuselageBREPByUID(m_cpacsHandle, qstringToCstring(fuselageUid), qstringToCstring(fileName));
         if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>exportFuselageBRepByUID</u>. Error code: %1").arg(err), "TIGL Error");
+            displayTiglError("Error in function <u>exportFuselageBRepByUID</u>.", err);
+
             return;
         }
     }
@@ -1654,19 +1669,13 @@ void TIGLViewerDocument::exportFusedConfigBRep()
     }
 
     START_COMMAND()
-    try {
-        TiglReturnCode err = tiglExportFusedBREP(m_cpacsHandle, qstringToCstring(fileName));
-        if (err != TIGL_SUCCESS) {
-            displayError(QString("Error in function <u>tiglExportBREP</u>. Error code: %1").arg(err), "TIGL Error");
-            return;
-        }
+
+    TiglReturnCode err = tiglExportFusedBREP(m_cpacsHandle, qstringToCstring(fileName));
+    if (err != TIGL_SUCCESS) {
+        displayTiglError("Error in function <u>tiglExportBREP</u>.", err);
+        return;
     }
-    catch(tigl::CTiglError & error){
-        displayError(error.what(), "Error in BRep export");
-    }
-    catch(...){
-        displayError("Unknown Exception during computation of fused aircraft.", "Error in BRep export");
-    }
+
 }
 
 void TIGLViewerDocument::exportWingCurvesBRep()

--- a/TIGLViewer/src/TIGLViewerDocument.h
+++ b/TIGLViewer/src/TIGLViewerDocument.h
@@ -167,6 +167,7 @@ private:
 
     void writeToStatusBar(const QString& text);
     void displayError(const QString& text, const QString& header="");
+    void displayTiglError(const QString& text, TiglReturnCode ret);
     QString myLastFolder; // TODO: synchronize with TIGLViewerWindow
     char* qstringToCstring(const QString& text);
 

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -5346,9 +5346,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportIGES(TiglCPACSConfigurationHandle cp
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::PTiglCADExporter exporter = tigl::createExporter("iges");
-        exporter->AddConfiguration(config);
-        bool ret = exporter->Write(filenamePtr);
-        return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
+        bool success = exporter->AddConfiguration(config);
+        success = exporter->Write(filenamePtr) && success;
+        return success ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();
@@ -5409,9 +5409,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportSTEP(TiglCPACSConfigurationHandle cp
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::PTiglCADExporter exporter = tigl::createExporter("step");
-        exporter->AddConfiguration(config);
-        bool ret = exporter->Write(filenamePtr);
-        return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
+        bool success = exporter->AddConfiguration(config);
+        success = exporter->Write(filenamePtr) && success;
+        return success ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();
@@ -5651,9 +5651,9 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglExportMeshedGeometrySTL(TiglCPACSConfigura
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::PTiglCADExporter exporter = tigl::createExporter("stl");
 
-        exporter->AddConfiguration(config, tigl::TriangulatedExportOptions(deflection));
-        bool ret = exporter->Write(filenamePtr);
-        return ret ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
+        bool success = exporter->AddConfiguration(config, tigl::TriangulatedExportOptions(deflection));
+        success = exporter->Write(filenamePtr) && success;
+        return success ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();
@@ -6958,7 +6958,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglComponentGetType(TiglCPACSConfigurationHan
 
 TIGL_COMMON_EXPORT const char * tiglGetErrorString(TiglReturnCode code)
 {
-    if (code > TIGL_MATH_ERROR || code < 0) {
+    if (code > TIGL_WRITE_FAILED || code < 0) {
         LOG(ERROR) << "TIGL error code " << code << " is unknown!";
         return "TIGL_UNKNOWN_ERROR";
     }
@@ -7276,19 +7276,16 @@ TiglReturnCode tiglExportConfiguration(TiglCPACSConfigurationHandle cpacsHandle,
         }
 
         tigl::PTiglCADExporter exporter = tigl::createExporter(extension);
+        bool success = true;
         if (fuseAllShapes) {
             exporter->AddFusedConfiguration(config, tigl::TriangulatedExportOptions(deflection));
         }
         else {
-            exporter->AddConfiguration(config, tigl::TriangulatedExportOptions(deflection));
+            success = exporter->AddConfiguration(config, tigl::TriangulatedExportOptions(deflection));
         }
 
-        if (exporter->Write(fileName) == true) {
-            return TIGL_SUCCESS;
-        }
-        else {
-            return TIGL_WRITE_FAILED;
-        }
+        success = exporter->Write(fileName) && success;
+        return success ? TIGL_SUCCESS : TIGL_WRITE_FAILED;
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << "In tiglExportConfiguration: " << ex.what();

--- a/src/exports/CTiglCADExporter.h
+++ b/src/exports/CTiglCADExporter.h
@@ -136,8 +136,9 @@ public:
     TIGL_EXPORT void AddShape(PNamedShape shape, const CCPACSConfiguration* config, const ShapeExportOptions& options = DefaultShapeExportOptions());
     
 
-    ///  Adds the whole non-fused configuration, to the exporter
-    TIGL_EXPORT void AddConfiguration(CCPACSConfiguration &config, const ShapeExportOptions& options = DefaultShapeExportOptions());
+    /// Adds the whole non-fused configuration, to the exporter
+    /// If one of the components fail to export, the function returns false
+    TIGL_EXPORT bool AddConfiguration(CCPACSConfiguration &config, const ShapeExportOptions& options = DefaultShapeExportOptions());
 
     /// Adds a whole geometry, boolean fused and meshed
     TIGL_EXPORT void AddFusedConfiguration(CCPACSConfiguration& config, const ShapeExportOptions& options = DefaultShapeExportOptions());

--- a/tests/unittests/tiglExports.cpp
+++ b/tests/unittests/tiglExports.cpp
@@ -334,8 +334,8 @@ TEST_F(tiglExportSimple, export_componentplane_vtk_newapi_meta)
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglSimpleHandle);
 
     tigl::CTiglExportVtk vtkWriter;
-    vtkWriter.AddConfiguration(config, tigl::TriangulatedExportOptions(0.01));
-    bool ret = vtkWriter.Write("TestData/export/simpletest_nonfusedplane_meta_newapi.vtp");
+    bool ret = vtkWriter.AddConfiguration(config, tigl::TriangulatedExportOptions(0.01));
+    ret = vtkWriter.Write("TestData/export/simpletest_nonfusedplane_meta_newapi.vtp") && ret;
 
     ASSERT_EQ(true, ret);
 }
@@ -421,10 +421,10 @@ TEST_F(tiglExportSimple, export_iges_symmetry)
     options.SetIncludeFarfield(false);
     tigl::PTiglCADExporter igesExporter = tigl::createExporter("iges", options);
 
-    igesExporter->AddConfiguration(config);
-    bool ret = igesExporter->Write("TestData/export/simpletest_export_iges_sym.igs");
+    bool success = igesExporter->AddConfiguration(config);
+    success = igesExporter->Write("TestData/export/simpletest_export_iges_sym.igs") && success;
 
-    ASSERT_EQ(true, ret);
+    ASSERT_EQ(true, success);
 }
 
 // check if face names were set correctly in the case with a trailing edge


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This improves the robustness of the non-fused CAD export. It will export as much as possible, even if
one component failed to built. In this case, the user still gets an exported file but an error code is returned.

## Description
- I catch all geometry building problems.
- If an error occurs, this is remembered and returned as an error.
- Minor refactoring of error messages, if a TiGL error occurs in TiGL Viewer.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I tested it with some CPACS files, where e.g. the pylons fail to create (because there are invalid).


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
