### PR TITLE
Add check for profiles database path within CPACSCreator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ Changes since last release
 
 - Fixes
 
+  - #1087 CPACSCreator uses a system-wide config file to store (among many others) the path to the profiles database. If TiGL is built in a second configuration on the same system, the first build will determine the path in this config file. If then later the first build (and path) is removed, TiGL will still try to load the database from this path. A check is included, whether the path exists and should overwrite the config file entry when it does not.
+
   - #936 A particular defined positioning (of the C++-type CCPACSPositioning) was not available via Python bindings since the std::vector<std::unique_ptr<**Type**>> is not exposed to swig. New getter functions have been implemented in CCPACSPositioning.h to make these elements accesible via index, similar to the implementation of for several other classes. For more information see https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59.
 
  - New API functions:

--- a/TIGLViewer/src/TIGLViewerSettings.cpp
+++ b/TIGLViewer/src/TIGLViewerSettings.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include "TIGLViewerMaterials.h"
 #include <QCoreApplication>
+#include <qglobal.h>
 #include "TIGLViewerSettings.h"
 
 const double DEFAULT_TESSELATION_ACCURACY = 0.000316;
@@ -207,6 +208,18 @@ void TIGLViewerSettings::loadSettings()
 
     setTemplateDir(settings.value("template_dir_path", DEFAULT_TEMPLATE_DIR_PATH ).toString());
     _profilesDBPath = settings.value("profiles_file_path", DEFAULT_PROFILES_FILE_PATH).toString();
+
+    // Test whether profilesDB exists in the stored path and if the path even exists in the first place
+    // Background:
+    //      - Path is stored in system-wide config file.
+    //      - If TiGL is built in two different directories, the first one always determines the path
+    //      - However, if this path does not exist anymore, the other TiGL build still tries to use it -> No file found
+    if (!QFile(_profilesDBPath).exists()) {
+        // If stored path does not exist (most likely it lies outside the current build),
+        // use the default path (-> current build) as TiGL internal one and also overwrite the config file
+        _profilesDBPath = DEFAULT_PROFILES_FILE_PATH;
+        settings.setValue("profiles_file_path", _profilesDBPath);
+    }
 }
 
 void TIGLViewerSettings::storeSettings()

--- a/src/fuselage/CCPACSFuselageSegments.h
+++ b/src/fuselage/CCPACSFuselageSegments.h
@@ -86,10 +86,10 @@ public:
 
     TIGL_EXPORT const TopoDS_Compound& GetGuideCurveWires() const;
 
-    void ReorderSegments();
+    TIGL_EXPORT void ReorderSegments();
 
     // check order of segments - each segment must start with the element of the previous segment
-    bool NeedReordering() const;
+    TIGL_EXPORT bool NeedReordering() const;
 private:
 
     void BuildGuideCurves(TopoDS_Compound& cache) const;


### PR DESCRIPTION
## Description
CPACSCreator uses a system-wide config file to store (among many others) the path to the profiles database.
If TiGL is built in a second configuration on the same system, the first build will determine the path in this config file.
If then later the first build (and path) is removed, TiGL will still try to load the database from this path. This PR includes a check, whether the path exists and overwrites the config file entry when it does not.


Fix #1087
Fix #1086 with two missing `TIGL_EXPORT`s

## Checklist:


| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [x] OK</li></ul> |
