### PR TITLE
Fix typos in TIGLViewer

### DIFF
--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -188,7 +188,7 @@ Handle(V3d_Viewer) TIGLViewerContext::createViewer( const Standard_ExtString aNa
 /*! 
 \brief    Deletes all objects.
 
-        This function deletes all dispayed objects from the AIS context.
+        This function deletes all displayed objects from the AIS context.
         No parameters.
 */
 void TIGLViewerContext::deleteAllObjects()
@@ -215,7 +215,7 @@ void TIGLViewerContext::gridXY  ( void )
 \brief    Sets the privileged plane to the XZ Axis.
 
           Note the negative direction of the Y axis.
-          This is corrrect for a right-handed co-ordinate set.
+          This is correct for a right-handed co-ordinate set.
 */
 void TIGLViewerContext::gridXZ  ( void )
 {

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -2714,7 +2714,7 @@ void TIGLViewerDocument::drawWingShells(tigl::CCPACSWing& wing)
 }
 
 /*
- * Reads traingles from Mesh of shape and creates vertices and triangular faces
+ * Reads triangles from Mesh of shape and creates vertices and triangular faces
  */
 void TIGLViewerDocument::createShapeTriangulation(const TopoDS_Shape& shape, TopoDS_Compound& compound)
 {

--- a/TIGLViewer/styles/qdarkstyle/README.md
+++ b/TIGLViewer/styles/qdarkstyle/README.md
@@ -186,7 +186,7 @@ Changelog
     - Add __version__ to python package.
 * 1.5:
     - improve QTabBar style: now works with all tab bar positions (North, South, West and East)
-    - fix bug #6: hide QTabBar base to avoid stange lines at the base of the tab bar.
+    - fix bug #6: hide QTabBar base to avoid strange lines at the base of the tab bar.
 * 1.4: Add style.qss to qrc file, this fix issues with cx_freeze
 * 1.3:
     - remove outline on button, checkbox and radio button


### PR DESCRIPTION
## Description
Fix typos in TIGLViewer  
Found via `codespell -q 3 -S thirdparty -L ane,ans,childs,globaly,inout,ist,oce,ontop,parm,parms,te`

## How Has This Been Tested?
n/a

## Screenshots, that help to understand the changes(if applicable):
n/a

## Checklist:
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
