### PR TITLE
Fix for hard crash if guiceCurves node is present but empty in wing segment

### DIFF
--- a/src/guide_curves/CCPACSGuideCurves.cpp
+++ b/src/guide_curves/CCPACSGuideCurves.cpp
@@ -97,6 +97,13 @@ bool CCPACSGuideCurves::GuideCurveExists(std::string uid) const
 std::vector<double> CCPACSGuideCurves::GetRelativeCircumferenceParameters() const
 {
     std::vector<double> relCircs;
+
+    // CPACS 3.3 requires guideCurves to be present. To prevent a hard crash if this is NOT the case,
+    // we shoud exit here (or at least before the call to relCircs.back())
+    if (GetGuideCurveCount() == 0) {
+        return relCircs;
+    }
+
     for (int iguide = 1; iguide <=  GetGuideCurveCount(); ++iguide) {
         const CCPACSGuideCurve* root = GetGuideCurve(iguide).GetRootCurve();
         relCircs.push_back(*root->GetFromRelativeCircumference_choice2());

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -499,3 +499,30 @@ TEST_F(WingGuideCurve, bug975)
     }
 
 }
+
+
+TEST_F(WingGuideCurve, bug962)
+{
+    //https://github.com/DLR-SC/tigl/issues/962
+
+    TixiDocumentHandle           tixi_h;
+    TiglCPACSConfigurationHandle tigl_h;
+
+    // open simpletest with tixi and add empty guidecurves node
+    const char* filename = "TestData/simpletest.cpacs.xml";
+    auto tixiRet = tixiOpenDocument(filename, &tixi_h);
+    ASSERT_EQ (tixiRet, SUCCESS);
+    tixiRet = tixiCreateElement(tixi_h, "/cpacs/vehicles/aircraft/model/wings/wing[1]/segments/segment[1]", "guideCurves");
+    ASSERT_EQ (tixiRet, SUCCESS);
+
+    // open with tigl and try to build segment loft
+    auto tiglRet = tiglOpenCPACSConfiguration(tixi_h, "Cpacs2Test", &tigl_h);
+    ASSERT_EQ(tiglRet, TIGL_SUCCESS);
+
+
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config = manager.GetConfiguration(tigl_h);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+    tigl::CCPACSWingSegment& segment1 = wing.GetSegment(1);
+    segment1.GetLoft();
+}


### PR DESCRIPTION
Fixes #962

## Description

This PR adds an internal check if an `std::vector` is empty before trying to access elements. As a consequence, the wing loft and segment loft will be build just as if there were no guide curves defined. 

Note that CPACS 3.3 requires the `guideCurves` node to be nonempty. We are less restrictive here.

## How Has This Been Tested?
A new test has been added

## Screenshots, that help to understand the changes(if applicable):
Not applicable

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- ~~[ ] New classes have been added to the Python interface.~~ Not applicable
- ~~[ ] API changes were documented properly in tigl.h.~~ Not applicable
