### PR TITLE
Fix issue with unsafe runtime search path in CMake

### DIFF
--- a/TIGLViewer/CMakeLists.txt
+++ b/TIGLViewer/CMakeLists.txt
@@ -12,8 +12,17 @@ else(APPLE)
    set(PROGNAME "tiglviewer-3")
 endif(APPLE)
 
-
 if (TIGL_VIEWER)
+
+# Give conda enviornment preference over system or other paths
+# This fixes an issue on Ubuntu 22.04, where inconsistent gl libraries were found, see 
+# https://github.com/DLR-SC/tigl/issues/1069
+if(DEFINED ENV{CONDA_PREFIX})
+    message(STATUS "Conda environment detected: $ENV{CONDA_PREFIX}")
+    list(PREPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
+    list(PREPEND CMAKE_LIBRARY_PATH "$ENV{CONDA_PREFIX}/lib")
+    list(PREPEND CMAKE_INCLUDE_PATH "$ENV{CONDA_PREFIX}/include")
+endif()
 
 include(SearchQt)
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,8 @@ dependencies:
  - opencascade=7.4.0             # library for dealing with b-spline and nurbs geometries. dlr-sc version contains patch for C2-cont. Coons patches
  # optional dependencies
  - conda-forge::qt=5.15.15       # needed to build tiglviewer
+ - conda-forge::libgl-devel      # needed to build tiglviewer
+ - conda-forge::libegl-devel     # needed to build tiglviewer
  - doxygen=1.8.15                # needed to build the documenation
  - python<=3.12                  # needed to build python bindings
  - swig>=3.0.11                  # needed to build python bindings


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We had an issue building TiGLViewer on our Ubuntu 22.04 teamserver, because CMake did in fact generate an unsafe runtime search path, see https://github.com/DLR-SC/tigl/issues/1069#issuecomment-3056386297. 

To fix this, we need to install `libgl-devel` and `libegl-devel` into our Anaconda environment and tell CMake to give the paths in the Anaconda environment preference over the system paths. Now that all GL-related libraries are found in the Anacona environment, the system path with the conflicting libraries is not a candidate for a runtime search path anymore.

Note I haven't added this build-chain related stuff to the Changelog.

## How Has This Been Tested?

Tested locally on the machine that had the issue.

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
