### PR TITLE
Small fixes to our build chain

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,10 +120,10 @@ jobs:
     strategy:
       matrix:
         config: ["Release"]
-        os: ["windows-2019", "windows-latest"]
+        os: ["windows-2022", "windows-latest"]
         include:
          - config: "Release"
-           os: "windows-2019"
+           os: "windows-2022"
            oce_static_libs: "ON"
            tigl_bindings_python_internal: "ON"
            documentation-artifact: ${{ inputs.documentation-artifact }}
@@ -150,10 +150,10 @@ jobs:
     strategy:
       matrix:
         config: ["Release"]
-        os: ["windows-2019", "windows-latest"]
+        os: ["windows-2022", "windows-latest"]
         include:
          - config: "Release"
-           os: "windows-2019"
+           os: "windows-2022"
            oce_static_libs: "ON"
            tigl_bindings_python_internal: "ON"
     runs-on: ${{ matrix.os }}

--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -53,20 +53,22 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
         # create the xml output with doxygen
-        add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doc/xml/index.xml
+        add_custom_target(generate_doxygen_xml
+            COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-            COMMAND ${DOXYGEN_EXECUTABLE}
-            ARGS ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+            COMMENT "Generating Doxygen XML output"
         )
 
-        # create the doc.i with doxy2swig
-        add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doc.i
-            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doc/xml/index.xml
-            COMMAND ${PYTHON_EXECUTABLE}
-            ARGS ${PROJECT_SOURCE_DIR}/thirdparty/doxy2swig/doxy2swig.py ${CMAKE_CURRENT_BINARY_DIR}/doc/xml/index.xml ${CMAKE_CURRENT_BINARY_DIR}/doc.i
+        # Create a custom target for generating the doc.i file using doxy2swig
+        add_custom_target(generate_doc_i
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/thirdparty/doxy2swig/doxy2swig.py
+                    ${CMAKE_CURRENT_BINARY_DIR}/doc/xml/index.xml ${CMAKE_CURRENT_BINARY_DIR}/doc.i
+            DEPENDS generate_doxygen_xml
+            COMMENT "Generating doc.i file using doxy2swig"
         )
+
+        # Ensure doc.i depends on the XML output
+        add_dependencies(generate_doc_i generate_doxygen_xml)
     endif()
 
 
@@ -104,7 +106,7 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
 
     foreach(MODULE ${MODULES})
         set_source_files_properties(${MODULE}.i PROPERTIES CPLUSPLUS ON)
-        set(SWIG_MODULE_${MODULE}_EXTRA_DEPS common.i doc.i)
+        set(SWIG_MODULE_${MODULE}_EXTRA_DEPS common.i generate_doc_i)
 
         swig_add_library(${MODULE} LANGUAGE python SOURCES ${MODULE}.i TYPE MODULE)
         swig_link_libraries(${MODULE} tigl3 tigl3_cpp Python3::Module)

--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -18,6 +18,15 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
 
     include(tiglmacros)
 
+    # Ensure the correct Python version is picked up by specifying the Python_EXECUTABLE
+    if (DEFINED ENV{CONDA_PREFIX})
+        if (WIN32)
+            set(Python3_EXECUTABLE "$ENV{CONDA_PREFIX}/python.exe")
+        else()
+            set(Python3_EXECUTABLE "$ENV{CONDA_PREFIX}/bin/python")
+        endif()
+    endif()
+
     find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
     message(STATUS "Python3 interpreter:" ${Python3_EXECUTABLE})
     message(STATUS "Python include directory: ${Python3_INCLUDE_DIR}")

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
  - tixi3=3.3.0                   # library for dealing with xml files
  - opencascade=7.4.0             # library for dealing with b-spline and nurbs geometries. dlr-sc version contains patch for C2-cont. Coons patches
  # optional dependencies
- - conda-forge::qt=5.15.8        # needed to build tiglviewer
+ - conda-forge::qt=5.15.15       # needed to build tiglviewer
  - doxygen=1.8.15                # needed to build the documenation
  - python                        # needed to build python bindings
  - swig>=3.0.11                  # needed to build python bindings


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces several changes

1. Use Python from within conda environment, if exists. Previously, CMake picked up the system-wide Python version on Windows when building the internal python bindings, which caused a conflict.
2. Sometimes the internal python bindings fail to build when using a parallel build, see issue #1103.
3. CI: Remove deprecated windows-2019 runners
4. Bump Qt from 5.15.8 to 5.15.15, because the previous version caused issues with autouic on Windows in CI.

Fixes #1103 

## How Has This Been Tested?
Tested locally on Windows 11 and Ubuntu 22.04 and in CI

## Screenshots, that help to understand the changes(if applicable):

None. 

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
