### PR TITLE
 Fix Python wrapper returns SwigPyObject instead of CPACSWalls (Issue #1012) 

### DIFF
--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -40,7 +40,9 @@
 #include "CCPACSExternalObject.h"
 #include "CTiglShapeCache.h"
 #include "CTiglError.h"
+#include "CCPACSWalls.h"
 #include "CCPACSWallPosition.h"
+#include "CCPACSFuselageWallSegment.h"
 #include "CCPACSWingSegment.h"
 #include "CCPACSFuselageSegment.h"
 #include "CTiglWingConnection.h"
@@ -87,6 +89,7 @@
 #include "generated/CPACSBoundingElementUIDs.h"
 #include "generated/CPACSStructuralWallElement.h"
 #include "generated/CPACSStructuralWallElements.h"
+#include "generated/CPACSWalls.h"
 #include "generated/CPACSWallPositionUIDs.h"
 #include "generated/CPACSWallPosition.h"
 #include "generated/CPACSWallPositions.h"
@@ -177,7 +180,6 @@
 %include "generated/CPACSLateralCap_placement.h"
 %boost_optional(tigl::generated::CPACSLateralCap)
 %include "generated/CPACSLateralCap.h"
-
 %boost_optional(tigl::generated::CPACSBoundingElementUIDs)
 %include "generated/CPACSBoundingElementUIDs.h"
 %include "generated/CPACSStructuralWallElement.h"
@@ -187,8 +189,14 @@
 %include "generated/CPACSWallPositions.h"
 %include "generated/CPACSWallSegment.h"
 %include "generated/CPACSWallSegments.h"
+%boost_optional(tigl::CCPACSWalls)
 %boost_optional(tigl::generated::CPACSWalls)
+%boost_optional(tigl::CCPACSWallPosition)
+%boost_optional(tigl::CCPACSFuselageWallSegment)
 %include "generated/CPACSWalls.h"
+%include "CCPACSWalls.h"
+%include "CCPACSWallPosition.h"
+%include "CCPACSFuselageWallSegment.h"
 
 // ----------------- Engines ---------------------------//
 %boost_optional(tigl::CCPACSEngines)
@@ -516,6 +524,7 @@ class CCPACSWingRibsPositioning;
 %factory(tigl::ITiglGeometricComponent& tigl::CTiglUIDManager::GetGeometricComponent,
          tigl::CCPACSFuselage,
          tigl::CCPACSFuselageSegment,
+         tigl::CCPACSFuselageWallSegment,
          tigl::CCPACSWing,
          tigl::CCPACSWingSegment,
          tigl::CCPACSWingComponentSegment,

--- a/src/structural_elements/CCPACSFuselageWallSegment.h
+++ b/src/structural_elements/CCPACSFuselageWallSegment.h
@@ -36,22 +36,22 @@ class CCPACSFuselageWallSegment : public generated::CPACSWallSegment, public CTi
 public:
     TIGL_EXPORT CCPACSFuselageWallSegment(CCPACSWallSegments* parent, CTiglUIDManager* uidMgr);
 
-    std::string GetDefaultedUID() const override
+    TIGL_EXPORT std::string GetDefaultedUID() const override
     {
         return GetUID().value_or("UnknownWallSegment");
     }
 
-    TiglGeometricComponentIntent GetComponentIntent() const override
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const override
     {
         return TIGL_INTENT_INNER_STRUCTURE | TIGL_INTENT_PHYSICAL;
     }
 
-    TiglGeometricComponentType   GetComponentType() const override
+    TIGL_EXPORT TiglGeometricComponentType   GetComponentType() const override
     {
         return TIGL_COMPONENT_FUSELAGE_WALL;
     }
 
-    TopoDS_Compound GetCutPlanes() const;
+    TIGL_EXPORT TopoDS_Compound GetCutPlanes() const;
 
     TIGL_EXPORT void SetPhi(const double& value) override;
     TIGL_EXPORT void SetDoubleSidedExtrusion(const boost::optional<bool>& value) override;

--- a/src/structural_elements/CCPACSWalls.h
+++ b/src/structural_elements/CCPACSWalls.h
@@ -32,12 +32,12 @@ namespace tigl
 class CCPACSWalls : public generated::CPACSWalls
 {
 public:
-    CCPACSWalls(CCPACSFuselageStructure* parent, CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSWalls(CCPACSFuselageStructure* parent, CTiglUIDManager* uidMgr);
 
-    const CCPACSFuselageWallSegment& GetWallSegment(const std::string& uid) const;
-    const CCPACSWallPosition& GetWallPosition(const std::string& uid) const;
+    TIGL_EXPORT const CCPACSFuselageWallSegment& GetWallSegment(const std::string& uid) const;
+    TIGL_EXPORT const CCPACSWallPosition& GetWallPosition(const std::string& uid) const;
 
-    void Invalidate(const boost::optional<std::string>& source = boost::none) const;
+    TIGL_EXPORT void Invalidate(const boost::optional<std::string>& source = boost::none) const;
 };
 
 } // namespace tigl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CCPACSWalls couldn't be processed correctly via swig, due to missing include statements in configuration.i.
Adding those includes fixes the issue.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

All required includes in configuration.i were added, which are:

- The header files of the C++ classes that need to be included
- all header files of classes, that deal with types of "boost-optional" or objects related to "ITiglGeometricComponent" that swig can't process otherwise
<!--- If it fixes an open issue, please link to the issue here. -->
The changes fixes #1012 and fixes #986.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Running a python script opening the configuration according to Issue  #1012 works as expected, also the geometry is exported successful.