### PR TITLE
Fix index in CCPACSFuselageProfiles::GetProfile

### DIFF
--- a/src/fuselage/CCPACSFuselageProfiles.cpp
+++ b/src/fuselage/CCPACSFuselageProfiles.cpp
@@ -106,15 +106,15 @@ CCPACSFuselageProfile& CCPACSFuselageProfiles::GetProfile(std::string uid)
     throw CTiglError("Fuselage profile \"" + uid + "\" not found in CPACS file!", TIGL_UID_ERROR);
 }
 
-// Returns the fuselage profile for a given index
+// Returns the fuselage profile for a given index decremented by 1 (indices in CPACS start at 1)
 const CCPACSFuselageProfile& CCPACSFuselageProfiles::GetProfile(size_t index) const
 {
-    return static_cast<CCPACSFuselageProfile&>(*m_fuselageProfiles[index]);
+    return static_cast<CCPACSFuselageProfile&>(*m_fuselageProfiles[index-1]);
 }
 
 CCPACSFuselageProfile& CCPACSFuselageProfiles::GetProfile(size_t index)
 {
-    return static_cast<CCPACSFuselageProfile&>(*m_fuselageProfiles[index]);
+    return static_cast<CCPACSFuselageProfile&>(*m_fuselageProfiles[index-1]);
 }
 
 } // end namespace tigl


### PR DESCRIPTION
This fixes an error that occurred in PR #1083. When updating the getter functions regarding const correctness, the decrement by 1 of the index was lost.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
