### PR TITLE
fix #865

### DIFF
--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -933,10 +933,10 @@ void CCPACSWingCell::BuildSkinGeometry(GeometryCache& cache) const
 
 
         // cut the shape at the cell borders
-        TopoDS_Shape resultShape = CutSpanwise(cache, loftShape, SpanWiseBorder::Inner, m_positioningInnerBorder, zRefDir, 1e-2);
-        resultShape              = CutSpanwise(cache, resultShape, SpanWiseBorder::Outer, m_positioningOuterBorder, zRefDir, 1e-2);
-        resultShape              = CutChordwise(cache, resultShape, ChordWiseBorder::LE, m_positioningLeadingEdge, zRefDir, 1e-2);
-        resultShape              = CutChordwise(cache, resultShape, ChordWiseBorder::TE, m_positioningTrailingEdge, zRefDir, 1e-2);
+        TopoDS_Shape resultShape = CutSpanwise(cache, loftShape, SpanWiseBorder::Inner, m_positioningInnerBorder, zRefDir, 1e-4);
+        resultShape              = CutSpanwise(cache, resultShape, SpanWiseBorder::Outer, m_positioningOuterBorder, zRefDir, 1e-4);
+        resultShape              = CutChordwise(cache, resultShape, ChordWiseBorder::LE, m_positioningLeadingEdge, zRefDir, 1e-4);
+        resultShape              = CutChordwise(cache, resultShape, ChordWiseBorder::TE, m_positioningTrailingEdge, zRefDir, 1e-4);
 
         // store the result
         cache.skinGeometry = resultShape;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix #865

## Description

This PR changes the tolerances used in the calls to `CCPACSWingCell::CutChordWise` and `CCPACSWIngCell::CutSpanWise`. These tolerances are used to check, wether a wing cell border lies on an isosurface of a single face *(within the bounds defined by said tolerance)*. If yes, TiGL will trim the face to create the cell geometry. If no, TiGL will cut the face using expensive Boolean operations. 

The consequence of a stricter tolerance is only that in more cases the Boolean operations will be used, increasing the calculation time and accuracy.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I wouldn't know how to define a unit test of this. This has been tested with an internal CPACS file where the inaccuracies were evident in TiGLViewer.

<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
