### PR TITLE
Make `tiglExportComponent` respect symmetries

### DIFF
--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -7342,6 +7342,15 @@ TiglReturnCode tiglExportComponent(TiglCPACSConfigurationHandle cpacsHandle, con
 
         tigl::PTiglCADExporter exporter = tigl::createExporter(extension);
         exporter->AddShape(component.GetLoft(), &config, tigl::TriangulatedExportOptions(deflection));
+
+        // Mirror symmetries if requested
+        if (exporter->GlobalExportOptions().Get<bool>("ApplySymmetries")) {
+            auto positionedComp = dynamic_cast<tigl::CTiglRelativelyPositionedComponent*>(&component);
+            if (positionedComp && positionedComp->GetSymmetryAxis() != TIGL_NO_SYMMETRY) {
+                exporter->AddShape(positionedComp->GetMirroredLoft(), &config, tigl::TriangulatedExportOptions(deflection));
+            }
+        }
+
         if (exporter->Write(fileName) == true) {
             return TIGL_SUCCESS;
         }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This makes `tiglExportComponent` respect the symmetry option of `tiglSetExportOptions`, e.g.

    tiglSetExportOptions("brep", "ApplySymmetries", "true");

such that a symmetric shape is exported if requested.

Before, only the asymmetric shape has been exported, ignoring the symmetry flag.

__Note__: This might break the behavior of client code that assumes non-symmetric geometries, even if the symmetry flag has been set.

Closes #1060

## How Has This Been Tested?

Manually.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
