### PR TITLE
Fix tigl wing get segment upper surface area trimmed

### DIFF
--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -614,13 +614,7 @@ double CCPACSWingSegment::GetSurfaceArea(bool fromUpper,
                                          double eta3, double xsi3,
                                          double eta4, double xsi4) const
 {
-    TopoDS_Face face;
-    if (fromUpper) {
-        face = TopoDS::Face(GetUpperShape());
-    }
-    else {
-        face = TopoDS::Face(GetLowerShape());
-    }
+    Handle(Geom_Surface) surf = fromUpper? surfaceCache->upperSurface : surfaceCache->lowerSurface;
 
     // convert eta xsi coordinates to u,v
     double u1, u2, u3, u4, v1, v2, v3, v4;

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -623,13 +623,15 @@ double CCPACSWingSegment::GetSurfaceArea(bool fromUpper,
     etaXsiToUV(fromUpper, eta3, xsi3, u3, v3);
     etaXsiToUV(fromUpper, eta4, xsi4, u4, v4);
     
+    TopoDS_Face face = BRepBuilderAPI_MakeFace(surf, 1e-8);
+
     TopoDS_Edge e1 = getFaceTrimmingEdge(face, u1, v1, u2, v2);
     TopoDS_Edge e2 = getFaceTrimmingEdge(face, u2, v2, u3, v3);
     TopoDS_Edge e3 = getFaceTrimmingEdge(face, u3, v3, u4, v4);
     TopoDS_Edge e4 = getFaceTrimmingEdge(face, u4, v4, u1, v1);
 
     TopoDS_Wire w = BRepBuilderAPI_MakeWire(e1,e2,e3,e4);
-    TopoDS_Face f = BRepBuilderAPI_MakeFace(BRep_Tool::Surface(face), w);
+    TopoDS_Face f = BRepBuilderAPI_MakeFace(surf, w);
 
     // compute the surface area
     GProp_GProps sprops;

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -1303,7 +1303,7 @@ TEST_F(WingSegmentGuideCurves, tiglWingGetSegmentUpperSurfaceAreaTrimmed)
                                                           0.05, 0,
                                                           &upperArea));
     // Test if the calculated area has the expected value. The first argument in the following test is computed by the function itself,
-    // and is therefore obviously true. The benifit of this test case lies in the fact, that the value of the first argument has been estimated visually from the test configuration's
+    // and is therefore obviously true. The benifit of this test case lies in the fact, that the value of the first argument has been roughly estimated visually from the test configuration's
     // CAD representation in TiGL Viewer and is meeting the computed value.
     ASSERT_NEAR(0.036530682797528628, upperArea, 1e-8);
 }

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -150,11 +150,51 @@ protected:
 TixiDocumentHandle WingSegmentSpecial::tixiSpecialHandle = 0;
 TiglCPACSConfigurationHandle WingSegmentSpecial::tiglSpecialHandle = 0;
 
+
 /***************************************************************************************************/
+
+class WingSegmentGuideCurves : public ::testing::Test
+{
+protected:
+
+    void SetUp() override {
+        const char* filename = "TestData/simpletest-with-guides.cpacs.xml";
+        ReturnCode tixiRet;
+        TiglReturnCode tiglRet;
+
+        tiglGuideCurvesHandle = -1;
+        tixiGuideCurvesHandle = -1;
+
+        tixiRet = tixiOpenDocument(filename, &tixiGuideCurvesHandle);
+        ASSERT_TRUE (tixiRet == SUCCESS);
+
+        tiglRet = tiglOpenCPACSConfiguration(tixiGuideCurvesHandle, "Cpacs2Test", &tiglGuideCurvesHandle);
+        ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+    }
+    void TearDown() override {
+        ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglGuideCurvesHandle) == TIGL_SUCCESS);
+        ASSERT_TRUE(tixiCloseDocument(tixiGuideCurvesHandle) == SUCCESS);
+        tiglGuideCurvesHandle = -1;
+        tixiGuideCurvesHandle = -1;
+    }
+
+
+    static TixiDocumentHandle           tixiGuideCurvesHandle;
+    static TiglCPACSConfigurationHandle tiglGuideCurvesHandle;
+};
+
+
+TixiDocumentHandle WingSegmentGuideCurves::tixiGuideCurvesHandle = 0;
+TiglCPACSConfigurationHandle WingSegmentGuideCurves::tiglGuideCurvesHandle = 0;
+
+/***************************************************************************************************/
+
+
 
 /**
 * Tests tiglGetWingCount with invalid CPACS handle.
 */
+
 TEST_F(WingSegment, tiglGetWingCount_invalidHandle)
 {
     int wingCount;
@@ -1247,4 +1287,17 @@ TEST_F(WingSegmentSimple, segmentIndexFromUID)
         wing.GetSegments().GetSegments(),
         "Unknown"), 1
     );
+}
+
+/* Tests with guide curves:*/
+
+TEST_F(WingSegmentGuideCurves, tiglWingGetSegmentUpperSurfaceAreaTrimmed)
+{
+    double upperArea;
+    EXPECT_EQ(1,tiglWingGetSegmentUpperSurfaceAreaTrimmed(tiglGuideCurvesHandle, 1, 1,
+                                                          0, 0,
+                                                          0, 1,
+                                                          0.05, 1,
+                                                          0.05, 0,
+                                                          &upperArea));
 }

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -1294,7 +1294,7 @@ TEST_F(WingSegmentSimple, segmentIndexFromUID)
 TEST_F(WingSegmentGuideCurves, tiglWingGetSegmentUpperSurfaceAreaTrimmed)
 {
     double upperArea;
-    EXPECT_EQ(1,tiglWingGetSegmentUpperSurfaceAreaTrimmed(tiglGuideCurvesHandle, 1, 1,
+    EXPECT_EQ(0,tiglWingGetSegmentUpperSurfaceAreaTrimmed(tiglGuideCurvesHandle, 1, 1,
                                                           0, 0,
                                                           0, 1,
                                                           0.05, 1,

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -1294,10 +1294,16 @@ TEST_F(WingSegmentSimple, segmentIndexFromUID)
 TEST_F(WingSegmentGuideCurves, tiglWingGetSegmentUpperSurfaceAreaTrimmed)
 {
     double upperArea;
+
+    // test if the return code 0 is returned by the function for the provided valid argument list
     EXPECT_EQ(0,tiglWingGetSegmentUpperSurfaceAreaTrimmed(tiglGuideCurvesHandle, 1, 1,
                                                           0, 0,
                                                           0, 1,
                                                           0.05, 1,
                                                           0.05, 0,
                                                           &upperArea));
+    // Test if the calculated area has the expected value. The first argument in the following test is computed by the function itself,
+    // and is therefore obviously true. The benifit of this test case lies in the fact, that the value of the first argument has been estimated visually from the test configuration's
+    // CAD representation in TiGL Viewer and is meeting the computed value.
+    ASSERT_NEAR(0.036530682797528628, upperArea, 1e-8);
 }


### PR DESCRIPTION
<!--- Fixing a conversion bug in the CCPACSWingSegment::GetSurfaceArea function -->

## Closes #961

## Bug Description 
The API function tiglWingGetSegmentUpperSurfaceAreaTrimmed(...) terminated with return code 1, when passing the valid arguments (tiglHandle, 1, 1, 0, 0, 0, 1, 0.05, 1, 0.05, 0, double*ReturnValue).


## Bug Analysis
This bug arises due to the fact that the implementation of the mentioned function contained a cast from TopoDS_Compound to a TopoDS_Face. As the used test data configuration has the property, that both its upper and lower wing consists of more than one face, respectively, arising through the use of additional guide curves, both the upper and lower wing are given by compounds containing more than one element, respectively. Trying to cast each of these compounds to a face yields an error.


The bug originates due to the fact that earlier, both upper and lower wings consisted of only one face, respectively. Hence, the mentioned conversion was not a problem.

## Bug Fix
It has been fixed by avoiding these falsy conversions by minor refactoring of the code.

## How Has This Been Tested?
Two unit tests have been added: One test for the correct return value of the above API function, and the second giving a roughly estimated check if the computed area leads to the right value.

