### PR TITLE
CPACS-Creator: Add error handling when a section should be added in (or next to) a segment containing guide curves

### DIFF
--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -40,7 +40,9 @@
 #include "CCPACSExternalObject.h"
 #include "CTiglShapeCache.h"
 #include "CTiglError.h"
+#include "CCPACSWalls.h"
 #include "CCPACSWallPosition.h"
+#include "CCPACSFuselageWallSegment.h"
 #include "CCPACSWingSegment.h"
 #include "CCPACSFuselageSegment.h"
 #include "CTiglWingConnection.h"
@@ -87,6 +89,7 @@
 #include "generated/CPACSBoundingElementUIDs.h"
 #include "generated/CPACSStructuralWallElement.h"
 #include "generated/CPACSStructuralWallElements.h"
+#include "generated/CPACSWalls.h"
 #include "generated/CPACSWallPositionUIDs.h"
 #include "generated/CPACSWallPosition.h"
 #include "generated/CPACSWallPositions.h"
@@ -180,7 +183,6 @@
 %include "generated/CPACSLateralCap_placement.h"
 %boost_optional(tigl::generated::CPACSLateralCap)
 %include "generated/CPACSLateralCap.h"
-
 %boost_optional(tigl::generated::CPACSBoundingElementUIDs)
 %include "generated/CPACSBoundingElementUIDs.h"
 %include "generated/CPACSStructuralWallElement.h"
@@ -190,8 +192,14 @@
 %include "generated/CPACSWallPositions.h"
 %include "generated/CPACSWallSegment.h"
 %include "generated/CPACSWallSegments.h"
+%boost_optional(tigl::CCPACSWalls)
 %boost_optional(tigl::generated::CPACSWalls)
+%boost_optional(tigl::CCPACSWallPosition)
+%boost_optional(tigl::CCPACSFuselageWallSegment)
 %include "generated/CPACSWalls.h"
+%include "CCPACSWalls.h"
+%include "CCPACSWallPosition.h"
+%include "CCPACSFuselageWallSegment.h"
 
 // ----------------- Engines ---------------------------//
 %boost_optional(tigl::CCPACSEngines)
@@ -538,6 +546,7 @@ class CCPACSWingRibsPositioning;
 %factory(tigl::ITiglGeometricComponent& tigl::CTiglUIDManager::GetGeometricComponent,
          tigl::CCPACSFuselage,
          tigl::CCPACSFuselageSegment,
+         tigl::CCPACSFuselageWallSegment,
          tigl::CCPACSWing,
          tigl::CCPACSWingSegment,
          tigl::CCPACSWingComponentSegment,

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -750,7 +750,8 @@ void CCPACSFuselage::CreateNewConnectedElementBetween(std::string startElementUI
 {
     if(GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetGuideCurves())
     {
-        throw tigl::CTiglError("Adding sections in fuselage segments containing guide curves is not supported", TIGL_UID_ERROR);
+        throw tigl::CTiglError("Adding sections in fuselage segments containing guide curves is currently not supported.\n"
+                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
     }
 
     std::string segmentToSplit = GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetUID();
@@ -810,7 +811,8 @@ void CCPACSFuselage::CreateNewConnectedElementAfter(std::string startElementUID)
             {
                 if(GetSegment(i).GetGuideCurves())
                 {
-                    throw tigl::CTiglError("Adding sections after fuselage segments containing guide curves is not supported", TIGL_UID_ERROR);
+                    throw tigl::CTiglError("Adding sections after fuselage segments containing guide curves is currently not supported.\n"
+                                           "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
                 }
             }
         }
@@ -875,7 +877,8 @@ void CCPACSFuselage::CreateNewConnectedElementBefore(std::string startElementUID
             {
                 if(GetSegment(i).GetGuideCurves())
                 {
-                    throw tigl::CTiglError("Adding sections before fuselage segments containing guide curves is not supported", TIGL_UID_ERROR);
+                    throw tigl::CTiglError("Adding sections before fuselage segments containing guide curves is currently not supported.\n"
+                                           "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
                 }
             }
         }

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -751,7 +751,7 @@ void CCPACSFuselage::CreateNewConnectedElementBetween(std::string startElementUI
     if(GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetGuideCurves())
     {
         throw tigl::CTiglError("Adding sections in fuselage segments containing guide curves is currently not supported.\n"
-                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
+                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_ERROR);
     }
 
     std::string segmentToSplit = GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetUID();
@@ -807,13 +807,10 @@ void CCPACSFuselage::CreateNewConnectedElementAfter(std::string startElementUID)
         // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
         for (int i=1; i <= GetSegmentCount(); i++)
         {
-            if (GetSegment(i).GetEndSectionElementUID() == startElementUID)
+            if(GetSegment(i).GetGuideCurves())
             {
-                if(GetSegment(i).GetGuideCurves())
-                {
-                    throw tigl::CTiglError("Adding sections after fuselage segments containing guide curves is currently not supported.\n"
-                                           "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
-                }
+                throw tigl::CTiglError("Adding sections after fuselage segments containing guide curves is currently not supported.\n"
+                                       "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_ERROR);
             }
         }
 
@@ -873,13 +870,10 @@ void CCPACSFuselage::CreateNewConnectedElementBefore(std::string startElementUID
         // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
         for (int i=1; i <= GetSegmentCount(); i++)
         {
-            if (GetSegment(i).GetStartSectionElementUID() == startElementUID)
+            if(GetSegment(i).GetGuideCurves())
             {
-                if(GetSegment(i).GetGuideCurves())
-                {
-                    throw tigl::CTiglError("Adding sections before fuselage segments containing guide curves is currently not supported.\n"
-                                           "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
-                }
+                throw tigl::CTiglError("Adding sections before fuselage segments containing guide curves is currently not supported.\n"
+                                       "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_ERROR);
             }
         }
 

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -748,6 +748,10 @@ void CCPACSFuselage::SetFuselageHelper(CTiglFuselageHelper& cache) const
 
 void CCPACSFuselage::CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID)
 {
+    if(GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetGuideCurves())
+    {
+        throw tigl::CTiglError("Adding sections in fuselage segments containing guide curves is not supported", TIGL_UID_ERROR);
+    }
 
     std::string segmentToSplit = GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetUID();
     CTiglFuselageSectionElement* startElement = fuselageHelper->GetCTiglElementOfFuselage(startElementUID);
@@ -797,6 +801,20 @@ void CCPACSFuselage::CreateNewConnectedElementAfter(std::string startElementUID)
         if ( elementsBefore.size() < 2) {
             throw  CTiglError("Impossible to add a element after if there is no previous element");
         }
+
+        // Iterate over segments to find the one ending in startElementUID
+        // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
+        for (int i=1; i <= GetSegmentCount(); i++)
+        {
+            if (GetSegment(i).GetEndSectionElementUID() == startElementUID)
+            {
+                if(GetSegment(i).GetGuideCurves())
+                {
+                    throw tigl::CTiglError("Adding sections after fuselage segments containing guide curves is not supported", TIGL_UID_ERROR);
+                }
+            }
+        }
+
         std::string  previousElementUID = elementsBefore[elementsBefore.size()-2];
 
         CTiglFuselageSectionElement* previousElement = fuselageHelper->GetCTiglElementOfFuselage(previousElementUID);
@@ -848,6 +866,20 @@ void CCPACSFuselage::CreateNewConnectedElementBefore(std::string startElementUID
         if (elementsAfter.size() < 1 ) {
             throw  CTiglError("Impossible to add a element before if there is no previous element");
         }
+
+        // Iterate over segments to find the one starting in startElementUID
+        // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
+        for (int i=1; i <= GetSegmentCount(); i++)
+        {
+            if (GetSegment(i).GetStartSectionElementUID() == startElementUID)
+            {
+                if(GetSegment(i).GetGuideCurves())
+                {
+                    throw tigl::CTiglError("Adding sections before fuselage segments containing guide curves is not supported", TIGL_UID_ERROR);
+                }
+            }
+        }
+
         std::string  previousElementUID = elementsAfter[0];
 
         CTiglFuselageSectionElement* previousElement = fuselageHelper->GetCTiglElementOfFuselage(previousElementUID);

--- a/src/structural_elements/CCPACSFuselageWallSegment.h
+++ b/src/structural_elements/CCPACSFuselageWallSegment.h
@@ -36,22 +36,22 @@ class CCPACSFuselageWallSegment : public generated::CPACSWallSegment, public CTi
 public:
     TIGL_EXPORT CCPACSFuselageWallSegment(CCPACSWallSegments* parent, CTiglUIDManager* uidMgr);
 
-    std::string GetDefaultedUID() const override
+    TIGL_EXPORT std::string GetDefaultedUID() const override
     {
         return GetUID().value_or("UnknownWallSegment");
     }
 
-    TiglGeometricComponentIntent GetComponentIntent() const override
+    TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const override
     {
         return TIGL_INTENT_INNER_STRUCTURE | TIGL_INTENT_PHYSICAL;
     }
 
-    TiglGeometricComponentType   GetComponentType() const override
+    TIGL_EXPORT TiglGeometricComponentType   GetComponentType() const override
     {
         return TIGL_COMPONENT_FUSELAGE_WALL;
     }
 
-    TopoDS_Compound GetCutPlanes() const;
+    TIGL_EXPORT TopoDS_Compound GetCutPlanes() const;
 
     TIGL_EXPORT void SetPhi(const double& value) override;
     TIGL_EXPORT void SetDoubleSidedExtrusion(const boost::optional<bool>& value) override;

--- a/src/structural_elements/CCPACSWalls.h
+++ b/src/structural_elements/CCPACSWalls.h
@@ -32,12 +32,12 @@ namespace tigl
 class CCPACSWalls : public generated::CPACSWalls
 {
 public:
-    CCPACSWalls(CCPACSFuselageStructure* parent, CTiglUIDManager* uidMgr);
+    TIGL_EXPORT CCPACSWalls(CCPACSFuselageStructure* parent, CTiglUIDManager* uidMgr);
 
-    const CCPACSFuselageWallSegment& GetWallSegment(const std::string& uid) const;
-    const CCPACSWallPosition& GetWallPosition(const std::string& uid) const;
+    TIGL_EXPORT const CCPACSFuselageWallSegment& GetWallSegment(const std::string& uid) const;
+    TIGL_EXPORT const CCPACSWallPosition& GetWallPosition(const std::string& uid) const;
 
-    void Invalidate(const boost::optional<std::string>& source = boost::none) const;
+    TIGL_EXPORT void Invalidate(const boost::optional<std::string>& source = boost::none) const;
 };
 
 } // namespace tigl

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -1409,7 +1409,8 @@ void CCPACSWing::CreateNewConnectedElementBetween(std::string startElementUID, s
 {
         if(GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetGuideCurves())
         {
-            throw tigl::CTiglError("Adding sections in wing segments containing guide curves is not supported", TIGL_UID_ERROR);
+            throw tigl::CTiglError("Adding sections in wing segments containing guide curves is currently not supported.\n"
+                                   "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
         }
 
         std::string segmentToSplit = GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetUID();
@@ -1467,7 +1468,8 @@ void CCPACSWing::CreateNewConnectedElementAfter(std::string startElementUID)
                 {
                     if(GetSegment(i).GetGuideCurves())
                     {
-                        throw tigl::CTiglError("Adding sections after wing segments containing guide curves is not supported", TIGL_UID_ERROR);
+                        throw tigl::CTiglError("Adding sections after wing segments containing guide curves is currently not supported.\n"
+                                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
                     }
                 }
             }
@@ -1533,7 +1535,8 @@ void CCPACSWing::CreateNewConnectedElementBefore(std::string startElementUID)
                 {
                     if(GetSegment(i).GetGuideCurves())
                     {
-                        throw tigl::CTiglError("Adding sections before wing segments containing guide curves is not supported", TIGL_UID_ERROR);
+                        throw tigl::CTiglError("Adding sections before wing segments containing guide curves is currently not supported.\n"
+                                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
                     }
                 }
             }

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -1410,7 +1410,7 @@ void CCPACSWing::CreateNewConnectedElementBetween(std::string startElementUID, s
         if(GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetGuideCurves())
         {
             throw tigl::CTiglError("Adding sections in wing segments containing guide curves is currently not supported.\n"
-                                   "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
+                                   "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_ERROR);
         }
 
         std::string segmentToSplit = GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetUID();
@@ -1464,13 +1464,10 @@ void CCPACSWing::CreateNewConnectedElementAfter(std::string startElementUID)
             // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
             for (int i=1; i <= GetSegmentCount(); i++)
             {
-                if (GetSegment(i).GetOuterSectionElementUID() == startElementUID)
+                if(GetSegment(i).GetGuideCurves())
                 {
-                    if(GetSegment(i).GetGuideCurves())
-                    {
-                        throw tigl::CTiglError("Adding sections after wing segments containing guide curves is currently not supported.\n"
-                                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
-                    }
+                    throw tigl::CTiglError("Adding sections after wing segments containing guide curves is currently not supported.\n"
+                                           "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_ERROR);
                 }
             }
 
@@ -1531,13 +1528,10 @@ void CCPACSWing::CreateNewConnectedElementBefore(std::string startElementUID)
             // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
             for (int i=1; i <= GetSegmentCount(); i++)
             {
-                if (GetSegment(i).GetInnerSectionElementUID() == startElementUID)
+                if(GetSegment(i).GetGuideCurves())
                 {
-                    if(GetSegment(i).GetGuideCurves())
-                    {
-                        throw tigl::CTiglError("Adding sections before wing segments containing guide curves is currently not supported.\n"
-                                               "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_UID_ERROR);
-                    }
+                    throw tigl::CTiglError("Adding sections before wing segments containing guide curves is currently not supported.\n"
+                                           "In general, guide curves should only be added when all sections are already defined, since the guide curves depend on them.", TIGL_ERROR);
                 }
             }
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -1407,6 +1407,10 @@ void CCPACSWing::SetARKeepArea(double newAR)
 
 void CCPACSWing::CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID)
 {
+        if(GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetGuideCurves())
+        {
+            throw tigl::CTiglError("Adding sections in wing segments containing guide curves is not supported", TIGL_UID_ERROR);
+        }
 
         std::string segmentToSplit = GetSegments().GetSegmentFromTo(startElementUID, endElementUID).GetUID();
         CTiglWingSectionElement *startElement = wingHelper->GetCTiglElementOfWing(startElementUID);
@@ -1454,6 +1458,20 @@ void CCPACSWing::CreateNewConnectedElementAfter(std::string startElementUID)
             if ( elementsBefore.size() < 2) {
                 throw  CTiglError("Impossible to add a element after if there is no previous element");
             }
+
+            // Iterate over segments to find the one ending in startElementUID
+            // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
+            for (int i=1; i <= GetSegmentCount(); i++)
+            {
+                if (GetSegment(i).GetOuterSectionElementUID() == startElementUID)
+                {
+                    if(GetSegment(i).GetGuideCurves())
+                    {
+                        throw tigl::CTiglError("Adding sections after wing segments containing guide curves is not supported", TIGL_UID_ERROR);
+                    }
+                }
+            }
+
             std::string  previousElementUID = elementsBefore[elementsBefore.size()-2];
 
             CTiglWingSectionElement* previousElement = wingHelper->GetCTiglElementOfWing(previousElementUID);
@@ -1506,6 +1524,20 @@ void CCPACSWing::CreateNewConnectedElementBefore(std::string startElementUID)
             if (elementsAfter.size() < 1 ) {
                 throw  CTiglError("Impossible to add a element before if there is no previous element");
             }
+
+            // Iterate over segments to find the one starting in startElementUID
+            // If the corresponding segment contains guide curves -> Throw error, since adding elements after gc-segments is not supported
+            for (int i=1; i <= GetSegmentCount(); i++)
+            {
+                if (GetSegment(i).GetInnerSectionElementUID() == startElementUID)
+                {
+                    if(GetSegment(i).GetGuideCurves())
+                    {
+                        throw tigl::CTiglError("Adding sections before wing segments containing guide curves is not supported", TIGL_UID_ERROR);
+                    }
+                }
+            }
+
             std::string  previousElementUID = elementsAfter[0];
 
             CTiglWingSectionElement* previousElement = wingHelper->GetCTiglElementOfWing(previousElementUID);

--- a/tests/unittests/creatorFuselage.cpp
+++ b/tests/unittests/creatorFuselage.cpp
@@ -330,6 +330,16 @@ TEST_F(creatorFuselage, setRotation_MultipleFuselagesModel)
 }
 
 
+TEST_F(creatorFuselage, createSection_FuselageSegmentGuideCurves)
+{
+
+    setVariables("TestData/simple_test_guide_curves.xml", "Fuselage");
+
+    EXPECT_THROW(fuselage->CreateNewConnectedElementBefore("GuideCurveModel_Fuselage_Sec1_El1"), tigl::CTiglError);
+    EXPECT_THROW(fuselage->CreateNewConnectedElementBetween("GuideCurveModel_Fuselage_Sec1_El1", "GuideCurveModel_Fuselage_Sec2_El1"), tigl::CTiglError);
+    EXPECT_THROW(fuselage->CreateNewConnectedElementAfter("GuideCurveModel_Fuselage_Sec3_El1"), tigl::CTiglError);
+}
+
 
 TEST_F(creatorFuselage, createSection_MultipleFuselageModel)
 {

--- a/tests/unittests/creatorWing.cpp
+++ b/tests/unittests/creatorWing.cpp
@@ -998,6 +998,17 @@ TEST_F(creatorWing, MultipleWings_SetARKeepArea) {
 }
 
 
+TEST_F(creatorWing, createSection_WingSegmentGuideCurves)
+{
+
+    setVariables("TestData/simple_test_guide_curves.xml", "Wing");
+
+    EXPECT_THROW(wing->CreateNewConnectedElementBefore("GuideCurveModel_Wing_Sec1_El1"), tigl::CTiglError);
+    EXPECT_THROW(wing->CreateNewConnectedElementBetween("GuideCurveModel_Wing_Sec1_El1", "GuideCurveModel_Wing_Sec2_El1"), tigl::CTiglError);
+    EXPECT_THROW(wing->CreateNewConnectedElementAfter("GuideCurveModel_Wing_Sec4_El1"), tigl::CTiglError);
+}
+
+
 TEST_F(creatorWing, MultipleWings_CreateSections)
 {
     setVariables("TestData/multiple_wings.xml", "Wing");


### PR DESCRIPTION
Currently, in the CPACS-Creator a section can be added within or next to a segment that contains guide curves (issue #626).
Right now, this results in an error occuring elsewhere or undefined behaviour. Therefore, for the moment it should not be allowed for a user to do this.
From a CPACS perspective it seems reasonable: The guide curves are generally defined after all sections are created as the guide curves depent on them.

Fixes #626 

If users seek for this feature, we can think about a way to handle this. But it should not be an urgent task.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] A test for the new functionality was added.
- [x] All tests run without failure.
- [ ] The new code complies with the TiGL style guide.
- [ ] New classes have been added to the Python interface.
- [ ] API changes were documented properly in tigl.h.
- [ ] Changes were documented in tigl/ChangeLog.md
