### PR TITLE
Fix various typos

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: "ON"
 
   tigl_bindings_python_internal:
-    description: "CMake option to build the interal python API"
+    description: "CMake option to build the internal python API"
     required: false
     default: "OFF"
 

--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: "ON"
 
   tigl_bindings-python-internal:
-    description: "CMake option to build the interal python API"
+    description: "CMake option to build the internal python API"
     required: false
     default: "OFF"
 

--- a/.github/actions/build-win/action.yml
+++ b/.github/actions/build-win/action.yml
@@ -25,7 +25,7 @@ inputs:
     default: "ON"
 
   tigl_bindings_python_internal:
-    description: "CMake option to build the interal python API"
+    description: "CMake option to build the internal python API"
     required: false
     default: "OFF"
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please head over to our TiGL website: https://dlr-sc.github.io/tigl/#news
 
 # Cite us
 
-TiGL is available as Open Source and we encourage anyone to make use of it. If you are applying TiGL in a scientific environment and publish any related work, please cite the following artice:
+TiGL is available as Open Source and we encourage anyone to make use of it. If you are applying TiGL in a scientific environment and publish any related work, please cite the following article:
 
 Siggel, M., Kleinert, J., Stollenwerk, T. et al.:  *TiGL: An Open Source Computational Geometry Library for Parametric Aircraft Design*, Math.Comput.Sci. (2019). https://doi.org/10.1007/s11786-019-00401-y
 

--- a/TIGLViewer/src/TIGLScriptEngine.cpp
+++ b/TIGLViewer/src/TIGLScriptEngine.cpp
@@ -323,7 +323,7 @@ void TIGLScriptEngine::displayHelp()
     helpString += "    app.viewer.makeScreenshot('image.png');//PNG image, white background<br/>";
     helpString += "    app.viewer.makeScreenshot('image.jpg', false);//JPEG image, current background<br/><br/>";
 
-    helpString += "Type 'help(tigl)' to get a list of available TiGL fuctions.<br/>";
+    helpString += "Type 'help(tigl)' to get a list of available TiGL functions.<br/>";
     helpString += "Use the help function on any object to display its public methods e.g. 'help(app.viewer)'.";
     emit scriptResult(helpString);
     emit evalDone();

--- a/TIGLViewer/src/TIGLViewerApp.cpp
+++ b/TIGLViewer/src/TIGLViewerApp.cpp
@@ -37,7 +37,7 @@ void showHelp(QString appName)
     helpText += "  --filename <filename>    Initial CPACS file to open and display.\n";
     helpText += "  --modelUID <uid>         Initial model uid open and display.\n";
     helpText += "  --script <filename>       Script to execute.\n";
-    helpText += "  --windowtitle <title>    The titel of the TiGL Viewer window.\n";
+    helpText += "  --windowtitle <title>    The title of the TiGL Viewer window.\n";
     helpText += "  --controlFile <filename>    Name of the control file.\n";
     helpText += "  --suppress-errors        Suppress all error message dialogs\n";
 

--- a/TIGLViewer/src/main.cpp
+++ b/TIGLViewer/src/main.cpp
@@ -73,13 +73,13 @@ int main(int argc, char *argv[])
     }
     
 #if OCC_VERSION_HEX >= 0x060700
-    // check existance of shader dir
+    // check existence of shader dir
     // This is only required for OpenCASCADE 6.7.0 and newer
     if (!QFile(shaderDir+"/PhongShading.fs").exists()) {
         std::stringstream str;
         str << "Illegal or non existing shader directory "
             << "<p><b>" << shaderDir.toStdString() << "</b></p>"
-            << "Set the enviroment variable <b>CSF_ShadersDirectory</b> to provide a path for the OpenCASCADE shaders.";
+            << "Set the environment variable <b>CSF_ShadersDirectory</b> to provide a path for the OpenCASCADE shaders.";
         QMessageBox::critical(0, "Startup error...",
                                   str.str().c_str(),
                                   QMessageBox::Ok );

--- a/bindings/bindings_generator/cheader_parser.py
+++ b/bindings/bindings_generator/cheader_parser.py
@@ -238,7 +238,7 @@ class Annotation(object):
         ins = res.group()
         # parse each input parameter
         while ins:
-            # find paramter
+            # find parameter
             tmp = re.search(Annotation.regex, ins)
             if not tmp:
                 break

--- a/bindings/bindings_generator/fortran03_generator.py
+++ b/bindings/bindings_generator/fortran03_generator.py
@@ -280,7 +280,7 @@ end type
 
     def requires_method_wrapper(self, fun_dec):
         '''
-        Checks wether there are subroutine/function arguments (or return values) that require a wrapper function
+        Checks whether there are subroutine/function arguments (or return values) that require a wrapper function
         '''
 
         for arg in fun_dec.arguments:

--- a/bindings/bindings_generator/matlab_generator.py
+++ b/bindings/bindings_generator/matlab_generator.py
@@ -242,13 +242,13 @@ class MatlabGenerator(object):
         pseudocall += ')'
         
         #check correct number in inargs
-        string += 4*' ' + '/* check for corect number of in and out args */\n'
+        string += 4*' ' + '/* check for correct number of in and out args */\n'
         string += 4*' ' + 'if (nrhs != %d) {\n' % (len(inargs_wo_sizes) + 1 + add_arg_count)
         
         string += 4*' ' + '    mexErrMsgTxt("%s: Wrong number of arguments\\n");\n' % pseudocall
         string += 4*' ' + '}\n'
         
-        #check correct bumber of outargs
+        #check correct number of outargs
         noutargs = len(outargs)
         if not func.returns_error and func.return_value.type != 'void':
             noutargs += 1

--- a/bindings/bindings_generator/python_generator.py
+++ b/bindings/bindings_generator/python_generator.py
@@ -195,7 +195,7 @@ class PythonGenerator(object):
                 num_outargs += 1
                 
         for index, arg in enumerate(fun_dec.arguments):
-            # create aditional size argument for manually allocated arrays
+            # create additional size argument for manually allocated arrays
             if arg.arrayinfos['is_array'] and arg.is_outarg and not arg.arrayinfos['autoalloc'] and len(arg.arrayinfos['arraysizes']) == 0:
                 string += ', %s_len' % arg.name
             
@@ -326,7 +326,7 @@ class PythonGenerator(object):
         call += ')'
         
         # we assume that each function is returning an error code
-        # only if explictly specified otherwise
+        # only if explicitly specified otherwise
         if not ret_val:
             call  = indent + 'errorCode = %s\n' % call
             call += indent + 'catch_error(errorCode, \'%s\'' % fun_dec.method_name
@@ -372,7 +372,7 @@ class PythonGenerator(object):
             if arg.is_outarg:
                 outargs.append(arg)
         
-        # convert c ouputs to python output values
+        # convert c outputs to python output values
         if len(outargs) > 0:
             string += '\n'
         # non array value

--- a/bindings/java/src/de/dlr/sc/tigl3/CpacsConfiguration.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/CpacsConfiguration.java
@@ -487,7 +487,7 @@ public class CpacsConfiguration implements AutoCloseable {
         DoubleByReference pointY = new DoubleByReference();
         DoubleByReference pointZ = new DoubleByReference();
 
-        // get uppper Point from TIGL
+        // get upper Point from TIGL
         errorCode = TiglNativeInterface.tiglWingGetUpperPoint(cpacsHandle, wingIndex, segmentIndex, eta, xsi, pointX, pointY, pointZ);
         throwIfError("tiglWingGetUpperPoint", errorCode);
 
@@ -558,7 +558,7 @@ public class CpacsConfiguration implements AutoCloseable {
         DoubleByReference pointZ  = new DoubleByReference();
         DoubleByReference errDist = new DoubleByReference();
 
-        // get uppper Point from TIGL
+        // get upper Point from TIGL
         errorCode = TiglNativeInterface.tiglWingGetUpperPointAtDirection(cpacsHandle, wingIndex, segmentIndex, 
                 eta, xsi, 
                 direction.getX(), direction.getY(), direction.getZ(), 
@@ -601,7 +601,7 @@ public class CpacsConfiguration implements AutoCloseable {
         DoubleByReference pointZ  = new DoubleByReference();
         DoubleByReference errDist = new DoubleByReference();
 
-        // get uppper Point from TIGL
+        // get upper Point from TIGL
         errorCode = TiglNativeInterface.tiglWingGetLowerPointAtDirection(cpacsHandle, wingIndex, segmentIndex, 
                 eta, xsi, 
                 direction.getX(), direction.getY(), direction.getZ(), 
@@ -1933,7 +1933,7 @@ public class CpacsConfiguration implements AutoCloseable {
      * to be called.
      * 
      * @param componentUid - The UID of the first component
-     * @param point, normal - The plane paramters i.e. a point on the plane and the plane's normal vector
+     * @param point, normal - The plane parameters i.e. a point on the plane and the plane's normal vector
      * 
      * @return A unique identifier that is associated with the computed intersection.
      * @throws TiglException

--- a/bindings/java/src/de/dlr/sc/tigl3/Tigl.java
+++ b/bindings/java/src/de/dlr/sc/tigl3/Tigl.java
@@ -76,7 +76,7 @@ public class Tigl {
         	throw new TiglException("openCPACSConfiguration", TiglReturnCode.getEnum(error));
         }
         config.setCPACSHandle(tiglHandleTemp.getValue());
-        LOGGER.info("TiGL: Cpacs configuration " + configurationUID + "opened succesfully");
+        LOGGER.info("TiGL: Cpacs configuration " + configurationUID + "opened successfully");
         
         
         return config;
@@ -112,7 +112,7 @@ public class Tigl {
             throw new TiglException("openCPACSConfiguration", TiglReturnCode.getEnum(error));
         }
         config.setCPACSHandle(tiglHandleTemp.getValue());
-        LOGGER.info("TiGL: Cpacs configuration " + configurationUID + "opened succesfully");
+        LOGGER.info("TiGL: Cpacs configuration " + configurationUID + "opened successfully");
 
         return config;
     }

--- a/bindings/python_internal/common.i
+++ b/bindings/python_internal/common.i
@@ -184,7 +184,7 @@ PyObject* tiglError_to_PyExc(const tigl::CTiglError& err) {
         SWIG_fail;
     }
     catch(...) {
-        PyErr_SetString(PyExc_RuntimeError, const_cast<char*>("An unkown error occured!"));
+        PyErr_SetString(PyExc_RuntimeError, const_cast<char*>("An unknown error occurred!"));
         SWIG_fail;
     }
 }

--- a/bindings/python_internal/tigl3/curve_factories.py
+++ b/bindings/python_internal/tigl3/curve_factories.py
@@ -29,7 +29,7 @@ def interpolate_points(points, params=None, degree=3, close_continuous=False):
 
 def bspline_curve(cp, knots, mults, degree):
     """
-    Creates a BSplineCurve from the control points, knots, multiplicites and degree
+    Creates a BSplineCurve from the control points, knots, multiplicities and degree
 
     :param points: Array of points (numpy array also works!). First dimension over number of points, second must be 3!
     :param knots: Knot vector (not flattened)

--- a/bindings/python_internal/tigl3/surface_factories.py
+++ b/bindings/python_internal/tigl3/surface_factories.py
@@ -8,7 +8,7 @@ def interpolate_curves(curve_list, params=None, degree=3, close_continuous=False
 
 
     :param curve_list: List of Geom_Curves, that are created using e.g. tigl3.curve_factories
-    :param params: Optional surface parameters (list of floats), at which the surfaces passes trough the curves.
+    :param params: Optional surface parameters (list of floats), at which the surfaces passes through the curves.
                    This has a strong effect on the final surface shape.
     :param degree: Maximum degree that is used for interpolation. When degree=1, a linear loft is created.
     :param close_continuous: If the first and last curve are equal close_continuous and is true,

--- a/cmake/FindJava.cmake
+++ b/cmake/FindJava.cmake
@@ -6,7 +6,7 @@
 #  Java_JAVA_EXECUTABLE    = the full path to the Java runtime
 #  Java_JAVAC_EXECUTABLE   = the full path to the Java compiler
 #  Java_JAVAH_EXECUTABLE   = the full path to the Java header generator
-#  Java_JAVADOC_EXECUTABLE = the full path to the Java documention generator
+#  Java_JAVADOC_EXECUTABLE = the full path to the Java documentation generator
 #  Java_JAR_EXECUTABLE     = the full path to the Java archiver
 #  Java_VERSION_STRING     = Version of the package found (java version), eg. 1.6.0_12^gol
 #  Java_VERSION_PATCH      = The patch version of the package found.

--- a/doc/tiglviewer_console.md
+++ b/doc/tiglviewer_console.md
@@ -10,7 +10,7 @@ The console has two purposes
  2. to enter user code to steer the TiGL Viewer application
 
 In many cases, the user wants to open a CPACS file and execute TiGL function to compute and draw some points
-on the aircraft surface. Another use case would be to automatize the creation of screenshots of a changing aircraft
+on the aircraft surface. Another use case would be to automate the creation of screenshots of a changing aircraft
 geometry.
 
 @image html images/tiglviewer_console.png "The scripting console"

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ Then type
 to build the c-demo.
 
 
-To build this example program by yourself without a makefile, one has to link against the following libaries:
+To build this example program by yourself without a makefile, one has to link against the following libraries:
   - (lib)tigl3
   - (lib)tixi3
 

--- a/examples/python/notebooks/geometry_airfoil.ipynb
+++ b/examples/python/notebooks/geometry_airfoil.ipynb
@@ -71,7 +71,7 @@
     "The points_to_curve function has some optional parameters as well.\n",
     " - degree: Controls the polynomial degree. If degree=1, the curve will be piecewise linear.\n",
     " - params: Controls, at which parameter the points will be interpolated. This array must have the same number of items as the points array!\n",
-    " - close_continuous: If you interpolate e.g. a fuselage section, you probably want a continous passing of the curve at the start and the end of the section. if close_continuous=True, the passing will be continous. For wings, where a discontinous trailing edge is desired, it should be False."
+    " - close_continuous: If you interpolate e.g. a fuselage section, you probably want a continuous passing of the curve at the start and the end of the section. if close_continuous=True, the passing will be continuous. For wings, where a discontinuous trailing edge is desired, it should be False."
    ]
   },
   {

--- a/examples/python/notebooks/geometry_guide_curves.ipynb
+++ b/examples/python/notebooks/geometry_guide_curves.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "## Importing modules ##\n",
     "\n",
-    "Again, all low lovel geomtry functions can be found in the ```tigl3.geometry``` module. The actual gordon surface algorithm is the class ```CTiglInterpolateCurveNetwork``` from the ```tigl3.geometry``` module. For a more convenient use,\n",
+    "Again, all low lovel geometry functions can be found in the ```tigl3.geometry``` module. The actual gordon surface algorithm is the class ```CTiglInterpolateCurveNetwork``` from the ```tigl3.geometry``` module. For a more convenient use,\n",
     "we again use the module __```tigl3.surface_factories```__ , which we are using now."
    ]
   },

--- a/examples/python/notebooks/geometry_wing.ipynb
+++ b/examples/python/notebooks/geometry_wing.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Wing modelling example #\n",
     "\n",
-    "In this example, we demonstrate, how to build up a wing surface by starting with a list of curves. These curves are then interpolated using a B-spline suface interpolation"
+    "In this example, we demonstrate, how to build up a wing surface by starting with a list of curves. These curves are then interpolated using a B-spline surface interpolation"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "source": [
     "## Importing modules ##\n",
     "\n",
-    "Again, all low lovel geomtry functions can be found in the ```tigl3.geometry``` module. For a more convenient use,\n",
+    "Again, all low lovel geometry functions can be found in the ```tigl3.geometry``` module. For a more convenient use,\n",
     "the module __```tigl3.surface_factories```__ offers functions to create surfaces. Lets use this!"
    ]
   },

--- a/misc/math-scripts/ms_componentSegmentGeom.py
+++ b/misc/math-scripts/ms_componentSegmentGeom.py
@@ -482,7 +482,7 @@ class ComponentSegmentGeometry:
 		vProj = array([0, 1, 1])
 		n = vProj*(self.__p2p-self.__p1p)
 		
-		# calc eta koordinate of that point
+		# calc eta coordinate of that point
 		eta = (dot(p_proj,n)*(self.__eta2 - self.__eta1) + dot(self.__p2,n)*self.__eta1 - dot(self.__p1,n)*self.__eta2) \
 				/ dot(self.__p2 - self.__p1, n);
 		

--- a/misc/math-scripts/ms_segmentGeometry.py
+++ b/misc/math-scripts/ms_segmentGeometry.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 # @file ms_segmentGeometry.py
-# @brief Implementation of the segement geometry
+# @brief Implementation of the segment geometry
 #
 
 from numpy import array, outer, ones, size, dot, linalg, zeros, cross, transpose 

--- a/src/api/tigl.h
+++ b/src/api/tigl.h
@@ -668,7 +668,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetUpperPoint(TiglCPACSConfigurationHa
 *   - TIGL_NOT_FOUND if no intersection point was found or the cpacs handle is not valid
 *   - TIGL_INDEX_ERROR if wingIndex or segmentIndex are not valid
 *   - TIGL_NULL_POINTER if pointXPtr, pointYPtr or pointZPtr are null pointers
-*   - TIGL_ERROR if some other error occured
+*   - TIGL_ERROR if some other error occurred
 */
 TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetLowerPoint(TiglCPACSConfigurationHandle cpacsHandle,
                                                         int wingIndex,
@@ -726,7 +726,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingSetGetPointBehavior(TiglCPACSConfigura
 *   - TIGL_NOT_FOUND if cpacs handle is not valid
 *   - TIGL_INDEX_ERROR if wingIndex or segmentIndex are not valid
 *   - TIGL_NULL_POINTER if pointXPtr, pointYPtr or pointZPtr are null pointers
-*   - TIGL_ERROR if some other error occured
+*   - TIGL_ERROR if some other error occurred
 */
 TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetChordPoint(TiglCPACSConfigurationHandle cpacsHandle,
                                                         int wingIndex,
@@ -758,7 +758,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetChordPoint(TiglCPACSConfigurationHa
 *   - TIGL_NOT_FOUND if cpacs handle is not valid
 *   - TIGL_INDEX_ERROR if wingIndex or segmentIndex are not valid
 *   - TIGL_NULL_POINTER if normalXPtr, normalYPtr or normalZPtr are null pointers
-*   - TIGL_ERROR if some other error occured
+*   - TIGL_ERROR if some other error occurred
 */
 TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetChordNormal(TiglCPACSConfigurationHandle cpacsHandle,
                                                          int wingIndex,
@@ -950,7 +950,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetOuterConnectedSegmentCount(TiglCPAC
 *   - TIGL_NOT_FOUND if no configuration was found for the given handle or no n-th connected segment was found
 *   - TIGL_INDEX_ERROR if wingIndex, segmentIndex or n are not valid
 *   - TIGL_NULL_POINTER if segmentIndexPtr is a null pointer
-*   - TIGL_ERROR if some other error occured
+*   - TIGL_ERROR if some other error occurred
 */
 TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetInnerConnectedSegmentIndex(TiglCPACSConfigurationHandle cpacsHandle,
                                                                         int wingIndex,
@@ -1663,11 +1663,11 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSpan(TiglCPACSConfigurationHandle c
 
 
 /**
-* @brief This function calculates location of the quarter of mean aerodynamic chord, and gives the chord lenght as well.
+* @brief This function calculates location of the quarter of mean aerodynamic chord, and gives the chord length as well.
 *
 * It uses the classical method that can be applied to trapozaidal wings. This method is used for each segment.
 * The values are found by taking into account of sweep and dihedral. But the effect of insidance angle is neglected.
-* These values should coinside with the values found with tornado tool.
+* These values should coincide with the values found with tornado tool.
 *
 * @param[in] cpacsHandle Handle for the CPACS configuration
 * @param[in] wingUID     UID of the Wing
@@ -2229,7 +2229,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetNumPointsOnXPlane(TiglCPACSConf
 * @param[in]  segmentIndex  The index of the segment of the fuselage, starting at 1
 * @param[in]  eta           eta in the range 0.0 <= eta <= 1.0
 * @param[in]  ypos          Y position
-* @param[out] numPointsPtr  Pointer to a interger for the number of intersection points
+* @param[out] numPointsPtr  Pointer to an integer for the number of intersection points
 *
 * @return
 *   - TIGL_SUCCESS if a point was found
@@ -3581,7 +3581,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetCurveIntersection(TiglCPACSConfiguratio
 *                             If no intersection could be computed, line count is 0.
 *
 * @return
-*   - TIGL_SUCCESS if no error occured
+*   - TIGL_SUCCESS if no error occurred
 *   - TIGL_NOT_FOUND if the cpacs handle  or the intersectionID is not valid
 *   - TIGL_NULL_POINTER if lineCount is a NULL pointer
 */
@@ -3599,7 +3599,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglIntersectGetLineCount(TiglCPACSConfigurati
 *                             If no intersection could be computed, pointCount is 0.
 *
 * @return
-*   - TIGL_SUCCESS if no error occured
+*   - TIGL_SUCCESS if no error occurred
 *   - TIGL_NOT_FOUND if the cpacs handle is not valid
 *   - TIGL_NULL_POINTER if either intersectionID or pointCount is a NULL pointer
 */
@@ -3621,7 +3621,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetCurveIntersectionCount(TiglCPACSConfigu
 * @param[out] pointZ          Z coordinate of the resulting point.
 *
 * @return
-*   - TIGL_SUCCESS if no error occured
+*   - TIGL_SUCCESS if no error occurred
 *   - TIGL_NOT_FOUND if the cpacs handle  or the intersectionID is not valid
 *   - TIGL_NULL_POINTER if pointX, pointY, or pointZ are NULL pointers
 *   - TIGL_INDEX_ERROR if lineIdx is not in valid range
@@ -3647,7 +3647,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglIntersectGetPoint(TiglCPACSConfigurationHa
 * @param[out] pointZ          Z coordinate of the resulting point.
 *
 * @return
-*   - TIGL_SUCCESS if no error occured
+*   - TIGL_SUCCESS if no error occurred
 *   - TIGL_NOT_FOUND if the cpacs handle is not valid
 *   - TIGL_NULL_POINTER if pointX, pointY, or pointZ or the intersectionID are NULL pointers
 *   - TIGL_INDEX_ERROR if pointIdx is not in valid range
@@ -3675,7 +3675,7 @@ The intersection line is specified by a curveID. The curveID can be calculated u
 * @param[out] eta             The parameter along the first curve.
 *
 * @return
-*   - TIGL_SUCCESS if no error occured
+*   - TIGL_SUCCESS if no error occurred
 *   - TIGL_NOT_FOUND if the cpacs handle is not valid
 *   - TIGL_NULL_POINTER if intersectionID, curveID or eta are NULL pointers
 *   - TIGL_INDEX_ERROR if curveIdx is not in valid range
@@ -3700,8 +3700,8 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetCurveParameter (TiglCPACSConfigurationH
 
 # VTK-Export #
     There a various different VTK exports functions in TIGL. All functions starting with 'tiglExportVTK[Fuselage|Wing]...' are exporting
-    a special triangulation with no duplicated points into a VTK file formated in XML (file extension .vtp) with some custom
-    informations added to the file.
+    a special triangulation with no duplicated points into a VTK file formatted in XML (file extension .vtp) with some custom
+    information added to the file.
 
     In addition to the triangulated geometry, additional data are written to the VTK file. These data currently include:
     - uID: The UID of the fuselage or wing component segment on which the triangle exists.
@@ -3789,7 +3789,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglSetExportOptions(const char* exporter_name
 /**
 * @brief Exports a geometric component (e.g. a wing, a fuselage etc.)
 * 
-* The component to be exported is definied via its uid. The export format
+* The component to be exported is defined via its uid. The export format
 * is specified with the file extension of fileName.
 * 
 * The export can be configured in more detail using ::tiglSetExportOptions.
@@ -4538,7 +4538,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetSurfaceArea(TiglCPACSConfigurat
 
 /**
 * @brief Returns the surface area of a segment of a wing. This includes only the area
-* of the upper and lower wing segment surface and does not include the trailing egde
+* of the upper and lower wing segment surface and does not include the trailing edge
 * or any closing faces.
 *
 *
@@ -4592,7 +4592,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSegmentSurfaceArea(TiglCPACSConfigu
 *   - TIGL_NOT_FOUND if no configuration was found for the given handle
 *   - TIGL_INDEX_ERROR if wingIndex ot segmentIndex are not valid
 *   - TIGL_NULL_POINTER if surfaceArea is a null pointer
-*   - TIGL_ERROR if the eta/xsi coordinates are not in the valid range [0,1] or another error occured
+*   - TIGL_ERROR if the eta/xsi coordinates are not in the valid range [0,1] or another error occurred
 */
 TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSegmentUpperSurfaceAreaTrimmed(TiglCPACSConfigurationHandle cpacsHandle,
                                                                             int wingIndex,
@@ -4627,7 +4627,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSegmentUpperSurfaceAreaTrimmed(Tigl
 *   - TIGL_NOT_FOUND if no configuration was found for the given handle
 *   - TIGL_INDEX_ERROR if wingIndex ot segmentIndex are not valid
 *   - TIGL_NULL_POINTER if surfaceArea is a null pointer
-*   - TIGL_ERROR if the eta/xsi coordinates are not in the valid range [0,1] or another error occured
+*   - TIGL_ERROR if the eta/xsi coordinates are not in the valid range [0,1] or another error occurred
 */
 TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetSegmentLowerSurfaceAreaTrimmed(TiglCPACSConfigurationHandle cpacsHandle,
                                                                             int wingIndex,
@@ -5019,7 +5019,7 @@ TIGL_COMMON_EXPORT void tiglSetDebugDataDirectory(const char* directory);
 /**
 * @brief Returns the length of the plane
 *
-* The calculation of the airplane lenght is realized as follows:
+* The calculation of the airplane length is realized as follows:
 *
 * All part of the configuration (currently all wing and fuselage segments) are put
 * into a bounding box. The length of the plane is returned as the length of the box
@@ -5058,14 +5058,14 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglConfigurationGetBoundingBox(TiglCPACSConfi
 
 
 /**
- * @brief Sets a flag, wether ducts defined in CPACS shall be removed from using Boolean operations.
+ * @brief Sets a flag, whether ducts defined in CPACS shall be removed from using Boolean operations.
  *
  * By default ducts are disabled. If no ducts are defined in CPACS, this function has no effect.
  *
  * Currently, ducts are only removed from fuselages and wings.
  *
  * @param[in] cpacsHandle         Handle for the CPACS configuration
- * @param[in] WithDuctCutoutsFlag flag, wether all geometric components shall be build with duct cutouts
+ * @param[in] WithDuctCutoutsFlag flag, whether all geometric components shall be build with duct cutouts
  *
  * @return
  *   - TIGL_SUCCESS if no error occurred
@@ -5081,7 +5081,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglConfigurationSetWithDuctCutouts(TiglCPACSC
  * if any ducts are defined in the CPACS configuration.
  *
  * @param[in]  cpacsHandle         Handle for the CPACS configuration
- * @param[out] WithDuctCutoutsFlag flag, wether all geometric components shall be build with duct cutouts
+ * @param[out] WithDuctCutoutsFlag flag, whether all geometric components shall be build with duct cutouts
  *
  * @return
  *   - TIGL_SUCCESS if no error occurred

--- a/src/common/sorting.h
+++ b/src/common/sorting.h
@@ -32,7 +32,7 @@ void rotate_right(ForwardIterator begin, ForwardIterator last)
 }
 
 /**
- * Sorts an array that contains a continous number of entries, possible unordered
+ * Sorts an array that contains a continuous number of entries, possible unordered
  */
 template<class ForwardIterator, class UnaryPredicate>
 void follow_sort(ForwardIterator begin, ForwardIterator end, UnaryPredicate follows)
@@ -59,7 +59,7 @@ void follow_sort(ForwardIterator begin, ForwardIterator end, UnaryPredicate foll
     }
 
     if (sorted+1 != end) {
-        throw std::invalid_argument("Vector not continous");
+        throw std::invalid_argument("Vector not continuous");
     }
 }
 

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -128,7 +128,7 @@ TIGL_EXPORT boost::optional<UVResult> GetFaceAndUV(TopoDS_Shape const& shape,
 
 
 /**
- * @brief TrimFace trims a face given new minium and maxinum values for the (u,v)-
+ * @brief TrimFace trims a face given new minimum and maximum values for the (u,v)-
  * coordinates
  * @param face The face to be trimmed
  * @param umin new minimum u value
@@ -298,7 +298,7 @@ TIGL_EXPORT void GetListOfShape(const TopoDS_Shape& shape, TopAbs_ShapeEnum type
 TIGL_EXPORT std::vector<TopoDS_Shape> GetSubShapes(const TopoDS_Shape& shape, TopAbs_ShapeEnum type);
 
 // Cuts two shapes and returns the common geometry (e.g. intersection edges)
-// Throws an exception in case the interesection failed
+// Throws an exception in case the intersection failed
 TIGL_EXPORT TopoDS_Shape CutShapes(const TopoDS_Shape& shape1, const TopoDS_Shape& shape2);
 
 // Helper for splitting a shape by another shape

--- a/src/control_devices/CCPACSTrailingEdgeDevice.cpp
+++ b/src/control_devices/CCPACSTrailingEdgeDevice.cpp
@@ -115,7 +115,7 @@ gp_Trsf CCPACSTrailingEdgeDevice::GetFlapTransform() const
     gp_Pnt outerHingeOld = wingTrafo.Transform(m_hingePoints->outer);
 
     // innerTranslationY on hingePoint1 on purpose, maybe consider setting it to zero as default. See CPACS definition on
-    // Path/Step/HingeLineTransformation for more informations.
+    // Path/Step/HingeLineTransformation for more information.
     gp_Pnt outerHingeNew = outerHingeOld.XYZ() + gp_XYZ(outerTranslationX, innerTranslationY, outerTranslationZ);
     gp_Pnt innerHingeNew = innerHingeOld.XYZ() + gp_XYZ(innerTranslationX, innerTranslationY, innerTranslationZ);
 

--- a/src/control_devices/CTiglControlSurfaceBorderCoordinateSystem.h
+++ b/src/control_devices/CTiglControlSurfaceBorderCoordinateSystem.h
@@ -28,7 +28,7 @@ namespace tigl
 {
 
 /**
- * @brief Defines are coordiante system for the wing flap
+ * @brief Defines a coordinate system for the wing flap
  * border.
  * 
  * The x direction of the coordinate system points from the

--- a/src/engine_nacelle/CCPACSEnginePositions.cpp
+++ b/src/engine_nacelle/CCPACSEnginePositions.cpp
@@ -55,4 +55,4 @@ TIGL_EXPORT CCPACSEnginePosition& CCPACSEnginePositions::GetEnginePosition(std::
     throw CTiglError("CCPACSEnginePositions::GetEnginePosition: EnginePosition \"" + uid + "\" not found in CPACS file!", TIGL_UID_ERROR);
 }
 
-} //namepsace tigl
+} //namespace tigl

--- a/src/engine_nacelle/CCPACSEngines.cpp
+++ b/src/engine_nacelle/CCPACSEngines.cpp
@@ -49,4 +49,4 @@ TIGL_EXPORT CCPACSEngine& CCPACSEngines::GetEngine(std::string const uid) const
     throw CTiglError("CCPACSEngines::GetEngine: Engine \"" + uid + "\" not found in CPACS file!", TIGL_UID_ERROR);
 }
 
-} //namepsace tigl
+} //namespace tigl

--- a/src/engine_nacelle/CCPACSNacelleGuideCurves.cpp
+++ b/src/engine_nacelle/CCPACSNacelleGuideCurves.cpp
@@ -38,4 +38,4 @@ CCPACSNacelleGuideCurve& CCPACSNacelleGuideCurves::GetGuideCurve(size_t index) c
     return *m_nacelleGuideCurves[index];
 }
 
-} //namepsace tigl
+} //namespace tigl

--- a/src/engine_nacelle/CCPACSNacelleProfile.cpp
+++ b/src/engine_nacelle/CCPACSNacelleProfile.cpp
@@ -63,7 +63,7 @@ bool CCPACSNacelleProfile::HasBluntTE() const
     if ( algoType == Airfoil ) {
         const ITiglWingProfileAlgo* algo = GetProfileAlgo();
         if (!algo) {
-            throw CTiglError("No wing profile algorithm regsitered in CCPACSNacelleProfile::HasBluntTE()!");
+            throw CTiglError("No wing profile algorithm registered in CCPACSNacelleProfile::HasBluntTE()!");
         }
         return algo->HasBluntTE();
     }
@@ -151,4 +151,4 @@ gp_Pnt CCPACSNacelleProfile::GetTEPoint() const
     return GetProfileAlgo()->GetTEPoint();
 }
 
-} //namepsace tigl
+} //namespace tigl

--- a/src/engine_nacelle/CCPACSNacelleSection.cpp
+++ b/src/engine_nacelle/CCPACSNacelleSection.cpp
@@ -119,4 +119,4 @@ double CCPACSNacelleSection::GetChordLength() const
 }
 
 
-} //namepsace tigl
+} //namespace tigl

--- a/src/engine_nacelle/CCPACSNacelleSections.cpp
+++ b/src/engine_nacelle/CCPACSNacelleSections.cpp
@@ -60,4 +60,4 @@ size_t CCPACSNacelleSections::GetSectionIndex(std::string const uid) const
     throw CTiglError("CCPACSNacelleSection::GetSectionIndex: Section \"" + uid + "\" not found in CPACS file!", TIGL_UID_ERROR);
 }
 
-} //namepsace tigl
+} //namespace tigl

--- a/src/engine_nacelle/CTiglNacelleGuideCurveBuilder.cpp
+++ b/src/engine_nacelle/CTiglNacelleGuideCurveBuilder.cpp
@@ -237,7 +237,7 @@ tigl::NacelleGuideCurveParameters GetGuideCurveParametersFromCPACS(const tigl::C
     params.toSection = &sections.GetSection(endSectionIdx);
     params.toZeta = curve.GetToZeta();
 
-    // get origin of nacelle cowl (inheritence: curve --> guidecurves --> nacelleCowl )
+    // get origin of nacelle cowl (inheritance: curve --> guidecurves --> nacelleCowl )
 //    tigl::CTiglTransformation trans = curve.GetParent()->GetParent()->GetTransformationMatrix();
 //    params.origin = tigl::CTiglPoint( trans.GetValue(0,3), trans.GetValue(1,3), trans.GetValue(2,3)  );
 

--- a/src/exports/CTiglExportCollada.cpp
+++ b/src/exports/CTiglExportCollada.cpp
@@ -157,7 +157,7 @@ bool writeGeometryMesh(TixiDocumentHandle handle, const CTiglPolyData& polyData,
     std::stringstream stream_verts;
     std::stringstream stream_normals;
     std::stringstream stream_trians;
-    unsigned long count_pos =0, count_norm =0, count_vert =0; // count Points, Normals, Verticies for COLLADA-schema arrays
+    unsigned long count_pos =0, count_norm =0, count_vert =0; // count Points, Normals, Vertices for COLLADA-schema arrays
 
     for (unsigned int i = 1; i <= polyData.getNObjects(); ++i) {
         const CTiglPolyObject& obj = polyData.getObject(i);

--- a/src/fuselage/CCPACSCrossBeamAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSCrossBeamAssemblyPosition.cpp
@@ -135,7 +135,7 @@ void CCPACSCrossBeamAssemblyPosition::BuildGeometry(TopoDS_Shape& cache, bool ju
         //debug.addShape(frameGeometry, "frameGeometry");
         const TopoDS_Shape frameFace = BRepBuilderAPI_MakeFace(CloseWire(TopoDS::Wire(frameGeometry)));
 
-        // for some rediculous reason, BRepBuilderAPI_MakeFace alters the tolerance of the underlying wire's edges and vertices,
+        // for some ridiculous reason, BRepBuilderAPI_MakeFace alters the tolerance of the underlying wire's edges and vertices,
         // causing subsequent boolean operations to fail (self intersections)
         ShapeFix_ShapeTolerance().SetTolerance(frameFace, Precision::Confusion());
         //debug.addShape(frameFace, "frameFace");

--- a/src/fuselage/CCPACSFuselageProfile.h
+++ b/src/fuselage/CCPACSFuselageProfile.h
@@ -107,7 +107,7 @@ private:
     void InvalidateImpl(const boost::optional<std::string>& source) const override;
 
 private:
-    bool mirrorSymmetry; /**< Mirror symmetry with repect to the x-z plane */
+    bool mirrorSymmetry; /**< Mirror symmetry with respect to the x-z plane */
     Cache<WireCache, CCPACSFuselageProfile> wireCache; /**< Original and force closed fuselage profile wire */
     Cache<DiameterPointsCache, CCPACSFuselageProfile> diameterPointsCache;
     std::unique_ptr<ITiglWireAlgorithm> profileWireAlgo;

--- a/src/fuselage/CCPACSFuselageSegment.h
+++ b/src/fuselage/CCPACSFuselageSegment.h
@@ -71,7 +71,7 @@ public:
     // Returns the end section index of this segment
     TIGL_EXPORT int GetEndSectionIndex();
 
-    // Returns the starting Segement Connection
+    // Returns the starting Segment Connection
     TIGL_EXPORT CTiglFuselageConnection& GetStartConnection();
 
     // Return the end Segment Connection
@@ -113,8 +113,8 @@ public:
     // 0.0 <= eta <= 1.0 and 0.0 <= zeta <= 1.0. For eta = 0.0 the point lies on the start
     // profile of the segment, for eta = 1.0 on the end profile of the segment. For zeta = 0.0
     // the point is the start point of the profile wire, for zeta = 1.0 the last profile wire point.
-    // The last input sets the behavior, e.g. wether a point on the linear loft for chordface parameters
-    // is output or wether a point is output for parameters on the surface.
+    // The last input sets the behavior, e.g. whether a point on the linear loft for chordface parameters
+    // is output or whether a point is output for parameters on the surface.
     TIGL_EXPORT gp_Pnt GetPoint(double eta, double zeta, TiglGetPointBehavior behavior = asParameterOnSurface);
 
     // Gets the origin (0, 0, 0) of the inner & outer profiles after trafo

--- a/src/fuselage/CCPACSFuselageSegments.cpp
+++ b/src/fuselage/CCPACSFuselageSegments.cpp
@@ -160,7 +160,7 @@ void CCPACSFuselageSegments::ReorderSegments()
     try {
         tigl::follow_sort(GetSegments().begin(), GetSegments().end(), segment_follows);
     } catch (std::invalid_argument) {
-        throw CTiglError("Fuselage segments not continous.");
+        throw CTiglError("Fuselage segments not continuous.");
     }
 }
 

--- a/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
+++ b/src/fuselage/CCPACSPressureBulkheadAssemblyPosition.cpp
@@ -160,7 +160,7 @@ void CCPACSPressureBulkheadAssemblyPosition::BuildGeometry(TopoDS_Shape& cache) 
 
         TopoDS_Face face = makeFace.Face();
 
-        // for some rediculous reason, BRepBuilderAPI_MakeFace alters the tolerance of the underlying wire's edges and vertices,
+        // for some ridiculous reason, BRepBuilderAPI_MakeFace alters the tolerance of the underlying wire's edges and vertices,
         // causing subsequent boolean operations to fail (self intersections)
         ShapeFix_ShapeTolerance().SetTolerance(face, Precision::Confusion());
 

--- a/src/geometry/CFunctionToBspline.cpp
+++ b/src/geometry/CFunctionToBspline.cpp
@@ -320,7 +320,7 @@ Handle(Geom_BSplineCurve) CFunctionToBspline::CFunctionToBsplineImpl::concatC1(c
             // omit the first control points of the current curve
         }
 
-        // just copy control points, weights, knots and multiplicites
+        // just copy control points, weights, knots and multiplicities
         for (int iknot = 2; iknot < curve->NbKnots(); ++iknot) {
             knots.SetValue(iknotT++, curve->Knot(iknot));
             mults.SetValue(imultT++, curve->Multiplicity(iknot));

--- a/src/geometry/CFunctionToBspline.h
+++ b/src/geometry/CFunctionToBspline.h
@@ -28,7 +28,7 @@ namespace tigl
 {
 
 /**
- * @brief The FunctionToBspline class can be used to approximate an arbitary 3D function
+ * @brief The FunctionToBspline class can be used to approximate an arbitrary 3D function
  * with a B-Spline. 
  * 
  * The function to approximate is given by 3 separate functions, one for the x values,

--- a/src/geometry/CTiglArcLengthReparameterization.cpp
+++ b/src/geometry/CTiglArcLengthReparameterization.cpp
@@ -66,7 +66,7 @@ double BSplineArcLength::getParameter(double arcLength)
         return algo.Parameter();
     }
     else {
-        throw tigl::CTiglError("BSplineArcLength: can't compute paramter for arc given length.", TIGL_MATH_ERROR);
+        throw tigl::CTiglError("BSplineArcLength: can't compute parameter for arc given length.", TIGL_MATH_ERROR);
     }
 }
 

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -640,7 +640,7 @@ CTiglApproxResult CTiglBSplineAlgorithms::reparametrizeBSplineContinuouslyApprox
 #ifdef MODEL_KINKS
     // remove kinks from breaks
     std::vector<double> kinks = CTiglBSplineAlgorithms::getKinkParameters(spline);
-    // convert kink parameters into reparamtetrized parameter using the
+    // convert kink parameters into reparametrized parameter using the
     // inverse reparametrization function
     for (size_t ikink = 0; ikink < kinks.size(); ++ikink) {
         kinks[ikink] = Geom2dAPI_ProjectPointOnCurve(gp_Pnt2d(kinks[ikink], 0.), reparametrizing_spline)
@@ -1099,7 +1099,7 @@ Handle(Geom_BSplineCurve) CTiglBSplineAlgorithms::concatCurves(std::vector<Handl
             weights.SetValue(iweightT++, (lastCurve->Weight(lastCurve->NbPoles()) + curve->Weight(1))/2.);
         }
 
-        // just copy control points, weights, knots and multiplicites
+        // just copy control points, weights, knots and multiplicities
         for (int iknot = 2; iknot < curve->NbKnots(); ++iknot) {
             knots.SetValue(iknotT++, curve->Knot(iknot));
             mults.SetValue(imultT++, curve->Multiplicity(iknot));

--- a/src/geometry/CTiglBSplineFit.h
+++ b/src/geometry/CTiglBSplineFit.h
@@ -48,7 +48,7 @@ public:
     /// Fits the given points by a B-spline
     TIGL_EXPORT error Fit(const TColgp_Array1OfPnt& points, const std::vector<double>& parameters);
 
-    /// Fits the given points by a B-spline using the centripetal paramterization scheme (alpha=0.5)
+    /// Fits the given points by a B-spline using the centripetal parameterization scheme (alpha=0.5)
     TIGL_EXPORT error Fit(const TColgp_Array1OfPnt& points, double alpha=1.0);
 
     /// Fits, by optimizing the fit parameters

--- a/src/geometry/CTiglCurvesToSurface.h
+++ b/src/geometry/CTiglCurvesToSurface.h
@@ -43,7 +43,7 @@ public:
      * of the interpolation in v-direction using ::SetMaxDegree.
      *
      * @param splines_vector Curves to be interpolated.
-     * @param continuousIfClosed Make a C2 continous surface at the start/end junction if the first and last curve are the same
+     * @param continuousIfClosed Make a C2 continuous surface at the start/end junction if the first and last curve are the same
      */
     TIGL_EXPORT explicit CTiglCurvesToSurface(const std::vector<Handle(Geom_Curve) >& splines_vector,
                                               bool continuousIfClosed = false);
@@ -56,7 +56,7 @@ public:
      *
      * @param splines_vector Curves to be interpolated.
      * @param parameters Parameters of v-direction at which the resulting surface should interpolate the input curves.
-     * @param continuousIfClosed Make a C2 continous surface at the start/end junction if the first and last curve are the same
+     * @param continuousIfClosed Make a C2 continuous surface at the start/end junction if the first and last curve are the same
      */
     TIGL_EXPORT explicit CTiglCurvesToSurface(const std::vector<Handle(Geom_Curve) >& splines_vector,
                                               const std::vector<double>& parameters,

--- a/src/geometry/CTiglGordonSurfaceBuilder.cpp
+++ b/src/geometry/CTiglGordonSurfaceBuilder.cpp
@@ -143,7 +143,7 @@ void CTiglGordonSurfaceBuilder::CreateGordonSurface(const std::vector<Handle(Geo
         }
     }
 
-    // check, whether to build a closed continous surface
+    // check, whether to build a closed continuous surface
     double curve_u_tolerance = CTiglBSplineAlgorithms::REL_TOL_CLOSED * CTiglBSplineAlgorithms::scale(guides);
     double curve_v_tolerance = CTiglBSplineAlgorithms::REL_TOL_CLOSED * CTiglBSplineAlgorithms::scale(profiles);
     double tp_tolerance      = CTiglBSplineAlgorithms::REL_TOL_CLOSED * CTiglBSplineAlgorithms::scale(intersection_pnts);

--- a/src/geometry/CTiglIntersectionCalculation.h
+++ b/src/geometry/CTiglIntersectionCalculation.h
@@ -111,7 +111,7 @@ public:
     // gives a reference to the computed vertex
     TIGL_EXPORT TopoDS_Vertex GetVertex(int vertexID);
 
-    // returnes the unique ID for the current intersection
+    // returns the unique ID for the current intersection
     TIGL_EXPORT const std::string& GetID();
 
 protected:
@@ -124,7 +124,7 @@ protected:
 private:        
     Standard_Real tolerance;
     TopoDS_Compound intersectionResult;     /* The full Intersection result */
-    std::string id;                         /* identifcation id of the intersection */
+    std::string id;                         /* identification id of the intersection */
     
 };
 

--- a/src/geometry/CTiglMakeLoft.h
+++ b/src/geometry/CTiglMakeLoft.h
@@ -60,7 +60,7 @@ public:
     TIGL_EXPORT void setMakeSolid(bool enabled);
 
     /**
-     * @brief setMakeSmooth switches, wether the resulting loft will be ruled
+     * @brief setMakeSmooth switches, whether the resulting loft will be ruled
      * or smoothed. This switch only applies, if no guide curves are applied.
      *
      * @param enabled Set to true, if smoothing should be enabled.

--- a/src/geometry/CTiglPatchShell.h
+++ b/src/geometry/CTiglPatchShell.h
@@ -49,9 +49,9 @@ public:
     explicit CTiglPatchShell(TopoDS_Shape const& shell, double tolerance = 1e-6);
 
     /**
-     * @brief Determine, wether the resulting shape shall be a solid or a closed shell
+     * @brief Determine, whether the resulting shape shall be a solid or a closed shell
      *
-     * @param enabled boolean wether to create a solid or not
+     * @param enabled boolean whether to create a solid or not
      */
     void SetMakeSolid(bool enabled = true) { _makeSolid = enabled; }
 

--- a/src/geometry/CTiglPolyData.cpp
+++ b/src/geometry/CTiglPolyData.cpp
@@ -533,7 +533,7 @@ unsigned int CTiglPolyObject::getNumberOfPolyRealData() const
     return static_cast<unsigned int>(impl->polyDataElems.size());
 }
 
-// retuns the  name of the ith data field (i = 0 .. getNumberPolyReadlData - 1)
+// returns the name of the ith data field (i = 0 .. getNumberPolyReadlData - 1)
 const char * CTiglPolyObject::getPolyDataFieldName(unsigned long iField) const 
 {
     if (iField < getNumberOfPolyRealData()) {

--- a/src/geometry/CTiglPolyData.h
+++ b/src/geometry/CTiglPolyData.h
@@ -132,7 +132,7 @@ public:
     // returns the number if different polygon data entries 
     TIGL_EXPORT unsigned int getNumberOfPolyRealData() const;
     
-    // retuns the  name of the ith data field (i = 0 .. getNumberPolyReadlData - 1)
+    // returns the name of the ith data field (i = 0 .. getNumberPolyReadlData - 1)
     TIGL_EXPORT const char * getPolyDataFieldName(unsigned long iField) const;
 
 

--- a/src/geometry/CTiglTopoAlgorithms.cpp
+++ b/src/geometry/CTiglTopoAlgorithms.cpp
@@ -113,7 +113,7 @@ TopoDS_Shape CTiglTopoAlgorithms::CutShellAtUVParameters(TopoDS_Shape const& sha
     builder.MakeShell(cutShape);
 
     for (TopExp_Explorer faces(shape, TopAbs_FACE); faces.More(); faces.Next()) {
-        // trim each face/surface of the compound at the uv paramters in the paramter vectors
+        // trim each face/surface of the compound at the uv parameters in the parameter vectors
         auto surface = BRep_Tool::Surface(TopoDS::Face(faces.Current()));
         CutSurfaceAtUVParametersImpl(surface, uparams, vparams, cutShape);
     }
@@ -128,7 +128,7 @@ TopoDS_Shape CTiglTopoAlgorithms::CutShellAtKinks(TopoDS_Shape const& shape)
     builder.MakeShell(cutShape);
 
     for (TopExp_Explorer faces(shape, TopAbs_FACE); faces.More(); faces.Next()) {
-        // trim each face/surface of the compound at the uv paramters in the paramter vectors
+        // trim each face/surface of the compound at the uv parameters in the parameter vectors
         auto surface = BRep_Tool::Surface(TopoDS::Face(faces.Current()));
         CutSurfaceAtKinks(GeomConvert::SurfaceToBSplineSurface(surface), cutShape);
     }

--- a/src/math/tiglmathfunctions.cpp
+++ b/src/math/tiglmathfunctions.cpp
@@ -235,7 +235,7 @@ double shape_function_deriv(const std::vector<double>& B, const int& n, const do
  * 
  * CST(psi)=C(psi)*S(psi)
  *
- * N1, N2 are the paramters of the class function C(psi) = psi^N1 * (1-psi)^N2
+ * N1, N2 are the parameters of the class function C(psi) = psi^N1 * (1-psi)^N2
  * B is the vector of coefficients for the bernstein polynomials P_i^n(psi) 
  * T is the trailing edge thickness
  * inside the shape function S(psi)=sum_i=1^N B_i * p_i^n(psi)

--- a/src/math/tiglmathfunctions.h
+++ b/src/math/tiglmathfunctions.h
@@ -115,7 +115,7 @@ TIGL_EXPORT double shape_function_deriv(const std::vector<double>& B, const int&
  * 
  * CST(psi)=C(psi)*S(psi)
  *
- * N1, N2 are the paramters of the class function C(psi) = psi^N1 * (1-psi)^N2
+ * N1, N2 are the parameters of the class function C(psi) = psi^N1 * (1-psi)^N2
  * B is the vector of coefficients for the bernstein polynomials P_i^n(psi) 
  * T is the trailing edge thickness
  * inside the shape function S(psi)=sum_i=1^N B_i * p_i^n(psi)

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -372,7 +372,7 @@ void CCPACSWing::BuildFusedSegments(PNamedShape& shape) const
 // Builds a fused shape of all wing segments
 void CCPACSWing::BuildUpperLowerShells()
 {
-    //@todo: this probably works only if the wings does not split somewere
+    //@todo: this probably works only if the wings does not split somewhere
     BRepOffsetAPI_ThruSections generatorUp(Standard_False, Standard_True, Precision::Confusion() );
     BRepOffsetAPI_ThruSections generatorLow(Standard_False, Standard_True, Precision::Confusion() );
 
@@ -723,7 +723,7 @@ double CCPACSWing::GetAspectRatio() const
 
 /**
     * This function calculates location of the quarter of mean aerodynamic chord,
-    * and gives the chord lenght as well. It uses the classical method that can
+    * and gives the chord length as well. It uses the classical method that can
     * be applied to trapozaidal wings. This method is used for each segment.
     * The values are found by taking into account of sweep and dihedral.
     * But the effect of insidance angle is neglected. These values should coincide

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -109,7 +109,7 @@ public:
     // Gets the loft of the whole wing
     TIGL_EXPORT TopoDS_Shape & GetLoftWithLeadingEdge();
 
-    // Returns the wing loft with cutted out control surfaces
+    // Returns the wing loft with cut out control surfaces
     TIGL_EXPORT TopoDS_Shape GetLoftWithCutouts();
         
     TIGL_EXPORT TopoDS_Shape & GetUpperShape();

--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -477,7 +477,7 @@ TopoDS_Shape CCPACSWingCell::CutSpanwise(GeometryCache& cache,
                                          double tol) const
 {
 
-    // Border not defined by contour cooordinate.
+    // Border not defined by contour coordinate.
     if (positioning.GetContourCoordinate_choice1()){
         throw CTiglError("Internal Error when trying to create the cell geometry");
     }

--- a/src/wing/CCPACSWingCell.h
+++ b/src/wing/CCPACSWingCell.h
@@ -143,7 +143,7 @@ private:
     void BuildSkinGeometry(GeometryCache& cache) const;
 
     // this enum is used internally by CutSpanWise to determine,
-    // wether it is an inner or an outer cut
+    // whether it is an inner or an outer cut
     enum class SpanWiseBorder {
         Inner,
         Outer
@@ -161,7 +161,7 @@ private:
      *
      * @param cache The shape cache of the wing cell
      * @param loftShape the shape of the wing skin
-     * @param border a SpanWiseBorder enum, denoting wether it is a inner
+     * @param border a SpanWiseBorder enum, denoting whether it is an inner
      * or outer border
      * @param positioning CPACS definition of the border
      * @param zRefDir a reference direction orthogonal to the chordface
@@ -185,7 +185,7 @@ private:
      * relative to the wing skin via contour coordinates.
      *
      * @param cache The shape of the wing cell
-     * @param border  a SpanWiseBorder enum, denoting wether it is a inner
+     * @param border  a SpanWiseBorder enum, denoting whether it is an inner
      * or outer border
      * @param positioning CPACS definition of the border
      * @param tol a tolerance
@@ -196,7 +196,7 @@ private:
                       double tol = 5e-3) const;
 
     // this enum is used internally by CutChordwise to determine,
-    // wether it is a leading edge or trailing edge cut
+    // whether it is a leading edge or trailing edge cut
     enum class ChordWiseBorder {
         LE,
         TE
@@ -214,7 +214,7 @@ private:
      *
      * @param cache The shape cache of the wing cell
      * @param loftShape the shape of the wing skin
-     * @param border a ChordWiseBorder enum, denoting wether it is a leading edge
+     * @param border a ChordWiseBorder enum, denoting whether it is a leading edge
      * or trailing edge border
      * @param positioning CPACS definition of the border
      * @param zRefDir a reference direction orthogonal to the chordface
@@ -238,7 +238,7 @@ private:
      * relative to the wing skin via contour coordinates.
      *
      * @param cache The shape of the wing cell
-     * @param border  a ChordWiseBorder enum, denoting wether it is a LE
+     * @param border  a ChordWiseBorder enum, denoting whether it is a LE
      * or a TE border
      * @param positioning CPACS definition of the border
      * @param tol a tolerance

--- a/src/wing/CCPACSWingProfile.cpp
+++ b/src/wing/CCPACSWingProfile.cpp
@@ -392,7 +392,7 @@ bool CCPACSWingProfile::HasBluntTE() const
 {
     const ITiglWingProfileAlgo* algo = GetProfileAlgo();
     if (!algo) {
-        throw CTiglError("No wing profile algorithm regsitered in CCPACSWingProfile::HasBluntTE()!");
+        throw CTiglError("No wing profile algorithm registered in CCPACSWingProfile::HasBluntTE()!");
     }
     return algo->HasBluntTE();
 }

--- a/src/wing/CCPACSWingProfileGetPointAlgo.h
+++ b/src/wing/CCPACSWingProfileGetPointAlgo.h
@@ -47,7 +47,7 @@ public:
      * \brief Constructor which expects a wire of to concatenated upper and lower wing edges as input
      *
      *
-     * \param wireContainer Containes exactly two wires: The upper and lower wing profile wires
+     * \param wireContainer Contains exactly two wires: The upper and lower wing profile wires
      */
     TIGL_EXPORT CCPACSWingProfileGetPointAlgo (const TopTools_SequenceOfShape& wireContainer);
 

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -240,7 +240,7 @@ TopoDS_Wire CCPACSWingSegment::GetInnerWire(TiglCoordinateSystem referenceCS, Ti
     /*
     * The loft algorithm with guide curves does not like splitted
     * wing profiles, we have to give him the unsplitted one.
-    * In all other cases, we need the splitted wire to distiguish
+    * In all other cases, we need the splitted wire to distinguish
     * upper und lower wing surface
     */
     if (m_guideCurves && m_guideCurves->GetGuideCurveCount() > 0) {
@@ -273,7 +273,7 @@ TopoDS_Wire CCPACSWingSegment::GetOuterWire(TiglCoordinateSystem referenceCS, Ti
     /*
     * The loft algorithm with guide curves does not like splitted
     * wing profiles, we have to give him the unsplitted one.
-    * In all other cases, we need the splitted wire to distiguish
+    * In all other cases, we need the splitted wire to distinguish
     * upper und lower wing surface
     */
     if (m_guideCurves && m_guideCurves->GetGuideCurveCount() > 0) {

--- a/src/wing/CCPACSWingSparPosition.cpp
+++ b/src/wing/CCPACSWingSparPosition.cpp
@@ -103,7 +103,7 @@ double CCPACSWingSparPosition::GetXsi() const
 const CCPACSEtaXsiPoint &CCPACSWingSparPosition::GetEtaXsiPoint() const
 {
     if (!GetSparPositionEtaXsi_choice2()) {
-        throw CTiglError("No EtaXsiPoint definied in SparPosition '" + GetUID() + "'");
+        throw CTiglError("No EtaXsiPoint defined in SparPosition '" + GetUID() + "'");
     }
     
     return GetSparPositionEtaXsi_choice2().value();
@@ -112,7 +112,7 @@ const CCPACSEtaXsiPoint &CCPACSWingSparPosition::GetEtaXsiPoint() const
 const generated::CPACSWingRibPoint& CCPACSWingSparPosition::GetRibPoint() const
 {
     if (!GetSparPositionRib_choice1()) {
-        throw CTiglError("No RibPoint definied in SparPosition '" + GetUID() + "'");
+        throw CTiglError("No RibPoint defined in SparPosition '" + GetUID() + "'");
     }
 
     return GetSparPositionRib_choice1().value();
@@ -196,7 +196,7 @@ gp_Vec CCPACSWingSparPosition::GetUpVector(const CCPACSWingCSStructure& structur
         }
         else {
             // this should actually not happen
-            throw CTiglError("A fatal error as occured");
+            throw CTiglError("A fatal error as occurred");
         }
         
         // compute bounding box of section element face

--- a/src/wing/CTiglWingProfilePointList.cpp
+++ b/src/wing/CTiglWingProfilePointList.cpp
@@ -143,7 +143,7 @@ void CTiglWingProfilePointList::BuildWires(WireCache& cache) const
 
     // CCPACSWingSegment::makeSurfaces cannot handle currently
     // wire with multiple edges. Thus we get problems if we have
-    // a linear interpolated wire consting of many edges.
+    // a linear interpolated wire consisting of many edges.
     if (dynamic_cast<const CTiglInterpolateLinearWire*>(&wireBuilder)) {
         LOG(ERROR) << "Linear Wing Profiles are currently not supported";
         throw CTiglError("Linear Wing Profiles are currently not supported",TIGL_ERROR);

--- a/src/wing/tigletaxsifunctions.cpp
+++ b/src/wing/tigletaxsifunctions.cpp
@@ -275,7 +275,7 @@ void InterpolateXsi(const std::string& refUID1, const EtaXsi& etaXsi1,
 
     // If parameter on CS line is < 0 or larger than
     // Length of line, there is not actual intersection,
-    // i.e. the CS Line is choosen to small
+    // i.e. the CS Line is chosen too small
     // We use a tolerance here, to account for small user errors
     double tol = 1e-5;
     if (pOnCSLine.Parameter() < -tol || pOnCSLine.Parameter() > p1.Distance(p2) + tol) {

--- a/tests/integrationtests/TestData/bugs/815/Beam_Composite_Export_Test_33_cell.xml
+++ b/tests/integrationtests/TestData/bugs/815/Beam_Composite_Export_Test_33_cell.xml
@@ -25,7 +25,7 @@
         <wings>
           <wing symmetry="x-z-plane" uID="beam">
             <name>beam</name>
-            <description>This has been crated manually</description>
+            <description>This has been created manually</description>
             <transformation uID="beam_transformation1">
               <scaling uID="beam_transformation1_scaling1">
                 <x>1</x>


### PR DESCRIPTION
## Description

Fix typos found via `codespell -q 3 -S thirdparty -L ane,ans,childs,globaly,inout,ist,oce,ontop,parm,parms,te`

3rd party and upstream schema code was avoided. 

## How Has This Been Tested?

n/a

## Screenshots, that help to understand the changes(if applicable):
n/a

## Checklist:
- [ ] A test for the new functionality was added.
- [x] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
