### PR TITLE
Consistent implementation for combining fuselage guide curves and kinks   

### DIFF
--- a/cpacs_gen_input/cpacs_schema.xsd
+++ b/cpacs_gen_input/cpacs_schema.xsd
@@ -13790,31 +13790,51 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                                 </xsd:complexType>
                             </xsd:element>
                         </xsd:sequence>
-                        <xsd:sequence>
-                            <xsd:element name="fromRelativeCircumference" type="doubleBaseType">
-                                <xsd:annotation>
-                                    <xsd:documentation>Reference to the relative circumference
-                                        position from which the guide curve shall start. Valid values
-                                        are in the interval -1.0...1.0.
-                                    </xsd:documentation>
-                                </xsd:annotation>
-                            </xsd:element>
-                            <xsd:element minOccurs="0" name="tangent" type="pointXYZType">
+			<xsd:sequence>
+			    <xsd:choice>
+                                <xsd:element name="fromRelativeCircumference" type="doubleBaseType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Reference to the relative circumference
+                                            position from which the guide curve shall start. Valid values
+                                            are in the interval -1.0...1.0.
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="fromParameter" type="doubleBaseType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Reference to the parameter
+                                            position from which the guide curve shall start. Valid values
+                                            are in the interval -1.0...1.0.
+                                            </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                            </xsd:choice>
+			    <xsd:element minOccurs="0" name="tangent" type="pointXYZType">
                                 <xsd:annotation>
                                     <xsd:documentation>Tangent at first point</xsd:documentation>
                                 </xsd:annotation>
                             </xsd:element>
                         </xsd:sequence>
                     </xsd:choice>
-                    <xsd:sequence>
-                        <xsd:element name="toRelativeCircumference" type="doubleBaseType">
-                            <xsd:annotation>
-                                <xsd:documentation>The relative circumference
-                                    position at which the guide curve shall end. Valid values
-                                    are in the interval -1.0...1.0.
-                                </xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
+		    <xsd:sequence>
+			<xsd:choice>
+                            <xsd:element name="toRelativeCircumference" type="doubleBaseType">
+                                <xsd:annotation>
+                                    <xsd:documentation>The relative circumference
+                                        position at which the guide curve shall end. Valid values
+                                        are in the interval -1.0...1.0.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+			    </xsd:element>
+			    <xsd:element name="toParameter" type="doubleBaseType">
+                                <xsd:annotation>
+                                    <xsd:documentation>The parameter
+                                        position at which the guide curve shall end. Valid values
+                                       are in the interval -1.0...1.0.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+		 	</xsd:choice>
                         <xsd:element minOccurs="0" name="tangent" type="pointXYZType">
                             <xsd:annotation>
                                 <xsd:documentation>Tangent at last point</xsd:documentation>

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -266,6 +266,21 @@ void EdgeGetPointTangent(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, g
     }
 }
 
+void EdgeGetPointTangentBasedOnParam(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, gp_Vec& tangent)
+{
+    if (alpha < 0.0 || alpha > 1.0) {
+        throw tigl::CTiglError("Parameter alpha not in the range 0.0 <= alpha <= 1.0 in EdgeGetPointTangent", TIGL_ERROR);
+    }
+    // ETA 3D point
+    Standard_Real umin, umax;
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, umin, umax);
+    GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
+    Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
+    adaptorCurve.D1( alpha, point, tangent );
+    // normalize tangent to length of the curve
+    tangent = len*tangent/tangent.Magnitude();
+}
+
 Standard_Real ProjectPointOnWire(const TopoDS_Wire& wire, gp_Pnt p)
 {
     return ProjectPointOnWireAtAngle(wire, p, gp_Dir(1,0,0), M_PI/2.);

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -268,12 +268,14 @@ void EdgeGetPointTangent(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, g
 
 void EdgeGetPointTangentBasedOnParam(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, gp_Vec& tangent)
 {
-    if (alpha < 0.0 || alpha > 1.0) {
-        throw tigl::CTiglError("Parameter alpha not in the range 0.0 <= alpha <= 1.0 in EdgeGetPointTangent", TIGL_ERROR);
-    }
     // ETA 3D point
     Standard_Real umin, umax;
     Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, umin, umax);
+
+    if (alpha < umin || alpha > umax) {
+        throw tigl::CTiglError("Parameter alpha not in the range umin <= alpha <= umax in EdgeGetPointTangent", TIGL_ERROR);
+    }
+
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
     adaptorCurve.D1( alpha, point, tangent );

--- a/src/common/tiglcommonfunctions.h
+++ b/src/common/tiglcommonfunctions.h
@@ -85,6 +85,7 @@ TIGL_EXPORT gp_Pnt GetLastPoint(const TopoDS_Edge& e);
 
 TIGL_EXPORT gp_Pnt EdgeGetPoint(const TopoDS_Edge& edge, double alpha);
 TIGL_EXPORT void EdgeGetPointTangent(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, gp_Vec& normal);
+TIGL_EXPORT void EdgeGetPointTangentBasedOnParam(const TopoDS_Edge& edge, double alpha, gp_Pnt& point, gp_Vec& tangent);
 
 // calculates the alpha value for a given point on a wire
 TIGL_EXPORT Standard_Real ProjectPointOnWire(const TopoDS_Wire& wire, gp_Pnt p);

--- a/src/fuselage/CCPACSFuselageProfileGetPointAlgo.cpp
+++ b/src/fuselage/CCPACSFuselageProfileGetPointAlgo.cpp
@@ -64,8 +64,9 @@ void CCPACSFuselageProfileGetPointAlgo::GetPointTangent(const double& alpha, gp_
         // <BRepAdaptor_CompCurve>.D1( alpha, point, tangent) based on a wire did not produce the expected result.
         // That is why, the first edge is extracted. It is implicitely assumed that the wire consists of exactly one edge.
         // More than one edge might lead to unexpected result when used in combination with PARAMETER
-        if (GetNumberOfEdges(wire) > 1)
+        if (GetNumberOfEdges(wire) > 1) {
             LOG(WARNING) << "CCPACSFuselageProfileGetPointAlgo::GetPointTangent: Defining start or end point of guide curve via parameter on wires consisting of 2 or more edges might lead to unexpected results.";
+        }
         // Get parameter range of edge
         edge = GetEdge(wire, 0);
         BRep_Tool::Range(edge, umin, umax);

--- a/src/fuselage/CCPACSFuselageProfileGetPointAlgo.h
+++ b/src/fuselage/CCPACSFuselageProfileGetPointAlgo.h
@@ -31,6 +31,7 @@
 #include "TopTools_SequenceOfShape.hxx"
 #include "gp_Pnt.hxx"
 #include "gp_Vec.hxx"
+#include "CCPACSGuideCurve.h"
 
 #ifndef CCPACSFUSELAGEPROFILEGETPOINTALGO_H
 #define CCPACSFUSELAGEPROFILEGETPOINTALGO_H
@@ -58,7 +59,8 @@ public:
      * \param point Point on the profile corresponding to the parameter alpha
      * \param tangent Tangent on the profile corresponding to the parameter alpha
      */
-    TIGL_EXPORT void GetPointTangent(const double& alpha, gp_Pnt& point, gp_Vec& tangent);
+    TIGL_EXPORT void GetPointTangent(const double& alpha, gp_Pnt& point,
+                                     gp_Vec& tangent, const CCPACSGuideCurve::FromOrToDefinition& fromOrToDefinition=CCPACSGuideCurve::FromOrToDefinition::CIRCUMFERENCE);
 
 private:
     TopoDS_Wire wire;    /**< Wire of the fuselage profile */

--- a/src/fuselage/CCPACSFuselageProfileGetPointAlgo.h
+++ b/src/fuselage/CCPACSFuselageProfileGetPointAlgo.h
@@ -58,6 +58,7 @@ public:
      *
      * \param point Point on the profile corresponding to the parameter alpha
      * \param tangent Tangent on the profile corresponding to the parameter alpha
+     * \param fromOrToDefinition Define the basis on which the point on the curve should be found (circumference or parameter)
      */
     TIGL_EXPORT void GetPointTangent(const double& alpha, gp_Pnt& point,
                                      gp_Vec& tangent, const CCPACSGuideCurve::FromOrToDefinition& fromOrToDefinition=CCPACSGuideCurve::FromOrToDefinition::CIRCUMFERENCE);

--- a/src/fuselage/CCPACSFuselageSegments.cpp
+++ b/src/fuselage/CCPACSFuselageSegments.cpp
@@ -191,7 +191,16 @@ void CCPACSFuselageSegments::BuildGuideCurves(TopoDS_Compound& cache) const
             const CCPACSGuideCurve& curve = segmentCurves.GetGuideCurve(iguide);
             if (!curve.GetFromGuideCurveUID_choice1()) {
                 // this is a root curve
-                double relCirc= *curve.GetFromRelativeCircumference_choice2();
+                double relCirc;
+                if (curve.GetFromRelativeCircumference_choice2_1()) {
+                    relCirc = *curve.GetFromRelativeCircumference_choice2_1();
+                }
+                else if(curve.GetFromParameter_choice2_2()) {
+                    relCirc = *curve.GetFromParameter_choice2_2();
+                }
+                else {
+                    throw CTiglError("CCPACSFuselageSegments::BuildGuideCurves(): Either a fromCircumference or a fromParameter must be present", TIGL_NOT_FOUND);
+                }
                 //TODO: determine if half fuselage or not. If not
                 //the guide curve at relCirc=1 should be inserted at relCirc=0
                 roots.insert(std::make_pair(relCirc, &curve));

--- a/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
+++ b/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
@@ -71,12 +71,20 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
 
 
     // get relative circumference of inner profile
-    double fromRelativeCircumference = guideCurve->GetFromRelativeCircumference();
+    double fromRelativeCircumference = guideCurve->GetFromDefinitionValue();
 
     // get relative circumference of outer profile
-    double toRelativeCircumference = guideCurve->GetToRelativeCircumference();
+    double toRelativeCircumference = guideCurve->GetToDefinitionValue();
     // get guide curve profile UID
     std::string guideCurveProfileUID = guideCurve->GetGuideCurveProfileUID();
+
+    // decide whether the guide curve's starting point is defined based on circumference or parameter
+    CCPACSGuideCurve::FromOrToDefinition fromDefinition = guideCurve->GetFromDefinition();
+    // decide whether the guide curve's end point is defined based on circumference or parameter
+    CCPACSGuideCurve::FromOrToDefinition toDefinition = guideCurve->GetToDefinition();
+    if (toDefinition == CCPACSGuideCurve::FromOrToDefinition::UID) {
+        throw CTiglError("CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(): toDefinition must not be UID", TIGL_NOT_FOUND);
+    }
 
     // get guide curve profile
     CCPACSConfiguration const& config = m_segment.GetParent()->GetConfiguration();
@@ -107,7 +115,9 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
                                                                                                   innerScale,
                                                                                                   outerScale,
                                                                                                   rxDir,
-                                                                                                  guideCurveProfile);
+                                                                                                  guideCurveProfile,
+                                                                                                  fromDefinition,
+                                                                                                  toDefinition);
     return guideCurvePnts;
 }
 

--- a/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
+++ b/src/fuselage/CTiglFuselageSegmentGuidecurveBuilder.cpp
@@ -70,11 +70,11 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
     double outerScale = GetLength(outerChordLineWire);
 
 
-    // get relative circumference of inner profile
-    double fromRelativeCircumference = guideCurve->GetFromDefinitionValue();
+    // get relative circumference or parameter value of inner profile (depending on chosen CPACS node)
+    double fromDefinitionValue = guideCurve->GetFromDefinitionValue();
+    // get relative circumference or parameter value of outer profile (depending on chosen CPACS node)
+    double toDefinitionValue = guideCurve->GetToDefinitionValue();
 
-    // get relative circumference of outer profile
-    double toRelativeCircumference = guideCurve->GetToDefinitionValue();
     // get guide curve profile UID
     std::string guideCurveProfileUID = guideCurve->GetGuideCurveProfileUID();
 
@@ -110,8 +110,8 @@ std::vector<gp_Pnt> CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(c
     // construct guide curve algorithm
     std::vector<gp_Pnt> guideCurvePnts = CCPACSGuideCurveAlgo<CCPACSFuselageProfileGetPointAlgo> (startWireContainer,
                                                                                                   endWireContainer,
-                                                                                                  fromRelativeCircumference,
-                                                                                                  toRelativeCircumference,
+                                                                                                  fromDefinitionValue,
+                                                                                                  toDefinitionValue,
                                                                                                   innerScale,
                                                                                                   outerScale,
                                                                                                   rxDir,

--- a/src/generated/CPACSGuideCurve.cpp
+++ b/src/generated/CPACSGuideCurve.cpp
@@ -29,7 +29,6 @@ namespace generated
 {
     CPACSGuideCurve::CPACSGuideCurve(CCPACSGuideCurves* parent, CTiglUIDManager* uidMgr)
         : m_uidMgr(uidMgr)
-        , m_toRelativeCircumference(0)
     {
         //assert(parent != NULL);
         m_parent = parent;
@@ -144,7 +143,12 @@ namespace generated
 
         // read element fromRelativeCircumference
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromRelativeCircumference")) {
-            m_fromRelativeCircumference_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fromRelativeCircumference");
+            m_fromRelativeCircumference_choice2_1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fromRelativeCircumference");
+        }
+
+        // read element fromParameter
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromParameter")) {
+            m_fromParameter_choice2_2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fromParameter");
         }
 
         // read element tangent
@@ -160,10 +164,12 @@ namespace generated
 
         // read element toRelativeCircumference
         if (tixi::TixiCheckElement(tixiHandle, xpath + "/toRelativeCircumference")) {
-            m_toRelativeCircumference = tixi::TixiGetElement<double>(tixiHandle, xpath + "/toRelativeCircumference");
+            m_toRelativeCircumference_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/toRelativeCircumference");
         }
-        else {
-            LOG(ERROR) << "Required element toRelativeCircumference is missing at xpath " << xpath;
+
+        // read element toParameter
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toParameter")) {
+            m_toParameter_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/toParameter");
         }
 
         // read element tangent
@@ -241,13 +247,24 @@ namespace generated
         }
 
         // write element fromRelativeCircumference
-        if (m_fromRelativeCircumference_choice2) {
+        if (m_fromRelativeCircumference_choice2_1) {
             tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/fromRelativeCircumference");
-            tixi::TixiSaveElement(tixiHandle, xpath + "/fromRelativeCircumference", *m_fromRelativeCircumference_choice2);
+            tixi::TixiSaveElement(tixiHandle, xpath + "/fromRelativeCircumference", *m_fromRelativeCircumference_choice2_1);
         }
         else {
             if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromRelativeCircumference")) {
                 tixi::TixiRemoveElement(tixiHandle, xpath + "/fromRelativeCircumference");
+            }
+        }
+
+        // write element fromParameter
+        if (m_fromParameter_choice2_2) {
+            tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/fromParameter");
+            tixi::TixiSaveElement(tixiHandle, xpath + "/fromParameter", *m_fromParameter_choice2_2);
+        }
+        else {
+            if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromParameter")) {
+                tixi::TixiRemoveElement(tixiHandle, xpath + "/fromParameter");
             }
         }
 
@@ -263,8 +280,26 @@ namespace generated
         }
 
         // write element toRelativeCircumference
-        tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/toRelativeCircumference");
-        tixi::TixiSaveElement(tixiHandle, xpath + "/toRelativeCircumference", m_toRelativeCircumference);
+        if (m_toRelativeCircumference_choice1) {
+            tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/toRelativeCircumference");
+            tixi::TixiSaveElement(tixiHandle, xpath + "/toRelativeCircumference", *m_toRelativeCircumference_choice1);
+        }
+        else {
+            if (tixi::TixiCheckElement(tixiHandle, xpath + "/toRelativeCircumference")) {
+                tixi::TixiRemoveElement(tixiHandle, xpath + "/toRelativeCircumference");
+            }
+        }
+
+        // write element toParameter
+        if (m_toParameter_choice2) {
+            tixi::TixiCreateElementIfNotExists(tixiHandle, xpath + "/toParameter");
+            tixi::TixiSaveElement(tixiHandle, xpath + "/toParameter", *m_toParameter_choice2);
+        }
+        else {
+            if (tixi::TixiCheckElement(tixiHandle, xpath + "/toParameter")) {
+                tixi::TixiRemoveElement(tixiHandle, xpath + "/toParameter");
+            }
+        }
 
         // write element tangent
         if (m_tangent) {
@@ -303,7 +338,9 @@ namespace generated
                     &&
                     // elements of other choices must not be there
                     !(
-                        m_fromRelativeCircumference_choice2.is_initialized()
+                        m_fromRelativeCircumference_choice2_1.is_initialized()
+                        ||
+                        m_fromParameter_choice2_2.is_initialized()
                         ||
                         m_tangent_choice2.is_initialized()
                     )
@@ -311,7 +348,28 @@ namespace generated
                 +
                 (
                     // mandatory elements of this choice must be there
-                    m_fromRelativeCircumference_choice2.is_initialized()
+                    (
+                        (
+                            // mandatory elements of this choice must be there
+                            m_fromRelativeCircumference_choice2_1.is_initialized()
+                            &&
+                            // elements of other choices must not be there
+                            !(
+                                m_fromParameter_choice2_2.is_initialized()
+                            )
+                        )
+                        +
+                        (
+                            // mandatory elements of this choice must be there
+                            m_fromParameter_choice2_2.is_initialized()
+                            &&
+                            // elements of other choices must not be there
+                            !(
+                                m_fromRelativeCircumference_choice2_1.is_initialized()
+                            )
+                        )
+                        == 1
+                    )
                     &&
                     true // m_tangent_choice2 is optional in choice
                     &&
@@ -320,6 +378,29 @@ namespace generated
                         m_fromGuideCurveUID_choice1.is_initialized()
                         ||
                         m_continuity_choice1.is_initialized()
+                    )
+                )
+                == 1
+            )
+            &&
+            (
+                (
+                    // mandatory elements of this choice must be there
+                    m_toRelativeCircumference_choice1.is_initialized()
+                    &&
+                    // elements of other choices must not be there
+                    !(
+                        m_toParameter_choice2.is_initialized()
+                    )
+                )
+                +
+                (
+                    // mandatory elements of this choice must be there
+                    m_toParameter_choice2.is_initialized()
+                    &&
+                    // elements of other choices must not be there
+                    !(
+                        m_toRelativeCircumference_choice1.is_initialized()
                     )
                 )
                 == 1
@@ -400,14 +481,24 @@ namespace generated
         m_continuity_choice1 = value;
     }
 
-    const boost::optional<double>& CPACSGuideCurve::GetFromRelativeCircumference_choice2() const
+    const boost::optional<double>& CPACSGuideCurve::GetFromRelativeCircumference_choice2_1() const
     {
-        return m_fromRelativeCircumference_choice2;
+        return m_fromRelativeCircumference_choice2_1;
     }
 
-    void CPACSGuideCurve::SetFromRelativeCircumference_choice2(const boost::optional<double>& value)
+    void CPACSGuideCurve::SetFromRelativeCircumference_choice2_1(const boost::optional<double>& value)
     {
-        m_fromRelativeCircumference_choice2 = value;
+        m_fromRelativeCircumference_choice2_1 = value;
+    }
+
+    const boost::optional<double>& CPACSGuideCurve::GetFromParameter_choice2_2() const
+    {
+        return m_fromParameter_choice2_2;
+    }
+
+    void CPACSGuideCurve::SetFromParameter_choice2_2(const boost::optional<double>& value)
+    {
+        m_fromParameter_choice2_2 = value;
     }
 
     const boost::optional<CPACSPointXYZ>& CPACSGuideCurve::GetTangent_choice2() const
@@ -420,14 +511,24 @@ namespace generated
         return m_tangent_choice2;
     }
 
-    const double& CPACSGuideCurve::GetToRelativeCircumference() const
+    const boost::optional<double>& CPACSGuideCurve::GetToRelativeCircumference_choice1() const
     {
-        return m_toRelativeCircumference;
+        return m_toRelativeCircumference_choice1;
     }
 
-    void CPACSGuideCurve::SetToRelativeCircumference(const double& value)
+    void CPACSGuideCurve::SetToRelativeCircumference_choice1(const boost::optional<double>& value)
     {
-        m_toRelativeCircumference = value;
+        m_toRelativeCircumference_choice1 = value;
+    }
+
+    const boost::optional<double>& CPACSGuideCurve::GetToParameter_choice2() const
+    {
+        return m_toParameter_choice2;
+    }
+
+    void CPACSGuideCurve::SetToParameter_choice2(const boost::optional<double>& value)
+    {
+        m_toParameter_choice2 = value;
     }
 
     const boost::optional<CPACSPointXYZ>& CPACSGuideCurve::GetTangent() const

--- a/src/generated/CPACSGuideCurve.h
+++ b/src/generated/CPACSGuideCurve.h
@@ -86,14 +86,20 @@ namespace generated
         TIGL_EXPORT virtual const boost::optional<CPACSGuideCurve_continuity>& GetContinuity_choice1() const;
         TIGL_EXPORT virtual void SetContinuity_choice1(const boost::optional<CPACSGuideCurve_continuity>& value);
 
-        TIGL_EXPORT virtual const boost::optional<double>& GetFromRelativeCircumference_choice2() const;
-        TIGL_EXPORT virtual void SetFromRelativeCircumference_choice2(const boost::optional<double>& value);
+        TIGL_EXPORT virtual const boost::optional<double>& GetFromRelativeCircumference_choice2_1() const;
+        TIGL_EXPORT virtual void SetFromRelativeCircumference_choice2_1(const boost::optional<double>& value);
+
+        TIGL_EXPORT virtual const boost::optional<double>& GetFromParameter_choice2_2() const;
+        TIGL_EXPORT virtual void SetFromParameter_choice2_2(const boost::optional<double>& value);
 
         TIGL_EXPORT virtual const boost::optional<CPACSPointXYZ>& GetTangent_choice2() const;
         TIGL_EXPORT virtual boost::optional<CPACSPointXYZ>& GetTangent_choice2();
 
-        TIGL_EXPORT virtual const double& GetToRelativeCircumference() const;
-        TIGL_EXPORT virtual void SetToRelativeCircumference(const double& value);
+        TIGL_EXPORT virtual const boost::optional<double>& GetToRelativeCircumference_choice1() const;
+        TIGL_EXPORT virtual void SetToRelativeCircumference_choice1(const boost::optional<double>& value);
+
+        TIGL_EXPORT virtual const boost::optional<double>& GetToParameter_choice2() const;
+        TIGL_EXPORT virtual void SetToParameter_choice2(const boost::optional<double>& value);
 
         TIGL_EXPORT virtual const boost::optional<CPACSPointXYZ>& GetTangent() const;
         TIGL_EXPORT virtual boost::optional<CPACSPointXYZ>& GetTangent();
@@ -138,7 +144,12 @@ namespace generated
         /// Reference to the relative circumference
         /// position from which the guide curve shall start. Valid values
         /// are in the interval -1.0...1.0.
-        boost::optional<double>                     m_fromRelativeCircumference_choice2;
+        boost::optional<double>                     m_fromRelativeCircumference_choice2_1;
+
+        /// Reference to the parameter
+        /// position from which the guide curve shall start. Valid values
+        /// are in the interval -1.0...1.0.
+        boost::optional<double>                     m_fromParameter_choice2_2;
 
         /// Tangent at first point
         boost::optional<CPACSPointXYZ>              m_tangent_choice2;
@@ -146,7 +157,12 @@ namespace generated
         /// The relative circumference
         /// position at which the guide curve shall end. Valid values
         /// are in the interval -1.0...1.0.
-        double                                      m_toRelativeCircumference;
+        boost::optional<double>                     m_toRelativeCircumference_choice1;
+
+        /// The parameter
+        /// position at which the guide curve shall end. Valid values
+        /// are in the interval -1.0...1.0.
+        boost::optional<double>                     m_toParameter_choice2;
 
         /// Tangent at last point
         boost::optional<CPACSPointXYZ>              m_tangent;

--- a/src/guide_curves/CCPACSGuideCurve.cpp
+++ b/src/guide_curves/CCPACSGuideCurve.cpp
@@ -26,6 +26,7 @@
 #include "CTiglPoint.h"
 #include "CTiglLogging.h"
 #include "tiglcommonfunctions.h"
+#include "CCPACSGuideCurve.h"
 
 #include <TopoDS_Edge.hxx>
 
@@ -51,28 +52,55 @@ void CCPACSGuideCurve::InvalidateImpl(const boost::optional<std::string>& source
     guideCurveTopo.clear();
 }
 
-CCPACSGuideCurve::FromDefinition CCPACSGuideCurve::GetFromDefinition() const {
+CCPACSGuideCurve::FromOrToDefinition CCPACSGuideCurve::GetFromDefinition() const {
     if (!ValidateChoices())
         throw CTiglError("Choices not valid", TIGL_XML_ERROR);
-    if (m_fromRelativeCircumference_choice2)
-        return FromDefinition::CIRCUMFERENCE;
+    if (m_fromRelativeCircumference_choice2_1)
+        return FromOrToDefinition::CIRCUMFERENCE;
+    if (m_fromParameter_choice2_2)
+        return FromOrToDefinition::PARAMETER;
     if (m_fromGuideCurveUID_choice1)
-        return FromDefinition::UID;
-    throw CTiglError("Logic error in FromDefinition detection");
+        return FromOrToDefinition::UID;
+    throw CTiglError("Logic error in GetFromDefinition detection");
 }
 
+CCPACSGuideCurve::FromOrToDefinition CCPACSGuideCurve::GetToDefinition() const {
+    if (!ValidateChoices())
+        throw CTiglError("Choices not valid", TIGL_XML_ERROR);
+    if (m_toRelativeCircumference_choice1)
+        return FromOrToDefinition::CIRCUMFERENCE;
+    if (m_toParameter_choice2)
+        return FromOrToDefinition::PARAMETER;
+    throw CTiglError("Logic error in GetToDefinition detection");
+}
 
-double CCPACSGuideCurve::GetFromRelativeCircumference() const
+double CCPACSGuideCurve::GetFromDefinitionValue() const
 {
     if ( GetFromGuideCurveUID_choice1() ) {
         CCPACSGuideCurve& pred = m_uidMgr->ResolveObject<CCPACSGuideCurve>(*GetFromGuideCurveUID_choice1());
-        return pred.GetToRelativeCircumference();
+        return pred.GetToDefinitionValue();
     }
-    else if (GetFromRelativeCircumference_choice2()) {
-        return *GetFromRelativeCircumference_choice2();
+    else if (GetFromRelativeCircumference_choice2_1()) {
+        return *GetFromRelativeCircumference_choice2_1();
+    }
+    else if (GetFromParameter_choice2_2()) {
+        return *GetFromParameter_choice2_2();
     }
     else {
-        throw CTiglError("CCPACSGuideCurve::GetFromRelativeCircumference(): Either a fromCircumference of a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
+        throw CTiglError("CCPACSGuideCurve::GetFromDefinitionValue(): Either a fromCircumference, a fromParameter or a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
+    }
+}
+
+double CCPACSGuideCurve::GetToDefinitionValue() const
+{
+    if (GetToRelativeCircumference_choice1()) {
+        return *GetToRelativeCircumference_choice1();
+    }
+    else if (GetToParameter_choice2()) {
+        return *GetToParameter_choice2();
+    }
+    else {
+        throw CTiglError("CCPACSGuideCurve::GetToDefinitionValue(): Either a toCircumference or a toParameter must be present", TIGL_NOT_FOUND);
     }
 }
 
@@ -115,8 +143,8 @@ CCPACSGuideCurve const* CCPACSGuideCurve::GetRootCurve() const
         return pred.GetRootCurve();
     }
     else {
-        if( !GetFromRelativeCircumference_choice2() ) {
-            throw CTiglError("CCPACSGuideCurve::GetRootCurve(): Either a fromCircumference of a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
+        if( ! (GetFromRelativeCircumference_choice2_1() || GetFromParameter_choice2_2()) ) {
+            throw CTiglError("CCPACSGuideCurve::GetRootCurve(): Either a fromCircumference, a fromParameter or a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
         } else {
             return this;
         }

--- a/src/guide_curves/CCPACSGuideCurve.cpp
+++ b/src/guide_curves/CCPACSGuideCurve.cpp
@@ -53,24 +53,31 @@ void CCPACSGuideCurve::InvalidateImpl(const boost::optional<std::string>& source
 }
 
 CCPACSGuideCurve::FromOrToDefinition CCPACSGuideCurve::GetFromDefinition() const {
-    if (!ValidateChoices())
+    if (!ValidateChoices()) {
         throw CTiglError("Choices not valid", TIGL_XML_ERROR);
-    if (m_fromRelativeCircumference_choice2_1)
+    }
+    if (m_fromRelativeCircumference_choice2_1) {
         return FromOrToDefinition::CIRCUMFERENCE;
-    if (m_fromParameter_choice2_2)
+    }
+    if (m_fromParameter_choice2_2) {
         return FromOrToDefinition::PARAMETER;
-    if (m_fromGuideCurveUID_choice1)
+    }
+    if (m_fromGuideCurveUID_choice1) {
         return FromOrToDefinition::UID;
+    }
     throw CTiglError("Logic error in GetFromDefinition detection");
 }
 
 CCPACSGuideCurve::FromOrToDefinition CCPACSGuideCurve::GetToDefinition() const {
-    if (!ValidateChoices())
+    if (!ValidateChoices()) {
         throw CTiglError("Choices not valid", TIGL_XML_ERROR);
-    if (m_toRelativeCircumference_choice1)
+    }
+    if (m_toRelativeCircumference_choice1) {
         return FromOrToDefinition::CIRCUMFERENCE;
-    if (m_toParameter_choice2)
+    }
+    if (m_toParameter_choice2) {
         return FromOrToDefinition::PARAMETER;
+    }
     throw CTiglError("Logic error in GetToDefinition detection");
 }
 

--- a/src/guide_curves/CCPACSGuideCurve.cpp
+++ b/src/guide_curves/CCPACSGuideCurve.cpp
@@ -87,7 +87,7 @@ double CCPACSGuideCurve::GetFromDefinitionValue() const
         return *GetFromParameter_choice2_2();
     }
     else {
-        throw CTiglError("CCPACSGuideCurve::GetFromDefinitionValue(): Either a fromCircumference, a fromParameter or a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
+        throw CTiglError("CCPACSGuideCurve::GetFromDefinitionValue(): Either a fromRelativeCircumference, a fromParameter or a fromGuideCurveUID must be present", TIGL_NOT_FOUND);
     }
 }
 
@@ -100,7 +100,7 @@ double CCPACSGuideCurve::GetToDefinitionValue() const
         return *GetToParameter_choice2();
     }
     else {
-        throw CTiglError("CCPACSGuideCurve::GetToDefinitionValue(): Either a toCircumference or a toParameter must be present", TIGL_NOT_FOUND);
+        throw CTiglError("CCPACSGuideCurve::GetToDefinitionValue(): Either a toRelativeCircumference or a toParameter must be present", TIGL_NOT_FOUND);
     }
 }
 

--- a/src/guide_curves/CCPACSGuideCurve.h
+++ b/src/guide_curves/CCPACSGuideCurve.h
@@ -47,10 +47,11 @@ class IGuideCurveBuilder;
 class CCPACSGuideCurve : public generated::CPACSGuideCurve
 {
 public:
-    enum FromDefinition
+    enum FromOrToDefinition
     {
         UID,
-        CIRCUMFERENCE
+        CIRCUMFERENCE,
+        PARAMETER
     };
 
 private:
@@ -64,11 +65,16 @@ public:
     // Virtual Destructor
     TIGL_EXPORT ~CCPACSGuideCurve(void) override;
 
-    TIGL_EXPORT FromDefinition GetFromDefinition() const;
+    TIGL_EXPORT FromOrToDefinition GetFromDefinition() const;
+    TIGL_EXPORT FromOrToDefinition GetToDefinition() const;
 
-    // Returns the relalive circumference
-    // If fromUID is set, the relativeCircumference is returned from the specified curve instead
-    TIGL_EXPORT double GetFromRelativeCircumference() const;
+    // Returns the value which defines the position of the starting point of a guide curve
+    // Depending on used CPACS node it is either based on the relative circumference, the parameter or the guide curve uid
+    TIGL_EXPORT double GetFromDefinitionValue() const;
+
+    // Returns the value which defines the position of the end point of a guide curve
+    // Depending on used CPACS node it is either based on the relative circumference or the parameter
+    TIGL_EXPORT double GetToDefinitionValue() const;
 
     TIGL_EXPORT std::vector<gp_Pnt> GetCurvePoints() const;
     TIGL_EXPORT TopoDS_Edge GetCurve() const;

--- a/src/guide_curves/CCPACSGuideCurveAlgo.h
+++ b/src/guide_curves/CCPACSGuideCurveAlgo.h
@@ -56,6 +56,8 @@ public:
      * \param scale2 Scaling factor from 2nd profile (outer profile chord line in the case of wing profiles)
      * \param x_direction is the vector, along which the first components of the guide curve points are defined
      * \param gcp Guide curve profile coordinates
+     * \param fromDefinition Choose the interpretation of alpha1 for the guide curve's starting point on profileContainer1 (circumference or parameter)
+     * \param toDefinition Choose the interpretation of alpha2 for the guide curve's end point on profileContainer2 (circumference or parameter)
      *
      * @return Guide curve wire in world coordinates
      */
@@ -136,8 +138,8 @@ private:
     Standard_Real           _scale2;               /**< 2nd scale factor */
     gp_Dir                  _x_direction;          /**< x-direction of the guide curve points */
     CCPACSGuideCurveProfile const& _guideCurveProfile;   /**< Guide curve profile */
-    CCPACSGuideCurve::FromOrToDefinition      _fromDefinition;
-    CCPACSGuideCurve::FromOrToDefinition      _toDefinition;
+    CCPACSGuideCurve::FromOrToDefinition      _fromDefinition;  /**< Define on which basis the starting point is calculated*/
+    CCPACSGuideCurve::FromOrToDefinition      _toDefinition;    /**< Define on which basis the end point is calculated*/
 };
 
 } // end namespace tigl

--- a/src/guide_curves/CCPACSGuideCurveAlgo.h
+++ b/src/guide_curves/CCPACSGuideCurveAlgo.h
@@ -29,6 +29,7 @@
 #include "tigl_internal.h"
 #include "CCPACSGuideCurveProfile.h"
 #include "CTiglLogging.h"
+#include "CCPACSGuideCurve.h"
 
 namespace tigl
 {
@@ -65,7 +66,9 @@ public:
                                      const Standard_Real& scale1,
                                      const Standard_Real& scale2,
                                      const gp_Dir& x_direction,
-                                     const CCPACSGuideCurveProfile& gcp) :
+                                     const CCPACSGuideCurveProfile& gcp,
+                                     const CCPACSGuideCurve::FromOrToDefinition& fromDefinition=CCPACSGuideCurve::FromOrToDefinition::CIRCUMFERENCE,
+                                     const CCPACSGuideCurve::FromOrToDefinition& toDefinition=CCPACSGuideCurve::FromOrToDefinition::CIRCUMFERENCE) :
         _getPointAlgo1(profileContainer1),
         _getPointAlgo2(profileContainer2),
         _alpha1(alpha1),
@@ -73,7 +76,9 @@ public:
         _scale1(scale1),
         _scale2(scale2),
         _x_direction(x_direction),
-        _guideCurveProfile(gcp)
+        _guideCurveProfile(gcp),
+        _fromDefinition(fromDefinition),
+        _toDefinition(toDefinition)
     {
     }
 
@@ -85,8 +90,11 @@ public:
         std::vector<gp_Pnt> guideCurvePoints(guideCurveProfilePoints.size()+2);
         // get anchor points in world coordinates
         gp_Vec tangent;
-        _getPointAlgo1.GetPointTangent(_alpha1, guideCurvePoints[0], tangent);
-        _getPointAlgo2.GetPointTangent(_alpha2, guideCurvePoints[guideCurvePoints.size()-1], tangent);
+        _getPointAlgo1.GetPointTangent(_alpha1, guideCurvePoints[0], tangent, _fromDefinition);
+        if (_toDefinition == CCPACSGuideCurve::FromOrToDefinition::UID) {
+            throw CTiglError("CCPACSGuideCurveAlgo(): toDefinition argument must not be set to UID", TIGL_NOT_FOUND);
+        }
+        _getPointAlgo2.GetPointTangent(_alpha2, guideCurvePoints[guideCurvePoints.size()-1], tangent, _toDefinition);
 
         gp_Vec vec_start(gp_Pnt(),guideCurvePoints[0]);
         gp_Vec vec_end(gp_Pnt(),guideCurvePoints[guideCurvePoints.size()-1]);
@@ -128,6 +136,8 @@ private:
     Standard_Real           _scale2;               /**< 2nd scale factor */
     gp_Dir                  _x_direction;          /**< x-direction of the guide curve points */
     CCPACSGuideCurveProfile const& _guideCurveProfile;   /**< Guide curve profile */
+    CCPACSGuideCurve::FromOrToDefinition      _fromDefinition;
+    CCPACSGuideCurve::FromOrToDefinition      _toDefinition;
 };
 
 } // end namespace tigl

--- a/src/guide_curves/CCPACSGuideCurves.cpp
+++ b/src/guide_curves/CCPACSGuideCurves.cpp
@@ -106,7 +106,12 @@ std::vector<double> CCPACSGuideCurves::GetRelativeCircumferenceParameters() cons
 
     for (int iguide = 1; iguide <=  GetGuideCurveCount(); ++iguide) {
         const CCPACSGuideCurve* root = GetGuideCurve(iguide).GetRootCurve();
-        relCircs.push_back(*root->GetFromRelativeCircumference_choice2());
+        if(root->GetFromRelativeCircumference_choice2_1()) {
+            relCircs.push_back(*root->GetFromRelativeCircumference_choice2_1());
+        }
+        else if(root->GetFromParameter_choice2_2()) {
+            relCircs.push_back(*root->GetFromParameter_choice2_2());
+        }
     }
 
     std::sort(relCircs.begin(), relCircs.end());

--- a/src/logging/CTiglLogging.cpp
+++ b/src/logging/CTiglLogging.cpp
@@ -163,6 +163,11 @@ void CTiglLogging::SetConsoleVerbosity(TiglLogLevel vlevel)
     }
 }
 
+TiglLogLevel CTiglLogging::GetConsoleVerbosity()
+{
+    return _consoleVerbosity;
+}
+
 void CTiglLogging::LogToConsole() 
 {
 #ifdef GLOG_FOUND

--- a/src/logging/CTiglLogging.cpp
+++ b/src/logging/CTiglLogging.cpp
@@ -163,7 +163,7 @@ void CTiglLogging::SetConsoleVerbosity(TiglLogLevel vlevel)
     }
 }
 
-TiglLogLevel CTiglLogging::GetConsoleVerbosity()
+TiglLogLevel CTiglLogging::GetConsoleVerbosity() const
 {
     return _consoleVerbosity;
 }

--- a/src/logging/CTiglLogging.h
+++ b/src/logging/CTiglLogging.h
@@ -113,6 +113,7 @@ public:
     TIGL_EXPORT void SetTimeIdInFilenameEnabled(bool enabled);
     TIGL_EXPORT void LogToConsole();
     TIGL_EXPORT void SetConsoleVerbosity(TiglLogLevel vlevel);
+    TIGL_EXPORT TiglLogLevel GetConsoleVerbosity();
     
     // allows installing a custom log sink/receiver
     // The logger becomes property of this class

--- a/src/logging/CTiglLogging.h
+++ b/src/logging/CTiglLogging.h
@@ -113,7 +113,7 @@ public:
     TIGL_EXPORT void SetTimeIdInFilenameEnabled(bool enabled);
     TIGL_EXPORT void LogToConsole();
     TIGL_EXPORT void SetConsoleVerbosity(TiglLogLevel vlevel);
-    TIGL_EXPORT TiglLogLevel GetConsoleVerbosity();
+    TIGL_EXPORT TiglLogLevel GetConsoleVerbosity() const;
     
     // allows installing a custom log sink/receiver
     // The logger becomes property of this class

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -965,7 +965,13 @@ void CCPACSWing::BuildGuideCurveWires(LocatedGuideCurves& cache) const
             const CCPACSGuideCurve& curve = segmentCurves.GetGuideCurve(iguide);
             if (!curve.GetFromGuideCurveUID_choice1()) {
                 // this is a root curve
-                double fromRef = *curve.GetFromRelativeCircumference_choice2();
+                double fromRef;
+                if (curve.GetFromRelativeCircumference_choice2_1()) {
+                    fromRef = *curve.GetFromRelativeCircumference_choice2_1();
+                }
+                else if (curve.GetFromParameter_choice2_2()) {
+                    fromRef = *curve.GetFromParameter_choice2_2();
+                }
                 if (fromRef >= 1. && !hasBluntTE) {
                     fromRef = -1.;
                 }

--- a/src/wing/CCPACSWingProfileGetPointAlgo.cpp
+++ b/src/wing/CCPACSWingProfileGetPointAlgo.cpp
@@ -36,6 +36,7 @@
 #include "TopoDS.hxx"
 #include "Geom_Line.hxx"
 #include "tiglcommonfunctions.h"
+#include "CCPACSGuideCurve.h"
 
 namespace tigl
 {
@@ -57,7 +58,8 @@ CCPACSWingProfileGetPointAlgo::CCPACSWingProfileGetPointAlgo (const TopTools_Seq
     upperWireLength = GetLength(upperWire);
 }
 
-void CCPACSWingProfileGetPointAlgo::GetPointTangent(const double& alpha, gp_Pnt& point, gp_Vec& tangent)
+void CCPACSWingProfileGetPointAlgo::GetPointTangent(const double& alpha, gp_Pnt& point,
+                                                    gp_Vec& tangent, const CCPACSGuideCurve::FromOrToDefinition& fromOrToDefinition)
 {
     // alpha<-1.0 : use line in the direction of the tangent at alpha=-1.0
     if (alpha<-1.0) {

--- a/src/wing/CCPACSWingProfileGetPointAlgo.h
+++ b/src/wing/CCPACSWingProfileGetPointAlgo.h
@@ -32,6 +32,7 @@
 #include "TopTools_SequenceOfShape.hxx"
 #include "gp_Pnt.hxx"
 #include "gp_Vec.hxx"
+#include "CCPACSGuideCurve.h"
 
 #ifndef CCPACSWINGPROFILEGETPOINTALGO_H
 #define CCPACSWINGPROFILEGETPOINTALGO_H
@@ -60,7 +61,8 @@ public:
      * \param point Point on the profile corresponding to the parameter alpha
      * \param tangent Tangent on the profile corresponding to the parameter alpha
      */
-    TIGL_EXPORT void GetPointTangent(const double& alpha, gp_Pnt& point, gp_Vec& tangent);
+    TIGL_EXPORT void GetPointTangent(const double& alpha, gp_Pnt& point,
+                                     gp_Vec& tangent, const CCPACSGuideCurve::FromOrToDefinition& fromOrToDefinition=CCPACSGuideCurve::FromOrToDefinition::CIRCUMFERENCE);
 
 private:
     TopoDS_Edge upperWire;         /**< Upper wire of wing profile */

--- a/src/wing/CCPACSWingProfileGetPointAlgo.h
+++ b/src/wing/CCPACSWingProfileGetPointAlgo.h
@@ -60,6 +60,7 @@ public:
      *
      * \param point Point on the profile corresponding to the parameter alpha
      * \param tangent Tangent on the profile corresponding to the parameter alpha
+     * \param fromOrToDefinition Define the basis on which the point on the curve should be found (circumference or parameter)
      */
     TIGL_EXPORT void GetPointTangent(const double& alpha, gp_Pnt& point,
                                      gp_Vec& tangent, const CCPACSGuideCurve::FromOrToDefinition& fromOrToDefinition=CCPACSGuideCurve::FromOrToDefinition::CIRCUMFERENCE);

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -380,11 +380,11 @@ PNamedShape CCPACSWingSegment::BuildLoft() const
             const CCPACSGuideCurves& curves = *m_guideCurves;
             bool hasTrailingEdge = !innerConnection.GetProfile().GetTrailingEdge().IsNull();
 
-            // order guide curves according to fromRelativeCircumeference
+            // order guide curves according to fromRelativeCircumeference or fromParameter (GetFromDefinitionValue())
             std::multimap<double, const CCPACSGuideCurve*> guideMap;
             for (int iguide = 1; iguide <= curves.GetGuideCurveCount(); ++iguide) {
                 const CCPACSGuideCurve* curve = &curves.GetGuideCurve(iguide);
-                double value = curve->GetFromRelativeCircumference();
+                double value = curve->GetFromDefinitionValue();
                 if (value >= 1. && !hasTrailingEdge) {
                     // this is a trailing edge profile, we should add it first
                     value = -1.;

--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -80,13 +80,21 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
 
 
     // get relative circumference of inner profile
-    double fromRelativeCircumference = guideCurve->GetFromRelativeCircumference();
+    double fromRelativeCircumference = guideCurve->GetFromDefinitionValue();
 
     // get relative circumference of outer profile
-    double toRelativeCircumference = guideCurve->GetToRelativeCircumference();
+    double toRelativeCircumference = guideCurve->GetToDefinitionValue();
     // get guide curve profile UID
     std::string guideCurveProfileUID = guideCurve->GetGuideCurveProfileUID();
     // get relative circumference of inner profile
+
+    // decide whether the guide curve's starting point is defined based on circumference or parameter
+    CCPACSGuideCurve::FromOrToDefinition fromDefinition = guideCurve->GetFromDefinition();
+    // decide whether the guide curve's end point is defined based on circumference or parameter
+    CCPACSGuideCurve::FromOrToDefinition toDefinition = guideCurve->GetToDefinition();
+    if (toDefinition == CCPACSGuideCurve::FromOrToDefinition::UID) {
+        throw CTiglError("CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(): toDefinition must not be UID", TIGL_NOT_FOUND);
+    }
 
     // get guide curve profile
     CCPACSGuideCurveProfile& guideCurveProfile = m_segment.GetUIDManager().ResolveObject<CCPACSGuideCurveProfile>(guideCurveProfileUID);
@@ -114,7 +122,9 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
                                                                                               innerScale,
                                                                                               outerScale,
                                                                                               rxDir,
-                                                                                              guideCurveProfile);
+                                                                                              guideCurveProfile,
+                                                                                              fromDefinition,
+                                                                                              toDefinition);
     return guideCurvePnts;
 }
 

--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -93,9 +93,11 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     // decide whether the guide curve's end point is defined based on circumference or parameter
     CCPACSGuideCurve::FromOrToDefinition toDefinition = guideCurve->GetToDefinition();
     if (toDefinition == CCPACSGuideCurve::FromOrToDefinition::UID) {
-        throw CTiglError("CTiglFuselageSegmentGuidecurveBuilder::BuildGuideCurvePnts(): toDefinition must not be UID", TIGL_NOT_FOUND);
+        throw CTiglError("CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(): toDefinition must not be UID", TIGL_NOT_FOUND);
     }
-
+    if (fromDefinition == CCPACSGuideCurve::FromOrToDefinition::PARAMETER || toDefinition == CCPACSGuideCurve::FromOrToDefinition::PARAMETER) {
+        throw CTiglError("CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(): Wing guide curves defined by parameter are not supported. Define them with the relative circumference.", TIGL_NOT_FOUND);
+    }
     // get guide curve profile
     CCPACSGuideCurveProfile& guideCurveProfile = m_segment.GetUIDManager().ResolveObject<CCPACSGuideCurveProfile>(guideCurveProfileUID);
 

--- a/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
+++ b/src/wing/CTiglWingSegmentGuidecurveBuilder.cpp
@@ -79,11 +79,11 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     double outerScale = GetLength(outerChordLineWire);
 
 
-    // get relative circumference of inner profile
-    double fromRelativeCircumference = guideCurve->GetFromDefinitionValue();
+    // get relative circumference or parameter value of inner profile (depending on chosen CPACS node)
+    double fromDefinitionValue = guideCurve->GetFromDefinitionValue();
+    // get relative circumference or parameter value of outer profile (depending on chosen CPACS node)
+    double toDefinitionValue = guideCurve->GetToDefinitionValue();
 
-    // get relative circumference of outer profile
-    double toRelativeCircumference = guideCurve->GetToDefinitionValue();
     // get guide curve profile UID
     std::string guideCurveProfileUID = guideCurve->GetGuideCurveProfileUID();
     // get relative circumference of inner profile
@@ -117,8 +117,8 @@ std::vector<gp_Pnt> CTiglWingSegmentGuidecurveBuilder::BuildGuideCurvePnts(const
     // construct guide curve algorithm
     std::vector<gp_Pnt> guideCurvePnts = CCPACSGuideCurveAlgo<CCPACSWingProfileGetPointAlgo> (concatenatedInnerWires,
                                                                                               concatenatedOuterWires,
-                                                                                              fromRelativeCircumference,
-                                                                                              toRelativeCircumference,
+                                                                                              fromDefinitionValue,
+                                                                                              toDefinitionValue,
                                                                                               innerScale,
                                                                                               outerScale,
                                                                                               rxDir,

--- a/tests/common/testUtils.h
+++ b/tests/common/testUtils.h
@@ -41,7 +41,7 @@ Handle(Geom_BSplineCurve) LoadBSplineCurve(const std::string& filename);
 class CaptureTiGLLog
 {
 public:
-    CaptureTiGLLog();
+    CaptureTiGLLog(TiglLogLevel logLevel);
 
     std::string log();
 

--- a/tests/common/testUtils.h
+++ b/tests/common/testUtils.h
@@ -27,6 +27,7 @@
 
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
+#include <tigl.h>
 // class TColgp_Array1OfPnt;
 
 // save x-y data
@@ -36,6 +37,19 @@ void StoreResult(const std::string& filename, const Handle(Geom_BSplineCurve)& c
 
 Handle(Geom_BSplineSurface) LoadBSplineSurface(const std::string& filename);
 Handle(Geom_BSplineCurve) LoadBSplineCurve(const std::string& filename);
+
+class CaptureTiGLLog
+{
+public:
+    CaptureTiGLLog();
+
+    std::string log();
+
+    ~CaptureTiGLLog();
+
+private:
+     TiglLogLevel _oldVerbosityLevel;
+};
 
 #endif // TESTUTILS_H
 

--- a/tests/unittests/TestData/kinks_withGC_ParameterDef.xml
+++ b/tests/unittests/TestData/kinks_withGC_ParameterDef.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.airbusds.com/cpacs/3.1">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Simple Wing for unit testing</description>
+    <creator>Martin Siggel</creator>
+    <timestamp>2012-10-09T15:12:47</timestamp>
+    <version>1.0</version>
+    <cpacsVersion>3.1</cpacsVersion>
+    <!--<updates>
+      <update>
+        <modification>Converted to cpacs 3.0 using cpacs2to3 - does not include structure update</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2018-01-15T09:22:57</timestamp>
+        <version>0.2</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Added missing UIDs.</modification>
+        <creator>fix_errors.py</creator>
+        <timestamp>2019-04-29T20:48:26</timestamp>
+        <version>0.3.0</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+    </updates>-->
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="Cpacs2Test">
+        <name>Cpacs2Test</name>
+        <reference>
+          <area>1</area>
+          <length>1</length>
+          <point uID="Cpacs2Test_point1">
+            <x>0</x>
+            <y>0</y>
+            <z>0</z>
+          </point>
+        </reference>
+        <fuselages>
+          <fuselage uID="SimpleFuselage">
+            <name>name</name>
+            <description>description</description>
+            <transformation uID="SimpleFuselage_transformation1">
+              <scaling uID="SimpleFuselage_transformation1_scaling1">
+                <x>1</x>
+                <y>0.5</y>
+                <z>0.5</z>
+              </scaling>
+              <rotation uID="SimpleFuselage_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absLocal" uID="SimpleFuselage_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="D150_Fuselage_1Section1ID">
+                <name>D150_Fuselage_1Section1</name>
+                <transformation uID="D150_Fuselage_1Section1ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section1ID_transformation1_scaling1">
+                    <x>1</x>
+                    <y>0.7</y>
+                    <z>0.5</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section1ID_transformation1_rotation1">
+                    <x>-0</x>
+                    <y>0</y>
+                    <z>-0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section1ID_transformation1_translation1">
+                    <x>-0.5</x>
+                    <y>1.91428e-16</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section1IDElement1">
+                    <name>D150_Fuselage_1Section1</name>
+                    <profileUID>fuselageKinkProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section1IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section1IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section1IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section1IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="D150_Fuselage_1Section2ID">
+                <name>D150_Fuselage_1Section2</name>
+                <transformation uID="D150_Fuselage_1Section2ID_transformation1">
+                  <scaling uID="D150_Fuselage_1Section2ID_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="D150_Fuselage_1Section2ID_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="D150_Fuselage_1Section2ID_transformation1_translation1">
+                    <x>0.5</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="D150_Fuselage_1Section2IDElement1">
+                    <name>D150_Fuselage_1Section2</name>
+                    <profileUID>fuselageCircleProfileuID</profileUID>
+                    <transformation uID="D150_Fuselage_1Section2IDElement1_transformation1">
+                      <scaling uID="D150_Fuselage_1Section2IDElement1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="D150_Fuselage_1Section2IDElement1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="D150_Fuselage_1Section2IDElement1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <segments>
+              <segment uID="segmentD150_Fuselage_1Segment2ID">
+                <name>D150_Fuselage_1Segment2</name>
+                <fromElementUID>D150_Fuselage_1Section1IDElement1</fromElementUID>
+                <toElementUID>D150_Fuselage_1Section2IDElement1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="Seg1_bottom">
+                    <name>Segment1_bottomCurve</name>
+                    <description>Segment1_bottomCurve</description>
+                    <guideCurveProfileUID>bottomFuselageCurve</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.</fromRelativeCircumference>
+                    <toRelativeCircumference>0.</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="Seg1_left">
+                    <name>Segment1_leftCurve</name>
+                    <description>Segment1_leftCurve</description>
+                    <guideCurveProfileUID>leftFuselageCurve</guideCurveProfileUID>
+					<fromParameter>0.28</fromParameter>
+					<toParameter>0.28</toParameter>
+                  </guideCurve>
+			    </guideCurves>
+              </segment>
+            </segments>
+          </fuselage>
+        </fuselages>
+      </model>
+    </aircraft>
+    <profiles>
+      <fuselageProfiles>
+        <fuselageProfile uID="fuselageCircleProfileuID">
+          <name>Circle</name>
+          <description>Profile build up from set of Points on Circle where may Dimensions are 1..-1</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0</x>
+            <y mapType="vector">0;1;0;-1;0</y>
+            <z mapType="vector">1;0;-1;0;1</z>
+			<kinkIndices mapType="vector">1;3</kinkIndices>
+			<parameterMap>
+              <pointIndices mapType="vector">1;3</pointIndices>
+              <paramOnCurve mapType="vector">0.3;0.8</paramOnCurve>
+            </parameterMap>
+          </pointList>
+        </fuselageProfile>
+        <fuselageProfile uID="fuselageKinkProfileuID">
+          <name>Kinks</name>
+          <description>Profile build up from set of Points on Circle where may Dimensions are 1..-1</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0</x>
+            <y mapType="vector">0;1;0;-1;0</y>
+            <z mapType="vector">1;0;-1;0;1</z>
+            <kinkIndices mapType="vector">1;3</kinkIndices>
+            <parameterMap>
+              <pointIndices mapType="vector">1;3</pointIndices>
+              <paramOnCurve mapType="vector">0.3;0.8</paramOnCurve>
+            </parameterMap>
+          </pointList>
+        </fuselageProfile>
+      </fuselageProfiles>
+      <guideCurves>
+        <guideCurveProfile uID="bottomFuselageCurve">
+          <name>bottom guide curve</name>
+          <pointList>
+            <rX mapType="vector">0;0;0;0;0;0;0;0;0</rX>
+            <rY mapType="vector">0.1;0.2;0.3;0.4;0.5;0.6;0.7;0.8;0.9</rY>
+            <rZ mapType="vector">0;0;0;0;0;0;0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="leftFuselageCurve">
+          <name>left guide curve</name>
+          <pointList>
+            <rX mapType="vector">0;0;0;0;0;0;0;0;0</rX>
+            <rY mapType="vector">0.1;0.2;0.3;0.4;0.5;0.6;0.7;0.8;0.9</rY>
+            <rZ mapType="vector">0;0.01;0.05;0.1;0.2;0.1;0.05;0.01;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+      </guideCurves>
+    </profiles>
+  </vehicles>
+</cpacs>

--- a/tests/unittests/TestData/simple_test_guide_curves_wrong_gc_Def.xml
+++ b/tests/unittests/TestData/simple_test_guide_curves_wrong_gc_Def.xml
@@ -1,0 +1,752 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<cpacs xmlns:NS0="http://www.w3.org/2001/XMLSchema-instance" NS0:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
+  <header>
+    <name>GuideCurveModel Test</name>
+    <description>Simple Test Model for Guide Curve Unit Testing</description>
+    <creator>Tobias Stollenwerk</creator>
+    <timestamp>2014-02-10T14:28:00</timestamp>
+    <version>1.5.0</version>
+    <cpacsVersion>3.2</cpacsVersion>
+    <updates>
+      <update>
+        <modification>Converted to cpacs 3.0 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2018-06-13T18:42:16</timestamp>
+        <version>1.2</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Fixed order of wing profiles.</modification>
+        <creator>fix_errors.py</creator>
+        <timestamp>2019-04-29T20:48:27</timestamp>
+        <version>1.3.0</version>
+        <cpacsVersion>3.0</cpacsVersion>
+      </update>
+      <update>
+        <modification>Converted to CPACS 3.1 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2020-04-26T02:01:34</timestamp>
+        <version>1.4.0</version>
+        <cpacsVersion>3.1</cpacsVersion>
+      </update>
+      <update>
+        <modification>Converted to CPACS 3.2 using cpacs2to3</modification>
+        <creator>cpacs2to3</creator>
+        <timestamp>2021-04-23T18:02:01</timestamp>
+        <version>1.5.0</version>
+        <cpacsVersion>3.2</cpacsVersion>
+      </update>
+    </updates>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="GuideCurveModel">
+        <name>GuideCurveModel</name>
+        <fuselages>
+          <fuselage uID="Fuselage" symmetry="x-z-plane">
+            <name>Fuselage</name>
+            <description>This fuselage has been generated using CATIA2CPACS.</description>
+            <transformation uID="Fuselage_transformation1">
+              <scaling uID="Fuselage_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Fuselage_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Fuselage_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="GuideCurveModel_Fuselage_Sec1">
+                <name>GuideCurveModel - Fuselage Section 1</name>
+                <description>GuideCurveModel - Fuselage Section 1</description>
+                <transformation uID="GuideCurveModel_Fuselage_Sec1_transformation1">
+                  <scaling uID="GuideCurveModel_Fuselage_Sec1_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Fuselage_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Fuselage_Sec1_El1">
+                    <name>GuideCurveModel - Fuselage Section 1 Main Element</name>
+                    <description>GuideCurveModel - Fuselage Section 1 Main Element</description>
+                    <profileUID>GuideCurveModel_Fuselage_Sec1_El1_Pro</profileUID>
+                    <transformation uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0.0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Fuselage_Sec2">
+                <name>GuideCurveModel - Fuselage Section 6</name>
+                <description>GuideCurveModel - Fuselage Section 6</description>
+                <transformation uID="GuideCurveModel_Fuselage_Sec2_transformation1">
+                  <scaling uID="GuideCurveModel_Fuselage_Sec2_transformation1_scaling1">
+                    <x>2</x>
+                    <y>2</y>
+                    <z>2</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Fuselage_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Fuselage_Sec2_El1">
+                    <name>GuideCurveModel - Fuselage Section 6 Main Element</name>
+                    <description>GuideCurveModel - Fuselage Section 6 Main Element</description>
+                    <profileUID>GuideCurveModel_Fuselage_Sec2_El1_Pro</profileUID>
+                    <transformation uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Fuselage_Sec3">
+                <name>GuideCurveModel - Fuselage Section 9</name>
+                <description>GuideCurveModel - Fuselage Section 9</description>
+                <transformation uID="GuideCurveModel_Fuselage_Sec3_transformation1">
+                  <scaling uID="GuideCurveModel_Fuselage_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Fuselage_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Fuselage_Sec3_El1">
+                    <name>GuideCurveModel - Fuselage Section 9 Main Element</name>
+                    <description>GuideCurveModel - Fuselage Section 9 Main Element</description>
+                    <profileUID>GuideCurveModel_Fuselage_Sec3_El1_Pro</profileUID>
+                    <transformation uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Fuselage_Sec3_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="LamAiR_Jig_Shape_Fuselage_Sec1_Positioning">
+                <name>GuideCurveModel - Fuselage Section 1 Positioning</name>
+                <description>GuideCurveModel - Fuselage Section 1 Positioning</description>
+                <length>-10</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>GuideCurveModel_Fuselage_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Fuselage_Sec2_Positioning">
+                <name>GuideCurveModel - Fuselage Section 6 Positioning</name>
+                <description>GuideCurveModel - Fuselage Section 6 Positioning</description>
+                <length>10</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Fuselage_Sec1</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Fuselage_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Fuselage_Sec3_Positioning">
+                <name>GuideCurveModel - Fuselage Section 9 Positioning</name>
+                <description>GuideCurveModel - Fuselage Section 9 Positioning</description>
+                <length>10</length>
+                <sweepAngle>90</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Fuselage_Sec2</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Fuselage_Sec3</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="GuideCurveModel_Fuselage_Seg_1_6">
+                <name>Segment from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element</name>
+                <description>Segment from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element</description>
+                <fromElementUID>GuideCurveModel_Fuselage_Sec1_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Fuselage_Sec2_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Lower">
+                    <name>Lower GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </name>
+                    <description>Lower GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Lower_Linear</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Middle">
+                    <name>Middle GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </name>
+                    <description>Middle GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.5</fromRelativeCircumference>
+                    <toRelativeCircumference>0.5</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Upper">
+                    <name>Upper GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </name>
+                    <description>Upper GuideCurve from GuideCurveModel - Fuselage Section 1 Main Element to GuideCurveModel - Fuselage Section 6 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Upper_Linear</guideCurveProfileUID>
+                    <fromRelativeCircumference>1.0</fromRelativeCircumference>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="GuideCurveModel_Fuselage_Seg_6_9">
+                <name>Segment from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element</name>
+                <description>Segment from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element</description>
+                <fromElementUID>GuideCurveModel_Fuselage_Sec2_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Fuselage_Sec3_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_6_9_GuideCurve_Lower">
+                    <name>Lower GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </name>
+                    <description>Lower GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Lower_Linear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Lower</fromGuideCurveUID>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_6_9_GuideCurve_Middle">
+                    <name>Middle GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </name>
+                    <description>Middle GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Middle</fromGuideCurveUID>
+                    <toRelativeCircumference>0.5</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Fuselage_Seg_6_9_GuideCurve_Upper">
+                    <name>Upper GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </name>
+                    <description>Upper GuideCurve from GuideCurveModel - Fuselage Section 6 Main Element to GuideCurveModel - Fuselage Section 9 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Fuselage_GuideCurveProfile_Upper_Linear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Fuselage_Seg_1_6_GuideCurve_Upper</fromGuideCurveUID>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+            </segments>
+          </fuselage>
+        </fuselages>
+        <wings>
+          <wing uID="Wing" symmetry="x-z-plane">
+            <name>Wing</name>
+            <description>This wing has been generated using CATIA2CPACS.</description>
+            <parentUID>Fuselage</parentUID>
+            <transformation uID="Wing_transformation1">
+              <scaling uID="Wing_transformation1_scaling1">
+                <x>1</x>
+                <y>1</y>
+                <z>1</z>
+              </scaling>
+              <rotation uID="Wing_transformation1_rotation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </rotation>
+              <translation refType="absGlobal" uID="Wing_transformation1_translation1">
+                <x>0</x>
+                <y>0</y>
+                <z>0</z>
+              </translation>
+            </transformation>
+            <sections>
+              <section uID="GuideCurveModel_Wing_Sec1">
+                <name>GuideCurveModel - Wing Section 1</name>
+                <description>GuideCurveModel - Wing Section 1</description>
+                <transformation uID="GuideCurveModel_Wing_Sec1_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec1_transformation1_scaling1">
+                    <x>2</x>
+                    <y>2</y>
+                    <z>2</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec1_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec1_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec1_El1">
+                    <name>GuideCurveModel - Wing Section 1 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 1 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec1_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec1_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec1_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec1_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec1_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Wing_Sec2">
+                <name>GuideCurveModel - Wing Section 2</name>
+                <description>GuideCurveModel - Wing Section 2</description>
+                <transformation uID="GuideCurveModel_Wing_Sec2_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec2_transformation1_scaling1">
+                    <x>2</x>
+                    <y>2</y>
+                    <z>2</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec2_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec2_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec2_El1">
+                    <name>GuideCurveModel - Wing Section 2 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 2 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec2_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec2_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec2_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec2_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec2_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Wing_Sec3">
+                <name>GuideCurveModel - Wing Section 3</name>
+                <description>GuideCurveModel - Wing Section 3</description>
+                <transformation uID="GuideCurveModel_Wing_Sec3_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec3_transformation1_scaling1">
+                    <x>1</x>
+                    <y>1</y>
+                    <z>1</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec3_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec3_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec3_El1">
+                    <name>GuideCurveModel - Wing Section 3 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 3 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec3_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec3_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec3_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec3_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec3_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+              <section uID="GuideCurveModel_Wing_Sec4">
+                <name>GuideCurveModel - Wing Section 4</name>
+                <description>GuideCurveModel - Wing Section 4</description>
+                <transformation uID="GuideCurveModel_Wing_Sec4_transformation1">
+                  <scaling uID="GuideCurveModel_Wing_Sec4_transformation1_scaling1">
+                    <x>0.5</x>
+                    <y>0.5</y>
+                    <z>0.5</z>
+                  </scaling>
+                  <rotation uID="GuideCurveModel_Wing_Sec4_transformation1_rotation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </rotation>
+                  <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec4_transformation1_translation1">
+                    <x>0</x>
+                    <y>0</y>
+                    <z>0</z>
+                  </translation>
+                </transformation>
+                <elements>
+                  <element uID="GuideCurveModel_Wing_Sec4_El1">
+                    <name>GuideCurveModel - Wing Section 4 Main Element</name>
+                    <description>GuideCurveModel - Wing Section 4 Main Element</description>
+                    <airfoilUID>GuideCurveModel_Wing_Sec3_El1_Pro</airfoilUID>
+                    <transformation uID="GuideCurveModel_Wing_Sec4_El1_transformation1">
+                      <scaling uID="GuideCurveModel_Wing_Sec4_El1_transformation1_scaling1">
+                        <x>1</x>
+                        <y>1</y>
+                        <z>1</z>
+                      </scaling>
+                      <rotation uID="GuideCurveModel_Wing_Sec4_El1_transformation1_rotation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </rotation>
+                      <translation refType="absLocal" uID="GuideCurveModel_Wing_Sec4_El1_transformation1_translation1">
+                        <x>0</x>
+                        <y>0</y>
+                        <z>0</z>
+                      </translation>
+                    </transformation>
+                  </element>
+                </elements>
+              </section>
+            </sections>
+            <positionings>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec1_Positioning">
+                <name>GuideCurveModel - Wing Section 1 Positioning</name>
+                <description>GuideCurveModel - Wing Section 1 Positioning</description>
+                <length>0</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <toSectionUID>GuideCurveModel_Wing_Sec1</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec2_Positioning">
+                <name>GuideCurveModel - Wing Section 2 Positioning</name>
+                <description>GuideCurveModel - Wing Section 2 Positioning</description>
+                <length>5</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Wing_Sec1</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Wing_Sec2</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec3_Positioning">
+                <name>GuideCurveModel - Wing Section 3 Positioning</name>
+                <description>GuideCurveModel - Wing Section 3 Positioning</description>
+                <length>7</length>
+                <sweepAngle>0</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Wing_Sec2</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Wing_Sec3</toSectionUID>
+              </positioning>
+              <positioning uID="LamAiR_Jig_Shape_Wing_Sec4_Positioning">
+                <name>GuideCurveModel - Wing Section 4 Positioning</name>
+                <description>GuideCurveModel - Wing Section 4 Positioning</description>
+                <length>2</length>
+                <sweepAngle>-30</sweepAngle>
+                <dihedralAngle>0</dihedralAngle>
+                <fromSectionUID>GuideCurveModel_Wing_Sec3</fromSectionUID>
+                <toSectionUID>GuideCurveModel_Wing_Sec4</toSectionUID>
+              </positioning>
+            </positionings>
+            <segments>
+              <segment uID="GuideCurveModel_Wing_Seg_1_2">
+                <name>Segment from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element</name>
+                <description>Segment from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element</description>
+                <fromElementUID>GuideCurveModel_Wing_Sec1_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Wing_Sec2_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower">
+                    <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                    <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear</guideCurveProfileUID>
+                    <fromParameter>-1.0</fromParameter>
+                    <toRelativeCircumference>-1.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_1_2_GuideCurve_LeadingEdge_NonLinear">
+                    <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                    <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper">
+                    <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </name>
+                    <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear</guideCurveProfileUID>
+                    <fromRelativeCircumference>1.0</fromRelativeCircumference>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="GuideCurveModel_Wing_Seg_2_3">
+                <name>Segment from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element</name>
+                <description>Segment from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element</description>
+                <fromElementUID>GuideCurveModel_Wing_Sec2_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Wing_Sec3_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeLower">
+                    <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                    <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
+                    <continuity>C1 from previous</continuity>
+                    <toRelativeCircumference>-1.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_2_3_GuideCurve_LeadingEdge">
+                    <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                    <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_1_2_GuideCurve_LeadingEdge_NonLinear</fromGuideCurveUID>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeUpper">
+                    <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </name>
+                    <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeUpper</fromGuideCurveUID>
+                    <continuity>C1 from previous</continuity>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="GuideCurveModel_Wing_Seg_3_4">
+                <name>Segment from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element</name>
+                <description>Segment from GuideCurveModel - Wing Section 4 Main Element to GuideCurveModel - Wing Section 4 Main Element</description>
+                <fromElementUID>GuideCurveModel_Wing_Sec3_El1</fromElementUID>
+                <toElementUID>GuideCurveModel_Wing_Sec4_El1</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_3_4_GuideCurve_TrailingEdgeLower">
+                    <name>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </name>
+                    <description>Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeLower</fromGuideCurveUID>
+                    <continuity>C2 from previous</continuity>
+                    <toRelativeCircumference>-1.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_3_4_GuideCurve_LeadingEdge">
+                    <name>Leading Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </name>
+                    <description>Leading Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_2_3_GuideCurve_LeadingEdge</fromGuideCurveUID>
+                    <continuity>C2 to previous</continuity>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                  </guideCurve>
+                  <guideCurve uID="GuideCurveModel_Wing_Seg_3_4_GuideCurve_TrailingEdgeUpper">
+                    <name>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </name>
+                    <description>Upper Trailing Edge GuideCurve from GuideCurveModel - Wing Section 3 Main Element to GuideCurveModel - Wing Section 4 Main Element </description>
+                    <guideCurveProfileUID>GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear</guideCurveProfileUID>
+                    <fromGuideCurveUID>GuideCurveModel_Wing_Seg_2_3_GuideCurve_TrailingEdgeUpper</fromGuideCurveUID>
+                    <continuity>C2 from previous</continuity>
+                    <toRelativeCircumference>1.0</toRelativeCircumference>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+            </segments>
+          </wing>
+        </wings>
+      </model>
+    </aircraft>
+    <profiles>
+      <fuselageProfiles>
+        <fuselageProfile uID="GuideCurveModel_Fuselage_Sec1_El1_Pro">
+          <name>Profile for GuideCurveModel - Fuselage Section 1 Main Element</name>
+          <description>Profile for GuideCurveModel - Fuselage Section 1 Main Element</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0;0;0;0;0</x>
+            <y mapType="vector">0.0; 0.19134171618254; 0.353553390593273; 0.461939766255643; 0.5; 0.461939766255643; 0.353553390593273; 0.19134171618254; 0.0</y>
+            <z mapType="vector">-0.5; -0.461939766255643; -0.353553390593273; -0.191341716182545; 0.0; 0.191341716182545; 0.353553390593273; 0.461939766255643; 0.5</z>
+          </pointList>
+          <symmetry>half</symmetry>
+        </fuselageProfile>
+        <fuselageProfile uID="GuideCurveModel_Fuselage_Sec2_El1_Pro">
+          <name>Profile for GuideCurveModel - Fuselage Section 2 Main Element</name>
+          <description>Profile for GuideCurveModel - Fuselage Section 2 Main Element</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0;0;0;0;0</x>
+            <y mapType="vector">0.0; 0.19134171618254; 0.353553390593273; 0.461939766255643; 0.5; 0.461939766255643; 0.353553390593273; 0.19134171618254; 0.0</y>
+            <z mapType="vector">-0.5; -0.461939766255643; -0.353553390593273; -0.191341716182545; 0.0; 0.191341716182545; 0.353553390593273; 0.461939766255643; 0.5</z>
+          </pointList>
+          <symmetry>half</symmetry>
+        </fuselageProfile>
+        <fuselageProfile uID="GuideCurveModel_Fuselage_Sec3_El1_Pro">
+          <name>Profile for GuideCurveModel - Fuselage Section 3 Main Element</name>
+          <description>Profile for GuideCurveModel - Fuselage Section 3 Main Element</description>
+          <pointList>
+            <x mapType="vector">0;0;0;0;0;0;0;0;0</x>
+            <y mapType="vector">0;.223860653;.432603294;.466631663;.499998888;.450157118;.311391445;.111113597;0</y>
+            <z mapType="vector">-.5;-.494434471;-.437105114;-.218786464;.001054491;.21762024;.391197352;.487497455;.487497455</z>
+          </pointList>
+          <symmetry>half</symmetry>
+        </fuselageProfile>
+      </fuselageProfiles>
+      <wingAirfoils>
+        <wingAirfoil uID="GuideCurveModel_Wing_Sec1_El1_Pro">
+          <name>Profile for GuideCurveModel - Wing Section 1 Main Element</name>
+          <description>Profile for GuideCurveModel - Wing Section 1 Main Element</description>
+          <pointList>
+            <x mapType="vector">.9999784;.968197388;.936349495;.904498754;.872660752;.84086439;.809165804;.777645373;.746369023;.715327073;.684414824;.653483715;.622409173;.59111906;.559609072;.527933591;.496162223;.464342346;.432498701;.400647422;.368800249;.336965189;.305148159;.273355754;.241594009;.209870517;.178197675;.146592625;.115081309;.083709634;.052577631;.022177734;0;.023262645;.053669824;.084769499;.116134169;.147647044;.179256233;.210921895;.242623663;.274356232;.306115173;.337894939;.369696476;.4015238;.433375739;.465267654;.497209966;.52916707;.56111429;.593048555;.624956577;.656807267;.688555686;.720154156;.751577886;.782831714;.813937486;.844909731;.875819929;.906731848;.937735348;.96884951;1.0000216</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">-.002501412;-.000514511;-.000066798;-.0002723;-.00118397;-.003037171;-.006133111;-.010694648;-.016709644;-.023842525;-.031521748;-.039124261;-.046113721;-.052058933;-.056696263;-.060026157;-.062272019;-.063681794;-.064384418;-.064427803;-.063891726;-.062868004;-.061383465;-.059441838;-.057050692;-.054196812;-.050827075;-.046874166;-.042233362;-.036731081;-.030013513;-.020616799;0;.019568135;.029342082;.036687505;.042814443;.048130166;.05284177;.057158942;.061202889;.06499762;.068565072;.071942056;.075106683;.078000774;.080609248;.082660055;.083617993;.083440607;.08259259;.081348039;.079559524;.076948121;.07330212;.068528372;.062711588;.056040221;.048707905;.040829923;.032710837;.024598326;.016844694;.00954676;.002501412</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="GuideCurveModel_Wing_Sec2_El1_Pro">
+          <name>Profile for GuideCurveModel - Wing Section 2 Main Element</name>
+          <description>Profile for GuideCurveModel - Wing Section 2 Main Element</description>
+          <pointList>
+            <x mapType="vector">.9999784;.968197367;.936349494;.904498765;.872660738;.840864376;.809165819;.777645367;.746368991;.715327071;.684414772;.65348374;.62240919;.591119061;.559609062;.527933678;.496162246;.46434231;.432498733;.400647404;.368800354;.336965189;.305148172;.273355781;.24159402;.209870542;.178197756;.146592645;.115081404;.083709644;.052577646;.022177748;0;.023262651;.053669828;.0847695;.116134159;.147647051;.179256214;.210921894;.24262364;.274356223;.306115158;.337894927;.369696505;.401523834;.433375785;.46526771;.497210025;.529167135;.561114345;.593048616;.624956639;.656807329;.688555755;.720154271;.751577946;.782831781;.813937535;.844909748;.875819947;.906731858;.937735354;.968849524;1.0000216</x>
+            <y mapType="vector">0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0</y>
+            <z mapType="vector">-.002501412;-.000514511;-.000066798;-.0002723;-.00118397;-.003037173;-.006133109;-.010694649;-.016709651;-.023842525;-.031521761;-.039124255;-.046113718;-.052058933;-.056696264;-.06002615;-.062272017;-.063681796;-.064384417;-.064427803;-.063891728;-.062868004;-.061383466;-.05944184;-.057050693;-.054196814;-.050827085;-.046874169;-.042233377;-.036731083;-.030013517;-.020616805;0;.019568138;.029342083;.036687505;.042814441;.048130167;.052841767;.057158942;.061202886;.064997619;.06856507;.071942054;.075106685;.078000777;.080609251;.082660058;.083617993;.083440606;.082592589;.081348037;.07955952;.076948115;.073302111;.068528353;.062711576;.056040206;.048707893;.040829919;.032710832;.024598324;.016844692;.009546757;.002501412</z>
+          </pointList>
+        </wingAirfoil>
+        <wingAirfoil uID="GuideCurveModel_Wing_Sec3_El1_Pro">
+          <name>Profile for GuideCurveModel - Wing Section 3 Main Element</name>
+          <description>Profile for GuideCurveModel - Wing Section 3 Main Element</description>
+          <pointList>
+            <x mapType="vector">1.00;0.975;0.9625;0.95;0.9375;0.925;0.9125;0.9;0.8875;0.875;0.8625;0.85;0.8375;0.825;0.8125;0.8;0.7875;0.775;0.7625;0.75;0.7375;0.725;0.7125;0.7;0.6875;0.675;0.6625;0.65;0.6375;0.625;0.6125;0.6;0.5875;0.575;0.5625;0.55;0.5375;0.525;0.5125;0.5;0.4875;0.475;0.4625;0.45;0.4375;0.425;0.4125;0.4;0.3875;0.375;0.3625;0.35;0.3375;0.325;0.3125;0.3;0.2875;0.275;0.2625;0.25;0.2375;0.225;0.2125;0.2;0.1875;0.175;0.1625;0.15;0.1375;0.125;0.1125;0.1;0.0875;0.075;0.0625;0.05;0.0375;0.025;0.0125;0.0;0.0125;0.025;0.0375;0.05;0.0625;0.075;0.0875;0.1;0.1125;0.125;0.1375;0.15;0.1625;0.175;0.1875;0.2;0.2125;0.225;0.2375;0.25;0.2625;0.275;0.2875;0.3;0.3125;0.325;0.3375;0.35;0.3625;0.375;0.3875;0.4;0.4125;0.425;0.4375;0.45;0.4625;0.475;0.4875;0.5;0.5125;0.525;0.5375;0.55;0.5625;0.575;0.5875;0.6;0.6125;0.625;0.6375;0.65;0.6625;0.675;0.6875;0.7;0.7125;0.725;0.7375;0.75;0.7625;0.775;0.7875;0.8;0.8125;0.825;0.8375;0.85;0.8625;0.875;0.8875;0.9;0.9125;0.925;0.9375;0.95;0.9625;0.975;0.9875;1.0</x>
+            <y mapType="vector">0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0.0</y>
+            <z mapType="vector">-0.003;-0.00471438572941;-0.00640256842113;-0.00806559133343;-0.00970403933653;-0.0113184567357;-0.0129093470398;-0.0144771727147;-0.0160223549226;-0.0175452732434;-0.0190462653789;-0.0205256268372;-0.0219836105968;-0.0234204267471;-0.024836242105;-0.0262311798047;-0.0276053188583;-0.0289586936852;-0.0302912936071;-0.0316030623052;-0.0328938972373;-0.0341636490097;-0.0354121207001;-0.0366390671268;-0.0378441940595;-0.0390271573644;-0.0401875620783;-0.0413249614032;-0.042438855614;-0.043528690869;-0.0445938579126;-0.0456336906587;-0.04664746464;-0.0476343953088;-0.0485936361694;-0.0495242767241;-0.0504253402064;-0.0512957810767;-0.0521344822472;-0.0529402520006;-0.0537118205596;-0.0544478362583;-0.0551468612564;-0.0558073667285;-0.0564277274483;-0.0570062156697;-0.0575409941929;-0.0580301084765;-0.0584714776309;-0.0588628840933;-0.059201961739;-0.0594861821311;-0.0597128385384;-0.059879027262;-0.0599816256958;-0.060017266394;-0.059982306219;-0.05987278938;-0.0596844028137;-0.059412421875;-0.059051643633;-0.0585963041308;-0.0580399746271;-0.0573754299024;-0.0565944788455;-0.0556877432118;-0.054644363746;-0.0534516022043;-0.0520942903127;-0.0505540468987;-0.0488081315259;-0.0468277042382;-0.0445750655553;-0.0419990347204;-0.0390266537476;-0.0355468568262;-0.0313738751622;-0.0261471986426;-0.0189390266528;0.0;0.0189390266528;0.0261471986426;0.0313738751622;0.0355468568262;0.0390266537476;0.0419990347204;0.0445750655553;0.0468277042382;0.0488081315259;0.0505540468987;0.0520942903127;0.0534516022043;0.054644363746;0.0556877432118;0.0565944788455;0.0573754299024;0.0580399746271;0.0585963041308;0.059051643633;0.059412421875;0.0596844028137;0.05987278938;0.059982306219;0.060017266394;0.0599816256958;0.059879027262;0.0597128385384;0.0594861821311;0.059201961739;0.0588628840933;0.0584714776309;0.0580301084765;0.0575409941929;0.0570062156697;0.0564277274483;0.0558073667285;0.0551468612564;0.0544478362583;0.0537118205596;0.0529402520006;0.0521344822472;0.0512957810767;0.0504253402064;0.0495242767241;0.0485936361694;0.0476343953088;0.04664746464;0.0456336906587;0.0445938579126;0.043528690869;0.042438855614;0.0413249614032;0.0401875620783;0.0390271573644;0.0378441940595;0.0366390671268;0.0354121207001;0.0341636490097;0.0328938972373;0.0316030623052;0.0302912936071;0.0289586936852;0.0276053188583;0.0262311798047;0.024836242105;0.0234204267471;0.0219836105968;0.0205256268372;0.0190462653789;0.0175452732434;0.0160223549226;0.0144771727147;0.0129093470398;0.0113184567357;0.00970403933653;0.00806559133343;0.00640256842113;0.00471438572941;0.0030004180415;0.00126</z>
+          </pointList>
+        </wingAirfoil>
+      </wingAirfoils>
+      <guideCurves>
+        <guideCurveProfile uID="GuideCurveModel_Fuselage_GuideCurveProfile_Lower_Linear">
+          <name>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>Linear Lower Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0;0;0</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Fuselage_GuideCurveProfile_Middle_NonLinear">
+          <name>NonLinear Middle Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>NonLinear Middle Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0;0;0;0;0;0;0;0;0</rX>
+            <rY mapType="vector">0.1;0.2;0.3;0.4;0.5;0.6;0.7;0.8;0.9</rY>
+            <rZ mapType="vector">0;0.012;0.037;0.110;0.098;0.086;0.073;0.024;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Fuselage_GuideCurveProfile_Upper_Linear">
+          <name>Linear Upper Guide Curve Profile for GuideCurveModel - Fuselage</name>
+          <description>Linear Upper Guide Curve Profile for GuideCurveModel - Fuselage</description>
+          <pointList>
+            <rX mapType="vector">0;0;0</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear">
+          <name>Linear Lower Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</name>
+          <description>Linear Lower Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</description>
+          <pointList>
+            <rX mapType="vector">0.001;0.01;0.001</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0;0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear">
+          <name>NonLinear Leading Edge Guide Curve Profile for GuideCurveModel - Wing</name>
+          <description>NonLinear Leading Edge Guide Curve Profile for GuideCurveModel - Wing</description>
+          <pointList>
+            <rX mapType="vector">0;-0.01;-0.03;-0.09;-0.08;-0.07;-0.06;-0.02;0</rX>
+            <rY mapType="vector">0.1;0.2;0.3;0.4;0.5;0.6;0.7;0.8;0.9</rY>
+            <rZ mapType="vector">0;0.0;0.0;0.0;0.0;0.0;0.0;0.0;0</rZ>
+          </pointList>
+        </guideCurveProfile>
+        <guideCurveProfile uID="GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeUpper_NonLinear">
+          <name>Linear Upper Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</name>
+          <description>Linear Upper Trailing Edge Guide Curve Profile for GuideCurveModel - Wing</description>
+          <pointList>
+            <rX mapType="vector">0.001;0.01;0.001</rX>
+            <rY mapType="vector">0.1;0.5;0.9</rY>
+            <rZ mapType="vector">0.0;0.0;0.0</rZ>
+          </pointList>
+        </guideCurveProfile>
+      </guideCurves>
+    </profiles>
+  </vehicles>
+</cpacs>

--- a/tests/unittests/testUtils.cpp
+++ b/tests/unittests/testUtils.cpp
@@ -32,6 +32,9 @@
 #include <TColgp_Array1OfPnt.hxx>
 #include <BRepTools.hxx>
 #include <TopoDS.hxx>
+#include <tigl.h>
+#include <CTiglLogging.h>
+#include "test.h" // Brings in the GTest framework
 
 // save x-y data
 void outputXY(const int & i, const double& x, const double&y, const std::string& filename)
@@ -97,4 +100,22 @@ Handle(Geom_BSplineSurface) LoadBSplineSurface(const std::string& filename)
 
     BRepTools::Read(shape, filename.c_str(), builder);
     return GeomConvert::SurfaceToBSplineSurface(BRep_Tool::Surface(TopoDS::Face(shape)));
+}
+
+CaptureTiGLLog::CaptureTiGLLog()
+{
+    _oldVerbosityLevel = tigl::CTiglLogging::Instance().GetConsoleVerbosity();
+    tigl::CTiglLogging::Instance().SetConsoleVerbosity(TILOG_WARNING);
+    tigl::CTiglLogging::Instance().LogToConsole();
+    testing::internal::CaptureStderr();
+}
+
+std::string CaptureTiGLLog::log()
+{
+    return testing::internal::GetCapturedStderr();
+}
+
+CaptureTiGLLog::~CaptureTiGLLog()
+{
+    tigl::CTiglLogging::Instance().SetConsoleVerbosity(_oldVerbosityLevel);
 }

--- a/tests/unittests/testUtils.cpp
+++ b/tests/unittests/testUtils.cpp
@@ -102,10 +102,10 @@ Handle(Geom_BSplineSurface) LoadBSplineSurface(const std::string& filename)
     return GeomConvert::SurfaceToBSplineSurface(BRep_Tool::Surface(TopoDS::Face(shape)));
 }
 
-CaptureTiGLLog::CaptureTiGLLog()
+CaptureTiGLLog::CaptureTiGLLog(TiglLogLevel logLevel)
 {
     _oldVerbosityLevel = tigl::CTiglLogging::Instance().GetConsoleVerbosity();
-    tigl::CTiglLogging::Instance().SetConsoleVerbosity(TILOG_WARNING);
+    tigl::CTiglLogging::Instance().SetConsoleVerbosity(logLevel);
     tigl::CTiglLogging::Instance().LogToConsole();
     testing::internal::CaptureStderr();
 }

--- a/tests/unittests/tiglCommonFunctions.cpp
+++ b/tests/unittests/tiglCommonFunctions.cpp
@@ -333,3 +333,18 @@ TEST_P(TestBuildFace, build)
 }
 
 INSTANTIATE_TEST_CASE_P(TiglCommonFunctions, TestBuildFace, ::testing::Range(1, 30, 1));
+
+TEST(TiglCommonFunctions, edgeGetPointTangentBasedOnParam_checkArgs)
+{
+    TopoDS_Edge edge;
+    double alpha;
+    gp_Pnt point;
+    gp_Vec tangent;
+    BRep_Builder b;
+    BRepTools::Read(edge, "TestData/checkEdgeContinuity_edge1.brep", b);
+
+    // Choose value too low
+    EXPECT_THROW(EdgeGetPointTangentBasedOnParam(edge, -0.5, point, tangent), tigl::CTiglError);
+    // Choose value too high
+    EXPECT_THROW(EdgeGetPointTangentBasedOnParam(edge, 2.0, point, tangent), tigl::CTiglError);
+}

--- a/tests/unittests/tiglFuselage.cpp
+++ b/tests/unittests/tiglFuselage.cpp
@@ -209,10 +209,16 @@ TEST(TiglSimpleFuselage, GetPointTangent_checkArgs)
     wireContainer.Append(wire);
     tigl::CCPACSFuselageProfileGetPointAlgo getPointAlgo(wireContainer);
 
-    CaptureTiGLLog t;
-    getPointAlgo.GetPointTangent(0.0, point, tangent, tigl::CCPACSGuideCurve::FromOrToDefinition::PARAMETER);
-    auto logOutput = t.log();
+    // Start by checking the warning based on the wire
+    { // Scope to destroy object of type CaptureTiGLLog and therefore reset console verbosity
+        CaptureTiGLLog t;
+        getPointAlgo.GetPointTangent(0.0, point, tangent, tigl::CCPACSGuideCurve::FromOrToDefinition::PARAMETER);
+        auto logOutput = t.log();
 
-    std::string comparisonString = "Defining start or end point of guide curve via parameter on wires consisting of 2 or more edges might lead to unexpected results.";
-    ASSERT_TRUE((logOutput.find(comparisonString)) != std::string::npos);
+        std::string comparisonString = "Defining start or end point of guide curve via parameter on wires consisting of 2 or more edges might lead to unexpected results.";
+        ASSERT_TRUE((logOutput.find(comparisonString)) != std::string::npos);
+    } // scope
+
+    // Check the argument FromOrToDefinition by parsing wrong enum int
+    EXPECT_THROW(getPointAlgo.GetPointTangent(0.0, point, tangent, (tigl::CCPACSGuideCurve::FromOrToDefinition) 100), tigl::CTiglError);
 }

--- a/tests/unittests/tiglFuselage.cpp
+++ b/tests/unittests/tiglFuselage.cpp
@@ -211,7 +211,7 @@ TEST(TiglSimpleFuselage, GetPointTangent_checkArgs)
 
     // Start by checking the warning based on the wire
     { // Scope to destroy object of type CaptureTiGLLog and therefore reset console verbosity
-        CaptureTiGLLog t;
+        CaptureTiGLLog t{TILOG_WARNING};
         getPointAlgo.GetPointTangent(0.0, point, tangent, tigl::CCPACSGuideCurve::FromOrToDefinition::PARAMETER);
         auto logOutput = t.log();
 

--- a/tests/unittests/tiglFuselage.cpp
+++ b/tests/unittests/tiglFuselage.cpp
@@ -24,9 +24,12 @@
 #include <cmath>
 
 #include "test.h" // Brings in the GTest framework
+#include "testUtils.h"
 #include "tigl.h"
 #include <string.h>
-
+#include <BRep_Builder.hxx>
+#include <BRepTools.hxx>
+#include <CCPACSFuselageProfileGetPointAlgo.h>
 
 /******************************************************************************/
 
@@ -187,4 +190,29 @@ TEST(TiglSimpleFuselage, getSurfaceArea_HalfModel)
 
     tiglCloseCPACSConfiguration(tiglHandle);
     tixiCloseDocument(tixiHandle);
+}
+
+TEST(TiglSimpleFuselage, GetPointTangent_checkArgs)
+{
+    const char* logfileName = "LogFile_GetPointTangent_checkArgs";
+    std::string content;
+    BRep_Builder b;
+    TopoDS_Wire wire;
+    std::string path_wire;
+    gp_Pnt point;
+    gp_Vec tangent;
+
+    path_wire = "TestData/functions/commonfunctions_BuildFace/1_wire.brep";
+    BRepTools::Read(wire, path_wire.c_str(), b);
+
+    TopTools_SequenceOfShape wireContainer;
+    wireContainer.Append(wire);
+    tigl::CCPACSFuselageProfileGetPointAlgo getPointAlgo(wireContainer);
+
+    CaptureTiGLLog t;
+    getPointAlgo.GetPointTangent(0.0, point, tangent, tigl::CCPACSGuideCurve::FromOrToDefinition::PARAMETER);
+    auto logOutput = t.log();
+
+    std::string comparisonString = "Defining start or end point of guide curve via parameter on wires consisting of 2 or more edges might lead to unexpected results.";
+    ASSERT_TRUE((logOutput.find(comparisonString)) != std::string::npos);
 }

--- a/tests/unittests/tiglFuselage.cpp
+++ b/tests/unittests/tiglFuselage.cpp
@@ -194,7 +194,6 @@ TEST(TiglSimpleFuselage, getSurfaceArea_HalfModel)
 
 TEST(TiglSimpleFuselage, GetPointTangent_checkArgs)
 {
-    const char* logfileName = "LogFile_GetPointTangent_checkArgs";
     std::string content;
     BRep_Builder b;
     TopoDS_Wire wire;

--- a/tests/unittests/tiglFuselageGuideCurves.cpp
+++ b/tests/unittests/tiglFuselageGuideCurves.cpp
@@ -150,6 +150,36 @@ protected:
     TiglCPACSConfigurationHandle tiglHandle;
 };
 
+class FuselageGuideCurveAtKink : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        const char* filename = "TestData/kinks_withGC_ParameterDef.xml";
+        ReturnCode tixiRet;
+        TiglReturnCode tiglRet;
+
+        tiglHandle = -1;
+        tixiHandle = -1;
+
+        tixiRet = tixiOpenDocument(filename, &tixiHandle);
+        ASSERT_TRUE(tixiRet == SUCCESS);
+        tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle);
+        ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglHandle) == TIGL_SUCCESS);
+        ASSERT_TRUE(tixiCloseDocument(tixiHandle) == SUCCESS);
+        tiglHandle = -1;
+        tixiHandle = -1;
+    }
+
+    TixiDocumentHandle tixiHandle;
+    TiglCPACSConfigurationHandle tiglHandle;
+};
+
 /******************************************************************************/
 
 /**
@@ -510,15 +540,8 @@ TEST(FuselageGuideCurve_bug, 766)
 
 }
 
-TEST_F(FuselageGuideCurve, kinksGuideCurvesParameterDef)
+TEST_F(FuselageGuideCurveAtKink, kinksGuideCurvesParameterDef)
 {
-    const char* filename = "TestData/kinks_withGC_ParameterDef.xml";
-
-    TiglCPACSConfigurationHandle tiglHandle = -1;
-    TixiDocumentHandle tixiHandle = -1;
-    ASSERT_EQ(SUCCESS, tixiOpenDocument(filename, &tixiHandle));
-    ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
-
     double x,y,z;
     double x2,y2,z2;
     // Get the points' coordinates and compare to guide curve start and end
@@ -546,15 +569,8 @@ TEST_F(FuselageGuideCurve, kinksGuideCurvesParameterDef)
     ASSERT_NEAR(z2, lastPointGC.Z(), tolerance);
 }
 
-TEST_F(FuselageGuideCurve, getFromDefinition_checkArgs)
+TEST_F(FuselageGuideCurveAtKink, getFromDefinition_checkArgs)
 {
-    const char* filename = "TestData/kinks_withGC_ParameterDef.xml";
-
-    TiglCPACSConfigurationHandle tiglHandle = -1;
-    TixiDocumentHandle tixiHandle = -1;
-    ASSERT_EQ(SUCCESS, tixiOpenDocument(filename, &tixiHandle));
-    ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
-
     auto& uid_mgr = tigl::CCPACSConfigurationManager::GetInstance().GetConfiguration(tiglHandle).GetUIDManager();
     auto& segment = uid_mgr.ResolveObject<tigl::CCPACSFuselageSegment>("segmentD150_Fuselage_1Segment2ID");
     auto& guideCurves = *segment.GetGuideCurves();
@@ -567,15 +583,8 @@ TEST_F(FuselageGuideCurve, getFromDefinition_checkArgs)
     EXPECT_THROW(guideCurve.GetRootCurve(), tigl::CTiglError);
 }
 
-TEST_F(FuselageGuideCurve, getToDefinition_checkArgs)
+TEST_F(FuselageGuideCurveAtKink, getToDefinition_checkArgs)
 {
-    const char* filename = "TestData/kinks_withGC_ParameterDef.xml";
-
-    TiglCPACSConfigurationHandle tiglHandle = -1;
-    TixiDocumentHandle tixiHandle = -1;
-    ASSERT_EQ(SUCCESS, tixiOpenDocument(filename, &tixiHandle));
-    ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
-
     auto& uid_mgr = tigl::CCPACSConfigurationManager::GetInstance().GetConfiguration(tiglHandle).GetUIDManager();
     auto& segment = uid_mgr.ResolveObject<tigl::CCPACSFuselageSegment>("segmentD150_Fuselage_1Segment2ID");
     auto& guideCurves = *segment.GetGuideCurves();
@@ -586,15 +595,8 @@ TEST_F(FuselageGuideCurve, getToDefinition_checkArgs)
     EXPECT_THROW(guideCurve.GetToDefinition(), tigl::CTiglError);
 }
 
-TEST_F(FuselageGuideCurve, GuideCurveAlgo_checkArgs)
+TEST_F(FuselageGuideCurveAtKink, GuideCurveAlgo_checkArgs)
 {
-    const char* filename = "TestData/kinks_withGC_ParameterDef.xml";
-
-    TiglCPACSConfigurationHandle tiglHandle = -1;
-    TixiDocumentHandle tixiHandle = -1;
-    ASSERT_EQ(SUCCESS, tixiOpenDocument(filename, &tixiHandle));
-    ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
-
     auto& uid_mgr = tigl::CCPACSConfigurationManager::GetInstance().GetConfiguration(tiglHandle).GetUIDManager();
     auto& segment = uid_mgr.ResolveObject<tigl::CCPACSFuselageSegment>("segmentD150_Fuselage_1Segment2ID");
     auto& guideCurves = *segment.GetGuideCurves();

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -526,3 +526,21 @@ TEST_F(WingGuideCurve, bug962)
     tigl::CCPACSWingSegment& segment1 = wing.GetSegment(1);
     segment1.GetLoft();
 }
+
+TEST_F(WingGuideCurve, BuildGuideCurvePnts_checkArgs)
+{
+    const char* filename = "TestData/simple_test_guide_curves_wrong_gc_Def.xml";
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+    TixiDocumentHandle tixiHandle = -1;
+    ASSERT_EQ(SUCCESS, tixiOpenDocument(filename, &tixiHandle));
+    ASSERT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle));
+
+    auto& uid_mgr = tigl::CCPACSConfigurationManager::GetInstance().GetConfiguration(tiglHandle).GetUIDManager();
+    auto& segment = uid_mgr.ResolveObject<tigl::CCPACSWingSegment>("GuideCurveModel_Wing_Seg_1_2");
+    auto& guideCurves = *segment.GetGuideCurves();
+    const tigl::CCPACSGuideCurve& guideCurve = guideCurves.GetGuideCurve(2);
+
+    tigl::CTiglWingSegmentGuidecurveBuilder builder(segment);
+    EXPECT_THROW(builder.BuildGuideCurvePnts(&guideCurve), tigl::CTiglError);
+}

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -137,7 +137,7 @@ TEST_F(WingGuideCurve, tiglWingGuideCurve_CCPACSGuideCurve)
     ASSERT_EQ(guideCurve.GetUID(), "GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower");
     ASSERT_EQ(guideCurve.GetName(), "Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element ");
     ASSERT_EQ(guideCurve.GetGuideCurveProfileUID(), "GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear");
-    ASSERT_FALSE(!guideCurve.GetFromRelativeCircumference_choice2_1());
+    ASSERT_TRUE(guideCurve.GetFromRelativeCircumference_choice2_1());
     ASSERT_EQ(*guideCurve.GetFromRelativeCircumference_choice2_1(), -1.0);
     ASSERT_EQ(*guideCurve.GetToRelativeCircumference_choice1(), -1.0);
 }

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -137,9 +137,9 @@ TEST_F(WingGuideCurve, tiglWingGuideCurve_CCPACSGuideCurve)
     ASSERT_EQ(guideCurve.GetUID(), "GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower");
     ASSERT_EQ(guideCurve.GetName(), "Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element ");
     ASSERT_EQ(guideCurve.GetGuideCurveProfileUID(), "GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear");
-    ASSERT_TRUE(!!guideCurve.GetFromRelativeCircumference_choice2());
-    ASSERT_EQ(*guideCurve.GetFromRelativeCircumference_choice2(), -1.0);
-    ASSERT_EQ(guideCurve.GetToRelativeCircumference(), -1.0);
+    ASSERT_TRUE(!!guideCurve.GetFromRelativeCircumference_choice2_1());
+    ASSERT_EQ(*guideCurve.GetFromRelativeCircumference_choice2_1(), -1.0);
+    ASSERT_EQ(*guideCurve.GetToRelativeCircumference_choice1(), -1.0);
 }
 
 /**
@@ -154,9 +154,9 @@ TEST_F(WingGuideCurve, tiglWingGuideCurve_CCPACSGuideCurves)
     ASSERT_EQ(guideCurve.GetUID(), "GuideCurveModel_Wing_Seg_2_3_GuideCurve_LeadingEdge");
     ASSERT_EQ(guideCurve.GetName(), "Leading Edge GuideCurve from GuideCurveModel - Wing Section 2 Main Element to GuideCurveModel - Wing Section 3 Main Element ");
     ASSERT_EQ(guideCurve.GetGuideCurveProfileUID(), "GuideCurveModel_Wing_GuideCurveProfile_LeadingEdge_NonLinear");
-    ASSERT_TRUE(!guideCurve.GetFromRelativeCircumference_choice2());
+    ASSERT_TRUE(!guideCurve.GetFromRelativeCircumference_choice2_1());
     ASSERT_EQ(*guideCurve.GetFromGuideCurveUID_choice1(), "GuideCurveModel_Wing_Seg_1_2_GuideCurve_LeadingEdge_NonLinear" );
-    ASSERT_EQ(guideCurve.GetToRelativeCircumference(), 0.0);
+    ASSERT_EQ(*guideCurve.GetToRelativeCircumference_choice1(), 0.0);
 }
 
 /**

--- a/tests/unittests/tiglWingGuideCurves.cpp
+++ b/tests/unittests/tiglWingGuideCurves.cpp
@@ -137,7 +137,7 @@ TEST_F(WingGuideCurve, tiglWingGuideCurve_CCPACSGuideCurve)
     ASSERT_EQ(guideCurve.GetUID(), "GuideCurveModel_Wing_Seg_1_2_GuideCurve_TrailingEdgeLower");
     ASSERT_EQ(guideCurve.GetName(), "Lower Trailing Edge GuideCurve from GuideCurveModel - Wing Section 1 Main Element to GuideCurveModel - Wing Section 2 Main Element ");
     ASSERT_EQ(guideCurve.GetGuideCurveProfileUID(), "GuideCurveModel_Wing_GuideCurveProfile_TrailingEdgeLower_NonLinear");
-    ASSERT_TRUE(!!guideCurve.GetFromRelativeCircumference_choice2_1());
+    ASSERT_FALSE(!guideCurve.GetFromRelativeCircumference_choice2_1());
     ASSERT_EQ(*guideCurve.GetFromRelativeCircumference_choice2_1(), -1.0);
     ASSERT_EQ(*guideCurve.GetToRelativeCircumference_choice1(), -1.0);
 }


### PR DESCRIPTION
Currently, the definition of (starting and end points of) fuselage guide curves is not consistent to user-defined parameterization for (e.g.) kinks. Those guide curve points are, up to now, defined based on the arc length of the start profile and end profile, respectively. While the user-defined parameterization can arbitrary differ from that (see issue #745).

This PR introduces the new CPACS nodes `fromParameter` and `toParameter` to account for this 'problem' to make it easier for users to sync guide curves with kinks.
The node is implemented via a `choice` element and the old implementation is kept as the default case to not get in the way with existing code, CPACS files and tests.
Since the CPACS scheme is changed, it has to be thought about a CPACS PR, as well.

TODO: 
- [x] Implement a meaningful test
- [x] Think about cases when the parameterization is not in the range of [0,1]
- [x] ~Take care about wings~
- [x] Code coverage
- [x] (Potentially clean up the changed code)

Fix issue #745


## Checklist:
- [x] A test for the new functionality was added.
- [X] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
