### PR TITLE
Do not link the tiglviewer executable explicitly against OpenGL

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ Changelog
 
 Changes since last release
 -------------
+08/04/2025
+
+- Fixes
+
+  - The explicit linking of the tiglviewer executable against OpenGL was removed. With the (current) QT version 5.15.8 used in the conda environment, a naming conflict appears since there are two libraries with the same name. One comes with conda and the other one is already installed within the system. The problem is related to OpenGL (GL, GLX) and results in CMake not being able to find the correct runtime path as it was ambiguous. At the end, the TiGLViewer was not executable due to that. We found out that an explicit linking against OpenGL is not necessary (anymore ?) since it already comes with OCCT. Hence, we deactivated the linking which also solved this issue (issue #1069, PR #1074).
+
 10/01/2025
 
 - Fixes

--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -40,10 +40,6 @@ else(OCE_FOUND)
   set(OpenCASCADE_LIBRARIES "")
 endif(OCE_FOUND)
 
-# we need opengl in order to build tiglviewer
-cmake_policy(SET CMP0072 NEW)
-find_package(OpenGL REQUIRED)
-
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   # set library search path to local lib directory during installation
   set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
@@ -115,7 +111,6 @@ target_link_libraries(${PROGNAME} PRIVATE
   tigl3_static tigl3_cpp
   ${CMake_QT_LIBRARIES} 
   ${OpenCASCADE_LIBRARIES} 
-  OpenGL::GL
   ${EXTRA_LIBRARIES} 
 )
 


### PR DESCRIPTION
## Description

With the (current) QT version 5.15.8 used in the conda environment, a naming conflict appears since there are two libraries with the same name. One comes with conda and the other one is already installed within the system. The problem is related to OpenGL (GL, GLX) and results in CMake not being able to find the correct runtime path as it was ambiguous. At the end, the TiGLViewer was not executable due to that. We found out that an explicit linking against OpenGL is not necessary (anymore ?) since it already comes with OCCT. Hence, we deactivated the linking which also solved this issue (#1069).

## How Has This Been Tested?
In both conda environments (the "old" one containing the QT version 5.9.7 as well as the current one), the build and execution of the tiglviewer program is possible after the change on our local machine. Also, a test file could be opened.

Fix #1069.

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
