### PR TITLE
CI: windows-latest  to windows-2019

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -37,14 +37,14 @@ jobs:
         config:
         - {
             name: 'Win64-dynamic',
-            os: windows-latest,
+            os: windows-2019,
             arch: amd64,
             link_type: dynamic,
             build_type: Release
           }
         - {
             name: 'Win64-static',
-            os: windows-latest,
+            os: windows-2019,
             arch: amd64,
             link_type: static,
             build_type: Release


### PR DESCRIPTION
Currently all builds fail on GH hosted windows-2022 runner. We should investigate this later and switch to windows-2019 for now.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
