### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -65,7 +65,7 @@ jobs:
           }
         - {
             name: 'MacOS',
-            os: macos-latest,
+            os: macOS-10.15,
             link_type: dynamic,
             build_type: Release
           }


### PR DESCRIPTION
Github Actions just updated their macOS latest image to 11.6, which now breaks the deployment stage.

This build fixes the macOS by reverting to the macOS 10.15 image used before.


