### PR TITLE
Fix unable to compile TiglViewer on  gcc (Ubuntu 12.2.0-3ubuntu1) 12.2.0

### DIFF
--- a/src/fuselage/ITiGLFuselageDuctStructure.cpp
+++ b/src/fuselage/ITiGLFuselageDuctStructure.cpp
@@ -31,7 +31,6 @@
 #include "TopExp_Explorer.hxx"
 #include "gp_Lin.hxx"
 
-
 namespace tigl {
 
 ITiglFuselageDuctStructure::ITiglFuselageDuctStructure(CTiglRelativelyPositionedComponent const* parent)

--- a/src/fuselage/ITiGLFuselageDuctStructure.cpp
+++ b/src/fuselage/ITiGLFuselageDuctStructure.cpp
@@ -22,6 +22,7 @@
 #include "CCPACSFuselageStringerFramePosition.h"
 #include "CNamedShape.h"
 
+#include "TopTools_ListIteratorOfListOfShape.hxx"
 #include "IntCurvesFace_Intersector.hxx"
 #include "BRepBuilderAPI_MakeEdge.hxx"
 #include "BRepBuilderAPI_MakeWire.hxx"
@@ -29,6 +30,7 @@
 #include "BRepProj_Projection.hxx"
 #include "TopExp_Explorer.hxx"
 #include "gp_Lin.hxx"
+
 
 namespace tigl {
 


### PR DESCRIPTION
I checked out the current master and simply tried.
```
mkdir build
cmake ..
make
```
which leads to the following error:

```
/<user>/git/tigl/src/fuselage/ITiGLFuselageDuctStructure.cpp: In function ‘TopoDS_Wire tigl::{anonymous}::project(TopoDS_Shape, BRepProj_Projection&, tigl::DebugScope&)’:
/<user>/git/tigl/src/fuselage/ITiGLFuselageDuctStructure.cpp:111:60: error: variable ‘TopTools_ListIteratorOfListOfShape it’ has initializer but incomplete type
  111 |         for (TopTools_ListIteratorOfListOfShape it(wireList); it.More(); it.Next()) {
      |                                                            ^
/home/kisle/git/tigl/src/fuselage/ITiGLFuselageDuctStructure.cpp:128:60: error: variable ‘TopTools_ListIteratorOfListOfShape it’ has initializer but incomplete type
  128 |         for (TopTools_ListIteratorOfListOfShape it(wireList); it.More(); it.Next()) {
```

## Description

The problem is resolved by importing the proper header required by TopTools_ListIteratorOfListOfShape.

## How Has This Been Tested?

running the build again:

```
mkdir build
cmake ..
make
```
This time it works.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
