### PR TITLE
Fix typos found in tests/unittests

### DIFF
--- a/tests/unittests/TestData/CPACS_30_CST_simple.xml
+++ b/tests/unittests/TestData/CPACS_30_CST_simple.xml
@@ -275,7 +275,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/CPACS_30_CST_simple_bluntTE.xml
+++ b/tests/unittests/TestData/CPACS_30_CST_simple_bluntTE.xml
@@ -275,7 +275,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/CPACS_30_D150.xml
+++ b/tests/unittests/TestData/CPACS_30_D150.xml
@@ -3973,7 +3973,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/CPACS_30_D250_10.xml
+++ b/tests/unittests/TestData/CPACS_30_D250_10.xml
@@ -9290,11 +9290,11 @@
       </fuselage>
       <designMode>presize<!--comment for designMode: use  presize, fsd or optimization-->
 			</designMode>
-      <optimizationMethod>1<!--comment for optimizationMethod: Method for internal mathematically optimization (only sensible if designMode 'optimization' is choosen) : values: 1,2,3; Modified Method of Feasible Directions [1] (default); Sequential Linear Programming [2]; Sequential Quadratic Programming [3]-->
+      <optimizationMethod>1<!--comment for optimizationMethod: Method for internal mathematically optimization (only sensible if designMode 'optimization' is chosen) : values: 1,2,3; Modified Method of Feasible Directions [1] (default); Sequential Linear Programming [2]; Sequential Quadratic Programming [3]-->
 			</optimizationMethod>
       <reducedModel>1<!--comment for reducedModel: should the A-Set structure reduction be modelled-->
 			</reducedModel>
-      <archiveMode>3<!--comment for archiveMode: Postprogram: to generate and copie more data to the output (value 1 (default),2)-->
+      <archiveMode>3<!--comment for archiveMode: Postprogram: to generate and copy more data to the output (value 1 (default),2)-->
 			</archiveMode>
       <debugMode>0<!--comment for debugMode: 1: to print all script output during the run, 0: print less-->
 			</debugMode>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_10_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_10_profiles.xml
@@ -4643,7 +4643,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_11_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_11_profiles.xml
@@ -4746,7 +4746,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_13_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_13_profiles.xml
@@ -4952,7 +4952,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_16_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_16_profiles.xml
@@ -5261,7 +5261,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_21_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_21_profiles.xml
@@ -5776,7 +5776,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_2_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_2_profiles.xml
@@ -3819,7 +3819,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_31_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_31_profiles.xml
@@ -6806,7 +6806,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_3_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_3_profiles.xml
@@ -3922,7 +3922,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_60_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_60_profiles.xml
@@ -9793,7 +9793,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_7_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_7_profiles.xml
@@ -4334,7 +4334,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_8_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_8_profiles.xml
@@ -4437,7 +4437,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_9_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_16_guides_9_profiles.xml
@@ -4540,7 +4540,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_10_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_10_profiles.xml
@@ -3995,7 +3995,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_11_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_11_profiles.xml
@@ -4026,7 +4026,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_13_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_13_profiles.xml
@@ -4088,7 +4088,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_16_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_16_profiles.xml
@@ -4181,7 +4181,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_21_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_21_profiles.xml
@@ -4336,7 +4336,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_2_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_2_profiles.xml
@@ -3747,7 +3747,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_31_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_31_profiles.xml
@@ -4646,7 +4646,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_3_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_3_profiles.xml
@@ -3778,7 +3778,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_5_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_5_profiles.xml
@@ -3840,7 +3840,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_60_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_60_profiles.xml
@@ -5545,7 +5545,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_7_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_7_profiles.xml
@@ -3902,7 +3902,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_8_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_8_profiles.xml
@@ -3933,7 +3933,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_9_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_4_guides_9_profiles.xml
@@ -3964,7 +3964,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_10_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_10_profiles.xml
@@ -4211,7 +4211,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_11_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_11_profiles.xml
@@ -4266,7 +4266,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_13_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_13_profiles.xml
@@ -4376,7 +4376,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_16_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_16_profiles.xml
@@ -4541,7 +4541,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_21_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_21_profiles.xml
@@ -4816,7 +4816,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_2_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_2_profiles.xml
@@ -3771,7 +3771,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_31_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_31_profiles.xml
@@ -5366,7 +5366,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_3_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_3_profiles.xml
@@ -3826,7 +3826,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_5_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_5_profiles.xml
@@ -3936,7 +3936,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_60_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_60_profiles.xml
@@ -6961,7 +6961,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_6_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_6_profiles.xml
@@ -3991,7 +3991,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_7_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_7_profiles.xml
@@ -4046,7 +4046,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_8_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_8_profiles.xml
@@ -4101,7 +4101,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_9_profiles.xml
+++ b/tests/unittests/TestData/D150_n_guides_m_profiles/D150_8_guides_9_profiles.xml
@@ -4156,7 +4156,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/D150_v30.xml
+++ b/tests/unittests/TestData/D150_v30.xml
@@ -3965,7 +3965,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/TestData/cpacs_25032009.xml
+++ b/tests/unittests/TestData/cpacs_25032009.xml
@@ -4460,7 +4460,7 @@
 							<missionUID>Mission_1</missionUID>
 							<trajectory>
 								<name>Standard approach</name>
-								<description>This is a standard approch with 3 deg</description>
+								<description>This is a standard approach with 3 deg</description>
 								<flightPath>
 									<flightPosition>
 										<coordinates>

--- a/tests/unittests/TestData/simple_test_logging.xml
+++ b/tests/unittests/TestData/simple_test_logging.xml
@@ -275,7 +275,7 @@
                     </ribsDefinition>
                     <ribsDefinition uID="ribs_EM">
                       <name>ribs_EM</name>
-                      <description>ribs for the Enginge Mount</description>
+                      <description>ribs for the Engine Mount</description>
                       <ribsPositioning>
                         <ribReference>frontSpar</ribReference>
                         <startCurvePoint>

--- a/tests/unittests/cpacsConfiguration.cpp
+++ b/tests/unittests/cpacsConfiguration.cpp
@@ -63,7 +63,7 @@ TEST_F(tiglOpenCpacsConfiguration, nullPointerArgument)
 }
 
 /**
-* Tests a successfull run of tiglOpenCPACSConfiguration.
+* Tests a successful run of tiglOpenCPACSConfiguration.
 */
 TEST_F(tiglOpenCpacsConfiguration, openSuccess) 
 {
@@ -73,7 +73,7 @@ TEST_F(tiglOpenCpacsConfiguration, openSuccess)
 }
 
 /**
-* Tests a successfull open of tiglOpenCPACSConfiguration with specifiing the uid of the configuration.
+* Tests a successful open of tiglOpenCPACSConfiguration with specifiing the uid of the configuration.
 */
 TEST_F(tiglOpenCpacsConfiguration, open_without_uid) 
 {
@@ -139,7 +139,7 @@ TEST_F(TiglGetCPACSTixiHandle, hanlde_notFound)
 }
 
 /**
-* Tests a successfull run of tiglGetCPACSTixiHandle.
+* Tests a successful run of tiglGetCPACSTixiHandle.
 */
 TEST_F(TiglGetCPACSTixiHandle, handle_success)
 {

--- a/tests/unittests/pythonwrapper-tests.py
+++ b/tests/unittests/pythonwrapper-tests.py
@@ -113,7 +113,7 @@ class TestTiglLogging(unittest.TestCase):
         process=subprocess.Popen(['python', 'test_logging.py', "%s" % loglevel], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err=process.communicate()
         status=process.returncode
-        # seperate output lines
+        # separate output lines
         out=out.decode("UTF-8").rstrip('\n').split('\n')
         err=err.decode("UTF-8").rstrip('\n').split('\n')
         return (status, out, err)

--- a/tests/unittests/testArcLengthReparameterization.cpp
+++ b/tests/unittests/testArcLengthReparameterization.cpp
@@ -75,7 +75,7 @@ TEST_F(TestArcLengthReparameterization, accuracy)
 
     GeomAdaptor_Curve adaptor(curve);
 
-    // total Lenght
+    // total Length
     double totalLen = GCPnts_AbscissaPoint::Length(adaptor);
 
     EXPECT_NEAR(totalLen, repa.totalLength(), 1e-6);

--- a/tests/unittests/testOptionList.cpp
+++ b/tests/unittests/testOptionList.cpp
@@ -68,7 +68,7 @@ TEST(OptionList, AddGetSet)
     EXPECT_STREQ("hello world", v2.c_str());
 
     // check failures
-    // connot convert
+    // cannot convert
     EXPECT_THROW(options.Set("my_string", 2.0), tigl::CTiglError);
 
     // no such option

--- a/tests/unittests/tiglFuselageGetPoint.cpp
+++ b/tests/unittests/tiglFuselageGetPoint.cpp
@@ -126,7 +126,7 @@ TEST_F(TiglFuselageGetPoint, nullPointerArgument)
 }
 
 /**
-* Tests successfull call to tiglFuselageGetPoint.
+* Tests successful call to tiglFuselageGetPoint.
 */
 TEST_F(TiglFuselageGetPoint, success)
 {

--- a/tests/unittests/tiglFuselageHelper.cpp
+++ b/tests/unittests/tiglFuselageHelper.cpp
@@ -18,7 +18,7 @@
 
 /**
 * @file
-* @brief Tests some fuselage fuctions like circumreference, volumen, etc...
+* @brief Tests some fuselage functions like circumreference, volume, etc...
 */
 
 #define _USE_MATH_DEFINES

--- a/tests/unittests/tiglFuselageSegment.cpp
+++ b/tests/unittests/tiglFuselageSegment.cpp
@@ -131,7 +131,7 @@ TEST_F( TiglFuselageSegment, FuselageCount_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglGetFuselageCount.
+* Tests successful call of tiglGetFuselageCount.
 */
 TEST_F( TiglFuselageSegment, FuselageCount_success)
 {
@@ -169,7 +169,7 @@ TEST_F( TiglFuselageSegment, FuselageSegmentCount_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglFuselageGetSegmentCount.
+* Tests successful call of tiglFuselageGetSegmentCount.
 */
 TEST_F( TiglFuselageSegment, FuselageSegmentCount_success)
 {
@@ -216,7 +216,7 @@ TEST_F( TiglFuselageSegment, FuselageGetStartConnectedSegmentCount_nullPointerAr
 }
 
 /**
-* Tests successfull call of tiglFuselageGetStartConnectedSegmentCount.
+* Tests successful call of tiglFuselageGetStartConnectedSegmentCount.
 */
 TEST_F( TiglFuselageSegment, FuselageGetStartConnectedSegmentCount_success)
 {
@@ -265,7 +265,7 @@ TEST_F( TiglFuselageSegment, FuselageGetEndConnectedSegmentCount_nullPointerArgu
 }
 
 /**
-* Tests successfull call of tiglFuselageGetEndConnectedSegmentCount.
+* Tests successful call of tiglFuselageGetEndConnectedSegmentCount.
 */
 TEST_F( TiglFuselageSegment, FuselageGetEndConnectedSegmentCount_success)
 {
@@ -325,7 +325,7 @@ TEST_F( TiglFuselageSegment, FuselageGetStartConnectedSegmentIndex_nullPointerAr
 }
 
 /**
-* Tests successfull call of tiglFuselageGetStartConnectedSegmentIndex.
+* Tests successful call of tiglFuselageGetStartConnectedSegmentIndex.
 */
 TEST_F( TiglFuselageSegment, FuselageGetStartConnectedSegmentIndex_success)
 {
@@ -385,7 +385,7 @@ TEST_F( TiglFuselageSegment, FuselageGetEndConnectedSegmentIndex_nullPointerArgu
 }
 
 /**
-* Tests successfull call of tiglFuselageGetEndConnectedSegmentIndex.
+* Tests successful call of tiglFuselageGetEndConnectedSegmentIndex.
 */
 TEST_F( TiglFuselageSegment, FuselageGetEndConnectedSegmentIndex_success)
 {
@@ -441,7 +441,7 @@ TEST_F( TiglFuselageSegment, FuselageGetStartSectionAndElementIndex_nullPointerA
 }
 
 /**
-* Tests successfull call of tiglFuselageGetStartSectionAndElementIndex.
+* Tests successful call of tiglFuselageGetStartSectionAndElementIndex.
 */
 TEST_F( TiglFuselageSegment, FuselageGetStartSectionAndElementIndex_success)
 {
@@ -503,7 +503,7 @@ TEST_F( TiglFuselageSegment, FuselageGetEndSectionAndElementIndex_nullPointerArg
 }
 
 /**
-* Tests successfull call of tiglFuselageGetEndSectionAndElementIndex.
+* Tests successful call of tiglFuselageGetEndSectionAndElementIndex.
 */
 TEST_F( TiglFuselageSegment, FuselageGetEndSectionAndElementIndex_success)
 {
@@ -559,7 +559,7 @@ TEST_F( TiglFuselageSegment, FuselageGetStartSectionAndElementUID_invalidSegment
 
 
 /**
-* Tests successfull call of tiglFuselageGetStartSectionAndElementUID.
+* Tests successful call of tiglFuselageGetStartSectionAndElementUID.
 */
 TEST_F( TiglFuselageSegment, FuselageGetStartSectionAndElementUID_success)
 {
@@ -611,7 +611,7 @@ TEST_F( TiglFuselageSegment, FuselageGetEndSectionAndElementUID_invalidSegment)
 }
 
 /**
-* Tests successfull call of tiglFuselageGetEndSectionAndElementUID.
+* Tests successful call of tiglFuselageGetEndSectionAndElementUID.
 */
 TEST_F( TiglFuselageSegment, FuselageGetEndSectionAndElementUID_success)
 {

--- a/tests/unittests/tiglPointTranslator.cpp
+++ b/tests/unittests/tiglPointTranslator.cpp
@@ -260,7 +260,7 @@ TEST(TiglPointTranslator, Bug4){
 
 
 /**
- * This bug occured because of the different scale. In this case,
+ * This bug occurred because of the different scale. In this case,
  * the tolerance of the gradient was chosen too small.
  * The gradient is quadratic in the scale, hence, the tolerance
  * must be adapted.

--- a/tests/unittests/tiglUidManager.cpp
+++ b/tests/unittests/tiglUidManager.cpp
@@ -52,7 +52,7 @@ namespace {
     };
 
     /**
-    * Tests wheter all uids can be resolved. Commented uids are currently pruned.
+    * Tests whether all uids can be resolved. Commented uids are currently pruned.
     */
     TEST_F(tiglUidManagerTest, allUids) {
         std::vector<std::string> uids;

--- a/tests/unittests/tiglWingGetPoint.cpp
+++ b/tests/unittests/tiglWingGetPoint.cpp
@@ -219,7 +219,7 @@ TEST_F(WingGetPoint, tiglWingGetLowerPoint_nullPointerArgument)
 }
 
 /**
-* Tests successfull call to tiglWingGetUpperPoint.
+* Tests successful call to tiglWingGetUpperPoint.
 */
 TEST_F(WingGetPoint, tiglWingGetUpperPoint_success)
 {
@@ -230,7 +230,7 @@ TEST_F(WingGetPoint, tiglWingGetUpperPoint_success)
 }
 
 /**
-* Tests successfull call to tiglWingGetLowerPoint.
+* Tests successful call to tiglWingGetLowerPoint.
 */
 TEST_F(WingGetPoint, tiglWingGetLowerPoint_success)
 {

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -422,7 +422,7 @@ TEST_F(WingGuideCurve, tiglWingGuideCurve_CCPACSWingSegment)
     std::vector<double> gammaDeviation (temp, temp + sizeof(temp) / sizeof(temp[0]) );
     // number of sample points
     unsigned int N=10;
-    // segement width
+    // segment width
     double width=2.0;
     // segment position
     double position=12.0;

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -170,7 +170,7 @@ TEST_F(WingSegment, tiglGetWingCount_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglGetWingCount.
+* Tests successful call of tiglGetWingCount.
 */
 TEST_F(WingSegment, tiglGetWingCount_success)
 {
@@ -208,7 +208,7 @@ TEST_F(WingSegment, tiglWingGetSegmentCount_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetSegmentCount.
+* Tests successful call of tiglWingGetSegmentCount.
 */
 TEST_F(WingSegment, tiglWingGetSegmentCount_success)
 {
@@ -255,7 +255,7 @@ TEST_F(WingSegment, tiglWingGetInnerConnectedSegmentCount_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetInnerConnectedSegmentCount.
+* Tests successful call of tiglWingGetInnerConnectedSegmentCount.
 */
 TEST_F(WingSegment, tiglWingGetInnerConnectedSegmentCount_success)
 {
@@ -304,7 +304,7 @@ TEST_F(WingSegment, tiglWingGetOuterConnectedSegmentCount_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetOuterConnectedSegmentCount.
+* Tests successful call of tiglWingGetOuterConnectedSegmentCount.
 */
 TEST_F(WingSegment, tiglWingGetOuterConnectedSegmentCount_success)
 {
@@ -364,7 +364,7 @@ TEST_F(WingSegment, tiglWingGetInnerConnectedSegmentIndex_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetInnerConnectedSegmentIndex.
+* Tests successful call of tiglWingGetInnerConnectedSegmentIndex.
 */
 TEST_F(WingSegment, tiglWingGetInnerConnectedSegmentIndex_success)
 {
@@ -424,7 +424,7 @@ TEST_F(WingSegment, tiglWingGetOuterConnectedSegmentIndex_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetOuterConnectedSegmentIndex.
+* Tests successful call of tiglWingGetOuterConnectedSegmentIndex.
 */
 TEST_F(WingSegment, tiglWingGetOuterConnectedSegmentIndex_success)
 {
@@ -480,7 +480,7 @@ TEST_F(WingSegment, tiglWingGetInnerSectionAndElementIndex_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetInnerSectionAndElementIndex.
+* Tests successful call of tiglWingGetInnerSectionAndElementIndex.
 */
 TEST_F(WingSegment, tiglWingGetInnerSectionAndElementIndex_success)
 {
@@ -542,7 +542,7 @@ TEST_F(WingSegment, tiglWingGetOuterSectionAndElementIndex_nullPointerArgument)
 }
 
 /**
-* Tests successfull call of tiglWingGetOuterSectionAndElementIndex.
+* Tests successful call of tiglWingGetOuterSectionAndElementIndex.
 */
 TEST_F(WingSegment, tiglWingGetOuterSectionAndElementIndex_success)
 {
@@ -597,7 +597,7 @@ TEST_F(WingSegment, tiglWingGetInnerSectionAndElementUID_invalidSegment)
 
 
 /**
-* Tests successfull call of tiglWingGetInnerSectionAndElementUID.
+* Tests successful call of tiglWingGetInnerSectionAndElementUID.
 */
 TEST_F(WingSegment, tiglWingGetInnerSectionAndElementUID_success)
 {
@@ -650,7 +650,7 @@ TEST_F(WingSegment, tiglWingGetOuterSectionAndElementUID_invalidSegment)
 }
 
 /**
-* Tests successfull call of tiglWingGetOuterSectionAndElementUID.
+* Tests successful call of tiglWingGetOuterSectionAndElementUID.
 */
 TEST_F(WingSegment, tiglWingGetOuterSectionAndElementUID_success)
 {


### PR DESCRIPTION
## Description

Found via `codespell -q 3 -S thirdparty -L ane,ans,childs,globaly,inout,ist,oce,ontop,parm,parms,te`. Fixed manually.


## How Has This Been Tested?

n/a

## Screenshots, that help to understand the changes(if applicable):

n/a

## Checklist:
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
