### PR TITLE
Fix #975: Transform rX-Direction of guide curve with wing coordinate system

### DIFF
--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -99,7 +99,7 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     }
 
     // get local x-direction for the guide curve
-    gp_Dir rxDir = gp_Dir(1., 0., 0.);
+    gp_Dir rxDir = wingTransform.Transform(gp_Dir(1., 0., 0.));
     if (guideCurve->GetRXDirection()) {
         rxDir.SetX(guideCurve->GetRXDirection()->GetX());
         rxDir.SetY(guideCurve->GetRXDirection()->GetY());

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -51,6 +51,7 @@
 #include "CCPACSGuideCurveAlgo.h"
 #include "CCPACSWingSegment.h"
 #include "tiglcommonfunctions.h"
+#include "CTiglWingSegmentGuidecurveBuilder.h"
 
 /******************************************************************************/
 
@@ -456,4 +457,45 @@ TEST_F(WingGuideCurve, tiglWingGuideCurve_CCPACSWingSegment)
         ASSERT_NEAR(predictedPoint.Y(), point.Y(), 1E-5);
         ASSERT_NEAR(predictedPoint.Z(), point.Z(), 1E-14);
     }
+}
+
+TEST_F(WingGuideCurve, bug975)
+{
+    //https://github.com/DLR-SC/tigl/issues/975
+
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+
+
+    tigl::CCPACSWingSegment& segment1 = wing.GetSegment(1);
+    tigl::CTiglWingSegmentGuidecurveBuilder builder(segment1);
+
+    auto const& guideCurves = segment1.GetGuideCurves();
+    if(guideCurves) {
+        tigl::CCPACSGuideCurve const& guidecurve = guideCurves->GetGuideCurve(1);
+        auto points_before = builder.BuildGuideCurvePnts(&guidecurve);
+
+        tigl::CCPACSTransformation& trafo = wing.GetTransformation();
+        trafo.setRotation(tigl::CTiglPoint(0, 90, 0));
+        wing.SetTransformation(trafo);
+        tigl::CTiglTransformation const& wingTrafo = wing.GetTransformationMatrix();
+
+        auto points_after = builder.BuildGuideCurvePnts(&guidecurve);
+        int idx = 0;
+        for (auto const& p : points_after) {
+
+            // per design, the guide curve should have a zero x-component
+            EXPECT_NEAR(p.X(), 0.0, 1e-12);
+
+            // transforming the guide curve points of the untransformed wing should
+            // yield the same points as building the points after transforming the wing
+            gp_Pnt pt = wingTrafo.Transform(points_before[idx++]);
+            EXPECT_NEAR(p.X(), pt.X(), 1e-12);
+            EXPECT_NEAR(p.Y(), pt.Y(), 1e-12);
+            EXPECT_NEAR(p.Z(), pt.Z(), 1e-12);
+
+        }
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Now the rX-Direction respects the wing coorddinate system
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Visual confirmation in TiGL Viewer and new unit test
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
