### PR TITLE
Downgrade qt version in env.yml to 5.9.7

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@ Changelog
 
 Changes since last release
 -------------
-10/01/2025
+24/03/2025
 
 - Fixes
 
@@ -17,7 +17,7 @@ Changes since last release
  
     - Update the C++ standard to C++17 (#1045).
     - Added the possibility to switch between two algorithms in the `CCSTCurveBuilder`. The default algorithm based on a Chebychev approximation results in a small number of control points, but introduces small discontinuities in the curvature. The new option is to use OCCT's `GeomAPI_PointsToBSpline`, which results in a C3 continuous B-Spline.
-
+    - Downgrade the used version of QT in the `environment.yml` to 5.9.7. The currently used version brings its own GL which leads to conflicts when the library is already installed on the system. CMake cannot resolve the problem that both libraries are found. Therefore, the runtime library paths are not meaningful. As a consequence, the tiglviewer cannot be executed. Fix #1069. (#1071)
 
 13/11/2024
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
  - tixi3=3.3.0                   # library for dealing with xml files
  - opencascade=7.4.0             # library for dealing with b-spline and nurbs geometries. dlr-sc version contains patch for C2-cont. Coons patches
  # optional dependencies
- - conda-forge::qt=5.15.8        # needed to build tiglviewer
+ - conda-forge::qt=5.9.7         # needed to build tiglviewer
  - doxygen=1.8.15                # needed to build the documenation
  - python=3.8                    # needed to build python bindings
  - swig>=3.0.11                  # needed to build python bindings


### PR DESCRIPTION
Currently used version (5.15.8) brings its own GL, EGL and GLX. Those lead to conflits when the libraries are already installed on system. CMake finds both libraries, respectively, and they will not be linked correctly. The tiglviewer cannot be executed because the runtime library path is not correct/meaningful.
The libraries are installed in the newer version of QT. The older version does not install those packages.

Fix #1069.

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
