### PR TITLE
Fix CI: Linux Test job capturing code coverage is broken

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,7 @@ jobs:
         # only enable coverage for Debug build on latest ubuntu
         include:
           - config: "Debug"
-            os: "ubuntu-latest"
+            os: "ubuntu-22.04"
             coverage: "ON"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,10 +98,10 @@ jobs:
         # generate coverage reports on latest ubuntu debug builds
         exclude:
           - config: "Debug"
-            os: "ubuntu-latest"
+            os: "ubuntu-22.04"
         include:
           - config: "Debug"
-            os: "ubuntu-latest"
+            os: "ubuntu-22.04"
             coverage: "ON"
             unit-tests: false
     runs-on: ${{ matrix.os }}

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -82,7 +82,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _testdir _outputname)
                 COMMAND ${_testrunner} ${ARGV3}
 
                 # Capturing lcov counters and generating report
-                COMMAND ${LCOV_PATH} --directory ../.. --capture --ignore-errors mismatch --output-file ${_outputname}_all.info
+                COMMAND ${LCOV_PATH} --directory ../.. --capture --output-file ${_outputname}_all.info
                 COMMAND ${LCOV_PATH} --remove ${_outputname}_all.info '${PROJECT_SOURCE_DIR}/${_testdir}/*' '${PROJECT_SOURCE_DIR}/tests/common/*' '${PROJECT_SOURCE_DIR}/thirdparty/**' '/usr/*' '*oce*' '*build*' '*tixi3*' '${PROJECT_SOURCE_DIR}/src/generated/*' --output-file ${_outputname}.info
 
                 COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}_all.info 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -85,10 +85,6 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _testdir _outputname)
                 COMMAND ${LCOV_PATH} --directory ../.. --capture --ignore-errors mismatch --output-file ${_outputname}_all.info
                 COMMAND ${LCOV_PATH} --remove ${_outputname}_all.info '${PROJECT_SOURCE_DIR}/${_testdir}/*' '${PROJECT_SOURCE_DIR}/tests/common/*' '${PROJECT_SOURCE_DIR}/thirdparty/**' '/usr/*' '*oce*' '*build*' '*tixi3*' '${PROJECT_SOURCE_DIR}/src/generated/*' --output-file ${_outputname}.info
 
-                IF(TIGL_COVERAGE_GENHTML)
-                        COMMAND ${GENHTML_PATH} -o ../../${_outputname} ${_outputname}.info
-                ENDIF()
-                
                 COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}_all.info 
 
                 USES_TERMINAL
@@ -96,11 +92,12 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _testdir _outputname)
                 COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
         )
 
-        # Show info where to find the report
-        ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
-                COMMAND ;
-                COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
-        )
+        IF(TIGL_COVERAGE_GENHTML)
+                ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+                        COMMAND ${GENHTML_PATH} -o ../../${_outputname} ${_outputname}.info
+                        COMMENT "Generating HTML report. Open ./${_outputname}/index.html in your browser to view the coverage report."
+                )
+        ENDIF()
 
 ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -11,10 +11,15 @@
 #    which runs your test executable and produces a lcov code coverage report.
 #
 
+OPTION(TIGL_COVERAGE_GENHTML "Use Genhtml to generate htmls from gcov output" OFF)
+
 # Check prereqs
 FIND_PROGRAM( GCOV_PATH gcov )
 FIND_PROGRAM( LCOV_PATH lcov )
-FIND_PROGRAM( GENHTML_PATH genhtml )
+
+IF(TIGL_COVERAGE_GENHTML)
+  FIND_PROGRAM( GENHTML_PATH genhtml )
+ENDIF()
 FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${PROJECT_SOURCE_DIR}/tests)
 
 IF(NOT GCOV_PATH)
@@ -55,9 +60,11 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _testdir _outputname)
                 MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
         ENDIF() # NOT LCOV_PATH
 
+        IF(TIGL_COVERAGE_GENHTML)
         IF(NOT GENHTML_PATH)
                 MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
         ENDIF() # NOT GENHTML_PATH
+        ENDIF() # TIGL_COVERAGE_GENHTML
         
         # copy testdata
         file(COPY ${PROJECT_SOURCE_DIR}/${_testdir}/TestData DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
@@ -77,7 +84,11 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _testdir _outputname)
                 # Capturing lcov counters and generating report
                 COMMAND ${LCOV_PATH} --directory ../.. --capture --output-file ${_outputname}_all.info
                 COMMAND ${LCOV_PATH} --remove ${_outputname}_all.info '${PROJECT_SOURCE_DIR}/${_testdir}/*' '${PROJECT_SOURCE_DIR}/tests/common/*' '${PROJECT_SOURCE_DIR}/thirdparty/**' '/usr/*' '*oce*' '*build*' '*tixi3*' '${PROJECT_SOURCE_DIR}/src/generated/*' --output-file ${_outputname}.info
-                COMMAND ${GENHTML_PATH} -o ../../${_outputname} ${_outputname}.info
+
+                IF(TIGL_COVERAGE_GENHTML)
+                        COMMAND ${GENHTML_PATH} -o ../../${_outputname} ${_outputname}.info
+                ENDIF()
+                
                 COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}_all.info 
 
                 USES_TERMINAL

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -82,7 +82,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _testdir _outputname)
                 COMMAND ${_testrunner} ${ARGV3}
 
                 # Capturing lcov counters and generating report
-                COMMAND ${LCOV_PATH} --directory ../.. --capture --output-file ${_outputname}_all.info
+                COMMAND ${LCOV_PATH} --directory ../.. --capture --ignore-errors mismatch --output-file ${_outputname}_all.info
                 COMMAND ${LCOV_PATH} --remove ${_outputname}_all.info '${PROJECT_SOURCE_DIR}/${_testdir}/*' '${PROJECT_SOURCE_DIR}/tests/common/*' '${PROJECT_SOURCE_DIR}/thirdparty/**' '/usr/*' '*oce*' '*build*' '*tixi3*' '${PROJECT_SOURCE_DIR}/src/generated/*' --output-file ${_outputname}.info
 
                 IF(TIGL_COVERAGE_GENHTML)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR basically just makes sure that the coverage reports are generated on Ubuntu 22.04 instead of Ubuntu 24.04. I do not fully understand why we started receiving lcov errors after `ubuntu-latest` became `ubuntu-24.04`, but for now, this resolves the issue.

Previously, the cmake target for generating coverage reports also generated human-readible html files. These aren't really used by us, because we are directly uploading the lcov *.info files to codecov.org without any further post-processing. Since I wasn't sure if this html generation was causing the problems, I disabled the generation of the html files by default. I added a cmake option so that the html files can still optionally be generated. 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it locally on a Ubuntu 22.04 and managed to reproduce the error in a Ubuntu 24.04 docker image. But mainly: CI works again.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
