### PR TITLE
Added Getter functions to CCPACSPositionings.h 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,8 +5,13 @@ Changes since last release
 -------------
 18/12/2024
 
-  - General changes:
+- Fixes
+  - #936 A particular defined positioning (of the C++-type CCPACSPositioning) was not available via Python bindings since the std::vector<std::unique_ptr<**Type**>> is not exposed to swig. New getter functions have been implemented in CCPACSPositioning.h to make these elements accesible via index, similar to the implementation of for several other classes. For more information see https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59.
+
+  
+- General changes:
     - Update the C++ standard to C++17 (#1045).
+
 
 13/11/2024
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,6 @@ Changelog
 Changes since last release
 -------------
 18/12/2024
-<<<<<<< HEAD
 
 - Fixes
   - #936 A particular defined positioning (of the C++-type CCPACSPositioning) was not available via Python bindings since the std::vector<std::unique_ptr<**Type**>> is not exposed to swig. New getter functions have been implemented in CCPACSPositioning.h to make these elements accesible via index, similar to the implementation of for several other classes. For more information see https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59.
@@ -14,11 +13,6 @@ Changes since last release
     - Update the C++ standard to C++17 (#1045).
 
 
-=======
-- Fixes
-  - #936 A particular defined positioning (of the C++-type CCPACSPositioning) was not available via Python bindings since the std::vector<std::unique_ptr<**Type**>> is not exposed to swig. New getter functions have been implemented in CCPACSPositioning.h to make these elements accesible via index, similar to the implementation of for several other classes. For more information see https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59.
-
->>>>>>> 95b5f3c0d71cb763533f8d9eac3f5ebd30b8b1f0
 13/11/2024
 
  - Fixes:

--- a/bindings/python_internal/configuration.i
+++ b/bindings/python_internal/configuration.i
@@ -96,6 +96,7 @@
 #include "generated/CPACSWallSegment.h"
 #include "generated/CPACSWallSegments.h"
 #include "generated/CPACSUIDSequence.h"
+#include "generated/CPACSWing.h"
 #include "CCPACSDucts.h"
 #include "CCPACSDuctAssembly.h"
 #include "CCPACSDuct.h"
@@ -128,6 +129,7 @@
 %boost_optional(tigl::generated::CPACSSparCells)
 %boost_optional(tigl::CCPACSGuideCurves)
 %boost_optional(tigl::CCPACSPositionings)
+%boost_optional(tigl::CCPACSPositioning)
 %boost_optional(tigl::CCPACSWingComponentSegments)
 %boost_optional(tigl::CCPACSWingRibsDefinitions)
 %boost_optional(tigl::CCPACSWingSpars)
@@ -397,6 +399,7 @@ class CCPACSWingRibsPositioning;
 %include "CCPACSWingComponentSegments.h"
 %include "generated/CPACSPositionings.h"
 %include "CCPACSPositionings.h"
+%include "CCPACSPositioning.h"
 // We have to rename the enums since they collide with those from tigl.h
 %rename(GuideCurve_C0) tigl::generated::C0;
 %rename(GuideCurve_C1_from_previous) tigl::generated::C1_from_previous;

--- a/src/CCPACSPositionings.cpp
+++ b/src/CCPACSPositionings.cpp
@@ -73,6 +73,24 @@ CTiglTransformation CCPACSPositionings::GetPositioningTransformation(const std::
     return CTiglTransformation();
 }
 
+//TODO write test
+int CCPACSPositionings::GetPositioningCount() const
+{
+    return CPACSPositionings::m_positionings.size();
+}
+
+//TODO write test
+CCPACSPositioning& CCPACSPositionings::GetPositioning(int index)
+{
+    {
+        index --;
+        if (index < 0 || index >= GetPositioningCount()) {
+            throw CTiglError("Invalid index in CCPACSPositionings::GetPositioning", TIGL_INDEX_ERROR);
+        }
+        return *m_positionings[index];
+    }
+}
+
 namespace
 {
 void UpdateNextPositioning(CCPACSPositioning* currPos, int depth)

--- a/src/CCPACSPositionings.cpp
+++ b/src/CCPACSPositionings.cpp
@@ -73,13 +73,11 @@ CTiglTransformation CCPACSPositionings::GetPositioningTransformation(const std::
     return CTiglTransformation();
 }
 
-//TODO write test
 int CCPACSPositionings::GetPositioningCount() const
 {
     return CPACSPositionings::m_positionings.size();
 }
 
-//TODO write test
 CCPACSPositioning& CCPACSPositionings::GetPositioning(int index)
 {
     {

--- a/src/CCPACSPositionings.h
+++ b/src/CCPACSPositionings.h
@@ -56,10 +56,10 @@ public:
     // Returns the positioning matrix for a given section-uid
     TIGL_EXPORT CTiglTransformation GetPositioningTransformation(const std::string& sectionIndex);
 
-    // Returns the total count of positionings in a configuration
+    // Returns the total count of positionings in a configuration per element (e.g. wing)
     TIGL_EXPORT int GetPositioningCount() const;
 
-    // Returns the positioning for a given index
+    // Returns the positioning for a given index, starting at 1
     TIGL_EXPORT CCPACSPositioning& GetPositioning(int index);
 
     // Cleanup routine

--- a/src/CCPACSPositionings.h
+++ b/src/CCPACSPositionings.h
@@ -56,6 +56,12 @@ public:
     // Returns the positioning matrix for a given section-uid
     TIGL_EXPORT CTiglTransformation GetPositioningTransformation(const std::string& sectionIndex);
 
+    // Returns the total count of positionings in a configuration
+    TIGL_EXPORT int GetPositioningCount() const;
+
+    // Returns the positioning for a given index
+    TIGL_EXPORT CCPACSPositioning& GetPositioning(int index);
+
     // Cleanup routine
     TIGL_EXPORT void Cleanup();
 

--- a/src/CCPACSPositionings.h
+++ b/src/CCPACSPositionings.h
@@ -53,13 +53,24 @@ public:
     // Read CPACS positionings element
     TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& wingXPath) override;
 
-    // Returns the positioning matrix for a given section-uid
+    /**
+     * @brief GetPositioningTransformation returns the positioning matrix for a given section-uid
+     * @param sectionIndex
+     * @return Returns CTiglTransformation positioning matrix by sectionIndex
+     */
     TIGL_EXPORT CTiglTransformation GetPositioningTransformation(const std::string& sectionIndex);
 
-    // Returns the total count of positionings in a configuration per element (e.g. wing)
+    /**
+     * @brief GetPositioningCount returns the total count of positionings in a configuration per element (e.g. wing)
+     * @return int Return total count of positionings
+     */
     TIGL_EXPORT int GetPositioningCount() const;
 
-    // Returns the positioning for a given index, starting at 1
+    /**
+     * @brief GetPositioning
+     * @param index Note that index starts at 1
+     * @return Returns CCPACSPositioning& by index
+     */
     TIGL_EXPORT CCPACSPositioning& GetPositioning(int index);
 
     // Cleanup routine

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -710,12 +710,16 @@ TEST_F(WingSegment, tiglWingGetOuterSectionAndElementUID_success)
     ASSERT_TRUE(strcmp(elementUID, "D150_VAMP_W1_Sec4_Elem1") == 0);
 }
 
+/* Test on positionings concerning the wings, using the CPACS_30_D150.xml */
 TEST_F(WingSegment, testGetPositioningCount)
 {
     tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
     tigl::CCPACSWing& wing = config.GetWing(1);
+    //check if function output matches values from xml file
     ASSERT_EQ(4, wing.GetPositionings()->GetPositioningCount());
+    ASSERT_STREQ("Wing_Position1" , wing.GetPositionings()->GetPositioning(1).GetName().c_str());
+    //check if index implementation is correct
     ASSERT_NO_THROW(wing.GetPositionings()->GetPositioning(1));
     ASSERT_THROW(wing.GetPositionings()->GetPositioning(0), tigl::CTiglError);
     ASSERT_THROW(wing.GetPositionings()->GetPositioning(5), tigl::CTiglError);

--- a/tests/unittests/tiglWingSegment.cpp
+++ b/tests/unittests/tiglWingSegment.cpp
@@ -19,6 +19,7 @@
 * @brief Tests for testing behavior of the routines for segment handling/query.
 */
 
+
 #include "test.h" // Brings in the GTest framework
 #include "tigl.h"
 
@@ -707,6 +708,17 @@ TEST_F(WingSegment, tiglWingGetOuterSectionAndElementUID_success)
     ASSERT_TRUE(tiglWingGetOuterSectionAndElementUID(tiglHandle, 1, 3, &sectionUID, &elementUID) == TIGL_SUCCESS);
     ASSERT_TRUE(strcmp(sectionUID, "D150_VAMP_W1_Sec4") == 0);
     ASSERT_TRUE(strcmp(elementUID, "D150_VAMP_W1_Sec4_Elem1") == 0);
+}
+
+TEST_F(WingSegment, testGetPositioningCount)
+{
+    tigl::CCPACSConfigurationManager & manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration & config = manager.GetConfiguration(tiglHandle);
+    tigl::CCPACSWing& wing = config.GetWing(1);
+    ASSERT_EQ(4, wing.GetPositionings()->GetPositioningCount());
+    ASSERT_NO_THROW(wing.GetPositionings()->GetPositioning(1));
+    ASSERT_THROW(wing.GetPositionings()->GetPositioning(0), tigl::CTiglError);
+    ASSERT_THROW(wing.GetPositionings()->GetPositioning(5), tigl::CTiglError);
 }
 
 /* Tests on simple geometry__________________________ */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added Getter functions to CCPACSPositionings.h to make Positionings available via Python Bindings, which is currently not true for classes that store elements using the std::vector<std::unique_prt<**TYPE**>> and don't provide getter functions that return elements by index.

For further information see  https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59

## Description
<!--- Describe your changes in detail -->
New Functions:

CCPACSPositionings::GetPositioningCount()
CCPACSPositionings::GetPositioning(int index)


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Implements Getter functions manually, as discussed in https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59, to fix missing functionality as described in #936.
Functions returning the type std::vector<std::unique_prt<**TYPE**>> will still not be available via Python Bindings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added a test, checking missing functionality described in #936


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
