### PR TITLE
Add GeomAPI_PointsToBSpline as an optional alternative algorithm in CSTCurveBuilder

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@ Changelog
 
 Changes since last release
 -------------
-18/12/2024
+10/01/2025
 
 - Fixes
   - #936 A particular defined positioning (of the C++-type CCPACSPositioning) was not available via Python bindings since the std::vector<std::unique_ptr<**Type**>> is not exposed to swig. New getter functions have been implemented in CCPACSPositioning.h to make these elements accesible via index, similar to the implementation of for several other classes. For more information see https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59.
@@ -11,6 +11,7 @@ Changes since last release
   
 - General changes:
     - Update the C++ standard to C++17 (#1045).
+    - Added the possibility to switch between two algorithms in the `CCSTCurveBuilder`. The default algorithm based on a Chebychev approximation results in a small number of control points, but introduces small discontinuities in the curvature. The new option is to use OCCT's `GeomAPI_PointsToBSpline`, which results in a C3 continuous B-Spline.
 
 
 13/11/2024

--- a/src/geometry/CCSTCurveBuilder.h
+++ b/src/geometry/CCSTCurveBuilder.h
@@ -35,7 +35,23 @@ namespace tigl
 class CCSTCurveBuilder
 {
 public:
-    TIGL_EXPORT CCSTCurveBuilder(double N1, double N2, const std::vector<double>& B, double T);
+
+    /**
+     * @brief The Algorithm enum gives a choice of the method.
+     *
+     * Piecewise_Chebychev_Approximation subdivides the curve into
+     * segments, where each segment is approximated using a Chebychev polynomials.
+     * The final result is the C1 concatenation of these polynomials to a B-Spline
+     *
+     * GeomAPI_PointsToBSpline uses OCCT's internal approximation algorithm to create
+     * a B-Spline that approximates a CST Curve.
+     */
+    enum class Algorithm {
+        Piecewise_Chebychev_Approximation = 0,
+        GeomAPI_PointsToBSpline
+    };
+
+    TIGL_EXPORT CCSTCurveBuilder(double N1, double N2, const std::vector<double>& B, double T, Algorithm method=Algorithm::Piecewise_Chebychev_Approximation);
 
     // returns parameters of cst curve
     TIGL_EXPORT double N1() const;
@@ -48,6 +64,9 @@ public:
 private:
     double _n1, _n2, _t;
     std::vector<double> _b;
+    int _degree;
+    double _tol;
+    Algorithm _algo;
 };
 
 } // namespace tigl


### PR DESCRIPTION
Fixes #1048 

## Description

This PR adds the option to set the algorithm in CCSTCurveBuilder. The current algorithm based on a Chebychev approximation creates relatively good curves with few control points, but it potentially introduces discontinuities in the curvature, because the approximation is performed segmentwise and the segments are concatenated without taking second derivatives into account. 

With the changes introduced here, the CCSTCurveBuilder constructor gets a new optional enum argument, to switch the algorithm to OCCT's GeomAPI_PointsToBSpline implementation for the approximation. This results in a C3 continuous B-Spline of degree 4 which is much smoother, but may have more control points.

## How Has This Been Tested?

The existing CSTApprox tests have been parametrized, such that the both algorithms are tested. In addition, the profile definition from the issue description in #1048 has been added. As it turns out, the old implementation fails to satisfy the prescribed tolerance of 1e-5 for this specific choice of CST parameters. 

![grafik](https://github.com/user-attachments/assets/aae9c978-bc34-4863-b40f-0818950d0d53)
The image shows the curvature comb for the Chebychev approximation (default algorithm that was used thus far) to the right in the back and the curvature comb for the approximation based on `GeomAPI_PointsToBSpline` to the left/front. 


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
