### PR TITLE
Resolve uninitialized dereference in rotor code

### DIFF
--- a/TIGLViewer/src/TIGLViewerDocument.cpp
+++ b/TIGLViewer/src/TIGLViewerDocument.cpp
@@ -2365,7 +2365,7 @@ void TIGLViewerDocument::showRotorProperties()
 
         tmpPoint = rotor.GetTranslation();
         ADD_PROPERTY_TEXT("Translation", "(" + QString::number(tmpPoint.x) + "; " + QString::number(tmpPoint.y) + "; " + QString::number(tmpPoint.z) + ")")
-        ADD_PROPERTY_TEXT("RPM", QString::number(rotor.GetNominalRotationsPerMinute().get_value_or(0)));
+        ADD_PROPERTY_TEXT("RPM", QString::number(rotor.GetNominalRotationsPerMinute()));
         ADD_PROPERTY_TEXT("Tip Speed", QString::number(rotor.GetTipSpeed()));
         ADD_PROPERTY_TEXT("RotorBladeAttachmentCount", QString::number(rotor.GetRotorBladeAttachmentCount()));
         ADD_PROPERTY_TEXT("RotorBladeCount", QString::number(rotor.GetRotorBladeCount()));

--- a/src/rotor/CCPACSRotor.cpp
+++ b/src/rotor/CCPACSRotor.cpp
@@ -213,11 +213,17 @@ double CCPACSRotor::GetRadius()
     return rotorRadius;
 }
 
+// Wrapper function to return the nominal rotations per minute or 0 if not defined
+double CCPACSRotor::GetNominalRotationsPerMinute()
+{
+    return generated::CPACSRotor::GetNominalRotationsPerMinute().get_value_or(0.);
+}
+
 // Returns the tip speed this rotor
 double CCPACSRotor::GetTipSpeed()
 {
     // return GetNominalRotationsPerMinute()/60. * 2.*M_PI*GetRadius();
-    return *GetNominalRotationsPerMinute() / 30. * M_PI * GetRadius();
+    return GetNominalRotationsPerMinute() / 30. * M_PI * GetRadius();
 }
 
 // Returns the sum of all blade planform areas of a rotor

--- a/src/rotor/CCPACSRotor.h
+++ b/src/rotor/CCPACSRotor.h
@@ -102,6 +102,9 @@ public:
     // Returns the radius of the rotor
     TIGL_EXPORT double GetRadius();
 
+    // Wrapper function to return the nominal rotations per minute or 0 if not defined
+    TIGL_EXPORT double GetNominalRotationsPerMinute();
+
     // Returns the tip speed this rotor
     TIGL_EXPORT double GetTipSpeed();
 

--- a/src/rotor/CTiglAttachedRotorBlade.cpp
+++ b/src/rotor/CTiglAttachedRotorBlade.cpp
@@ -213,7 +213,7 @@ double CTiglAttachedRotorBlade::GetRadius()
 double CTiglAttachedRotorBlade::GetTipSpeed()
 {
     // return GetRotor().GetNominalRotationsPerMinute()/60. * 2.*M_PI*GetRadius();
-    return *GetRotor().GetNominalRotationsPerMinute() / 30. * M_PI * GetRadius();
+    return GetRotor().GetNominalRotationsPerMinute() / 30. * M_PI * GetRadius();
 }
 
 // Returns the radius of a point on the rotor blade quarter chord line for a given segment index and eta


### PR DESCRIPTION
Fix the issue of (possible) uninitialized dereference if the CPACS rotor parameter `nominalRotationsPerMinute` is not defined.

A wrapper function is added around `CPACSRotor::GetNominalRotationsPerMinute()` that returns a `0.` if the value is not defined to avoid uninitialized dereference.

Fixes #998