### PR TITLE
Reduce tolerance when creating cells via contourCoordinate in chordwise direction

### DIFF
--- a/src/wing/CCPACSWingCell.cpp
+++ b/src/wing/CCPACSWingCell.cpp
@@ -912,8 +912,8 @@ void CCPACSWingCell::BuildSkinGeometry(GeometryCache& cache) const
          */
         TrimSpanwise(cache, SpanWiseBorder::Inner, m_positioningInnerBorder, 1e-4);
         TrimSpanwise(cache, SpanWiseBorder::Outer, m_positioningOuterBorder, 1e-4);
-        TrimChordwise(cache, ChordWiseBorder::LE, m_positioningLeadingEdge, 1e-2);
-        TrimChordwise(cache, ChordWiseBorder::TE, m_positioningTrailingEdge, 1e-2);
+        TrimChordwise(cache, ChordWiseBorder::LE, m_positioningLeadingEdge, 1e-4);
+        TrimChordwise(cache, ChordWiseBorder::TE, m_positioningTrailingEdge, 1e-4);
 
         TopoDS_Builder builder;
         TopoDS_Compound resultShape;


### PR DESCRIPTION
This fix is related to PR #1026 and the belonging issue #933.
In the named PR, the tolerance was only reduced in spanwise direction. This PR also adds the reduction for the chordwise direction to fix cell overlap in the other direction.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
- [ ] Changes were documented in tigl/ChangeLog.md
