### PR TITLE
Fix bug causing wrong rotor rotation in y direction (fixes #870)

### DIFF
--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -600,7 +600,7 @@ void CTiglTransformation::Decompose(double scale[3], double rotation[3], double 
 
     // calculate intrinsic Euler angles from rotation matrix U
     //
-    // This implementation is based on http://www.gregslabaugh.net/publications/euler.pdf, where the same argumentation
+    // This implementation is based on https://www.eecs.qmul.ac.uk/~gslabaugh/publications/euler.pdf, where the same argumentation
     // is used for intrinsic x,y',z'' angles and the rotatation matrix
     //
     //                |                        cos(y)*cos(z) |               -        cos(y)*cos(z) |         sin(y) |

--- a/src/geometry/CTiglTransformation.cpp
+++ b/src/geometry/CTiglTransformation.cpp
@@ -609,18 +609,22 @@ void CTiglTransformation::Decompose(double scale[3], double rotation[3], double 
     //
     // rather than extrinsic angles and the Rotation matrix mentioned in that pdf.
 
+    // U_13 = sin(y) \neq \pm 1
     if( fabs( fabs(U(1, 3)) - 1) > 1e-10 ){
         rotation[1] = asin(U(1, 3));
         double cosTheta = cos(rotation[1]);
         rotation[0] = -atan2(U(2,3)/cosTheta, U(3,3)/cosTheta);
         rotation[2] = -atan2(U(1,2)/cosTheta, U(1,1)/cosTheta);
     }
+    // U_13 = \pm 1
     else {
         rotation[0] = 0;
-        if ( fabs(U(1,3) + 1) > 1e-10 ) {
+        // U_13 = -1
+        if ( fabs(U(1,3) - 1) > 1e-10 ) {
             rotation[2] = -rotation[0] - atan2(U(2,1), U(2,2));
             rotation[1] = -M_PI/2;
         }
+        // U_13 = 1
         else{
             rotation[2] = -rotation[0] + atan2(U(2,1), U(2,2));
             rotation[1] = M_PI/2;

--- a/tests/unittests/tiglMath.cpp
+++ b/tests/unittests/tiglMath.cpp
@@ -401,6 +401,40 @@ TEST(TiglMath, CTiglTransform_Decompose2)
     EXPECT_NEAR(resultV.Z(), expectV.Z(), 1e-8 );
 }
 
+TEST(TiglMath, CTiglTransform_Decompose3)
+{
+    // Simulate the case where a cpacs transformation has a rotation RX:0;RY:90;RZ:00 and RX:0;RY:-90;RZ:00, respectively
+    // This caused a bug due to a wrong if condition in the decompose routine which resulted in a sign flip of RY afterwards
+    tigl::CTiglTransformation rotA, rotB;
+
+    // Set up 2 example rotations
+    rotA.AddRotationZ(0);
+    rotA.AddRotationY(90);
+    rotA.AddRotationX(0);
+
+    rotB.AddRotationZ(0);
+    rotB.AddRotationY(-90);
+    rotB.AddRotationX(0);
+
+    double ScalA[3] = {0., 0., 0.};
+    double RotA[3] = {0., 0., 0.};
+    double TransA[3] = {0., 0., 0.};
+    double ScalB[3] = {0., 0., 0.};
+    double RotB[3] = {0., 0., 0.};
+    double TransB[3] = {0., 0., 0.};
+
+    rotA.Decompose(ScalA, RotA, TransA);
+    rotB.Decompose(ScalB, RotB, TransB);
+
+    EXPECT_NEAR(RotA[0], 0, 1e-8);
+    EXPECT_NEAR(RotA[1], 90, 1e-8);
+    EXPECT_NEAR(RotA[2], 0, 1e-8);
+
+    EXPECT_NEAR(RotB[0], 0, 1e-8);
+    EXPECT_NEAR(RotB[1], -90, 1e-8);
+    EXPECT_NEAR(RotB[2], 0, 1e-8);
+}
+
 TEST(TiglMath, CTiglTransform_setTransformationMatrix)
 {
     double scale[3] = {2., 4., 8.};


### PR DESCRIPTION
Fix issue  #870: Wrong if clause condition caused misinterpretation of the sign and caused wrong rotation in decompose routine 