### PR TITLE
Fix #864

### DIFF
--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -770,7 +770,10 @@ TopoDS_Shape CCPACSWingCell::CutChordwise(GeometryCache& cache,
         TopoDS_Shape cuttingShape;
         if (positioning.GetInputType() == CCPACSWingCellPositionChordwise::InputType::Spar ) {
             // we can use the cutting shape defined by the spar
-            cuttingShape = m_uidMgr->ResolveObject<CCPACSWingSparSegment>(m_positioningLeadingEdge.GetSparUId())
+            auto sparUid =
+                    (border == ChordWiseBorder::LE)? m_positioningLeadingEdge.GetSparUId()
+                                                   : m_positioningTrailingEdge.GetSparUId();
+            cuttingShape = m_uidMgr->ResolveObject<CCPACSWingSparSegment>(sparUid)
                     .GetSparCutGeometry(WING_COORDINATE_SYSTEM);
         } else {
 

--- a/tests/integrationtests/TestData/cell_rib_spar_test.xml
+++ b/tests/integrationtests/TestData/cell_rib_spar_test.xml
@@ -196,6 +196,29 @@
                           <ribDefinitionUID>Wing_CS_RibDef1</ribDefinitionUID>
                         </positioningOuterBorder>
                       </cell>
+                      <cell uID="Wing_CS_upperShell_Cell2">
+                        <skin>
+                          <material>
+                            <materialUID>
+                                                                                materialUID
+                                                                        </materialUID>
+                          </material>
+                        </skin>
+                        <positioningLeadingEdge>
+                          <sparUID>Wing_CS_spar1</sparUID>
+                        </positioningLeadingEdge>
+                        <positioningTrailingEdge>
+                          <sparUID>Wing_CS_spar2</sparUID>
+                        </positioningTrailingEdge>
+                        <positioningInnerBorder>
+                          <ribNumber>1</ribNumber>
+                          <ribDefinitionUID>Wing_CS_RibDef1</ribDefinitionUID>
+                        </positioningInnerBorder>
+                        <positioningOuterBorder>
+                          <ribNumber>2</ribNumber>
+                          <ribDefinitionUID>Wing_CS_RibDef1</ribDefinitionUID>
+                        </positioningOuterBorder>
+                      </cell>
                     </cells>
                   </upperShell>
                   <lowerShell uID="CS1_lowerShell1">

--- a/tests/integrationtests/testWingCellSpar.cpp
+++ b/tests/integrationtests/testWingCellSpar.cpp
@@ -336,6 +336,28 @@ TEST_F(WingCellRibSpar, computeGeometry) {
    BRepTools::Write(cellGeom, "TestData/export/WingCellRibSpar_CellGeometry.brep");
 }
 
+TEST_F(WingCellRibSpar, bug864)
+{
+    // A test for Bug #864 https://github.com/DLR-SC/tigl/issues/864
+
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+    tigl::CCPACSWingComponentSegment& componentSegment = static_cast<tigl::CCPACSWingComponentSegment&>(wing.GetComponentSegment(1));
+
+    tigl::CCPACSWingCell& cell = componentSegment.GetStructure()->GetUpperShell().GetCell(2);
+
+
+    const std::pair<double, double> arr[] = { DP(0.2, 0.3), DP(0.95, 0.4), DP(0.2, 0.72), DP(0.95, 0.75) };
+    std::vector< std::pair<double, double> > expectedEtaXsi (arr, arr + sizeof(arr) / sizeof(arr[0]));
+    checkCellEtaXsis(cell, expectedEtaXsi, 1.E-2);
+
+
+    TopoDS_Shape cellGeom = cell.GetSkinGeometry();
+    BRepTools::Write(cellGeom, "TestData/export/WingCellRibSpar_CellGeometry.brep");
+
+}
+
 TEST_F(WingCellContourCoordinates, mixedBorderDefError)
 {
    // This cell is defined with both borders relative to the skin and the chordface.

--- a/tests/integrationtests/testWingCellSpar.cpp
+++ b/tests/integrationtests/testWingCellSpar.cpp
@@ -75,8 +75,11 @@ TiglCPACSConfigurationHandle WingCellSpar::tiglHandle = 0;
 class WingCellRibSpar : public ::testing::Test
 {
 protected:
-   static void SetUpTestCase()
-   {
+   static void SetUpTestCase(){}
+
+   static void TearDownTestCase(){}
+
+   void SetUp() override {
        const char* filename = "TestData/cell_rib_spar_test.xml";
        ReturnCode tixiRet;
        TiglReturnCode tiglRet;
@@ -89,17 +92,12 @@ protected:
        tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "model", &tiglHandle);
        ASSERT_EQ(TIGL_SUCCESS, tiglRet);
    }
-
-   static void TearDownTestCase()
-   {
+   void TearDown() override {
        ASSERT_EQ(TIGL_SUCCESS, tiglCloseCPACSConfiguration(tiglHandle));
        ASSERT_EQ(SUCCESS, tixiCloseDocument(tixiHandle));
        tiglHandle = -1;
        tixiHandle = -1;
    }
-
-   void SetUp() override {}
-   void TearDown() override {}
 
    static TixiDocumentHandle           tixiHandle;
    static TiglCPACSConfigurationHandle tiglHandle;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix #864 

## Description

The `CCPACSWingCell::CutChordwise` function always used the cutting face defined by the leading edge spar, even if cutting the trailing edge border of the cell. 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

A new unit test has been added.
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
