### PR TITLE
Change the CPACS header in creator template files

### DIFF
--- a/TIGLViewer/data/templates/concorde.cpacs.xml
+++ b/TIGLViewer/data/templates/concorde.cpacs.xml
@@ -6,21 +6,14 @@
     <creator>CFSE, Aidan Jungo</creator>
     <version>1.0</version>
     <cpacsVersion>3.0</cpacsVersion>
-    <updates>
-      <update>
-        <modification>Converted to cpacs 3.0 using cpacs2to3</modification>
-        <creator>cpacs2to3</creator>
-        <version>ver1</version>
-        <cpacsVersion>3.0</cpacsVersion>
-      </update>
-      <update>
-        <modification>Converted to cpacs 3.0 using cpacs2to3</modification>
+    <versionInfos>
+      <versionInfo version="1.0.0">
+        <description>Converted to cpacs 3.0 using cpacs2to3</description>
         <creator>cpacs2to3</creator>
         <timestamp>2018-11-21T12:08:31</timestamp>
-        <version>ver1</version>
         <cpacsVersion>3.0</cpacsVersion>
-      </update>
-    </updates>
+      </versionInfo>
+    </versionInfos>
   </header>
   <vehicles xsi:type="vehiclesType">
     <aircraft xsi:type="aircraftType">

--- a/TIGLViewer/data/templates/empty.cpacs.xml
+++ b/TIGLViewer/data/templates/empty.cpacs.xml
@@ -7,7 +7,14 @@
     <timestamp>2019-02-27T15:12:47</timestamp>
     <version>1.0</version>
     <cpacsVersion>3.0</cpacsVersion>
-    <updates/>
+    <versionInfos>
+      <versionInfo version="1.0.0">
+        <description>Empty aircraft</description>
+        <creator>Malo Drougard</creator>
+        <timestamp>2019-02-27T15:12:47</timestamp>
+        <cpacsVersion>3.0</cpacsVersion>
+      </versionInfo>
+    </versionInfos>
   </header>
   <vehicles>
     <aircraft>

--- a/TIGLViewer/data/templates/simpletest.cpacs.xml
+++ b/TIGLViewer/data/templates/simpletest.cpacs.xml
@@ -7,15 +7,14 @@
     <timestamp>2012-10-09T15:12:47</timestamp>
     <version>0.2</version>
     <cpacsVersion>3.0</cpacsVersion>
-    <updates>
-      <update>
-        <modification>Converted to cpacs 3.0 using cpacs2to3 - does not include structure update</modification>
+    <versionInfos>
+      <versionInfo version="0.2.0">
+        <description>Converted to cpacs 3.0 using cpacs2to3 - does not include structure update</description>
         <creator>cpacs2to3</creator>
         <timestamp>2018-01-15T09:22:57</timestamp>
-        <version>0.2</version>
         <cpacsVersion>3.0</cpacsVersion>
-      </update>
-    </updates>
+      </versionInfo>
+    </versionInfos>
   </header>
   <vehicles>
     <aircraft>


### PR DESCRIPTION
The header style within the CPACS schema has changed (see [CPACS docu](https://dlr-sl.github.io/CPACS/html/a430c658-6111-6868-d855-201b284ca81e.htm)). The templates were not fitted to that and raised errors due to missing nodes.
With this PR, the nodes are changed with respect to the current CPACS version and TiGL implementation to not throw that type of errors.

Fixes #1124.

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
