### PR TITLE
add CCPACSEnginePosition to swig interface

### DIFF
--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -80,6 +80,7 @@
 #include "CCPACSTrailingEdgeDevice.h"
 #include "CCPACSEnginePylons.h"
 #include "CCPACSEnginePylon.h"
+#include "CCPACSEnginePosition.h"
 #include "generated/CPACSLateralCap_placement.h"
 #include "generated/CPACSLateralCap.h"
 #include "generated/CPACSBoundingElementUIDs.h"
@@ -190,6 +191,8 @@
 %boost_optional(tigl::CCPACSEnginePositions)
 %include "generated/CPACSEnginePositions.h"
 %include "CCPACSEnginePositions.h"
+%include "generated/CPACSEnginePosition.h"
+%include "CCPACSEnginePosition.h"
 %include "generated/CPACSNacelleCenterCowl.h"
 %include "CCPACSNacelleCenterCowl.h"
 %include "generated/CPACSNacelleSections.h"

--- a/src/engine_nacelle/CCPACSEnginePosition.h
+++ b/src/engine_nacelle/CCPACSEnginePosition.h
@@ -38,8 +38,6 @@ public:
     TIGL_EXPORT void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value) override;
     TIGL_EXPORT void SetEngineUID(const std::string& value) override;
 
-    TIGL_EXPORT bool HasLoft() const;
-
 protected:
     virtual PNamedShape BuildLoft() const override;
 


### PR DESCRIPTION
fixes #858

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adds the CCPACSEnginePosition to the swig exports. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with a local conda build.


## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
