### PR TITLE
CI: MacOS tests failed due to bizarre tar issue with github actions

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -102,6 +102,7 @@ runs:
                          -DTIGL_NIGHTLY=${{ inputs.tigl_nightly }} \
                          -DMATLAB_DIR=/tmp/matlab-libs-macos
         cmake --build . -j 4 --target install
+        file tests/unittests/TiGL-unittests
 
     - name: Create package
       if: ${{ inputs.package-artifact }}

--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -102,7 +102,6 @@ runs:
                          -DTIGL_NIGHTLY=${{ inputs.tigl_nightly }} \
                          -DMATLAB_DIR=/tmp/matlab-libs-macos
         cmake --build . -j 4 --target install
-        file tests/unittests/TiGL-unittests
 
     - name: Create package
       if: ${{ inputs.package-artifact }}
@@ -122,7 +121,7 @@ runs:
     - name: create build dir archive
       shell: bash
       run: |
-        tar -czf build.tar.gz build
+        gtar -czf build.tar.gz build
 
     - name: Upload build directory
       uses: actions/upload-artifact@v3

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -44,14 +44,13 @@ runs:
     - name: extract build archive
       shell: bash
       run: |
-        tar -xzf build.tar.gz
+        gtar -xzf build.tar.gz
 
     - name: Run unit tests
       if: ${{ inputs.unit-tests == 'true' }}
       shell: bash
       run: |
         cd build/tests/unittests/
-        file TiGL-unittests
         chmod a+x ./TiGL-unittests
         ./TiGL-unittests --gtest_shuffle --gtest_output=xml:unit_test_results.xml
 

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -51,6 +51,7 @@ runs:
       shell: bash
       run: |
         cd build/tests/unittests/
+        file TiGL-unittests
         chmod a+x ./TiGL-unittests
         ./TiGL-unittests --gtest_shuffle --gtest_output=xml:unit_test_results.xml
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -176,6 +176,7 @@ jobs:
 
   test-macos:
     needs: build-macos
+    continue-on-error: true
     runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -176,7 +176,6 @@ jobs:
 
   test-macos:
     needs: build-macos
-    continue-on-error: true
     runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #977 

## Description

Previously, `TiGL-unittests` was not executable in the macos-test job. The reason seems to be that the `tar` archive of the `build` directory was corrupted. Switching from `tar` to `gtar` (GNU tar) works around this issue.

See https://github.com/actions/runner-images/pull/2163 and https://github.com/orgs/community/discussions/24994.


## How Has This Been Tested?
CI works again

## Screenshots, that help to understand the changes(if applicable):
Not applicable

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~~[ ] A test for the new functionality was added.~~
- [x] All tests run without failure.
- ~~[ ] The new code complies with the TiGL style guide.~~
- ~~[ ] New classes have been added to the Python interface.~~
- ~~[ ] API changes were documented properly in tigl.h.~~
