### PR TITLE
Fix recursive signals in dockwidgets

### DIFF
--- a/TIGLViewer/src/ModificatorContainerWidget.ui
+++ b/TIGLViewer/src/ModificatorContainerWidget.ui
@@ -85,7 +85,7 @@
          <string/>
         </property>
         <property name="text">
-         <string>No element seclected or unavailble interface. </string>
+         <string>Please select an editable element from the CPACS Tree. </string>
         </property>
        </widget>
       </item>

--- a/TIGLViewer/src/TIGLViewerWindow.cpp
+++ b/TIGLViewer/src/TIGLViewerWindow.cpp
@@ -959,19 +959,39 @@ void TIGLViewerWindow::connectSignals()
     connect(viewResetAction, SIGNAL(triggered()), myOCC, SLOT(viewReset()));
     connect(viewZoomInAction, SIGNAL(triggered()), myOCC, SLOT(zoomIn()));
     connect(viewZoomOutAction, SIGNAL(triggered()), myOCC, SLOT(zoomOut()));
-    connect(showConsoleAction, SIGNAL(toggled(bool)), consoleDockWidget, SLOT(setVisible(bool)));
-    connect(consoleDockWidget, SIGNAL(visibilityChanged(bool)), showConsoleAction, SLOT(setChecked(bool)));
+
+    connect(showConsoleAction, &QAction::toggled, this, [=](bool toggled) {
+        QSignalBlocker blocker(consoleDockWidget); // Prevent recursion
+        consoleDockWidget->setVisible(toggled);
+    });
+    connect(consoleDockWidget, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+        QSignalBlocker blocker(showConsoleAction); // Prevent recursion
+        showConsoleAction->setChecked(visible);
+    });
 
     // Addition for creator
 
     // modificatorManager will emit a configurationEdited when he modifies the tigl configuration (for later)
     connect(modificatorManager, SIGNAL(configurationEdited()), this, SLOT(updateScene()));
     connect(modificatorManager, SIGNAL(configurationEdited()), this, SLOT(changeColorSaveButton()));
+
     // creator view
-    connect(showModificatorAction, SIGNAL(toggled(bool)), editorDockWidget, SLOT(setVisible(bool)));
-    connect(editorDockWidget, SIGNAL(visibilityChanged(bool)), showModificatorAction, SLOT(setChecked(bool)));
-    connect(showTreeAction, SIGNAL(toggled(bool)), treeDockWidget, SLOT(setVisible(bool)));
-    connect(treeDockWidget, SIGNAL(visibilityChanged(bool)), showTreeAction, SLOT(setChecked(bool)));
+    connect(showModificatorAction, &QAction::toggled, this, [=](bool toggled) {
+        QSignalBlocker blocker(editorDockWidget); // Prevent recursion
+        editorDockWidget->setVisible(toggled);
+    });
+    connect(editorDockWidget, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+        QSignalBlocker blocker(showModificatorAction); // Prevent recursion
+        showModificatorAction->setChecked(visible);
+    });
+    connect(showTreeAction, &QAction::toggled, this, [=](bool toggled) {
+        QSignalBlocker blocker(treeDockWidget); // Prevent recursion
+        treeDockWidget->setVisible(toggled);
+    });
+    connect(treeDockWidget, &QDockWidget::visibilityChanged, this, [=](bool visible) {
+        QSignalBlocker blocker(showTreeAction); // Prevent recursion
+        showTreeAction->setChecked(visible);
+    });
 
 
     connect(showWireframeAction, SIGNAL(toggled(bool)), myScene, SLOT(wireFrame(bool)));

--- a/TIGLViewer/src/TIGLViewerWindow.ui
+++ b/TIGLViewer/src/TIGLViewerWindow.ui
@@ -382,12 +382,18 @@
    </widget>
   </widget>
   <widget class="QDockWidget" name="editorDockWidget">
+   <property name="windowTitle">
+    <string>CPACS Editor</string>
+   </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
    <widget class="ModificatorContainerWidget" name="modificatorContainerWidget"/>
   </widget>
   <widget class="QDockWidget" name="treeDockWidget">
+   <property name="windowTitle">
+    <string>CPACS Tree</string>
+   </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1118. 

In CPACSCreator we have three QDockWidgets: The Console, CPACS Editor and CPACS Tree. When one drags a QDockWidget into a QDockArea, that is already occupied by another QDockWidget, it is added to a tabbed QDockWidget containing both. 

### Problem

Previously the tabs could be seen shortly before releasing the mouse button, but the tab ui would immediatly be hidden. In addition, the QDockWidget that was in that docking area before is now hidden and cannot be accessed anymore.

This was due to a problem with signals that recursively called each other. For each of our three dock widgets we have an action in the menu bar.

Connection 1: When the action in the menu bar is toggled, the visibility of the corresponding dock widget is changed.
Connection 2: When the visibility of a dock widget is changed, the action in the menu bar gets toggled appropriately.

These connections are a loop and the loop caused unpredictable issues with the tab ui of tabbed QDockWidgets, because the visibility of the widgets frequently changes in the event loop during docking of the widgets.

**Note 1:** that this problem also exists in vanilla TiGL (TiGLViewer), but it doesn't have any consequences, because with one dockwidget to choose from (the console) there is never the possibility to hide one dock widget below the other.

**Note 2:** I added titles to the CPACS Editor widget and the CPACS Tree widget. I also changed the description in the placeholder Modificator Widget that is visible in the CPACS Editor, if no configuration is loaded or no editable element is selected in the CPACS Tree.

### Solution

We change the connections using a QSignalBlocker, which prevents Connection2 to be triggered when Connection 1 is triggered and vice versa.

## How Has This Been Tested?

Manually, by playing around with the dock widgets in the GUI.

## Screenshots, that help to understand the changes(if applicable):

<img width="1813" height="1088" alt="image" src="https://github.com/user-attachments/assets/26e2f95e-220d-4d22-8bef-caa7cfe3740a" />

Before this change, the tabs UI in the bottom right corner was never visible. Now it is and we can select the hidden dock widget using it.

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
