### PR TITLE
Added support for OCCT 7.6.2

### DIFF
--- a/TIGLViewer/shaders/PhongShading-v7.6.fs
+++ b/TIGLViewer/shaders/PhongShading-v7.6.fs
@@ -1,0 +1,215 @@
+// Created on: 2013-10-10
+// Created by: Denis BOGOLEPOV
+// Copyright (c) 2013-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+varying vec3 View;          //!< Direction to the viewer
+varying vec3 Normal;        //!< Vertex normal in view space
+varying vec4 Position;      //!< Vertex position in view space.
+varying vec4 PositionWorld; //!< Vertex position in world space
+varying vec4 uv;            //!< Vertex uv coordinate
+
+uniform bool enableZebra; //!< Whether the zebra stripe mode is enabled
+
+vec3 Ambient;  //!< Ambient  contribution of light sources
+vec3 Diffuse;  //!< Diffuse  contribution of light sources
+vec3 Specular; //!< Specular contribution of light sources
+
+//! Computes contribution of isotropic point light source
+void pointLight (in int  theId,
+                 in vec3 theNormal,
+                 in vec3 theView,
+                 in vec3 thePoint)
+{
+  vec3 aLight = occLight_Position (theId).xyz;
+  if (!occLight_IsHeadlight (theId))
+  {
+    aLight = vec3 (occWorldViewMatrix * vec4 (aLight, 1.0));
+  }
+  aLight -= thePoint;
+
+  float aDist = length (aLight);
+  aLight = aLight * (1.0 / aDist);
+
+  float anAtten = 1.0 / (occLight_ConstAttenuation  (theId)
+                       + occLight_LinearAttenuation (theId) * aDist);
+
+  vec3 aHalf = normalize (aLight + theView);
+
+  vec3  aFaceSideNormal = gl_FrontFacing ? theNormal : -theNormal;
+  float aNdotL = max (0.0, dot (aFaceSideNormal, aLight));
+  float aNdotH = max (0.0, dot (aFaceSideNormal, aHalf ));
+
+  float aSpecl = 0.0;
+  if (aNdotL > 0.0)
+  {
+    aSpecl = pow (aNdotH, occMaterial_Shininess (gl_FrontFacing));
+  }
+
+  Diffuse  += occLight_Diffuse  (theId).rgb * aNdotL * anAtten;
+  Specular += occLight_Specular (theId).rgb * aSpecl * anAtten;
+}
+
+//! Computes contribution of spotlight source
+void spotLight (in int  theId,
+                in vec3 theNormal,
+                in vec3 theView,
+                in vec3 thePoint)
+{
+  vec3 aLight   = occLight_Position      (theId).xyz;
+  vec3 aSpotDir = occLight_SpotDirection (theId).xyz;
+  if (!occLight_IsHeadlight (theId))
+  {
+    aLight   = vec3 (occWorldViewMatrix * vec4 (aLight,   1.0));
+    aSpotDir = vec3 (occWorldViewMatrix * vec4 (aSpotDir, 0.0));
+  }
+  aLight -= thePoint;
+
+  float aDist = length (aLight);
+  aLight = aLight * (1.0 / aDist);
+
+  aSpotDir = normalize (aSpotDir);
+
+  // light cone
+  float aCosA = dot (aSpotDir, -aLight);
+  if (aCosA >= 1.0 || aCosA < cos (occLight_SpotCutOff (theId)))
+  {
+    return;
+  }
+
+  float anExponent = occLight_SpotExponent (theId);
+  float anAtten    = 1.0 / (occLight_ConstAttenuation  (theId)
+                          + occLight_LinearAttenuation (theId) * aDist);
+  if (anExponent > 0.0)
+  {
+    anAtten *= pow (aCosA, anExponent * 128.0);
+  }
+
+  vec3 aHalf = normalize (aLight + theView);
+
+  vec3  aFaceSideNormal = gl_FrontFacing ? theNormal : -theNormal;
+  float aNdotL = max (0.0, dot (aFaceSideNormal, aLight));
+  float aNdotH = max (0.0, dot (aFaceSideNormal, aHalf ));
+
+  float aSpecl = 0.0;
+  if (aNdotL > 0.0)
+  {
+    aSpecl = pow (aNdotH, occMaterial_Shininess (gl_FrontFacing));
+  }
+
+  Diffuse  += occLight_Diffuse  (theId).rgb * aNdotL * anAtten;
+  Specular += occLight_Specular (theId).rgb * aSpecl * anAtten;
+}
+
+//! Computes contribution of directional light source
+void directionalLight (in int  theId,
+                       in vec3 theNormal,
+                       in vec3 theView)
+{
+  vec3 aLight = normalize (occLight_Position (theId).xyz);
+  if (!occLight_IsHeadlight (theId))
+  {
+    aLight = vec3 (occWorldViewMatrix * vec4 (aLight, 0.0));
+  }
+
+  vec3 aHalf = normalize (aLight + theView);
+
+  vec3  aFaceSideNormal = gl_FrontFacing ? theNormal : -theNormal;
+  float aNdotL = max (0.0, dot (aFaceSideNormal, aLight));
+  float aNdotH = max (0.0, dot (aFaceSideNormal, aHalf ));
+
+  float aSpecl = 0.0;
+  if (aNdotL > 0.0)
+  {
+    aSpecl = pow (aNdotH, occMaterial_Shininess (gl_FrontFacing));
+  }
+
+  Diffuse  += occLight_Diffuse  (theId).rgb * aNdotL;
+  Specular += occLight_Specular (theId).rgb * aSpecl;
+}
+
+//! Computes illumination from light sources
+vec4 computeLighting (in vec3 theNormal,
+                      in vec3 theView,
+                      in vec4 thePoint)
+{
+  // Clear the light intensity accumulators
+  Ambient  = occLightAmbient.rgb;
+  Diffuse  = vec3 (0.0);
+  Specular = vec3 (0.0);
+  vec3 aPoint = thePoint.xyz / thePoint.w;
+  for (int anIndex = 0; anIndex < occLightSourcesCount; ++anIndex)
+  {
+    int aType = occLight_Type (anIndex);
+    if (aType == OccLightType_Direct)
+    {
+      directionalLight (anIndex, theNormal, theView);
+    }
+    else if (aType == OccLightType_Point)
+    {
+      pointLight (anIndex, theNormal, theView, aPoint);
+    }
+    else if (aType == OccLightType_Spot)
+    {
+      spotLight (anIndex, theNormal, theView, aPoint);
+    }
+  }
+
+  vec3 aMatAmbient  = occMaterial_Ambient (gl_FrontFacing);
+  vec4 aMatDiffuse  = occMaterial_Diffuse (gl_FrontFacing);
+  vec3 aMatSpecular = occMaterial_Specular(gl_FrontFacing);
+  vec3 aMatEmission = occMaterial_Emission(gl_FrontFacing);
+  vec3 aColor = Ambient  * aMatAmbient.rgb
+              + Diffuse  * aMatDiffuse.rgb
+              + Specular * aMatSpecular.rgb
+                         + aMatEmission.rgb;
+
+  float attenuation = 1.0;
+  if (enableZebra)
+  {
+    vec3 v = vec3(0., 0., -1.);
+
+    // Direction of the view reflected on the surface
+    vec3 vReflect = 2. * (dot(Normal, v)*Normal - v);
+
+    // normal vector of the light stripe plane
+    vec3 lightDir = normalize(vec3(0., 1., 0.));
+
+    // View projected into light plane
+    vec3 vProj = normalize(v - dot(v, lightDir)*lightDir);
+
+    // x-position of the reflected view on the light plane
+    float posLightPlane = dot(vReflect, vProj);
+
+    attenuation = max(min(2.0, sin(posLightPlane*30.0)*3. + 2.0), -1.0);
+  }
+
+  return vec4 (aColor, aMatDiffuse.a) * vec4(attenuation, attenuation, attenuation, 1.0);
+}
+
+//! Entry point to the Fragment Shader
+void main()
+{
+  // process clipping planes
+  for (int anIndex = 0; anIndex < occClipPlaneCount; ++anIndex)
+  {
+    vec4 aClipEquation = occClipPlaneEquations[anIndex];
+    if (dot (aClipEquation.xyz, PositionWorld.xyz / PositionWorld.w) + aClipEquation.w < 0.0)
+    {
+      discard;
+    }
+  }
+
+  vec4 aColor = computeLighting (normalize (Normal), normalize (View), Position);
+  occSetFragColor (aColor);
+}

--- a/TIGLViewer/shaders/PhongShading-v7.6.fs
+++ b/TIGLViewer/shaders/PhongShading-v7.6.fs
@@ -180,7 +180,7 @@ vec4 computeLighting (in vec3 theNormal,
     vec3 v = vec3(0., 0., -1.);
 
     // Direction of the view reflected on the surface
-    vec3 vReflect = 2. * (dot(Normal, v)*Normal - v);
+    vec3 vReflect = 2. * (dot(theNormal, v)*theNormal - v);
 
     // normal vector of the light stripe plane
     vec3 lightDir = normalize(vec3(0., 1., 0.));

--- a/TIGLViewer/shaders/PhongShading-v7.6.vs
+++ b/TIGLViewer/shaders/PhongShading-v7.6.vs
@@ -1,0 +1,45 @@
+// Created on: 2013-10-10
+// Created by: Denis BOGOLEPOV
+// Copyright (c) 2013-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+varying vec3 View;          //!< Direction to the viewer
+varying vec3 Normal;        //!< Vertex normal in view space
+varying vec4 Position;      //!< Vertex position in view space
+varying vec4 PositionWorld; //!< Vertex position in world space
+varying vec4 uv;            //!< Vertex uv coordinates
+
+//! Computes the normal in view space
+vec3 TransformNormal (in vec3 theNormal)
+{
+  vec4 aResult = occWorldViewMatrixInverseTranspose
+               * occModelWorldMatrixInverseTranspose
+               * vec4 (theNormal, 0.0);
+  return normalize (aResult.xyz);
+}
+
+//! Entry point to the Vertex Shader
+void main()
+{
+  PositionWorld = occModelWorldMatrix * occVertex;
+  Position      = occWorldViewMatrix * PositionWorld;
+  Normal        = TransformNormal (occNormal);
+
+  // Note: The specified view vector is absolutely correct only for the orthogonal projection.
+  // For perspective projection it will be approximate, but it is in good agreement with the OpenGL calculations.
+  View = vec3 (0.0, 0.0, 1.0);
+
+  // Do fixed functionality vertex transform
+  gl_Position = occProjectionMatrix * occWorldViewMatrix * occModelWorldMatrix * occVertex;
+  uv = occTexCoord;
+}

--- a/TIGLViewer/src/ISession_Text.cpp
+++ b/TIGLViewer/src/ISession_Text.cpp
@@ -35,6 +35,7 @@ IMPLEMENT_STANDARD_RTTIEXT(ISession_Text,AIS_InteractiveObject)
 #include <SelectMgr_Selection.hxx>
 #include <Prs3d_Text.hxx>
 #include <Prs3d_Presentation.hxx>
+#include <Prs3d_Root.hxx>
 #include <PrsMgr_PresentationManager3d.hxx>
 #include <gp_Pnt.hxx>
 #include <TCollection_ExtendedString.hxx>

--- a/TIGLViewer/src/TIGLAISTriangulation.cpp
+++ b/TIGLViewer/src/TIGLAISTriangulation.cpp
@@ -119,22 +119,21 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
                         );
 
 
-            gp_Vec3f aNormal;
             if (hasVNormals) {
                 if (hasVColors) {
                     const TColStd_Array1OfInteger& colors = myColor->Array1();
                     for (int i = 1; i <= myTriangulation->NbNodes(); i++ ) {
                         anArray->AddVertex(myTriangulation->Node(i), AttenuateColor(colors(i), ambient));
-                        myTriangulation->Normal(i, aNormal);
-                        anArray->SetVertexNormal(i, aNormal.x(), aNormal.y(), aNormal.z());
+                        auto aNormal = myTriangulation->Normal(i);
+                        anArray->SetVertexNormal(i, aNormal.X(), aNormal.Y(), aNormal.Z());
                     }
                 }
                 // !hasVColors
                 else {
                     for (int i = 1; i <= myTriangulation->NbNodes(); i++ ) {
                         anArray->AddVertex(myTriangulation->Node(i));
-                        myTriangulation->Normal(i, aNormal);
-                        anArray->SetVertexNormal(i, aNormal.x(), aNormal.y(), aNormal.z());
+                        auto aNormal = myTriangulation->Normal(i);
+                        anArray->SetVertexNormal(i, aNormal.X(), aNormal.Y(), aNormal.Z());
 
                     }
                 }

--- a/TIGLViewer/src/TIGLAISTriangulation.cpp
+++ b/TIGLViewer/src/TIGLAISTriangulation.cpp
@@ -74,9 +74,8 @@ TIGLAISTriangulation::TIGLAISTriangulation(const Handle(Poly_Triangulation)& Tri
     maxy = DBL_MIN; 
     maxz = DBL_MIN;
     
-    const TColgp_Array1OfPnt& nodes = Triangulation->Nodes();
-    for (int i = nodes.Lower(); i <= nodes.Upper(); ++i) {
-        const gp_Pnt& p = nodes.Value(i);
+    for (int i = 1; i <= Triangulation->NbNodes(); ++i) {
+        const gp_Pnt& p = Triangulation->Node(i);
         minx = min(minx, p.X());
         miny = min(miny, p.Y());
         minz = min(minz, p.Z());
@@ -108,9 +107,6 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
             Standard_Real ambient = 1.0;
 #endif
 
-            const TColgp_Array1OfPnt& nodes = myTriangulation->Nodes();             //Nodes
-            const Poly_Array1OfTriangle& triangles = myTriangulation->Triangles();  //Triangle
-
             Standard_Boolean hasVNormals = myTriangulation->HasNormals();
             Standard_Boolean hasVColors  = (myFlagColor == 1);
 
@@ -122,25 +118,24 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
                         Standard_False    //hasTexels
                         );
 
-            Standard_Integer i;
-            Standard_Integer j;
 
+            gp_Vec3f aNormal;
             if (hasVNormals) {
-                const TShort_Array1OfShortReal& normals = myTriangulation->Normals();
                 if (hasVColors) {
                     const TColStd_Array1OfInteger& colors = myColor->Array1();
-                    for ( i = nodes.Lower(); i <= nodes.Upper(); i++ ) {
-                        j = (i - nodes.Lower()) * 3;
-                        anArray->AddVertex(nodes(i), AttenuateColor(colors(i), ambient));
-                        anArray->SetVertexNormal(i, normals(j+1), normals(j+2), normals(j+3));
+                    for (int i = 1; i <= myTriangulation->NbNodes(); i++ ) {
+                        anArray->AddVertex(myTriangulation->Node(i), AttenuateColor(colors(i), ambient));
+                        myTriangulation->Normal(i, aNormal);
+                        anArray->SetVertexNormal(i, aNormal.x(), aNormal.y(), aNormal.z());
                     }
                 }
                 // !hasVColors
                 else {
-                    for ( i = nodes.Lower(); i <= nodes.Upper(); i++ ) {
-                        j = (i - nodes.Lower()) * 3;
-                        anArray->AddVertex(nodes(i));
-                        anArray->SetVertexNormal(i, normals(j+1), normals(j+2), normals(j+3));
+                    for (int i = 1; i <= myTriangulation->NbNodes(); i++ ) {
+                        anArray->AddVertex(myTriangulation->Node(i));
+                        myTriangulation->Normal(i, aNormal);
+                        anArray->SetVertexNormal(i, aNormal.x(), aNormal.y(), aNormal.z());
+
                     }
                 }
             }
@@ -148,21 +143,21 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
             else {
                 if (hasVColors) {
                     const TColStd_Array1OfInteger& colors = myColor->Array1();
-                    for ( i = nodes.Lower(); i <= nodes.Upper(); i++ ) {
-                        anArray->AddVertex(nodes(i), AttenuateColor(colors(i), ambient));
+                    for (int i = 1; i <= myTriangulation->NbNodes(); i++ ) {
+                        anArray->AddVertex(myTriangulation->Node(i), AttenuateColor(colors(i), ambient));
                     }
                 }
                 // !hasVColors
                 else {
-                    for ( i = nodes.Lower(); i <= nodes.Upper(); i++ ) {
-                        anArray->AddVertex(nodes(i));
+                    for (int i = 1; i <= myTriangulation->NbNodes(); i++ ) {
+                        anArray->AddVertex(myTriangulation->Node(i));
                     }
                 }
             }
 
             Standard_Integer indexTriangle[3] = {0,0,0};
-            for ( i = triangles.Lower(); i<= triangles.Upper(); i++ ) {
-                triangles(i).Get(indexTriangle[0], indexTriangle[1], indexTriangle[2]);
+            for (Standard_Integer i = 1; i<= myTriangulation->NbTriangles(); i++ ) {
+                myTriangulation->Triangle(i).Get(indexTriangle[0], indexTriangle[1], indexTriangle[2]);
                 anArray->AddEdge(indexTriangle[0]);
                 anArray->AddEdge(indexTriangle[1]);
                 anArray->AddEdge(indexTriangle[2]);
@@ -172,18 +167,16 @@ void TIGLAISTriangulation::Compute(const Handle(PrsMgr_PresentationManager3d)& a
             break;
         }
         case 0: {
-            const TColgp_Array1OfPnt& nodes = myTriangulation->Nodes();
-            const Poly_Array1OfTriangle& triangles = myTriangulation->Triangles();
             Handle(Graphic3d_AspectLine3d) aspect = myDrawer->WireAspect()->Aspect();
      
-            Handle(Graphic3d_ArrayOfPrimitives) segments =  new Graphic3d_ArrayOfSegments(nodes.Length(),triangles.Length()*6);
-            for (Standard_Integer i = nodes.Lower(); i <= nodes.Upper(); i++ ) {
-                segments->AddVertex(nodes(i));
+            Handle(Graphic3d_ArrayOfPrimitives) segments =  new Graphic3d_ArrayOfSegments(myTriangulation->NbNodes(),myTriangulation->NbTriangles()*6);
+            for (Standard_Integer i = 1; i <= myTriangulation->NbNodes(); i++ ) {
+                segments->AddVertex(myTriangulation->Node(i));
             }
      
             Standard_Integer indexTriangle[3] = {0,0,0};
-            for (Standard_Integer i = triangles.Lower(); i<= triangles.Upper(); i++ ) {
-                triangles(i).Get(indexTriangle[0], indexTriangle[1], indexTriangle[2]);
+            for (Standard_Integer i = 1; i<= myTriangulation->NbTriangles(); i++ ) {
+                myTriangulation->Triangle(i).Get(indexTriangle[0], indexTriangle[1], indexTriangle[2]);
                 segments->AddEdge(indexTriangle[0]);
                 segments->AddEdge(indexTriangle[1]);
                 segments->AddEdge(indexTriangle[1]);

--- a/TIGLViewer/src/TIGLQAspectWindow.cpp
+++ b/TIGLViewer/src/TIGLQAspectWindow.cpp
@@ -103,7 +103,11 @@ void TIGLQAspectWindow::Unmap() const
 // function : DoResize
 // purpose  :
 // =======================================================================
+#if OCC_VERSION_HEX >= 0x070600
+Aspect_TypeOfResize TIGLQAspectWindow::DoResize()
+#else
 Aspect_TypeOfResize TIGLQAspectWindow::DoResize() const
+#endif
 {
     int                 aMask = 0;
     Aspect_TypeOfResize aMode = Aspect_TOR_UNKNOWN;

--- a/TIGLViewer/src/TIGLQAspectWindow.h
+++ b/TIGLViewer/src/TIGLQAspectWindow.h
@@ -73,7 +73,11 @@ public:
     Aspect_Drawable NativeParentHandle() const override;
     
     //! Applies the resizing to the window <me>
+#if OCC_VERSION_HEX >= 0x070600
+    Aspect_TypeOfResize DoResize() override;
+#else
     Aspect_TypeOfResize DoResize() const override;
+#endif
     
     //! Returns True if the window <me> is opened
     //! and False if the window is closed.

--- a/TIGLViewer/src/TIGLViewer.h
+++ b/TIGLViewer/src/TIGLViewer.h
@@ -32,7 +32,6 @@
 #include <Standard_TypeDef.hxx>
 #include <Standard_Real.hxx>
 #include <Quantity_NameOfColor.hxx>
-#include <V3d_Coordinate.hxx>
 
 #include "tigl_internal.h"
 

--- a/TIGLViewer/src/TIGLViewer.qrc
+++ b/TIGLViewer/src/TIGLViewer.qrc
@@ -28,6 +28,8 @@
         <file>../shaders/PhongShading-v6.vs</file>
         <file>../shaders/PhongShading-v7.fs</file>
         <file>../shaders/PhongShading-v7.vs</file>
+        <file>../shaders/PhongShading-v7.6.fs</file>
+        <file>../shaders/PhongShading-v7.6.vs</file>
         <file>../gfx/error.png</file>
     </qresource>
 </RCC>

--- a/TIGLViewer/src/TIGLViewerContext.cpp
+++ b/TIGLViewer/src/TIGLViewerContext.cpp
@@ -111,7 +111,9 @@ TIGLViewerContext::TIGLViewerContext(QUndoStack* stack)
 
 void TIGLViewerContext::initShaders()
 {
-#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,0,0)
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,6,0)
+    QString shaderVersion = "v7.6";
+#elif OCC_VERSION_HEX >= VERSION_HEX_CODE(7,0,0)
     QString shaderVersion = "v7";
 #elif OCC_VERSION_HEX >= VERSION_HEX_CODE(6,7,0)
     QString shaderVersion = "v6";

--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -2734,16 +2734,14 @@ void TIGLViewerDocument::createShapeTriangulation(const TopoDS_Shape& shape, Top
         }
 
         gp_Trsf nodeTransformation = location;
-        const TColgp_Array1OfPnt& nodes = triangulation->Nodes();
 
         int index1, index2, index3;
-        const Poly_Array1OfTriangle& triangles = triangulation->Triangles();
-        for (int j = triangles.Lower(); j <= triangles.Upper(); j++) {
-            const Poly_Triangle& triangle = triangles(j);
+        for (int j = 1; j <= triangulation->NbTriangles(); j++) {
+            const Poly_Triangle& triangle = triangulation->Triangle(j);
             triangle.Get(index1, index2, index3);
-            gp_Pnt point1 = nodes(index1).Transformed(nodeTransformation);
-            gp_Pnt point2 = nodes(index2).Transformed(nodeTransformation);
-            gp_Pnt point3 = nodes(index3).Transformed(nodeTransformation);
+            gp_Pnt point1 = triangulation->Node(index1).Transformed(nodeTransformation);
+            gp_Pnt point2 = triangulation->Node(index2).Transformed(nodeTransformation);
+            gp_Pnt point3 = triangulation->Node(index3).Transformed(nodeTransformation);
 
             BRepBuilderAPI_MakeEdge edge1(point1, point2);
             BRepBuilderAPI_MakeEdge edge2(point2, point3);

--- a/TIGLViewer/src/TIGLViewerInternal.h
+++ b/TIGLViewer/src/TIGLViewerInternal.h
@@ -83,7 +83,6 @@
 
 #include <Graphic3d_AspectMarker3d.hxx>
 #include <Graphic3d_NameOfMaterial.hxx>
-#include <MMgt_TShared.hxx>
 #include <OSD_Environment.hxx>
 #include <Precision.hxx>
 #include <Prs3d_IsoAspect.hxx>

--- a/TIGLViewer/src/TIGLViewerWidget.h
+++ b/TIGLViewer/src/TIGLViewerWidget.h
@@ -109,8 +109,8 @@ signals:
 
     void initialized();
     void selectionChanged();
-    void mouseMoved   ( V3d_Coordinate X, V3d_Coordinate Y, V3d_Coordinate Z );
-    void pointClicked ( V3d_Coordinate X, V3d_Coordinate Y, V3d_Coordinate Z );
+    void mouseMoved   ( Standard_Real X, Standard_Real Y, Standard_Real Z );
+    void pointClicked ( Standard_Real X, Standard_Real Y, Standard_Real Z );
     void sendStatus   ( QString aMessage );
 
     void error ( int errorCode, QString& errorDescription );
@@ -191,7 +191,7 @@ private: // members
     Standard_Boolean                myGridSnap;
     AIS_StatusOfDetection           myDetection;
 
-    V3d_Coordinate                  myV3dX,
+    Standard_Real                  myV3dX,
                                     myV3dY,
                                     myV3dZ;
         

--- a/TIGLViewer/src/TIGLViewerWindow.cpp
+++ b/TIGLViewer/src/TIGLViewerWindow.cpp
@@ -544,9 +544,9 @@ void TIGLViewerWindow::aboutQt()
 }
 
 
-void TIGLViewerWindow::xyzPosition (V3d_Coordinate X,
-                                    V3d_Coordinate Y,
-                                    V3d_Coordinate Z)
+void TIGLViewerWindow::xyzPosition (Standard_Real X,
+                                    Standard_Real Y,
+                                    Standard_Real Z)
 {
     QString aString;
     QTextStream ts(&aString);
@@ -731,8 +731,8 @@ void TIGLViewerWindow::connectSignals()
     connect(openTimer, SIGNAL(timeout()), this, SLOT(reopenFile()));
 
     // The co-ordinates from the view
-    connect( myOCC, SIGNAL(mouseMoved(V3d_Coordinate,V3d_Coordinate,V3d_Coordinate)),
-             this,   SLOT(xyzPosition(V3d_Coordinate,V3d_Coordinate,V3d_Coordinate)) );
+    connect( myOCC, SIGNAL(mouseMoved(Standard_Real,Standard_Real,Standard_Real)),
+             this,   SLOT(xyzPosition(Standard_Real,Standard_Real,Standard_Real)) );
 
 
     connect( myOCC, SIGNAL(sendStatus(const QString)), this,  SLOT  (statusMessage(const QString)) );

--- a/TIGLViewer/src/TIGLViewerWindow.h
+++ b/TIGLViewer/src/TIGLViewerWindow.h
@@ -94,9 +94,9 @@ private slots:
     void setBackgroundImage();
     void about();
     void aboutQt();
-    void xyzPosition (V3d_Coordinate X,
-                      V3d_Coordinate Y,
-                      V3d_Coordinate Z);
+    void xyzPosition (Standard_Real X,
+                      Standard_Real Y,
+                      Standard_Real Z);
     void statusMessage (const QString& aMessage);
     void loadSettings();
     void saveSettings();

--- a/cmake/UseOpenCASCADE.cmake
+++ b/cmake/UseOpenCASCADE.cmake
@@ -48,7 +48,7 @@ if(OCE_FOUND)
   option(OCE_STATIC_LIBS "Should be checked, if static OCE libs are linked" OFF)
 else(OCE_FOUND)
   message("OCE not found! Searching for OpenCASCADE.")
-  find_package(OpenCASCADE 7.4.0 CONFIG REQUIRED)
+  find_package(OpenCASCADE CONFIG REQUIRED)
   option(OpenCASCADE_STATIC_LIBS "Should be checked, if static OpenCASCADE libs are linked" OFF)
 
   message(STATUS "Found opencascade " ${OpenCASCADE_VERSION})

--- a/src/boolean_operations/GEOMAlgo_Splitter.cxx
+++ b/src/boolean_operations/GEOMAlgo_Splitter.cxx
@@ -212,7 +212,11 @@ void GEOMAlgo_Splitter::BuildResult(const TopAbs_ShapeEnum theType)
 //function : PostTreat
 //purpose  : 
 //=======================================================================
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,6,0)
+void GEOMAlgo_Splitter::PostTreat(const Message_ProgressRange& p)
+#else
 void GEOMAlgo_Splitter::PostTreat()
+#endif
 {
   if (myLimit!=TopAbs_SHAPE) {
     Standard_Integer i, aNbS;
@@ -340,7 +344,11 @@ void GEOMAlgo_Splitter::PostTreat()
     myShape=aLS.First();
   }
   //
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,6,0)
+  BOPAlgo_Builder::PostTreat(p);
+#else
   BOPAlgo_Builder::PostTreat();
+#endif
 }
 //=======================================================================
 //function : TreatCompound

--- a/src/boolean_operations/GEOMAlgo_Splitter.hxx
+++ b/src/boolean_operations/GEOMAlgo_Splitter.hxx
@@ -99,7 +99,11 @@ public:
     void BuildResult(const TopAbs_ShapeEnum theType) override;
 
   TIGL_EXPORT
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,6,0)
+    void PostTreat(const Message_ProgressRange&) override;
+#else
     void PostTreat() override;
+#endif
   
  protected:
 #if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,3,0)

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -58,7 +58,13 @@
 #include "TopTools_IndexedMapOfShape.hxx"
 #include "TopTools_HSequenceOfShape.hxx"
 #include "GeomAdaptor_Curve.hxx"
+
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,6,0)
 #include "BRepAdaptor_CompCurve.hxx"
+#else
+#include "BRepAdaptor_HCompCurve.hxx"
+#endif
+
 #include "BRepAdaptor_Curve.hxx"
 #include "GCPnts_AbscissaPoint.hxx"
 #include "BRep_Builder.hxx"
@@ -1102,8 +1108,13 @@ TopoDS_Face BuildRuledFace(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2)
 
     // Wrap the adaptor in a class which manages curve access via handle (HCurve). According to doxygen
     // this is required by the algorithms
+#if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,6,0)
     const Handle(Adaptor3d_Curve) curve1 = new BRepAdaptor_CompCurve(compCurve1);
     const Handle(Adaptor3d_Curve) curve2 = new BRepAdaptor_CompCurve(compCurve2);
+#else
+    Handle(Adaptor3d_HCurve) curve1 = new BRepAdaptor_HCompCurve(compCurve1);
+    Handle(Adaptor3d_HCurve) curve2 = new BRepAdaptor_HCompCurve(compCurve2);
+#endif
 
     // We have to generate an approximated curve now from the wire using the adaptor
     // NOTE: last parameter value unknown

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -43,6 +43,8 @@
 #include "CTiglProjectPointOnCurveAtAngle.h"
 #include "CTiglBSplineAlgorithms.h"
 
+#include "Standard_Version.hxx"
+
 #include "Geom_Curve.hxx"
 #include "Geom_Surface.hxx"
 #include "GeomAdaptor_Curve.hxx"
@@ -77,7 +79,6 @@
 #include "BRepExtrema_DistShapeShape.hxx"
 
 #include <Approx_Curve3d.hxx>
-#include <BRepAdaptor_HCompCurve.hxx>
 #include <BRepAlgoAPI_Section.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_FindPlane.hxx>
@@ -1101,8 +1102,8 @@ TopoDS_Face BuildRuledFace(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2)
 
     // Wrap the adaptor in a class which manages curve access via handle (HCurve). According to doxygen
     // this is required by the algorithms
-    Handle(Adaptor3d_HCurve) curve1 = new BRepAdaptor_HCompCurve(compCurve1);
-    Handle(Adaptor3d_HCurve) curve2 = new BRepAdaptor_HCompCurve(compCurve2);
+    const Handle(Adaptor3d_Curve) curve1 = new BRepAdaptor_CompCurve(compCurve1);
+    const Handle(Adaptor3d_Curve) curve2 = new BRepAdaptor_CompCurve(compCurve2);
 
     // We have to generate an approximated curve now from the wire using the adaptor
     // NOTE: last parameter value unknown

--- a/src/configuration/CCPACSConfiguration.cpp
+++ b/src/configuration/CCPACSConfiguration.cpp
@@ -29,7 +29,6 @@
 #include "Standard_CString.hxx"
 #include "BRepOffsetAPI_ThruSections.hxx"
 #include "BRepAlgoAPI_Fuse.hxx"
-#include "BRepAlgo_Fuse.hxx"
 #include "ShapeFix_Shape.hxx"
 #include "TopoDS_Compound.hxx"
 #include "BRepFeat_Gluer.hxx"

--- a/src/control_devices/CControlSurfaceBorderBuilder.cpp
+++ b/src/control_devices/CControlSurfaceBorderBuilder.cpp
@@ -25,6 +25,7 @@
 #include <gp_Vec.hxx>
 #include <Geom_Plane.hxx>
 #include <Geom2dAPI_Interpolate.hxx>
+#include <Geom2d_BSplineCurve.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepIntCurveSurface_Inter.hxx>

--- a/src/geometry/CTiglTriangularizer.cpp
+++ b/src/geometry/CTiglTriangularizer.cpp
@@ -294,13 +294,11 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
         
         BRepGProp_Face prop(face);
         
-        const TColgp_Array1OfPnt2d& uvnodes = triangulation->UVNodes(); // get (face-local) list of nodes
-        ilower = uvnodes.Lower();
-        
-        iBufferSize = uvnodes.Upper()-uvnodes.Lower()+1;
+        ilower = 1;
+        iBufferSize = triangulation->NbNodes();
         indexBuffer.reserve(iBufferSize);
-        for (int inode = uvnodes.Lower(); inode <= uvnodes.Upper(); ++inode) {
-            const gp_Pnt2d& uv_pnt = uvnodes(inode);
+        for (int inode = 1; inode <= triangulation->NbNodes(); ++inode) {
+            const gp_Pnt2d& uv_pnt = triangulation->UVNode(inode);
             gp_Pnt p; gp_Vec n;
             prop.Normal(uv_pnt.X(),uv_pnt.Y(),p,n);
             if (n.SquareMagnitude() > 0.) {
@@ -315,23 +313,20 @@ int CTiglTriangularizer::triangularizeFace(const TopoDS_Face & face, unsigned lo
     else {
         // we cannot compute normals
         
-        const TColgp_Array1OfPnt& nodes = triangulation->Nodes(); // get (face-local) list of nodes
-        ilower = nodes.Lower();
-
-        iBufferSize = nodes.Upper()-nodes.Lower()+1;
+        ilower = 1;
+        iBufferSize = triangulation->NbNodes();
         indexBuffer.reserve(iBufferSize);
-        for (int inode = nodes.Lower(); inode <= nodes.Upper(); inode++) {
-            const gp_Pnt& p = nodes(inode).Transformed(nodeTransformation);
+        for (int inode = 1; inode <= triangulation->NbNodes(); inode++) {
+            const gp_Pnt& p = triangulation->Node(inode).Transformed(nodeTransformation);
             indexBuffer.push_back(polys.currentObject().addPointNormal(p.XYZ(), CTiglPoint(1,0,0)));
         }
     }
 
-    const Poly_Array1OfTriangle& triangles = triangulation->Triangles();
     iPolyLower = ULONG_MAX;
     iPolyUpper = 0;
-    // iterate over triangles in the array 
-    for (int j = triangles.Lower(); j <= triangles.Upper(); j++) {
-        const Poly_Triangle& triangle = triangles(j);
+    // iterate over triangles in the array
+    for (int j = 1; j <= triangulation->NbTriangles(); j++) {
+        const Poly_Triangle& triangle = triangulation->Triangle(j);
         int occindex1, occindex2, occindex3;
         triangle.Get(occindex1, occindex2, occindex3); // get indices into index1..3
         unsigned long index1, index2, index3;

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -94,7 +94,6 @@
 
 #include "Geom_BSplineCurve.hxx"
 #include "GeomAPI_PointsToBSpline.hxx"
-#include "GeomAdaptor_HCurve.hxx"
 #include "GeomFill.hxx"
 #include "GeomFill_SimpleBound.hxx"
 #include "GeomFill_BSplineCurves.hxx"
@@ -105,7 +104,6 @@
 #include "BRepExtrema_DistShapeShape.hxx"
 #include "BRepIntCurveSurface_Inter.hxx"
 #include "GCPnts_AbscissaPoint.hxx"
-#include "BRepAdaptor_CompCurve.hxx"
 #include "BRepTools.hxx"
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>

--- a/tests/integrationtests/testWingCellSpar.cpp
+++ b/tests/integrationtests/testWingCellSpar.cpp
@@ -350,9 +350,9 @@ TEST_F(WingCellRibSpar, bug864)
     tigl::CCPACSWingCell& cell = componentSegment.GetStructure()->GetUpperShell().GetCell(2);
 
 
-    const std::pair<double, double> arr[] = { DP(0.2, 0.3), DP(0.95, 0.4), DP(0.2, 0.72), DP(0.95, 0.75) };
+    const std::pair<double, double> arr[] = { DP(0.2, 0.3), DP(0.95, 0.4), DP(0.2, 0.72), DP(0.95, 0.76) };
     std::vector< std::pair<double, double> > expectedEtaXsi (arr, arr + sizeof(arr) / sizeof(arr[0]));
-    checkCellEtaXsis(cell, expectedEtaXsi, 1.E-2);
+    checkCellEtaXsis(cell, expectedEtaXsi, 1.E-3);
 
 
     TopoDS_Shape cellGeom = cell.GetSkinGeometry();

--- a/tests/unittests/tiglShapeCache.cpp
+++ b/tests/unittests/tiglShapeCache.cpp
@@ -94,9 +94,10 @@ TEST(ShapeCache, Get)
     TopoDS_Shape shape1(wireBuilder.Wire()), shape2(wireBuilder.Wire()), shape3(wireBuilder.Wire());
     
     gp_Trsf trafo1, trafo2, trafo3;
-    trafo1.SetScaleFactor(1.0);
-    trafo2.SetScaleFactor(2.0);
-    trafo3.SetScaleFactor(3.0);
+    trafo1.SetTranslation(gp_Vec(1., 0., 0.));
+    trafo2.SetTranslation(gp_Vec(0., 1., 0.));
+    trafo3.SetTranslation(gp_Vec(0., 0., 1.));
+
     shape1.Move(trafo1);
     shape2.Move(trafo2);
     shape3.Move(trafo3);


### PR DESCRIPTION
OpenCASCADE 7.6.2 support

## Description
I adapted the code to allow TiGL to be used with OCCT 7.6.1 as well.
Fixes #973

## How Has This Been Tested?
I compiled it with OCCT 7.6.1, executed the unit tests, and started TiGL Viewer.

Here are some notes:
 - The colors in TiGL Viewer are somewhat (slightly) different due to the new Color Space in OCCT
 - The test WingSegmentGuideCurves.tiglWingGetSegmentUpperSurfaceAreaTrimmed is failing due to some tolerance error. I did not look into it further.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
