### PR TITLE
Implemented high dpi screen support

### DIFF
--- a/TIGLViewer/src/TIGLQAspectWindow.cpp
+++ b/TIGLViewer/src/TIGLQAspectWindow.cpp
@@ -180,8 +180,9 @@ Standard_Real TIGLQAspectWindow::Ratio() const
 void TIGLQAspectWindow::Size ( Standard_Integer& theWidth, Standard_Integer& theHeight ) const
 {
     QRect aRect = myWidget->rect();
-    theWidth  = aRect.width();
-    theHeight = aRect.height();
+    auto scale = myWidget->devicePixelRatioF();
+    theWidth  = aRect.width() * scale;
+    theHeight = aRect.height() * scale;
 }
 
 // =======================================================================
@@ -191,8 +192,9 @@ void TIGLQAspectWindow::Size ( Standard_Integer& theWidth, Standard_Integer& the
 void TIGLQAspectWindow::Position ( Standard_Integer& theX1, Standard_Integer& theY1,
                                    Standard_Integer& theX2, Standard_Integer& theY2 ) const
 {
-    theX1 = myWidget->rect().left();
-    theX2 = myWidget->rect().right();
-    theY1 = myWidget->rect().top();
-    theY2 = myWidget->rect().bottom();
+    auto scale = myWidget->devicePixelRatioF();
+    theX1 = myWidget->rect().left() * scale;
+    theX2 = myWidget->rect().right() * scale;
+    theY1 = myWidget->rect().top() * scale;
+    theY2 = myWidget->rect().bottom() * scale;
 }

--- a/TIGLViewer/src/TIGLViewerWidget.cpp
+++ b/TIGLViewer/src/TIGLViewerWidget.cpp
@@ -295,7 +295,7 @@ void TIGLViewerWidget::mouseMoveEvent(QMouseEvent* e)
 {
     Standard_Real X, Y, Z;
     
-    myCurrentPoint = e->pos();
+    setCurrentPoint(e->pos());
     Handle(AIS_InteractiveContext) myContext = viewerContext->getContext();
     //Check if the grid is active and that we're snapping to it
     if ( myContext->CurrentViewer()->Grid()->IsActive() && myGridSnap ) {
@@ -734,7 +734,7 @@ void TIGLViewerWidget::setObjectsTexture()
 void TIGLViewerWidget::onLeftButtonDown(  Qt::KeyboardModifiers nFlags, const QPoint point )
 {
     setFocus(Qt::MouseFocusReason);
-    myStartPoint = point;
+    setStartPoint(point);
     if ( nFlags & CASCADESHORTCUTKEY ) {
         setMode( CurAction3d_DynamicZooming );
     }
@@ -772,7 +772,7 @@ void TIGLViewerWidget::onLeftButtonDown(  Qt::KeyboardModifiers nFlags, const QP
 
 void TIGLViewerWidget::onMiddleButtonDown(  Qt::KeyboardModifiers nFlags, const QPoint point )
 {
-    myStartPoint = point;
+    setStartPoint(point);
     if ( nFlags & CASCADESHORTCUTKEY ) {
         setMode( CurAction3d_DynamicPanning );
     }
@@ -786,7 +786,7 @@ void TIGLViewerWidget::onMiddleButtonDown(  Qt::KeyboardModifiers nFlags, const 
 
 void TIGLViewerWidget::onRightButtonDown(  Qt::KeyboardModifiers nFlags, const QPoint point )
 {
-    myStartPoint = point;
+    setStartPoint(point);
 //    if ( nFlags & CASCADESHORTCUTKEY )
 //    {
 //        setMode( CurAction3d_DynamicRotation );
@@ -802,7 +802,7 @@ void TIGLViewerWidget::onRightButtonDown(  Qt::KeyboardModifiers nFlags, const Q
 
 void TIGLViewerWidget::onLeftButtonUp(  Qt::KeyboardModifiers nFlags, const QPoint point )
 {
-    myCurrentPoint = point;
+    setCurrentPoint(point);
     if ( nFlags & CASCADESHORTCUTKEY ) {
         // Deactivates dynamic zooming
         setMode( CurAction3d_Nothing );
@@ -865,7 +865,7 @@ void TIGLViewerWidget::onMiddleButtonUp(  Qt::KeyboardModifiers /* nFlags */, co
 
 void TIGLViewerWidget::onRightButtonUp(  Qt::KeyboardModifiers nFlags, const QPoint point )
 {
-    myCurrentPoint = point;
+    setCurrentPoint(point);
     if ( nFlags & CASCADESHORTCUTKEY ) {
         setMode( CurAction3d_Nothing );
     }
@@ -887,7 +887,7 @@ void TIGLViewerWidget::onMouseMove( Qt::MouseButtons buttons,
     if (myView.IsNull()) {
         return;
     }
-    myCurrentPoint = point;
+    setCurrentPoint(point);
 
     if ( buttons & Qt::LeftButton  || buttons & Qt::RightButton || buttons & Qt::MidButton ) {
         switch ( myMode ) {
@@ -1132,13 +1132,14 @@ void TIGLViewerWidget::drawRubberBand( const QPoint origin, const QPoint positio
         myLayer->End();
     }
 #else
+    auto scale = devicePixelRatioF();
     if (viewerContext) {
         Handle(AIS_InteractiveContext) myContext = viewerContext->getContext();
         // Draw black-white dotted, imitate a shadowy look
         // This makes it possible to draw even on white or
         // black backgrounds
-        whiteRect->SetRectangle(left, height()-bottom, right, height()-top);
-        blackRect->SetRectangle(left+1, height()-bottom-1, right+1, height()-top-1);
+        whiteRect->SetRectangle(left, height()*scale-bottom, right, height()*scale-top);
+        blackRect->SetRectangle(left+1, height()*scale-bottom-1, right+1, height()*scale-top-1);
 
         if (!myContext->IsDisplayed (whiteRect)) {
             myContext->Display (whiteRect, Standard_False);
@@ -1338,3 +1339,15 @@ void TIGLViewerWidget::contextMenuEvent(QContextMenuEvent *event)
      }
 
  }
+
+void TIGLViewerWidget::setStartPoint(const QPoint& p)
+{
+    auto scale = devicePixelRatioF();
+    myStartPoint = QPoint(p.x()*scale, p.y()*scale);
+}
+
+void TIGLViewerWidget::setCurrentPoint(const QPoint& p)
+{
+    auto scale = devicePixelRatioF();
+    myCurrentPoint = QPoint(p.x()*scale, p.y()*scale);
+}

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -172,6 +172,9 @@ protected: // methods
 private: // members
     void initializeOCC(const Handle(AIS_InteractiveContext)& aContext);
 
+    void setStartPoint(const QPoint&);
+    void setCurrentPoint(const QPoint&);
+
     Handle(V3d_View)                myView;
     Handle(V3d_Viewer)              myViewer;
 

--- a/TIGLViewer/src/main.cpp
+++ b/TIGLViewer/src/main.cpp
@@ -40,6 +40,10 @@ void loadStyle();
 
 int main(int argc, char *argv[])
 {
+    // make sure, that the proper scaling is automatically used on highdpi displays
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+
     TIGLViewerApp app(argc, argv);
 
 #ifdef __APPLE__


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a backport from out GTlab code and also works well for TiGL.

Please test this by setting the screen scaling (under windows display settings) to 200%.

This includes:
 - Proper view scaling
 - Conversion between relative mouse coordinates and opengl mouse interactions
 - Fixup for the rubber band geometry

Closes #953

## How Has This Been Tested?
I tested it by either setting the windows scaling settings and by settings the variable QT_SCALE_FACTOR to a larger value than 1.0.

## Screenshots, that help to understand the changes(if applicable):

Before:
![image](https://user-images.githubusercontent.com/3213107/220760221-c2c180ea-0672-4c13-8e1a-5775c659c9ab.png)

After:
![image](https://user-images.githubusercontent.com/3213107/220760344-1383dbdb-7ae2-4a16-9322-32991bdc3438.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
