### PR TITLE
fix GetLoftWithCutOuts() in CCPACSWing crashes without warning (Issue #1022) 

### DIFF
--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -360,7 +360,13 @@ PNamedShape CCPACSWing::BuildLoft() const
 
 TopoDS_Shape CCPACSWing::GetLoftWithCutouts()
 {
-    return (*wingShapeWithCutouts)->Shape();
+    if (NumberOfControlSurfaces(*this) == 0) {
+        LOG(WARNING) << "No control devices defined, GetLoftWithCutOuts() will return a clean shape.";
+        return (*wingCleanShape)->Shape();
+    }
+    else {
+        return (*wingShapeWithCutouts)->Shape();
+    }
 }
 
 // Builds a fused shape of all wing segments

--- a/tests/unittests/tiglWing.cpp
+++ b/tests/unittests/tiglWing.cpp
@@ -411,22 +411,10 @@ TEST_F(TiglWing, depthDirection)
     vtp.SetSymmetryAxis(vtpSymAx);
 }
 
-TEST_F(TiglWing, testGetWingWithCutOuts)
+TEST_F(WingSimple, testGetWingWithCutOuts)
 {
-    const char* filename = "TestData/simpletest.cpacs.xml";
-    ReturnCode tixiRetX;
-    TiglReturnCode tiglRetX;
-
-    TixiDocumentHandle tiglHandleX = -1;
-    TiglCPACSConfigurationHandle tixiHandleX = -1;
-
-    tixiRetX = tixiOpenDocument(filename, &tixiHandleX);
-    ASSERT_TRUE (tixiRetX == SUCCESS);
-    tiglRetX = tiglOpenCPACSConfiguration(tixiHandleX, "", &tiglHandleX);
-    ASSERT_TRUE(tiglRetX == TIGL_SUCCESS);
-
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
-    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglHandleX);
+    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglSimpleWingHandle);
     tigl::CTiglUIDManager& uidmgr = config.GetUIDManager();
     auto& wing = uidmgr.ResolveObject<tigl::CCPACSWing>("Wing");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See Issue #1022. 

Changed CCPACSWing::GetLoftWithCutOuts() to return a warning and a clean shape if no control surfaces are defined.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added Unittest to tiglWing.cpp to assert that warning is thrown and shape is valid.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [x] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
