### PR TITLE
Improved visual quality of zebra stripes

### DIFF
--- a/TIGLViewer/shaders/PhongShading-v6.fs
+++ b/TIGLViewer/shaders/PhongShading-v6.fs
@@ -183,7 +183,7 @@ vec4 computeLighting (in vec3 theNormal,
     vec3 v = vec3(0., 0., -1.);
 
     // Direction of the view reflected on the surface
-    vec3 vReflect = 2. * (dot(Normal, v)*Normal - v);
+    vec3 vReflect = 2. * (dot(theNormal, v)*theNormal - v);
 
     // normal vector of the light stripe plane
     vec3 lightDir = normalize(vec3(0., 1., 0.));

--- a/TIGLViewer/shaders/PhongShading-v7.fs
+++ b/TIGLViewer/shaders/PhongShading-v7.fs
@@ -183,7 +183,7 @@ vec4 computeLighting (in vec3 theNormal,
     vec3 v = vec3(0., 0., -1.);
 
     // Direction of the view reflected on the surface
-    vec3 vReflect = 2. * (dot(Normal, v)*Normal - v);
+    vec3 vReflect = 2. * (dot(theNormal, v)*theNormal - v);
 
     // normal vector of the light stripe plane
     vec3 lightDir = normalize(vec3(0., 1., 0.));


### PR DESCRIPTION
This improves the visual quality of the zebra stripe plot in case of low triangulation resolution.

## Description
Before, the stripes were computed based on the normal vector of the vertex, not on the fragment. This lead to
visual distortions. Now, we use the normal vector from the fragment shader as offered by the occt api.

## How Has This Been Tested?
See screenshots

## Screenshots, that help to understand the changes(if applicable):
Before:
![Zebra-Before](https://github.com/DLR-SC/tigl/assets/3213107/629ff84b-04dc-4730-bdd8-c09ffdb4f34f)

After fix:
![Zebra-After](https://github.com/DLR-SC/tigl/assets/3213107/4a90ccec-e046-43b1-9315-a8f52fea7576)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
