### PR TITLE
Fix #1094, consistent parametrization so that kinks of super ellipses are connected in a loft

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@ Changes since last release
 
 - Fixes
 
+  - #1094 Fix inconsistent parametrization of super ellipse profiles. Before, the super ellipses ware parametrized by arc length, which resulted in 
+    different parameters at the four distinct points of the super ellipse. Potential kinks in two super ellipses were not necessarily connected by a
+    v-isoline in the resulting loft. This has been fixed.
   - #936 A particular defined positioning (of the C++-type CCPACSPositioning) was not available via Python bindings since the std::vector<std::unique_ptr<**Type**>> is not exposed to swig. New getter functions have been implemented in CCPACSPositioning.h to make these elements accesible via index, similar to the implementation of for several other classes. For more information see https://github.com/RISCSoftware/cpacs_tigl_gen/issues/59.
 
  - New API functions:

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1472,7 +1472,15 @@ TIGL_EXPORT TopoDS_Wire BuildWireSuperEllipse(const double lowerHeightFraction, 
     auto curve4 = tigl::CFunctionToBspline(ellipse, uMin3, uMax3, degree, tol).Curve();
     curves.push_back(curve4);
 
-    opencascade::handle<Geom_BSplineCurve> curve = tigl::CTiglBSplineAlgorithms::concatCurves(curves);
+    // reparametrize such that the parameters for all connection points are the same. Otherwise
+    // the four intersection points of each super ellipse in a loft are not guaranteed to be
+    // connected.
+    tigl::CTiglBSplineAlgorithms::reparametrizeBSpline(*curve1, 0., 0.25);
+    tigl::CTiglBSplineAlgorithms::reparametrizeBSpline(*curve2, 0., 0.25);
+    tigl::CTiglBSplineAlgorithms::reparametrizeBSpline(*curve3, 0., 0.25);
+    tigl::CTiglBSplineAlgorithms::reparametrizeBSpline(*curve4, 0., 0.25);
+
+    opencascade::handle<Geom_BSplineCurve> curve = tigl::CTiglBSplineAlgorithms::concatCurves(curves, false);
 
     //build wire
     TopoDS_Wire wire;

--- a/tests/unittests/TestData/superellipses_kink.xml
+++ b/tests/unittests/TestData/superellipses_kink.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cpacs xsi:noNamespaceSchemaLocation="https://www.cpacs.de/schema/v3_5_0/cpacs_schema.xsd"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+        <name>Superellipses_test</name>
+        <version>1.0</version>
+        <cpacsVersion>3.5</cpacsVersion>
+        <versionInfos>
+            <versionInfo version="1.0">
+                <cpacsVersion>3.5</cpacsVersion>
+                <description>Superellipses test</description>
+                <timestamp>2025-05-16T12:46:13.412+02:00</timestamp>
+                <creator>Guybrush Threepwood</creator>
+            </versionInfo>
+        </versionInfos>
+    </header>
+    <vehicles>
+        <aircraft>
+            <model uID="SE">
+                <name>SE</name>
+        <reference>
+          <area>42</area>
+          <length>1</length>
+          <point>
+            <x>0</x>
+            <y>0</y>
+            <z>0</z>
+          </point>
+        </reference>
+                <fuselages>
+                    <fuselage uID="fuselage">
+                        <name>fuselage</name>
+                        <transformation/>
+                        <sections>
+                            <section uID="fuselageProfile0">
+                                <name>fuselageProfile0</name>
+                                <transformation>
+                                    <scaling>
+                                        <x>1.0</x>
+                                        <y>2.9800873266855112</y>
+                                        <z>2.2491676811491947</z>
+                                    </scaling>
+                                    <rotation>
+                                        <x>0.0</x>
+                                        <y>0.0</y>
+                                        <z>0.0</z>
+                                    </rotation>
+                                    <translation refType="absGlobal">
+                                        <x>-1.1901598978704255</x>
+                                        <y>0.0</y>
+                                        <z>0.15494266247916674</z>
+                                    </translation>
+                                </transformation>
+                                <elements>
+                                    <element uID="fuselageProfile0_element">
+                                        <name>fuselageProfile0 Element</name>
+                                        <profileUID>fuselageProfile0_profile</profileUID>
+                                        <transformation/>
+                                    </element>
+                                </elements>
+                            </section>
+                            <section uID="fuselageProfile1">
+                                <name>fuselageProfile1</name>
+                                <transformation>
+                                    <scaling>
+                                        <x>1.0</x>
+                                        <y>3.6402672386944572</y>
+                                        <z>2.118787196637192</z>
+                                    </scaling>
+                                    <rotation>
+                                        <x>0.0</x>
+                                        <y>0.0</y>
+                                        <z>0.0</z>
+                                    </rotation>
+                                    <translation refType="absGlobal">
+                                        <x>-0.18013607173502155</x>
+                                        <y>0.0</y>
+                                        <z>0.06995995460594512</z>
+                                    </translation>
+                                </transformation>
+                                <elements>
+                                    <element uID="fuselageProfile1_element">
+                                        <name>fuselageProfile1 Element</name>
+                                        <profileUID>fuselageProfile1_profile</profileUID>
+                                        <transformation/>
+                                    </element>
+                                </elements>
+                            </section>
+                        </sections>
+                        <segments>
+                            <segment uID="fuselageProfile0_element_fuselageProfile1_element">
+                                <name>fuselageSegment4</name>
+                                <fromElementUID>fuselageProfile0_element</fromElementUID>
+                                <toElementUID>fuselageProfile1_element</toElementUID>
+                            </segment>
+                        </segments>
+                    </fuselage>
+                </fuselages>
+            </model>
+        </aircraft>
+        <profiles>
+            <fuselageProfiles>
+                <fuselageProfile uID="fuselageProfile0_profile">
+                    <name>fuselageProfile0</name>
+                    <standardProfile>
+                        <superEllipse>
+                            <mUpper>2.0</mUpper>
+                            <nUpper>1.0</nUpper>
+                            <mLower>2.0</mLower>
+                            <nLower>1.0</nLower>
+                            <lowerHeightFraction>0.4311111111111111</lowerHeightFraction>
+                        </superEllipse>
+                    </standardProfile>
+                </fuselageProfile>
+                <fuselageProfile uID="fuselageProfile1_profile">
+                    <name>fuselageProfile1</name>
+                    <standardProfile>
+                        <superEllipse>
+                            <mUpper>2.0</mUpper>
+                            <nUpper>1.0</nUpper>
+                            <mLower>2.0</mLower>
+                            <nLower>1.0</nLower>
+                            <lowerHeightFraction>0.8</lowerHeightFraction><!--<lowerHeightFraction>0.46698113207547165</lowerHeightFraction>-->
+                        </superEllipse>
+                    </standardProfile>
+                </fuselageProfile>
+            </fuselageProfiles>
+        </profiles>
+    </vehicles>
+</cpacs>

--- a/tests/unittests/testFuselageStandardProfileSuperellipse.cpp
+++ b/tests/unittests/testFuselageStandardProfileSuperellipse.cpp
@@ -150,3 +150,38 @@ TEST_F(FuselageStandardProfileSuperEllipse, BuildFuselageMixedProfilesInvalidInp
     // fuselage cannot be build with invalid profile
     ASSERT_THROW(config1.GetFuselage(1).GetLoft(),tigl::CTiglError);
 }
+
+
+TEST(FuselageStandardProfileSuperEllipse_kinks, issue_1094)
+{
+    const char* filename = "TestData/superellipses_kink.xml";
+    ReturnCode tixiRet;
+    TiglReturnCode tiglRet;
+
+    TixiDocumentHandle tiglHandle = -1;
+    TiglCPACSConfigurationHandle tixiHandle = -1;
+
+    tixiRet = tixiOpenDocument(filename, &tixiHandle);
+    ASSERT_TRUE (tixiRet == SUCCESS);
+    tiglRet = tiglOpenCPACSConfiguration(tixiHandle, "", &tiglHandle);
+    ASSERT_TRUE(tiglRet == TIGL_SUCCESS);
+
+    tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
+    tigl::CCPACSConfiguration& config         = manager.GetConfiguration(tiglHandle);
+
+    // check number of faces. It should be Front, Rear and additionally four faces, one face per quadrant.
+    // If there are additional kinks, there are more faces
+    auto fuselage = config.GetFuselage(1).GetLoft();
+    int face_count = 0;
+    for (int i=0; i < fuselage->GetFaceCount(); ++i) {
+        if (fuselage->GetFaceTraits(i).Name() != "Front" && fuselage->GetFaceTraits(i).Name() != "Rear") {
+            face_count++;
+        }
+    }
+    ASSERT_EQ(face_count, 4);
+
+    ASSERT_TRUE(tiglCloseCPACSConfiguration(tiglHandle) == TIGL_SUCCESS);
+    ASSERT_TRUE(tixiCloseDocument(tixiHandle) == SUCCESS);
+    tiglHandle = -1;
+    tixiHandle = -1;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, super ellipse profiles were parametrized by arc length. This meant that potential kinks at the four distinct points of a super ellipse were not automatically connected by an isocurve in a loft. This has now been fixed by reparametrizing the B-Spline approximating the superellipse in such a way, that the intersection with the positive z-axis is at parameter 0, the intersection with the positive y-axis is at parameter 0.25, the intersection with the negative z-axis at parameter 0.5, the intersection with the negative y-axis at 0.75.

Fixes #1094.

## How Has This Been Tested?

I checked the example file from the issue in the TIGL Viewer and added a unit test.

## Screenshots, that help to understand the changes(if applicable):

![image](https://github.com/user-attachments/assets/a9a3f819-5e61-4852-9966-bec720a2e460)

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
