### PR TITLE
Fix bug in wing cell creation

### DIFF
--- a/tests/integrationtests/TestData/bugs/930/IEA-25-310-UWT_ModGrid_final_red_mass_ver_2_loads_CPACS_cc_surface.xml
+++ b/tests/integrationtests/TestData/bugs/930/IEA-25-310-UWT_ModGrid_final_red_mass_ver_2_loads_CPACS_cc_surface.xml
@@ -1,0 +1,4647 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs>
+  <header>
+    <version>1.0</version>
+    <timestamp>2022-10-17T10:25:10</timestamp>
+    <name>CPACS wing</name>
+    <description>lightworks CPACS interface generated wing</description>
+    <creator>lightworks CPACS interface</creator>
+    <cpacsVersion>3.2</cpacsVersion>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="aircraft">
+        <description>Example Aircraft</description>
+        <name>Aircraft</name>
+        <wings>
+          <wing uID="blade">
+            <description>The blade of IEA-15-240-RWT</description>
+            <name>blade</name>
+            <componentSegments>
+              <componentSegment uID="component_segment">
+                <toElementUID>wing_section_26_element_1</toElementUID>
+                <fromElementUID>wing_section_1_element_1</fromElementUID>
+                <description></description>
+                <name>component_segment</name>
+                <structure>
+                  <spars>
+                    <sparPositions>
+                      <sparPosition uID="web0_position">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.1</eta>
+                          <xsi>0.351399</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web0_position_u0">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.2</eta>
+                          <xsi>0.280776</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web0_position_u1">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.4</eta>
+                          <xsi>0.225737</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web0_position_u2">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.6</eta>
+                          <xsi>0.193544</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web0_position_u3">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.8</eta>
+                          <xsi>0.187126</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web0_position_u4">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.975</eta>
+                          <xsi>0.10414</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web1_position">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.1</eta>
+                          <xsi>0.483401</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web1_position_u0">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.2</eta>
+                          <xsi>0.403662</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web1_position_u1">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.4</eta>
+                          <xsi>0.374905</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web1_position_u2">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.6</eta>
+                          <xsi>0.384173</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web1_position_u3">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.8</eta>
+                          <xsi>0.440138</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                      <sparPosition uID="web1_position_u4">
+                        <sparPositionEtaXsi>
+                          <referenceUID>component_segment</referenceUID>
+                          <eta>0.975</eta>
+                          <xsi>0.605704</xsi>
+                        </sparPositionEtaXsi>
+                      </sparPosition>
+                    </sparPositions>
+                    <sparSegments>
+                      <sparSegment uID="web0">
+                        <description></description>
+                        <name>web0</name>
+                        <sparCrossSection>
+                          <web1>
+                            <material>
+                              <compositeUID>base_material_u5</compositeUID>
+                              <orthotropyDirection>0</orthotropyDirection>
+                            </material>
+                          </web1>
+                          <sparCells>
+                            <sparCell uID="span00_web0_cell00">
+                              <fromEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.2</eta>
+                              </fromEta>
+                              <toEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.4</eta>
+                              </toEta>
+                              <web1>
+                                <material>
+                                  <compositeUID>span00_web0_cell00_composite</compositeUID>
+                                  <orthotropyDirection>0</orthotropyDirection>
+                                </material>
+                              </web1>
+                              <rotation>90</rotation>
+                            </sparCell>
+                            <sparCell uID="span01_web0_cell01">
+                              <fromEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.4</eta>
+                              </fromEta>
+                              <toEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.6</eta>
+                              </toEta>
+                              <web1>
+                                <material>
+                                  <compositeUID>span01_web0_cell01_composite</compositeUID>
+                                  <orthotropyDirection>0</orthotropyDirection>
+                                </material>
+                              </web1>
+                              <rotation>90</rotation>
+                            </sparCell>
+                            <sparCell uID="span02_web0_cell02">
+                              <fromEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.6</eta>
+                              </fromEta>
+                              <toEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.8</eta>
+                              </toEta>
+                              <web1>
+                                <material>
+                                  <compositeUID>span02_web0_cell02_composite</compositeUID>
+                                  <orthotropyDirection>0</orthotropyDirection>
+                                </material>
+                              </web1>
+                              <rotation>90</rotation>
+                            </sparCell>
+                          </sparCells>
+                        </sparCrossSection>
+                        <sparPositionUIDs>
+                          <sparPositionUID>web0_position</sparPositionUID>
+                          <sparPositionUID>web0_position_u0</sparPositionUID>
+                          <sparPositionUID>web0_position_u1</sparPositionUID>
+                          <sparPositionUID>web0_position_u2</sparPositionUID>
+                          <sparPositionUID>web0_position_u3</sparPositionUID>
+                          <sparPositionUID>web0_position_u4</sparPositionUID>
+                        </sparPositionUIDs>
+                      </sparSegment>
+                      <sparSegment uID="web1">
+                        <description></description>
+                        <name>web1</name>
+                        <sparCrossSection>
+                          <web1>
+                            <material>
+                              <compositeUID>base_material_u6</compositeUID>
+                              <orthotropyDirection>0</orthotropyDirection>
+                            </material>
+                          </web1>
+                          <sparCells>
+                            <sparCell uID="span00_web1_cell00">
+                              <fromEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.2</eta>
+                              </fromEta>
+                              <toEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.4</eta>
+                              </toEta>
+                              <web1>
+                                <material>
+                                  <compositeUID>span00_web0_cell00_composite</compositeUID>
+                                  <orthotropyDirection>0</orthotropyDirection>
+                                </material>
+                              </web1>
+                              <rotation>90</rotation>
+                            </sparCell>
+                            <sparCell uID="span01_web1_cell01">
+                              <fromEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.4</eta>
+                              </fromEta>
+                              <toEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.6</eta>
+                              </toEta>
+                              <web1>
+                                <material>
+                                  <compositeUID>span01_web0_cell01_composite</compositeUID>
+                                  <orthotropyDirection>0</orthotropyDirection>
+                                </material>
+                              </web1>
+                              <rotation>90</rotation>
+                            </sparCell>
+                            <sparCell uID="span02_web1_cell02">
+                              <fromEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.6</eta>
+                              </fromEta>
+                              <toEta>
+                                <referenceUID>component_segment</referenceUID>
+                                <eta>0.8</eta>
+                              </toEta>
+                              <web1>
+                                <material>
+                                  <compositeUID>span02_web0_cell02_composite</compositeUID>
+                                  <orthotropyDirection>0</orthotropyDirection>
+                                </material>
+                              </web1>
+                              <rotation>90</rotation>
+                            </sparCell>
+                          </sparCells>
+                        </sparCrossSection>
+                        <sparPositionUIDs>
+                          <sparPositionUID>web1_position</sparPositionUID>
+                          <sparPositionUID>web1_position_u0</sparPositionUID>
+                          <sparPositionUID>web1_position_u1</sparPositionUID>
+                          <sparPositionUID>web1_position_u2</sparPositionUID>
+                          <sparPositionUID>web1_position_u3</sparPositionUID>
+                          <sparPositionUID>web1_position_u4</sparPositionUID>
+                        </sparPositionUIDs>
+                      </sparSegment>
+                    </sparSegments>
+                  </spars>
+                  <upperShell uID="component_segment_upper_shell">
+                    <skin>
+                      <material>
+                        <compositeUID>base_material_u3</compositeUID>
+                        <orthotropyDirection>0</orthotropyDirection>
+                      </material>
+                    </skin>
+                    <cells>
+                      <cell uID="span01_circ01">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ01_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.908305</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ02">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ02_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.573623</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.908305</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ03">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ03_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.459759</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.573623</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ04">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ04_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.062385</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.459759</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ05">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ05_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.062385</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ01">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ01_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.874572</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ02">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ02_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.450679</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.874572</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ03">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ03_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.316783</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.450679</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ04">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ04_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.081294</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.316783</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ05">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ05_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.081294</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ01">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ01_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.844916</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ02">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ02_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.436534</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.844916</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ03">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ03_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.256575</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.436534</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ04">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ04_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.116246</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.256575</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ05">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ05_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.116246</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ01">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ01_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.809371</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ02">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ02_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.461337</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.809371</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ03">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ03_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.224905</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.461337</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ04">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ04_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.152141</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.224905</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ05">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ05_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.152141</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span05_circ01">
+                        <skin>
+                          <material>
+                            <compositeUID>span05_circ01_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.534306</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span05_circ02">
+                        <skin>
+                          <material>
+                            <compositeUID>span05_circ02_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.200046</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.534306</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span05_circ03">
+                        <skin>
+                          <material>
+                            <compositeUID>span05_circ03_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.200046</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                    </cells>
+                  </upperShell>
+                  <lowerShell uID="component_segment_lower_shell">
+                    <skin>
+                      <material>
+                        <compositeUID>base_material_u4</compositeUID>
+                        <orthotropyDirection>0</orthotropyDirection>
+                      </material>
+                    </skin>
+                    <cells>
+                      <cell uID="span01_circ06">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ06_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.054232</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ07">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ07_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.054232</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.337838</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ08">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ08_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.337838</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.456178</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ09">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ09_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.456178</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.900362</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span01_circ10">
+                        <skin>
+                          <material>
+                            <compositeUID>span01_circ10_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.900362</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ06">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ06_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.082008</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ07">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ07_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.082008</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.286973</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ08">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ08_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.286973</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.422938</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ09">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ09_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.422938</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.873416</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span02_circ10">
+                        <skin>
+                          <material>
+                            <compositeUID>span02_circ10_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.200000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.873416</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ06">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ06_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.117881</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ07">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ07_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.117881</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.246856</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ08">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ08_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.246856</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.427417</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ09">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ09_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.427417</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.843969</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span03_circ10">
+                        <skin>
+                          <material>
+                            <compositeUID>span03_circ10_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.400000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.843969</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ06">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ06_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.157204</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ07">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ07_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.157204</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.221230</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ08">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ08_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.221230</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.458992</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ09">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ09_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.458992</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.807127</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span04_circ10">
+                        <skin>
+                          <material>
+                            <compositeUID>span04_circ10_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.600000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.807127</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span05_circ04">
+                        <skin>
+                          <material>
+                            <compositeUID>span05_circ04_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.000000</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.200236</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span05_circ05">
+                        <skin>
+                          <material>
+                            <compositeUID>span05_circ05_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.200236</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>0.536303</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                      <cell uID="span05_circ06">
+                        <skin>
+                          <material>
+                            <compositeUID>span05_circ06_composite</compositeUID>
+                            <orthotropyDirection>0</orthotropyDirection>
+                          </material>
+                        </skin>
+                        <positioningInnerBorder>
+                          <contourCoordinate>0.800000</contourCoordinate>
+                        </positioningInnerBorder>
+                        <positioningLeadingEdge>
+                          <contourCoordinate>0.536303</contourCoordinate>
+                        </positioningLeadingEdge>
+                        <positioningOuterBorder>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningOuterBorder>
+                        <positioningTrailingEdge>
+                          <contourCoordinate>1.000000</contourCoordinate>
+                        </positioningTrailingEdge>
+                      </cell>
+                    </cells>
+                  </lowerShell>
+                </structure>
+              </componentSegment>
+            </componentSegments>
+            <sections>
+              <section uID="wing_section_1">
+                <description/>
+                <name>wing_section_1</name>
+                <transformation uID="wing_section_1_transformation">
+                  <scaling uID="wing_section_1_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_1_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-15.594600</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_1_transformation_translation">
+                    <x>0.000000</x>
+                    <y>0.000000</y>
+                    <z>0.000000</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_1_element_1">
+                    <name>wing_section_1_element_1</name>
+                    <transformation uID="wing_section_1_element_1_transformation">
+                      <scaling uID="wing_section_1_element_1_transformation_scaling">
+                        <x>6.71667</x>
+                        <y>6.71667</y>
+                        <z>6.71667</z>
+                      </scaling>
+                      <rotation uID="wing_section_1_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_1_element_1_transformation_translation">
+                        <x>-3.38886</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_0.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_2">
+                <description/>
+                <name>wing_section_2</name>
+                <transformation uID="wing_section_2_transformation">
+                  <scaling uID="wing_section_2_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_2_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-15.428600</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_2_transformation_translation">
+                    <x>0.000000</x>
+                    <y>6.045000</y>
+                    <z>0.053203</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_2_element_1">
+                    <name>wing_section_2_element_1</name>
+                    <transformation uID="wing_section_2_element_1_transformation">
+                      <scaling uID="wing_section_2_element_1_transformation_scaling">
+                        <x>6.76325</x>
+                        <y>6.76325</y>
+                        <z>6.76325</z>
+                      </scaling>
+                      <rotation uID="wing_section_2_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_2_element_1_transformation_translation">
+                        <x>-3.20203</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_4.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_3">
+                <description/>
+                <name>wing_section_3</name>
+                <transformation uID="wing_section_3_transformation">
+                  <scaling uID="wing_section_3_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_3_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-14.325300</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_3_transformation_translation">
+                    <x>0.000000</x>
+                    <y>12.090000</y>
+                    <z>0.130896</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_3_element_1">
+                    <name>wing_section_3_element_1</name>
+                    <transformation uID="wing_section_3_element_1_transformation">
+                      <scaling uID="wing_section_3_element_1_transformation_scaling">
+                        <x>6.9271</x>
+                        <y>6.9271</y>
+                        <z>6.9271</z>
+                      </scaling>
+                      <rotation uID="wing_section_3_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_3_element_1_transformation_translation">
+                        <x>-3.02147</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_8.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_4">
+                <description/>
+                <name>wing_section_4</name>
+                <transformation uID="wing_section_4_transformation">
+                  <scaling uID="wing_section_4_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_4_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-12.546400</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_4_transformation_translation">
+                    <x>0.000000</x>
+                    <y>18.135000</y>
+                    <z>0.215073</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_4_element_1">
+                    <name>wing_section_4_element_1</name>
+                    <transformation uID="wing_section_4_element_1_transformation">
+                      <scaling uID="wing_section_4_element_1_transformation_scaling">
+                        <x>7.14819</x>
+                        <y>7.14819</y>
+                        <z>7.14819</z>
+                      </scaling>
+                      <rotation uID="wing_section_4_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_4_element_1_transformation_translation">
+                        <x>-2.85881</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_12.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_5">
+                <description/>
+                <name>wing_section_5</name>
+                <transformation uID="wing_section_5_transformation">
+                  <scaling uID="wing_section_5_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_5_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-10.526700</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_5_transformation_translation">
+                    <x>0.000000</x>
+                    <y>24.180000</y>
+                    <z>0.285353</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_5_element_1">
+                    <name>wing_section_5_element_1</name>
+                    <transformation uID="wing_section_5_element_1_transformation">
+                      <scaling uID="wing_section_5_element_1_transformation_scaling">
+                        <x>7.34787</x>
+                        <y>7.34787</y>
+                        <z>7.34787</z>
+                      </scaling>
+                      <rotation uID="wing_section_5_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_5_element_1_transformation_translation">
+                        <x>-2.7023</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_16.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_6">
+                <description/>
+                <name>wing_section_6</name>
+                <transformation uID="wing_section_6_transformation">
+                  <scaling uID="wing_section_6_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_6_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-8.701110</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_6_transformation_translation">
+                    <x>0.000000</x>
+                    <y>30.225000</y>
+                    <z>0.321353</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_6_element_1">
+                    <name>wing_section_6_element_1</name>
+                    <transformation uID="wing_section_6_element_1_transformation">
+                      <scaling uID="wing_section_6_element_1_transformation_scaling">
+                        <x>7.4475</x>
+                        <y>7.4475</y>
+                        <z>7.4475</z>
+                      </scaling>
+                      <rotation uID="wing_section_6_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_6_element_1_transformation_translation">
+                        <x>-2.54727</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_20.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_7">
+                <description/>
+                <name>wing_section_7</name>
+                <transformation uID="wing_section_7_transformation">
+                  <scaling uID="wing_section_7_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_7_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-7.342810</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_7_transformation_translation">
+                    <x>0.000000</x>
+                    <y>36.270000</y>
+                    <z>0.322569</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_7_element_1">
+                    <name>wing_section_7_element_1</name>
+                    <transformation uID="wing_section_7_element_1_transformation">
+                      <scaling uID="wing_section_7_element_1_transformation_scaling">
+                        <x>7.389</x>
+                        <y>7.389</y>
+                        <z>7.389</z>
+                      </scaling>
+                      <rotation uID="wing_section_7_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_7_element_1_transformation_translation">
+                        <x>-2.40572</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_24.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_8">
+                <description/>
+                <name>wing_section_8</name>
+                <transformation uID="wing_section_8_transformation">
+                  <scaling uID="wing_section_8_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_8_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-6.103650</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_8_transformation_translation">
+                    <x>0.000000</x>
+                    <y>42.315000</y>
+                    <z>0.317344</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_8_element_1">
+                    <name>wing_section_8_element_1</name>
+                    <transformation uID="wing_section_8_element_1_transformation">
+                      <scaling uID="wing_section_8_element_1_transformation_scaling">
+                        <x>7.11936</x>
+                        <y>7.11936</y>
+                        <z>7.11936</z>
+                      </scaling>
+                      <rotation uID="wing_section_8_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_8_element_1_transformation_translation">
+                        <x>-2.24778</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_28.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_9">
+                <description/>
+                <name>wing_section_9</name>
+                <transformation uID="wing_section_9_transformation">
+                  <scaling uID="wing_section_9_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_9_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-4.965520</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_9_transformation_translation">
+                    <x>0.000000</x>
+                    <y>48.360000</y>
+                    <z>0.308002</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_9_element_1">
+                    <name>wing_section_9_element_1</name>
+                    <transformation uID="wing_section_9_element_1_transformation">
+                      <scaling uID="wing_section_9_element_1_transformation_scaling">
+                        <x>6.73775</x>
+                        <y>6.73775</y>
+                        <z>6.73775</z>
+                      </scaling>
+                      <rotation uID="wing_section_9_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_9_element_1_transformation_translation">
+                        <x>-2.08614</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_32.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_10">
+                <description/>
+                <name>wing_section_10</name>
+                <transformation uID="wing_section_10_transformation">
+                  <scaling uID="wing_section_10_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_10_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-3.998300</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_10_transformation_translation">
+                    <x>0.000000</x>
+                    <y>54.405000</y>
+                    <z>0.295379</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_10_element_1">
+                    <name>wing_section_10_element_1</name>
+                    <transformation uID="wing_section_10_element_1_transformation">
+                      <scaling uID="wing_section_10_element_1_transformation_scaling">
+                        <x>6.36894</x>
+                        <y>6.36894</y>
+                        <z>6.36894</z>
+                      </scaling>
+                      <rotation uID="wing_section_10_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_10_element_1_transformation_translation">
+                        <x>-1.94376</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_36.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_11">
+                <description/>
+                <name>wing_section_11</name>
+                <transformation uID="wing_section_11_transformation">
+                  <scaling uID="wing_section_11_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_11_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-3.217560</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_11_transformation_translation">
+                    <x>0.000000</x>
+                    <y>60.450000</y>
+                    <z>0.257384</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_11_element_1">
+                    <name>wing_section_11_element_1</name>
+                    <transformation uID="wing_section_11_element_1_transformation">
+                      <scaling uID="wing_section_11_element_1_transformation_scaling">
+                        <x>6.07091</x>
+                        <y>6.07091</y>
+                        <z>6.07091</z>
+                      </scaling>
+                      <rotation uID="wing_section_11_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_11_element_1_transformation_translation">
+                        <x>-1.82312</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_40.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_12">
+                <description/>
+                <name>wing_section_12</name>
+                <transformation uID="wing_section_12_transformation">
+                  <scaling uID="wing_section_12_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_12_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-2.548230</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_12_transformation_translation">
+                    <x>0.000000</x>
+                    <y>66.495000</y>
+                    <z>0.157963</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_12_element_1">
+                    <name>wing_section_12_element_1</name>
+                    <transformation uID="wing_section_12_element_1_transformation">
+                      <scaling uID="wing_section_12_element_1_transformation_scaling">
+                        <x>5.78347</x>
+                        <y>5.78347</y>
+                        <z>5.78347</z>
+                      </scaling>
+                      <rotation uID="wing_section_12_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_12_element_1_transformation_translation">
+                        <x>-1.70602</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_44.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_13">
+                <description/>
+                <name>wing_section_13</name>
+                <transformation uID="wing_section_13_transformation">
+                  <scaling uID="wing_section_13_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_13_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-1.960650</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_13_transformation_translation">
+                    <x>0.000000</x>
+                    <y>72.540000</y>
+                    <z>0.012055</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_13_element_1">
+                    <name>wing_section_13_element_1</name>
+                    <transformation uID="wing_section_13_element_1_transformation">
+                      <scaling uID="wing_section_13_element_1_transformation_scaling">
+                        <x>5.50211</x>
+                        <y>5.50211</y>
+                        <z>5.50211</z>
+                      </scaling>
+                      <rotation uID="wing_section_13_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_13_element_1_transformation_translation">
+                        <x>-1.60038</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_48.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_14">
+                <description/>
+                <name>wing_section_14</name>
+                <transformation uID="wing_section_14_transformation">
+                  <scaling uID="wing_section_14_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_14_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-1.432440</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_14_transformation_translation">
+                    <x>0.000000</x>
+                    <y>78.585000</y>
+                    <z>-0.156591</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_14_element_1">
+                    <name>wing_section_14_element_1</name>
+                    <transformation uID="wing_section_14_element_1_transformation">
+                      <scaling uID="wing_section_14_element_1_transformation_scaling">
+                        <x>5.23316</x>
+                        <y>5.23316</y>
+                        <z>5.23316</z>
+                      </scaling>
+                      <rotation uID="wing_section_14_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_14_element_1_transformation_translation">
+                        <x>-1.50878</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_52.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_15">
+                <description/>
+                <name>wing_section_15</name>
+                <transformation uID="wing_section_15_transformation">
+                  <scaling uID="wing_section_15_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_15_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-0.963808</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_15_transformation_translation">
+                    <x>0.000000</x>
+                    <y>84.630000</y>
+                    <z>-0.361554</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_15_element_1">
+                    <name>wing_section_15_element_1</name>
+                    <transformation uID="wing_section_15_element_1_transformation">
+                      <scaling uID="wing_section_15_element_1_transformation_scaling">
+                        <x>4.98126</x>
+                        <y>4.98126</y>
+                        <z>4.98126</z>
+                      </scaling>
+                      <rotation uID="wing_section_15_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_15_element_1_transformation_translation">
+                        <x>-1.4339</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_56.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_16">
+                <description/>
+                <name>wing_section_16</name>
+                <transformation uID="wing_section_16_transformation">
+                  <scaling uID="wing_section_16_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_16_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-0.555805</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_16_transformation_translation">
+                    <x>0.000000</x>
+                    <y>90.675000</y>
+                    <z>-0.637378</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_16_element_1">
+                    <name>wing_section_16_element_1</name>
+                    <transformation uID="wing_section_16_element_1_transformation">
+                      <scaling uID="wing_section_16_element_1_transformation_scaling">
+                        <x>4.74331</x>
+                        <y>4.74331</y>
+                        <z>4.74331</z>
+                      </scaling>
+                      <rotation uID="wing_section_16_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_16_element_1_transformation_translation">
+                        <x>-1.37014</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_60.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_17">
+                <description/>
+                <name>wing_section_17</name>
+                <transformation uID="wing_section_17_transformation">
+                  <scaling uID="wing_section_17_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_17_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>-0.168589</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_17_transformation_translation">
+                    <x>0.000000</x>
+                    <y>96.720000</y>
+                    <z>-0.962513</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_17_element_1">
+                    <name>wing_section_17_element_1</name>
+                    <transformation uID="wing_section_17_element_1_transformation">
+                      <scaling uID="wing_section_17_element_1_transformation_scaling">
+                        <x>4.51147</x>
+                        <y>4.51147</y>
+                        <z>4.51147</z>
+                      </scaling>
+                      <rotation uID="wing_section_17_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_17_element_1_transformation_translation">
+                        <x>-1.31614</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_64.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_18">
+                <description/>
+                <name>wing_section_18</name>
+                <transformation uID="wing_section_18_transformation">
+                  <scaling uID="wing_section_18_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_18_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>0.243981</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_18_transformation_translation">
+                    <x>0.000000</x>
+                    <y>102.765000</y>
+                    <z>-1.310060</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_18_element_1">
+                    <name>wing_section_18_element_1</name>
+                    <transformation uID="wing_section_18_element_1_transformation">
+                      <scaling uID="wing_section_18_element_1_transformation_scaling">
+                        <x>4.27831</x>
+                        <y>4.27831</y>
+                        <z>4.27831</z>
+                      </scaling>
+                      <rotation uID="wing_section_18_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_18_element_1_transformation_translation">
+                        <x>-1.26641</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_68.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_19">
+                <description/>
+                <name>wing_section_19</name>
+                <transformation uID="wing_section_19_transformation">
+                  <scaling uID="wing_section_19_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_19_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>0.766471</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_19_transformation_translation">
+                    <x>0.000000</x>
+                    <y>108.810000</y>
+                    <z>-1.676230</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_19_element_1">
+                    <name>wing_section_19_element_1</name>
+                    <transformation uID="wing_section_19_element_1_transformation">
+                      <scaling uID="wing_section_19_element_1_transformation_scaling">
+                        <x>4.04346</x>
+                        <y>4.04346</y>
+                        <z>4.04346</z>
+                      </scaling>
+                      <rotation uID="wing_section_19_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_19_element_1_transformation_translation">
+                        <x>-1.21865</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_72.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_20">
+                <description/>
+                <name>wing_section_20</name>
+                <transformation uID="wing_section_20_transformation">
+                  <scaling uID="wing_section_20_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_20_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>1.398280</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_20_transformation_translation">
+                    <x>0.000000</x>
+                    <y>114.855000</y>
+                    <z>-2.083640</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_20_element_1">
+                    <name>wing_section_20_element_1</name>
+                    <transformation uID="wing_section_20_element_1_transformation">
+                      <scaling uID="wing_section_20_element_1_transformation_scaling">
+                        <x>3.81173</x>
+                        <y>3.81173</y>
+                        <z>3.81173</z>
+                      </scaling>
+                      <rotation uID="wing_section_20_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_20_element_1_transformation_translation">
+                        <x>-1.17199</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_76.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_21">
+                <description/>
+                <name>wing_section_21</name>
+                <transformation uID="wing_section_21_transformation">
+                  <scaling uID="wing_section_21_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_21_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>1.936660</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_21_transformation_translation">
+                    <x>0.000000</x>
+                    <y>120.900000</y>
+                    <z>-2.524750</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_21_element_1">
+                    <name>wing_section_21_element_1</name>
+                    <transformation uID="wing_section_21_element_1_transformation">
+                      <scaling uID="wing_section_21_element_1_transformation_scaling">
+                        <x>3.57562</x>
+                        <y>3.57562</y>
+                        <z>3.57562</z>
+                      </scaling>
+                      <rotation uID="wing_section_21_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_21_element_1_transformation_translation">
+                        <x>-1.12144</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_80.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_22">
+                <description/>
+                <name>wing_section_22</name>
+                <transformation uID="wing_section_22_transformation">
+                  <scaling uID="wing_section_22_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_22_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>2.168640</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_22_transformation_translation">
+                    <x>0.000000</x>
+                    <y>126.945000</y>
+                    <z>-2.990860</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_22_element_1">
+                    <name>wing_section_22_element_1</name>
+                    <transformation uID="wing_section_22_element_1_transformation">
+                      <scaling uID="wing_section_22_element_1_transformation_scaling">
+                        <x>3.32711</x>
+                        <y>3.32711</y>
+                        <z>3.32711</z>
+                      </scaling>
+                      <rotation uID="wing_section_22_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_22_element_1_transformation_translation">
+                        <x>-1.06756</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_84.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_23">
+                <description/>
+                <name>wing_section_23</name>
+                <transformation uID="wing_section_23_transformation">
+                  <scaling uID="wing_section_23_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_23_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>2.153080</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_23_transformation_translation">
+                    <x>0.000000</x>
+                    <y>132.990000</y>
+                    <z>-3.483930</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_23_element_1">
+                    <name>wing_section_23_element_1</name>
+                    <transformation uID="wing_section_23_element_1_transformation">
+                      <scaling uID="wing_section_23_element_1_transformation_scaling">
+                        <x>3.06284</x>
+                        <y>3.06284</y>
+                        <z>3.06284</z>
+                      </scaling>
+                      <rotation uID="wing_section_23_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_23_element_1_transformation_translation">
+                        <x>-1.01086</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_88.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_24">
+                <description/>
+                <name>wing_section_24</name>
+                <transformation uID="wing_section_24_transformation">
+                  <scaling uID="wing_section_24_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_24_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>2.013800</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_24_transformation_translation">
+                    <x>0.000000</x>
+                    <y>139.035000</y>
+                    <z>-4.012820</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_24_element_1">
+                    <name>wing_section_24_element_1</name>
+                    <transformation uID="wing_section_24_element_1_transformation">
+                      <scaling uID="wing_section_24_element_1_transformation_scaling">
+                        <x>2.7858</x>
+                        <y>2.7858</y>
+                        <z>2.7858</z>
+                      </scaling>
+                      <rotation uID="wing_section_24_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_24_element_1_transformation_translation">
+                        <x>-0.948654</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_92.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_25">
+                <description/>
+                <name>wing_section_25</name>
+                <transformation uID="wing_section_25_transformation">
+                  <scaling uID="wing_section_25_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_25_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>1.725150</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_25_transformation_translation">
+                    <x>0.000000</x>
+                    <y>145.080000</y>
+                    <z>-4.574890</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_25_element_1">
+                    <name>wing_section_25_element_1</name>
+                    <transformation uID="wing_section_25_element_1_transformation">
+                      <scaling uID="wing_section_25_element_1_transformation_scaling">
+                        <x>2.49801</x>
+                        <y>2.49801</y>
+                        <z>2.49801</z>
+                      </scaling>
+                      <rotation uID="wing_section_25_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_25_element_1_transformation_translation">
+                        <x>-0.881467</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_96.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+              <section uID="wing_section_26">
+                <description/>
+                <name>wing_section_26</name>
+                <transformation uID="wing_section_26_transformation">
+                  <scaling uID="wing_section_26_transformation_scaling">
+                    <x>1.000000</x>
+                    <y>1.000000</y>
+                    <z>1.000000</z>
+                  </scaling>
+                  <rotation uID="wing_section_26_transformation_rotation">
+                    <x>0.000000</x>
+                    <y>1.242390</y>
+                    <z>0.000000</z>
+                  </rotation>
+                  <translation uID="wing_section_26_transformation_translation">
+                    <x>0.000000</x>
+                    <y>151.125000</y>
+                    <z>-5.166670</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="wing_section_26_element_1">
+                    <name>wing_section_26_element_1</name>
+                    <transformation uID="wing_section_26_element_1_transformation">
+                      <scaling uID="wing_section_26_element_1_transformation_scaling">
+                        <x>0.645833</x>
+                        <y>0.645833</y>
+                        <z>0.645833</z>
+                      </scaling>
+                      <rotation uID="wing_section_26_element_1_transformation_rotation">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation uID="wing_section_26_element_1_transformation_translation">
+                        <x>-0.237784</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                    <airfoilUID>airfoil_100.00</airfoilUID>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <segments>
+              <segment uID="wing_segment_1">
+                <name>wing_segment_1</name>
+                <fromElementUID>wing_section_1_element_1</fromElementUID>
+                <toElementUID>wing_section_2_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_2">
+                <name>wing_segment_2</name>
+                <fromElementUID>wing_section_2_element_1</fromElementUID>
+                <toElementUID>wing_section_3_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_3">
+                <name>wing_segment_3</name>
+                <fromElementUID>wing_section_3_element_1</fromElementUID>
+                <toElementUID>wing_section_4_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_4">
+                <name>wing_segment_4</name>
+                <fromElementUID>wing_section_4_element_1</fromElementUID>
+                <toElementUID>wing_section_5_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_5">
+                <name>wing_segment_5</name>
+                <fromElementUID>wing_section_5_element_1</fromElementUID>
+                <toElementUID>wing_section_6_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_6">
+                <name>wing_segment_6</name>
+                <fromElementUID>wing_section_6_element_1</fromElementUID>
+                <toElementUID>wing_section_7_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_7">
+                <name>wing_segment_7</name>
+                <fromElementUID>wing_section_7_element_1</fromElementUID>
+                <toElementUID>wing_section_8_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_8">
+                <name>wing_segment_8</name>
+                <fromElementUID>wing_section_8_element_1</fromElementUID>
+                <toElementUID>wing_section_9_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_9">
+                <name>wing_segment_9</name>
+                <fromElementUID>wing_section_9_element_1</fromElementUID>
+                <toElementUID>wing_section_10_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_10">
+                <name>wing_segment_10</name>
+                <fromElementUID>wing_section_10_element_1</fromElementUID>
+                <toElementUID>wing_section_11_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_11">
+                <name>wing_segment_11</name>
+                <fromElementUID>wing_section_11_element_1</fromElementUID>
+                <toElementUID>wing_section_12_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_12">
+                <name>wing_segment_12</name>
+                <fromElementUID>wing_section_12_element_1</fromElementUID>
+                <toElementUID>wing_section_13_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_13">
+                <name>wing_segment_13</name>
+                <fromElementUID>wing_section_13_element_1</fromElementUID>
+                <toElementUID>wing_section_14_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_14">
+                <name>wing_segment_14</name>
+                <fromElementUID>wing_section_14_element_1</fromElementUID>
+                <toElementUID>wing_section_15_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_15">
+                <name>wing_segment_15</name>
+                <fromElementUID>wing_section_15_element_1</fromElementUID>
+                <toElementUID>wing_section_16_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_16">
+                <name>wing_segment_16</name>
+                <fromElementUID>wing_section_16_element_1</fromElementUID>
+                <toElementUID>wing_section_17_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_17">
+                <name>wing_segment_17</name>
+                <fromElementUID>wing_section_17_element_1</fromElementUID>
+                <toElementUID>wing_section_18_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_18">
+                <name>wing_segment_18</name>
+                <fromElementUID>wing_section_18_element_1</fromElementUID>
+                <toElementUID>wing_section_19_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_19">
+                <name>wing_segment_19</name>
+                <fromElementUID>wing_section_19_element_1</fromElementUID>
+                <toElementUID>wing_section_20_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_20">
+                <name>wing_segment_20</name>
+                <fromElementUID>wing_section_20_element_1</fromElementUID>
+                <toElementUID>wing_section_21_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_21">
+                <name>wing_segment_21</name>
+                <fromElementUID>wing_section_21_element_1</fromElementUID>
+                <toElementUID>wing_section_22_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_22">
+                <name>wing_segment_22</name>
+                <fromElementUID>wing_section_22_element_1</fromElementUID>
+                <toElementUID>wing_section_23_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_23">
+                <name>wing_segment_23</name>
+                <fromElementUID>wing_section_23_element_1</fromElementUID>
+                <toElementUID>wing_section_24_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_24">
+                <name>wing_segment_24</name>
+                <fromElementUID>wing_section_24_element_1</fromElementUID>
+                <toElementUID>wing_section_25_element_1</toElementUID>
+              </segment>
+              <segment uID="wing_segment_25">
+                <name>wing_segment_25</name>
+                <fromElementUID>wing_section_25_element_1</fromElementUID>
+                <toElementUID>wing_section_26_element_1</toElementUID>
+              </segment>
+            </segments>
+            <transformation uID="blade_transformation">
+              <scaling uID="blade_transformation_scaling">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="blade_transformation_rotation">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation uID="blade_transformation_translation">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <dynamicAircraftModel>
+              <dynamicAircraftModelPoints>
+                <uID>blade_load_application_points</uID>
+                <x mapType="vector">0;0;0;0;0;0;0;0;0;0;0</x>
+                <y mapType="vector">0;15.1125;30.225;45.3375;60.45;75.5625;90.675;105.788;120.9;136.013;151.125</y>
+                <z mapType="vector">0;0;0;0;0;0;0;0;0;0;0</z>
+              </dynamicAircraftModelPoints>
+            </dynamicAircraftModel>
+          </wing>
+        </wings>
+        <analyses>
+          <loadAnalysis>
+            <loadCases>
+              <flightLoadCases>
+                <flightLoadCase uID="fx_max">
+                  <description/>
+                  <name>fx_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="fx_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">1.3186e+06;1.36991e+06;683739;482076;341244;237101;146206;66609.2;18589.9;499.023;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;-3.63798e-12;0;0;0;0;7.10543e-15;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="fx_min">
+                  <description/>
+                  <name>fx_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="fx_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">-1.73098e+06;-1.51666e+06;-775642;-555506;-420611;-309177;-202151;-100742;-33328.5;-890.075;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;5.82077e-11;0;0;0;-1.81899e-12;0;0;-2.27374e-13;-1.42109e-14;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="fy_max">
+                  <description/>
+                  <name>fy_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="fy_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">2.443e+06;2.359e+06;1.489e+06;1.172e+06;902600;629000;381100;172700;48930;1257;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="fy_min">
+                  <description/>
+                  <name>fy_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="fy_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">-1.037e+06;-965000;-357600;-209500;-122300;-60240;-22050;-2105;2379;88.51;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="fz_max">
+                  <description/>
+                  <name>fz_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="fz_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;2.91038e-11;-2.91038e-11;0;-7.27596e-12;-1.81899e-12;0;4.54747e-13;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">1.05542e+06;1.04014e+06;933553;834495;689739;509645;376230;289913;132791;3847.34;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="fz_min">
+                  <description/>
+                  <name>fz_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="fz_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">3.63798e-12;-9.09495e-13;-3.63798e-12;0;0;9.09495e-13;-1.13687e-13;-8.88178e-16;0;3.55271e-15;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">-111378;-32060.9;117227;80752.8;-21184.9;-88421.6;-79460.4;-691.44;14796.3;-587.759;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="my_max">
+                  <description/>
+                  <name>my_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="my_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">0.1117;0.00917;-0.005171;0.0002265;-0.001166;0.0003591;8191;18240;24710;1381;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="my_min">
+                  <description/>
+                  <name>my_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="my_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mx>
+                      <my mapType="vector">-471100;-475700;-482800;-432500;-337800;-230200;-140100;-86630;-40810;-989.1;0</my>
+                      <mz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_0.0_deg_max">
+                  <description/>
+                  <name>m_0.0_deg_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_0.0_deg_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">6.69773e+07;7.15015e+07;5.20518e+07;3.75491e+07;2.65802e+07;1.76191e+07;1.10271e+07;5.05602e+06;1.21884e+06;3925.5;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">0;0;0;4.65661e-10;2.32831e-10;0;-1.45519e-11;0;0;5.68434e-14;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_0.0_deg_min">
+                  <description/>
+                  <name>m_0.0_deg_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_0.0_deg_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">1.21216e+07;1.12955e+07;1.89473e+06;-1.04482e+06;-2.42033e+06;-1.47983e+06;195043;415615;47272.7;72.222;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">-4.65661e-10;0;0;-1.45519e-11;0;0;-2.27374e-13;-4.54747e-13;2.27374e-13;8.88178e-16;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_30.0_deg_max">
+                  <description/>
+                  <name>m_30.0_deg_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_30.0_deg_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">6.22521e+07;6.01792e+07;4.1789e+07;3.0433e+07;2.07829e+07;1.30841e+07;7.28839e+06;3.36643e+06;822638;2721;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">-3.59412e+07;-3.47445e+07;-2.41269e+07;-1.75705e+07;-1.1999e+07;-7.55409e+06;-4.20795e+06;-1.94361e+06;-474950;-1570.97;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_30.0_deg_min">
+                  <description/>
+                  <name>m_30.0_deg_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_30.0_deg_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">-1.34832e+07;1.40686e+06;1.59258e+06;-873596;-1.62631e+06;-892418;81646.6;260402;18084.1;-2.75018;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">7.78451e+06;-812248;-919474;504371;938948;515238;-47138.7;-150343;-10440.8;1.58782;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_60.0_deg_max">
+                  <description/>
+                  <name>m_60.0_deg_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_60.0_deg_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">2.95482e+07;3.31505e+07;2.17471e+07;1.49142e+07;9.65603e+06;5.73087e+06;2.94911e+06;1.16343e+06;259711;879.813;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">-5.1179e+07;-5.74184e+07;-3.7667e+07;-2.58321e+07;-1.67247e+07;-9.92615e+06;-5.10801e+06;-2.01512e+06;-449832;-1523.88;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_60.0_deg_min">
+                  <description/>
+                  <name>m_60.0_deg_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_60.0_deg_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">-2.18372e+07;-1.27746e+07;-6.44692e+06;-4.02515e+06;-2.16614e+06;-899604;-223019;17888.6;-9571.74;-38.8612;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">3.78231e+07;2.21262e+07;1.11664e+07;6.97177e+06;3.75186e+06;1.55816e+06;386281;-30984;16578.7;67.3095;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_90.0_deg_max">
+                  <description/>
+                  <name>m_90.0_deg_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_90.0_deg_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">1.86265e-09;0;0;4.65661e-10;1.16415e-10;2.91038e-11;0;-9.09495e-13;0;1.77636e-15;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">-4.2896e+07;-4.89661e+07;-2.87627e+07;-1.87446e+07;-1.14772e+07;-6.23157e+06;-2.76098e+06;-842855;-138482;-379.609;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_90.0_deg_min">
+                  <description/>
+                  <name>m_90.0_deg_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_90.0_deg_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">0;0;0;4.65661e-10;-1.16415e-10;-5.82077e-11;0;3.63798e-12;-1.81899e-12;0;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">6.84134e+07;5.35121e+07;3.32602e+07;2.33915e+07;1.51163e+07;8.62051e+06;4.01484e+06;1.42421e+06;279769;623.161;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_120.0_deg_max">
+                  <description/>
+                  <name>m_120.0_deg_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_120.0_deg_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">-1.1328e+07;-1.69018e+07;-9.36428e+06;-5.5753e+06;-3.05381e+06;-1.46039e+06;-519542;-85371.5;-5001.06;37.4065;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">-1.96206e+07;-2.92747e+07;-1.62194e+07;-9.6567e+06;-5.28935e+06;-2.52947e+06;-899874;-147868;-8662.08;64.79;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_120.0_deg_min">
+                  <description/>
+                  <name>m_120.0_deg_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_120.0_deg_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">3.92526e+07;3.55414e+07;2.33963e+07;1.66018e+07;1.10118e+07;6.93367e+06;4.06099e+06;1.77423e+06;409618;1204.5;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">6.79874e+07;6.15595e+07;4.05236e+07;2.87551e+07;1.90729e+07;1.20095e+07;7.03384e+06;3.07306e+06;709479;2086.26;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_150.0_deg_max">
+                  <description/>
+                  <name>m_150.0_deg_max</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_150.0_deg_max_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">2.82014e+06;-9.97904e+06;-3.83556e+06;-1.01582e+06;-2.00418e+06;-1.32732e+06;19519.8;361908;51182.2;109.667;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">1.62821e+06;-5.7614e+06;-2.21446e+06;-586486;-1.15712e+06;-766330;11269.8;208948;29550.1;63.316;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+                <flightLoadCase uID="m_150.0_deg_min">
+                  <description/>
+                  <name>m_150.0_deg_min</name>
+                  <cutLoads>
+                    <wingCutLoad uID="m_150.0_deg_min_load_set">
+                      <parentUID>blade</parentUID>
+                      <description/>
+                      <fx mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fx>
+                      <fy mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fy>
+                      <fz mapType="vector">0;0;0;0;0;0;0;0;0;0;0</fz>
+                      <mx mapType="vector">6.50914e+07;6.63769e+07;4.63633e+07;3.33331e+07;2.28871e+07;1.53262e+07;9.4413e+06;4.26461e+06;1.0117e+06;3167.26;0</mx>
+                      <my mapType="vector">0;0;0;0;0;0;0;0;0;0;0</my>
+                      <mz mapType="vector">3.75805e+07;3.83227e+07;2.67679e+07;1.92449e+07;1.32139e+07;8.84857e+06;5.45094e+06;2.46218e+06;584105;1828.62;0</mz>
+                    </wingCutLoad>
+                  </cutLoads>
+                </flightLoadCase>
+              </flightLoadCases>
+            </loadCases>
+          </loadAnalysis>
+        </analyses>
+      </model>
+    </aircraft>
+    <materials>
+      <material uID="Gelcoat">
+        <name>Gelcoat</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1235</rho>
+        <isotropicProperties>
+          <E>3440000000.00000</E>
+          <G>1323076923.07692</G>
+          <nu>0.30000</nu>
+          <sigc>74.00000</sigc>
+          <sigt>74.00000</sigt>
+          <tau12>44.40000</tau12>
+        </isotropicProperties>
+      </material>
+      <material uID="steel">
+        <name>steel</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>7800</rho>
+        <isotropicProperties>
+          <E>200000000000.00000</E>
+          <G>76923076923.07692</G>
+          <nu>0.30000</nu>
+          <sigc>450000000.00000</sigc>
+          <sigt>450000000.00000</sigt>
+          <tau12>270000000.00000</tau12>
+        </isotropicProperties>
+      </material>
+      <material uID="steel_drive">
+        <name>steel_drive</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>6672</rho>
+        <isotropicProperties>
+          <E>204999999999.99997</E>
+          <G>78846153846.15384</G>
+          <nu>0.30000</nu>
+          <sigc>814000000.00000</sigc>
+          <sigt>814000000.00000</sigt>
+          <tau12>488400000.00000</tau12>
+        </isotropicProperties>
+      </material>
+      <material uID="cast_iron">
+        <name>cast_iron</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>6120</rho>
+        <isotropicProperties>
+          <E>118000000000.00000</E>
+          <G>45384615384.61538</G>
+          <nu>0.30000</nu>
+          <sigc>310000000.00000</sigc>
+          <sigt>310000000.00000</sigt>
+          <tau12>186000000.00000</tau12>
+        </isotropicProperties>
+      </material>
+      <material uID="glass_uni">
+        <name>glass_uni</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1940</rho>
+        <orthotropicShellProperties>
+          <E1>44600000000.00000</E1>
+          <E2>17000000000.00000</E2>
+          <G12>3270000000.00000</G12>
+          <G23>3500000000.00000</G23>
+          <G31>3480000000.00000</G31>
+          <nu>0.26400</nu>
+          <sig1c>474710000.00000</sig1c>
+          <sig1t>609200000.00000</sig1t>
+          <sig2c>112640000.00000</sig2c>
+          <sig2t>38100000.00000</sig2t>
+          <tau12>365520000.00000</tau12>
+        </orthotropicShellProperties>
+      </material>
+      <material uID="glass_uni1">
+        <name>glass_uni1</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1649</rho>
+        <orthotropicShellProperties>
+          <E1>44600000000.00000</E1>
+          <E2>17000000000.00000</E2>
+          <G12>3270000000.00000</G12>
+          <G23>3500000000.00000</G23>
+          <G31>3480000000.00000</G31>
+          <nu>0.26400</nu>
+          <sig1c>474710000.00000</sig1c>
+          <sig1t>609200000.00000</sig1t>
+          <sig2c>112640000.00000</sig2c>
+          <sig2t>38100000.00000</sig2t>
+          <tau12>365520000.00000</tau12>
+        </orthotropicShellProperties>
+      </material>
+      <material uID="CarbonUD">
+        <name>CarbonUD</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1220</rho>
+        <orthotropicShellProperties>
+          <E1>114500000000.00002</E1>
+          <E2>8390000000.00000</E2>
+          <G12>5990000000.00000</G12>
+          <G23>5990000000.00000</G23>
+          <G31>5990000000.00000</G31>
+          <nu>0.27000</nu>
+          <sig1c>1047000000.00000</sig1c>
+          <sig1t>1546000000.00000</sig1t>
+          <sig2c>0.00000</sig2c>
+          <sig2t>0.00000</sig2t>
+          <tau12>927600000.00000</tau12>
+        </orthotropicShellProperties>
+      </material>
+      <material uID="glass_biax">
+        <name>glass_biax</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1940</rho>
+        <orthotropicShellProperties>
+          <E1>11100000000.00000</E1>
+          <E2>11100000000.00000</E2>
+          <G12>13530000000.00000</G12>
+          <G23>3490000000.00000</G23>
+          <G31>3490000000.00000</G31>
+          <nu>0.06600</nu>
+          <sig1c>70700000.00000</sig1c>
+          <sig1t>42900000.00000</sig1t>
+          <sig2c>70700000.00000</sig2c>
+          <sig2t>42600000.00000</sig2t>
+          <tau12>25740000.00000</tau12>
+        </orthotropicShellProperties>
+      </material>
+      <material uID="glass_triax">
+        <name>glass_triax</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1940</rho>
+        <orthotropicShellProperties>
+          <E1>28700000000.00000</E1>
+          <E2>16600000000.00000</E2>
+          <G12>8400000000.00000</G12>
+          <G23>3490000000.00000</G23>
+          <G31>3490000000.00000</G31>
+          <nu>0.17000</nu>
+          <sig1c>448900000.00000</sig1c>
+          <sig1t>396000000.00000</sig1t>
+          <sig2c>174700000.00000</sig2c>
+          <sig2t>76400000.00000</sig2t>
+          <tau12>237600000.00000</tau12>
+        </orthotropicShellProperties>
+      </material>
+      <material uID="medium_density_foam">
+        <name>medium_density_foam</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>130</rho>
+        <isotropicProperties>
+          <E>129200000.00000</E>
+          <G>48939393.93939</G>
+          <nu>0.32000</nu>
+          <sigc>2083000.00000</sigc>
+          <sigt>2083000.00000</sigt>
+          <tau12>1249800.00000</tau12>
+        </isotropicProperties>
+      </material>
+      <material uID="resin">
+        <name>resin</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1150</rho>
+        <isotropicProperties>
+          <E>1000000.00000</E>
+          <G>384615.38462</G>
+          <nu>0.30000</nu>
+        </isotropicProperties>
+      </material>
+      <material uID="adhesive">
+        <name>adhesive</name>
+        <description>Material exported by VCP CPACS interface DLR-FA-FLB</description>
+        <rho>1100</rho>
+        <isotropicProperties>
+          <E>4560000.00000</E>
+          <G>1530201.34228</G>
+          <nu>0.49000</nu>
+          <sigc>690000.00000</sigc>
+          <sigt>690000.00000</sigt>
+          <tau12>414000.00000</tau12>
+        </isotropicProperties>
+      </material>
+      <composites>
+        <composite uID="base_material">
+          <name>base_material</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u0">
+          <name>base_material_u0</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u1">
+          <name>base_material_u1</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u2">
+          <name>base_material_u2</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u3">
+          <name>base_material_u3</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u4">
+          <name>base_material_u4</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u5">
+          <name>base_material_u5</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="base_material_u6">
+          <name>base_material_u6</name>
+          <compositeLayer>
+            <name>0</name>
+            <thickness>0.0010</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span00_web0_cell00_composite">
+          <name>span00_web0_cell00_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0021</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0440</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0021</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_web0_cell01_composite">
+          <name>span01_web0_cell01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0017</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0324</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0017</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_web0_cell02_composite">
+          <name>span02_web0_cell02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0012</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0209</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0012</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span00_web1_cell00_composite">
+          <name>span00_web1_cell00_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0021</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0440</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0021</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_web1_cell01_composite">
+          <name>span01_web1_cell01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0017</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0324</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0017</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_web1_cell02_composite">
+          <name>span02_web1_cell02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0012</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0209</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0012</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_biax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ01_composite">
+          <name>span01_circ01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0061</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ02_composite">
+          <name>span01_circ02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0775</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ03_composite">
+          <name>span01_circ03_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0369</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ04_composite">
+          <name>span01_circ04_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0775</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ05_composite">
+          <name>span01_circ05_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0039</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ06_composite">
+          <name>span01_circ06_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0039</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ07_composite">
+          <name>span01_circ07_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0775</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ08_composite">
+          <name>span01_circ08_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0369</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ09_composite">
+          <name>span01_circ09_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0775</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span01_circ10_composite">
+          <name>span01_circ10_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0061</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0323</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ01_composite">
+          <name>span02_circ01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0309</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ02_composite">
+          <name>span02_circ02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0572</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ03_composite">
+          <name>span02_circ03_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.1203</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ04_composite">
+          <name>span02_circ04_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0572</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ05_composite">
+          <name>span02_circ05_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0035</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ06_composite">
+          <name>span02_circ06_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0035</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ07_composite">
+          <name>span02_circ07_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0572</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ08_composite">
+          <name>span02_circ08_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.1203</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ09_composite">
+          <name>span02_circ09_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0572</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span02_circ10_composite">
+          <name>span02_circ10_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0309</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0027</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ01_composite">
+          <name>span03_circ01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0206</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ02_composite">
+          <name>span03_circ02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0369</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ03_composite">
+          <name>span03_circ03_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.1172</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ04_composite">
+          <name>span03_circ04_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0369</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ05_composite">
+          <name>span03_circ05_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0031</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ06_composite">
+          <name>span03_circ06_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0031</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ07_composite">
+          <name>span03_circ07_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0369</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ08_composite">
+          <name>span03_circ08_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.1172</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ09_composite">
+          <name>span03_circ09_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0369</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span03_circ10_composite">
+          <name>span03_circ10_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0206</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ01_composite">
+          <name>span04_circ01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0016</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ02_composite">
+          <name>span04_circ02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0166</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ03_composite">
+          <name>span04_circ03_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0876</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ04_composite">
+          <name>span04_circ04_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0166</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ05_composite">
+          <name>span04_circ05_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0028</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ06_composite">
+          <name>span04_circ06_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0028</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ07_composite">
+          <name>span04_circ07_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0166</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ08_composite">
+          <name>span04_circ08_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0876</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ09_composite">
+          <name>span04_circ09_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0166</thickness>
+            <phi>0.00</phi>
+            <materialUID>medium_density_foam</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span04_circ10_composite">
+          <name>span04_circ10_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0016</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_uni</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0026</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span05_circ01_composite">
+          <name>span05_circ01_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span05_circ02_composite">
+          <name>span05_circ02_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0147</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span05_circ03_composite">
+          <name>span05_circ03_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span05_circ04_composite">
+          <name>span05_circ04_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span05_circ05_composite">
+          <name>span05_circ05_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0147</thickness>
+            <phi>0.00</phi>
+            <materialUID>CarbonUD</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+        <composite uID="span05_circ06_composite">
+          <name>span05_circ06_composite</name>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0005</thickness>
+            <phi>0.00</phi>
+            <materialUID>Gelcoat</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+          <compositeLayer>
+            <name>0.0</name>
+            <thickness>0.0013</thickness>
+            <phi>0.00</phi>
+            <materialUID>glass_triax</materialUID>
+          </compositeLayer>
+        </composite>
+      </composites>
+    </materials>
+    <profiles>
+      <wingAirfoils>
+        <wingAirfoil uID="airfoil_0.00">
+          <name>airfoil_0.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0;0.0779814;0.161974;0.237976;0.307109;0.367856;0.418578;0.457885;0.484697;0.498291;0.498291;0.484697;0.457885;0.418578;0.367856;0.307109;0.237976;0.161974;0.0779814;0;0;-0.0779814;-0.161974;-0.237976;-0.307109;-0.367856;-0.418578;-0.457885;-0.484697;-0.498291;-0.498291;-0.484697;-0.457885;-0.418578;-0.367856;-0.30711;-0.23797;-0.162209;-0.0794089;-0.0175275</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_4.00">
+          <name>airfoil_4.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00161538;0.068289;0.141324;0.20863;0.270923;0.326781;0.37448;0.412533;0.439736;0.455119;0.458072;0.448248;0.425816;0.391209;0.345313;0.289385;0.224938;0.15344;0.0739184;0;0;-0.0741171;-0.153507;-0.224669;-0.288887;-0.344716;-0.39069;-0.425514;-0.448119;-0.457752;-0.454125;-0.437517;-0.408785;-0.369319;-0.321006;-0.265577;-0.204587;-0.139317;-0.0687812;-0.0163232</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_8.00">
+          <name>airfoil_8.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00484615;0.0489043;0.100025;0.149938;0.198549;0.244631;0.286286;0.321829;0.349814;0.368774;0.377635;0.375349;0.36168;0.33647;0.300228;0.253937;0.198863;0.136372;0.0657925;0;0;-0.0663886;-0.136572;-0.198055;-0.252444;-0.298438;-0.334915;-0.360773;-0.374963;-0.376673;-0.365792;-0.343158;-0.310586;-0.270801;-0.227306;-0.182512;-0.13782;-0.0935323;-0.0475259;-0.0139148</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_12.00">
+          <name>airfoil_12.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00807692;0.0295195;0.0587248;0.0912458;0.126176;0.162482;0.198092;0.231126;0.259893;0.28243;0.297197;0.302451;0.297544;0.281732;0.255143;0.218489;0.172788;0.119304;0.0576666;0;0;-0.05866;-0.119637;-0.171442;-0.216;-0.252159;-0.27914;-0.296032;-0.301807;-0.295595;-0.27746;-0.248798;-0.212388;-0.172283;-0.133606;-0.0994473;-0.0710524;-0.0477476;-0.0262705;-0.0115063</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_16.00">
+          <name>airfoil_16.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0107606;0.0149818;0.0270321;0.0454617;0.068882;0.0964984;0.126278;0.156321;0.184842;0.20961;0.228747;0.239994;0.24228;0.23438;0.216018;0.187608;0.149991;0.104349;0.0505611;0;0;-0.0515684;-0.104349;-0.14777;-0.183913;-0.211787;-0.230827;-0.240205;-0.238913;-0.226102;-0.202104;-0.16894;-0.13029;-0.0913443;-0.0581206;-0.0338488;-0.0191658;-0.0122767;-0.00940056;-0.00875433</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_20.00">
+          <name>airfoil_20.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0118029;0.0149854;0.0241608;0.0384011;0.0568285;0.0790138;0.103605;0.129212;0.154403;0.177363;0.196258;0.20886;0.213635;0.209188;0.194776;0.170428;0.137026;0.0957318;0.046517;0;0;-0.0463878;-0.0940047;-0.132925;-0.1649;-0.189139;-0.204898;-0.211119;-0.206808;-0.191366;-0.165681;-0.132583;-0.096495;-0.0631418;-0.0372769;-0.0206498;-0.0119211;-0.00774709;-0.00568706;-0.00497163</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_24.00">
+          <name>airfoil_24.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0128453;0.014989;0.0212894;0.0313404;0.0447751;0.0615293;0.080933;0.102103;0.123965;0.145117;0.16377;0.177727;0.18499;0.183995;0.173534;0.153248;0.124061;0.0871148;0.0424729;0;0;-0.0412073;-0.0836599;-0.118079;-0.145886;-0.16649;-0.178968;-0.182033;-0.174703;-0.15663;-0.129258;-0.0962273;-0.0627001;-0.0349394;-0.0164333;-0.00745084;-0.00467645;-0.00321752;-0.00197355;-0.00118894</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_28.00">
+          <name>airfoil_28.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0127594;0.0146681;0.0203027;0.0293493;0.0416519;0.0571628;0.075311;0.0952679;0.115966;0.136099;0.15401;0.16758;0.174808;0.174108;0.164193;0.144692;0.116633;0.0814713;0.0396791;0.000407931;0.000407931;-0.037458;-0.0773313;-0.110517;-0.137658;-0.15778;-0.169805;-0.172465;-0.164832;-0.146626;-0.119293;-0.0866064;-0.0540894;-0.0279237;-0.0112577;-0.00388184;-0.0027929;-0.00371076;-0.00494269;-0.00524968</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_32.00">
+          <name>airfoil_32.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.012506;0.0142989;0.0195957;0.0281108;0.0398544;0.0547436;0.0722201;0.0914423;0.111298;0.13053;0.147624;0.160548;0.167365;0.166493;0.156619;0.137417;0.110027;0.0762693;0.037071;0.000876418;0.000876418;-0.0339211;-0.0715988;-0.104035;-0.13103;-0.151139;-0.163131;-0.165795;-0.15826;-0.140294;-0.113256;-0.0809542;-0.0492173;-0.0240531;-0.00840797;-0.00174237;-0.00170519;-0.00494961;-0.00890385;-0.0104747</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_36.00">
+          <name>airfoil_36.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.011504;0.0132414;0.0183422;0.0265823;0.0380002;0.0525134;0.0695646;0.0882993;0.107564;0.12611;0.142478;0.154699;0.160933;0.159611;0.149499;0.130419;0.103691;0.0713507;0.0343472;0.000703272;0.000703272;-0.0315416;-0.0670826;-0.0985506;-0.125401;-0.145715;-0.157932;-0.160836;-0.153604;-0.136029;-0.109411;-0.0775475;-0.0464483;-0.0220336;-0.00708762;-0.000865249;-0.00117083;-0.00489768;-0.00917884;-0.0109156</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_40.00">
+          <name>airfoil_40.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0102896;0.0119886;0.0169334;0.0249715;0.03613;0.0503368;0.0670328;0.0853502;0.104095;0.122017;0.137685;0.149186;0.154786;0.152936;0.142509;0.123499;0.0974313;0.0665126;0.0315906;0.000347991;0.000347991;-0.0294905;-0.0629117;-0.0933489;-0.120055;-0.140636;-0.153152;-0.156362;-0.14949;-0.132351;-0.106188;-0.0747781;-0.0442764;-0.0205396;-0.0062014;-0.000346464;-0.000793555;-0.00447934;-0.00840748;-0.00999839</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_44.00">
+          <name>airfoil_44.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0090785;0.0107386;0.0155278;0.0233629;0.0342604;0.0481581;0.0644961;0.082395;0.100622;0.117924;0.132896;0.143683;0.148655;0.14628;0.135543;0.116611;0.0912074;0.0617036;0.0288568;-1.58311e-06;-1.58311e-06;-0.027434;-0.0587324;-0.08813;-0.114677;-0.135512;-0.14832;-0.151835;-0.145325;-0.128623;-0.102919;-0.071968;-0.0420699;-0.0190178;-0.00529547;0.000185734;-0.000406752;-0.0040516;-0.00763001;-0.00907525</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_48.00">
+          <name>airfoil_48.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0080307;0.00962456;0.0142714;0.0218609;0.0324171;0.0458768;0.0617283;0.0791554;0.096959;0.113838;0.128346;0.138679;0.143224;0.14052;0.129762;0.111248;0.0866953;0.058289;0.0272103;-7.87467e-05;-7.87467e-05;-0.0251191;-0.054151;-0.0820951;-0.107795;-0.128226;-0.140998;-0.144749;-0.138686;-0.122548;-0.0974521;-0.067215;-0.0382163;-0.0161744;-0.00344846;0.00135827;0.000434719;-0.00317458;-0.00656066;-0.00786906</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_52.00">
+          <name>airfoil_52.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0069829;0.00851056;0.013015;0.0203589;0.0305738;0.0435955;0.0589606;0.0759157;0.0932955;0.109751;0.123796;0.133675;0.137792;0.134761;0.123982;0.105884;0.0821831;0.0548743;0.0255639;-0.00015591;-0.00015591;-0.0228041;-0.0495697;-0.0760602;-0.100913;-0.120941;-0.133676;-0.137664;-0.132047;-0.116472;-0.091985;-0.062462;-0.0343626;-0.0133311;-0.00160145;0.00253081;0.00127619;-0.00229757;-0.00549131;-0.00666288</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_56.00">
+          <name>airfoil_56.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00601584;0.00748643;0.0118497;0.0189681;0.0288621;0.0414756;0.0564088;0.0729741;0.0900373;0.106194;0.119911;0.129462;0.133235;0.129879;0.11902;0.101272;0.0783537;0.0521733;0.0242414;-0.000147802;-0.000147802;-0.0209774;-0.0458185;-0.0707253;-0.0943747;-0.113673;-0.126155;-0.130282;-0.125086;-0.110092;-0.0862892;-0.0576664;-0.0306557;-0.0107342;6.4964e-05;0.00361998;0.00212155;-0.00138987;-0.00440123;-0.00549259</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_60.00">
+          <name>airfoil_60.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00511269;0.00653344;0.0107566;0.0176654;0.0272546;0.0394835;0.0540279;0.0702683;0.0870998;0.103055;0.116554;0.125877;0.12937;0.125691;0.114706;0.0972548;0.0750646;0.0500371;0.0231752;-7.22073e-05;-7.22073e-05;-0.019537;-0.0427244;-0.0659444;-0.0881093;-0.10642;-0.118476;-0.122666;-0.117871;-0.10347;-0.0804123;-0.052837;-0.0270649;-0.00833256;0.00158845;0.00464319;0.00296999;-0.000457895;-0.00329474;-0.00435071</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_64.00">
+          <name>airfoil_64.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00420557;0.00557529;0.00965558;0.0163522;0.0256385;0.0374893;0.0516545;0.0675826;0.0841959;0.0999639;0.113257;0.122364;0.12558;0.121573;0.110447;0.0932717;0.0717874;0.0478873;0.0220961;0;0;-0.0181104;-0.0396497;-0.0611898;-0.0818737;-0.0991974;-0.110827;-0.115082;-0.110692;-0.0968902;-0.0745826;-0.0480686;-0.0235493;-0.00600524;0.00305547;0.00562698;0.00379157;0.000454952;-0.00220375;-0.00322121</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_68.00">
+          <name>airfoil_68.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00321408;0.00450738;0.0083865;0.0148178;0.0238402;0.0354507;0.0494409;0.0653251;0.08201;0.0978805;0.111271;0.120392;0.123409;0.118925;0.107348;0.0900202;0.0687628;0.0454498;0.0207401;0;0;-0.0169763;-0.0369912;-0.0569956;-0.076273;-0.0926097;-0.103822;-0.108195;-0.104295;-0.0911892;-0.0697593;-0.0446027;-0.0216365;-0.00526294;0.00331882;0.00577061;0.00404068;0.00096001;-0.00144297;-0.00235553</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_72.00">
+          <name>airfoil_72.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00222259;0.00343947;0.00711742;0.0132834;0.022042;0.0334121;0.0472272;0.0630676;0.079824;0.095797;0.109284;0.11842;0.121239;0.116277;0.104249;0.0867687;0.0657382;0.0430122;0.0193841;0;0;-0.0158422;-0.0343327;-0.0528014;-0.0706724;-0.086022;-0.0968175;-0.101309;-0.0978977;-0.0854883;-0.064936;-0.0411367;-0.0197238;-0.00452063;0.00358217;0.00591424;0.00428978;0.00146507;-0.000682194;-0.00148984</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_76.00">
+          <name>airfoil_76.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.0012311;0.00237157;0.00584835;0.0117489;0.0202437;0.0313735;0.0450136;0.0608102;0.0776381;0.0937136;0.107298;0.116449;0.119068;0.11363;0.10115;0.0835172;0.0627137;0.0405747;0.0180281;0;0;-0.0147082;-0.0316742;-0.0486072;-0.0650718;-0.0794342;-0.0898126;-0.0944227;-0.0915005;-0.0797874;-0.0601127;-0.0376707;-0.0178111;-0.00377833;0.00384552;0.00605787;0.00453889;0.00197013;7.85819e-05;-0.000624161</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_80.00">
+          <name>airfoil_80.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00094;0.00205803;0.00547575;0.0112984;0.0197157;0.030775;0.0443637;0.0601474;0.0769963;0.0931019;0.106715;0.11587;0.11843;0.112852;0.10024;0.0825626;0.0618257;0.0398591;0.01763;0;0;-0.0143752;-0.0308937;-0.0473758;-0.0634275;-0.0775001;-0.087756;-0.0924009;-0.0896223;-0.0781136;-0.0586966;-0.0366531;-0.0172495;-0.0035604;0.00392283;0.00610004;0.00461203;0.00211841;0.000301943;-0.00037</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_84.00">
+          <name>airfoil_84.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00094;0.00205803;0.00547575;0.0112984;0.0197157;0.030775;0.0443637;0.0601474;0.0769963;0.0931019;0.106715;0.11587;0.11843;0.112852;0.10024;0.0825626;0.0618257;0.0398591;0.01763;0;0;-0.0143752;-0.0308937;-0.0473758;-0.0634275;-0.0775001;-0.087756;-0.0924009;-0.0896223;-0.0781136;-0.0586966;-0.0366531;-0.0172495;-0.0035604;0.00392283;0.00610004;0.00461203;0.00211841;0.000301943;-0.00037</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_88.00">
+          <name>airfoil_88.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00094;0.00205803;0.00547575;0.0112984;0.0197157;0.030775;0.0443637;0.0601474;0.0769963;0.0931019;0.106715;0.11587;0.11843;0.112852;0.10024;0.0825626;0.0618257;0.0398591;0.01763;0;0;-0.0143752;-0.0308937;-0.0473758;-0.0634275;-0.0775001;-0.087756;-0.0924009;-0.0896223;-0.0781136;-0.0586966;-0.0366531;-0.0172495;-0.0035604;0.00392283;0.00610004;0.00461203;0.00211841;0.000301943;-0.00037</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_92.00">
+          <name>airfoil_92.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00094;0.00205803;0.00547575;0.0112984;0.0197157;0.030775;0.0443637;0.0601474;0.0769963;0.0931019;0.106715;0.11587;0.11843;0.112852;0.10024;0.0825626;0.0618257;0.0398591;0.01763;0;0;-0.0143752;-0.0308937;-0.0473758;-0.0634275;-0.0775001;-0.087756;-0.0924009;-0.0896223;-0.0781136;-0.0586966;-0.0366531;-0.0172495;-0.0035604;0.00392283;0.00610004;0.00461203;0.00211841;0.000301943;-0.00037</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_96.00">
+          <name>airfoil_96.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00094;0.00205803;0.00547575;0.0112984;0.0197157;0.030775;0.0443637;0.0601474;0.0769963;0.0931019;0.106715;0.11587;0.11843;0.112852;0.10024;0.0825626;0.0618257;0.0398591;0.01763;0;0;-0.0143752;-0.0308937;-0.0473758;-0.0634275;-0.0775001;-0.087756;-0.0924009;-0.0896223;-0.0781136;-0.0586966;-0.0366531;-0.0172495;-0.0035604;0.00392283;0.00610004;0.00461203;0.00211841;0.000301943;-0.00037</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="airfoil_100.00">
+          <name>airfoil_100.00</name>
+          <pointList>
+            <x mapType="vector">1;0.993181;0.972909;0.939737;0.89457;0.838641;0.773474;0.700848;0.622743;0.54129;0.45871;0.377257;0.299152;0.226526;0.161359;0.10543;0.0602631;0.0270914;0.00681935;0;0;0.00681935;0.0270914;0.0602631;0.10543;0.161359;0.226526;0.299152;0.377257;0.45871;0.54129;0.622743;0.700848;0.773474;0.838641;0.89457;0.939737;0.972909;0.993181;1</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">0.00094;0.00205803;0.00547575;0.0112984;0.0197157;0.030775;0.0443637;0.0601474;0.0769963;0.0931019;0.106715;0.11587;0.11843;0.112852;0.10024;0.0825626;0.0618257;0.0398591;0.01763;0;0;-0.0143752;-0.0308937;-0.0473758;-0.0634275;-0.0775001;-0.087756;-0.0924009;-0.0896223;-0.0781136;-0.0586966;-0.0366531;-0.0172495;-0.0035604;0.00392283;0.00610004;0.00461203;0.00211841;0.000301943;-0.00037</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+    </profiles>
+  </vehicles>
+</cpacs>

--- a/tests/integrationtests/testBug930.cpp
+++ b/tests/integrationtests/testBug930.cpp
@@ -1,0 +1,51 @@
+/*
+* Copyright (C) 2021 German Aerospace Center
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "test.h"
+#include "tigl.h"
+
+#include "CCPACSConfigurationManager.h"
+#include "CTiglUIDManager.h"
+#include "CNamedShape.h"
+#include "tiglcommonfunctions.h"
+#include "BRepTools.hxx"
+
+
+TEST(Bug930, cell_getLoft)
+{
+   // https://github.com/DLR-SC/tigl/issues/930
+   // cells on the lower shell span until the trailing edge, eventhough the contour coordinate is not 1. The same contour coordinates work
+   // as expected on the upper shell. The cell span01_circ07 is one such offending cell.
+
+   TiglHandleWrapper handle("TestData/bugs/930/IEA-25-310-UWT_ModGrid_final_red_mass_ver_2_loads_CPACS_cc_surface.xml", "aircraft");
+
+   tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+   tigl::CCPACSConfiguration & config = manager.GetConfiguration(handle);
+   tigl::CTiglUIDManager& uidMgr = config.GetUIDManager();
+
+   auto span01_circ07 = uidMgr.GetGeometricComponent("span01_circ07").GetLoft()->Shape();
+
+   double xmin, xmax, ymin, ymax, zmin, zmax;
+   GetShapeExtension(span01_circ07, xmin, xmax, ymin, ymax, zmin, zmax);
+   EXPECT_NEAR(xmin, -3.067, 0.01);
+   EXPECT_NEAR(xmax, -0.372, 0.01);
+   EXPECT_NEAR(ymin, 0., 0.01);
+   EXPECT_NEAR(ymax, 30.225, 0.01);
+   EXPECT_NEAR(zmin, -3.267, 0.01);
+   EXPECT_NEAR(zmax, -0.443, 0.01);
+
+   BRepTools::Write(span01_circ07, "TestData/export/bug930_span01_circ07.brep");
+
+}

--- a/tests/integrationtests/testBug930.cpp
+++ b/tests/integrationtests/testBug930.cpp
@@ -20,7 +20,6 @@
 #include "CTiglUIDManager.h"
 #include "CNamedShape.h"
 #include "tiglcommonfunctions.h"
-#include "BRepTools.hxx"
 
 
 TEST(Bug930, cell_getLoft)

--- a/tests/integrationtests/testBug930.cpp
+++ b/tests/integrationtests/testBug930.cpp
@@ -46,6 +46,5 @@ TEST(Bug930, cell_getLoft)
    EXPECT_NEAR(zmin, -3.267, 0.01);
    EXPECT_NEAR(zmax, -0.443, 0.01);
 
-   BRepTools::Write(span01_circ07, "TestData/export/bug930_span01_circ07.brep");
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes #930. 

The code for creating wing cells based on contour coordinates contained a small bug in mapping `u` parameters of the wing faces to CPACS contour coordinates: 

The internal `u` parameters go from lower trailing edge over the leading edge to upper trailing edge. The CPACS contour coordinates always go from leading edge to trailing edge. The differentiation between upper and lower side is clear from the CPACS hierarchy. 

This means that for the lower side, the contour coordinates and internal `u` coordinates have a reversed orientation, while for the upper side they do not. This was not properly taken into account before.


## How Has This Been Tested?

A new test case has been added specifically for this issue.

## Screenshots, that help to understand the changes(if applicable):

See the issue description #930.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- ~~[ ] New classes have been added to the Python interface.~~
- ~~[ ] API changes were documented properly in tigl.h.~~
