### PR TITLE
CMake adjustments for building with OpenCascade 7.5

### DIFF
--- a/TIGLViewer/src/TIGLQAspectWindow.cpp
+++ b/TIGLViewer/src/TIGLQAspectWindow.cpp
@@ -103,7 +103,7 @@ void TIGLQAspectWindow::Unmap() const
 // function : DoResize
 // purpose  :
 // =======================================================================
-#if OCC_VERSION_HEX >= 0x070600
+#if OCC_VERSION_HEX >= 0x070500
 Aspect_TypeOfResize TIGLQAspectWindow::DoResize()
 #else
 Aspect_TypeOfResize TIGLQAspectWindow::DoResize() const

--- a/TIGLViewer/src/TIGLQAspectWindow.h
+++ b/TIGLViewer/src/TIGLQAspectWindow.h
@@ -73,7 +73,7 @@ public:
     Aspect_Drawable NativeParentHandle() const override;
     
     //! Applies the resizing to the window <me>
-#if OCC_VERSION_HEX >= 0x070600
+#if OCC_VERSION_HEX >= 0x070500
     Aspect_TypeOfResize DoResize() override;
 #else
     Aspect_TypeOfResize DoResize() const override;

--- a/cmake/UseOpenCASCADE.cmake
+++ b/cmake/UseOpenCASCADE.cmake
@@ -48,9 +48,12 @@ if(OCE_FOUND)
   option(OCE_STATIC_LIBS "Should be checked, if static OCE libs are linked" OFF)
 else(OCE_FOUND)
   message("OCE not found! Searching for OpenCASCADE.")
-  find_package(OpenCASCADE CONFIG REQUIRED)
+  find_package(OpenCASCADE CONFIG REQUIRED COMPONENTS FoundationClasses ModelingData ModelingAlgorithms Visualization ApplicationFramework DataExchange)
   option(OpenCASCADE_STATIC_LIBS "Should be checked, if static OpenCASCADE libs are linked" OFF)
 
+  # PATCH OpenCASCADE_LIBRARIES for removing unnecessary libraries
+  list (REMOVE_ITEM OpenCASCADE_LIBRARIES ${OpenCASCADE_Draw_LIBRARIES})
+  list (REMOVE_ITEM OpenCASCADE_LIBRARIES ${OpenCASCADE_DETools_LIBRARIES})
   message(STATUS "Found opencascade " ${OpenCASCADE_VERSION})
 
   FIND_PATH(OpenCASCADE_SHADER_DIRECTORY


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The number of features linked into TiGL was reduced in CMake to only selected used features.
A minor change in TIGLQAspectWindow to allow building with OpenCASCADE 7.5

## How Has This Been Tested?
Not

## Screenshots, that help to understand the changes(if applicable):
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] A test for the new functionality was added.
- [ ] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
