### PR TITLE
Reorder segments after the user adds a new segment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ Changes since last release
 
 - Fixes
 
+  - #1096 When a user adds a non-boundary segment to a wing/fuselage, the respective segment is split and a new one is created. After this split, a reordering of the segments is necessary. Otherwise, the segments cannot be lofted and created correctly. That would result in a wrong visualization and errors when trying to build them on user's demand in the tiglviewer.
+For that reason, the CCPACSFuselageSegments::ReorderSegments() and CCPACSWingSegments::ReorderSegments(), respectively, were added within the call of the SplitSegment() function.
   - #752 When creating a new file out of a template, the CPACSCreator automatically creates a new `.temp` file in the template directory. It might be the case that the user does not have write access to this directory, e.g. when TiGL is not configured and built but just downloaded via the installer. On the other hand it does not seem to be reasonable to directly create and store (!) a new file every time the 'new file' command is activated. Now, no temporary file is created. The content of the wanted template is copied into a string which then will be opened and read by tixi. Only if wanted, the resulting and edited CPACS file is stored.
   - #1087 CPACSCreator uses a system-wide config file to store (among many others) the path to the profiles database. If TiGL is built in a second configuration on the same system, the first build will determine the path in this config file. If then later the first build (and path) is removed, TiGL will still try to load the database from this path. A check is included, whether the path exists and should overwrite the config file entry when it does not.
 

--- a/src/fuselage/CCPACSFuselageSegments.cpp
+++ b/src/fuselage/CCPACSFuselageSegments.cpp
@@ -277,6 +277,9 @@ CCPACSFuselageSegment& CCPACSFuselageSegments::SplitSegment(const std::string& s
     segment.SetToElementUID(splitterElement.GetUID());
 
     Invalidate();
+    // Reordering is necessary: After splitting a segment and adding another one, the order is not correct
+    // Without reordering, this results in a wrong shape visible in the TiGLViewer
+    ReorderSegments();
 
     return additionalSegment;
 }

--- a/src/wing/CCPACSWingSegments.cpp
+++ b/src/wing/CCPACSWingSegments.cpp
@@ -223,6 +223,9 @@ CCPACSWingSegment& CCPACSWingSegments::SplitSegment(const std::string& segmentUI
     segment.SetToElementUID(splitterElement.GetUID());
 
     Invalidate();
+    // Reordering is necessary: After splitting a segment and adding another one, the order is not correct
+    // Without reordering, this results in a wrong shape visible in the TiGLViewer
+    ReorderSegments();
 
     return additionalSegment;
 }

--- a/tests/unittests/creatorFuselage.cpp
+++ b/tests/unittests/creatorFuselage.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "CNamedShape.h"
 #include "test.h" // Brings in the GTest framework
 #include "tigl.h"
 #include "tixi.h"
@@ -30,6 +31,7 @@
 #include "CTiglWingSectionElement.h"
 #include "CCPACSFuselageSectionElement.h"
 #include "CCPACSWingSectionElement.h"
+#include "CCPACSFuselageSegment.h"
 
 
 #include <string.h>
@@ -540,6 +542,29 @@ TEST_F(creatorFuselage, createSection_MultipleFuselageModel)
 
 }
 
+TEST_F(creatorFuselage, fuselageCreateSectionNonBoundary)
+{
+    setVariables("TestData/simpletest.cpacs.xml", "SimpleFuselage");
+    std::vector<std::string> orderedUIDS, expectedOrderedUIDS;
+
+    // Add a non-boundary section to a wing and check whether all shapes can be built
+    fuselage->CreateNewConnectedElementBetween("D150_Fuselage_1Section1IDElement1", "D150_Fuselage_1Section2IDElement1");
+
+    orderedUIDS = fuselage->GetSegments().GetElementUIDsInOrder();
+    expectedOrderedUIDS.clear();
+    expectedOrderedUIDS.push_back("D150_Fuselage_1Section1IDElement1");
+    expectedOrderedUIDS.push_back("D150_Fuselage_1Section1IDBisElem1"); // new element
+    expectedOrderedUIDS.push_back("D150_Fuselage_1Section2IDElement1");
+    expectedOrderedUIDS.push_back("D150_Fuselage_1Section3IDElement1");
+    for (int i = 0; i < expectedOrderedUIDS.size(); i++) {
+        EXPECT_EQ(expectedOrderedUIDS[i], orderedUIDS[i]); // Check sections order
+    }
+
+    for (int i = 1; i <= fuselage->GetSegments().GetSegmentCount(); i++) {
+        // Check whether all section's segments are valid and can be built
+        EXPECT_NO_THROW(const TopoDS_Shape& shape = fuselage->GetSegments().GetSegment(i).GetLoft()->Shape());
+    }
+}
 
 TEST_F(creatorFuselage, deleteSection_multipleFuselgaesModel)
 {

--- a/tests/unittests/creatorWing.cpp
+++ b/tests/unittests/creatorWing.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "CNamedShape.h"
 #include "test.h"
 #include "tigl.h"
 #include <tixi.h>
@@ -27,6 +28,7 @@
 #include "CCPACSConfigurationManager.h"
 #include "CCPACSFuselageSectionElement.h"
 #include "CCPACSWingSectionElement.h"
+#include "CCPACSWingSegment.h"
 
 class creatorWing : public ::testing::Test
 {
@@ -1090,6 +1092,30 @@ TEST_F(creatorWing, MultipleWings_CreateSections)
     EXPECT_TRUE(expectedCenter.isNear(newElement->GetCenter(), 0.2));
 
 
+}
+
+TEST_F(creatorWing, wingCreateSectionNonBoundary)
+{
+    setVariables("TestData/simpletest.cpacs.xml", "Wing");
+    std::vector<std::string> orderedUIDS, expectedOrderedUIDS;
+
+    // Add a non-boundary section to a wing and check whether all shapes can be built
+    wing->CreateNewConnectedElementBetween("Cpacs2Test_Wing_Sec1_El1", "Cpacs2Test_Wing_Sec2_El1");
+
+    orderedUIDS = wing->GetSegments().GetElementUIDsInOrder();
+    expectedOrderedUIDS.clear();
+    expectedOrderedUIDS.push_back("Cpacs2Test_Wing_Sec1_El1");
+    expectedOrderedUIDS.push_back("Cpacs2Test_Wing_Sec1BisElem1"); // new element
+    expectedOrderedUIDS.push_back("Cpacs2Test_Wing_Sec2_El1");
+    expectedOrderedUIDS.push_back("Cpacs2Test_Wing_Sec3_El1");
+    for (int i = 0; i < expectedOrderedUIDS.size(); i++) {
+        EXPECT_EQ(expectedOrderedUIDS[i], orderedUIDS[i]); // Check sections order
+    }
+
+    for (int i = 1; i <= wing->GetSegments().GetSegmentCount(); i++) {
+        // Check whether all section's segments are valid and can be built
+        EXPECT_NO_THROW(const TopoDS_Shape& shape = wing->GetSegments().GetSegment(i).GetLoft()->Shape());
+    }
 }
 
 TEST_F(creatorWing, D250_DeleteSection )


### PR DESCRIPTION
## Description

When a user adds a non-boundary segment to a wing/fuselage, the respective segment is split and a new one is created. After this split, a reordering of the segments is necessary. Otherwise, the segments cannot be lofted and created correctly. That would result in a wrong visualization and errors when trying to build them on user's demand in the tiglviewer.
For that reason, the `CCPACSFuselageSegments::ReorderSegments()` and CCPACSWingSegments::ReorderSegments(), respectively, were added within the call of the `SplitSegment()` function.

## How Has This Been Tested?
Testing was done by observing the behaviour of the tiglviewer. The root issue for the wrong visualization was that segments were not or wrong displayed in the GUI. Hence, a unittest was added working on the file the behaviour was tested on and fixed.
Here at first, a non-boundary segment is added. Then, it is checked whether the elements are in the right order and all the segments can be lofted.

## Screenshots, that help to understand the changes(if applicable):
The first picture shows the configuration before modification. In this wing, a section should be added right after the first section (counting from the root/fuselage).
![origin](https://github.com/user-attachments/assets/18985ee1-3df5-4e7c-8ba5-d1c4a6b6a0bf)

Without the reordering, the following (wrong) shape is generated:
![wrong](https://github.com/user-attachments/assets/e5d08dc5-50e6-47c5-bba7-2dffebe3c99b)

And now, when the reordering is included, the wanted shape is built. Here, one can see an additional section on the rectangle part of the wing:
![right](https://github.com/user-attachments/assets/084555a2-8a97-4523-b8e7-1c21f83990bb)


Fix #1096.

## Checklist:

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [x] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
