### PR TITLE
Update to C++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ cmake_minimum_required (VERSION 3.11.0)
 project (TIGL VERSION 3.4.0)
 set(TIGL_VERSION 3.4.0)
 
-# enable C++11 support
-set(CMAKE_CXX_STANDARD 11)
+# enable C++17 support
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ Changelog
 
 Changes since last release
 -------------
+18/12/2024
+
+  - General changes:
+    - Update the C++ standard to C++17 (#1045).
+
 13/11/2024
 
  - Fixes:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,6 @@ endforeach()
 
 # object library containing just the compiled sources
 add_library(tigl3_objects OBJECT ${TIGL_SRC})
-target_compile_features(tigl3_objects PRIVATE cxx_std_11)
 set_property(TARGET tigl3_objects PROPERTY POSITION_INDEPENDENT_CODE ON) # needed for shared libraries
 
 target_include_directories(tigl3_objects
@@ -208,7 +207,6 @@ target_include_directories(tigl3_cpp INTERFACE
 )
 
 target_link_libraries(tigl3_cpp INTERFACE ${OpenCASCADE_LIBRARIES} Boost::boost Boost::disable_autolinking)
-target_compile_features(tigl3_cpp INTERFACE cxx_std_11)
 
 if (TARGET glog::glog)
   target_link_libraries (tigl3_cpp INTERFACE glog::glog)


### PR DESCRIPTION
## Description
This PR updates the C++ standard to 17 to make use of newer coding features.
Moreover, the standard was also defined in the `src/CMakeLists.txt` which seems redundant. Now, the C++ standard only needs to be defined in the `<ROOT>/CMakeLists.txt`.

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
