### PR TITLE
Deprecate the use of the old CPACS header

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ Changelog
 
 Changes since last release
 -------------
+05/08/2025
+- Deprecation warning
+  - The use of the node cpacsVersion right within the CPACS path /cpacs/header/ is deprecated according to CPACS 3.5. Hence, now a deprecation warning is printed if it is still used (issue #1126).
+
+
 29/07/2025
 - General changes
   - Remove the hard-wired gtest source code from the repository. Now, it is downloaded from GitHub and configured during the TiGL-configuration-process by default (issue #1114).

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -183,7 +183,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglOpenCPACSConfiguration(TixiDocumentHandle 
         }
 
         if (tixiCheckElement(tixiHandle, "/cpacs/header/cpacsVersion") == SUCCESS) {
-            LOG(WARNING) << "The use of the cpacsVersion node right at /cpacs/header/ is deprecated according to CPACS version 3.5.\n" \
+            LOG(WARNING) << "The use of the cpacsVersion node right at /cpacs/header/ is deprecated since CPACS version 3.5.\n" \
                 "This value has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
                 "More information can be found in the CPACS documentation.";
         }

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -184,7 +184,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglOpenCPACSConfiguration(TixiDocumentHandle 
 
         if (tixiCheckElement(tixiHandle, "/cpacs/header/cpacsVersion") == SUCCESS) {
             LOG(WARNING) << "The use of the cpacsVersion node right at /cpacs/header/ is deprecated since CPACS version 3.5.\n" \
-                "This value has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
+                "This node has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
                 "More information can be found in the CPACS documentation.";
         }
 

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -182,6 +182,12 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglOpenCPACSConfiguration(TixiDocumentHandle 
             tixiRet = tixiGetTextElement(tixiHandle, "/cpacs/header/cpacsVersion", &cpacsVersionStr);
         }
 
+        if (tixiCheckElement(tixiHandle, "/cpacs/header/cpacsVersion") == SUCCESS) {
+            LOG(WARNING) << "The use of the cpacsVersion node right at /cpacs/header/ is deprecated according to CPACS version 3.5.\n" \
+                "This value has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
+                "More information can be found in the CPACS documentation.";
+        }
+
         if (tixiRet != SUCCESS) {
             // NO CPACS Version Information in Header
             if (tixiRet == ELEMENT_PATH_NOT_UNIQUE) {

--- a/tests/unittests/TestData/testversion_old_header.xml
+++ b/tests/unittests/TestData/testversion_old_header.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../cpacs_gen_input/cpacs_schema.xsd">
+  <header>
+    <name>Cpacs2Test</name>
+    <description>Test file to check versioning according to new CPACS header. Expected to throw deprecation warning due to mentioning cpacsVersion in header.</description>
+    <version>1.0.0</version>
+    <cpacsVersion>3.4</cpacsVersion>
+    <versionInfos>
+      <versionInfo version="1.0.0">
+        <description>Test for version 1.0.0</description>
+        <cpacsVersion>3.3</cpacsVersion>
+        <creator>Marko Alder</creator>
+        <timestamp>2024-05-30T10:00:00</timestamp>
+      </versionInfo>
+    </versionInfos>
+  </header>
+  <vehicles>
+    <aircraft>
+      <model uID="LoggingTestModel">
+        <name>VersionTest</name>
+      </model>
+    </aircraft>
+  </vehicles>
+
+</cpacs>

--- a/tests/unittests/testCpacsVersion.cpp
+++ b/tests/unittests/testCpacsVersion.cpp
@@ -85,7 +85,7 @@ TEST(CPACSVersion, deprecateOldCPACSHeader)
         CaptureTiGLLog t{TILOG_WARNING};
         EXPECT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
         logOutput = t.log();
-        std::string comparisonString = "The use of the cpacsVersion node right at /cpacs/header/ is deprecated according to CPACS version 3.5.\n" \
+        std::string comparisonString = "The use of the cpacsVersion node right at /cpacs/header/ is deprecated since CPACS version 3.5.\n" \
                 "This value has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
                 "More information can be found in the CPACS documentation.";
         ASSERT_TRUE((logOutput.find(comparisonString)) != std::string::npos);

--- a/tests/unittests/testCpacsVersion.cpp
+++ b/tests/unittests/testCpacsVersion.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "test.h"
+#include "testUtils.h"
 
 #include "tigl.h"
 
@@ -67,6 +68,28 @@ TEST(CPACSVersion, newCPACSHeader)
 
     TiglCPACSConfigurationHandle tiglHandle = -1;
     EXPECT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
+
+    tiglCloseCPACSConfiguration(tiglHandle);
+}
+
+TEST(CPACSVersion, deprecateOldCPACSHeader)
+{
+    TixiHandleWrapper tixihandle("TestData/testversion_old_header.xml");
+
+    TiglCPACSConfigurationHandle tiglHandle = -1;
+
+    // Check whether deprecation warning appears when cpacsVersion node is stored right at /cpacs/header/
+
+    std::string logOutput;
+    { // Scope to destroy object of type CaptureTiGLLog and therefore reset console verbosity
+        CaptureTiGLLog t{TILOG_WARNING};
+        EXPECT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
+        logOutput = t.log();
+        std::string comparisonString = "The use of the cpacsVersion node right at /cpacs/header/ is deprecated according to CPACS version 3.5.\n" \
+                "This value has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
+                "More information can be found in the CPACS documentation.";
+        ASSERT_TRUE((logOutput.find(comparisonString)) != std::string::npos);
+    } //scope
 
     tiglCloseCPACSConfiguration(tiglHandle);
 }

--- a/tests/unittests/testCpacsVersion.cpp
+++ b/tests/unittests/testCpacsVersion.cpp
@@ -86,7 +86,7 @@ TEST(CPACSVersion, deprecateOldCPACSHeader)
         EXPECT_EQ(TIGL_SUCCESS, tiglOpenCPACSConfiguration(tixihandle, "", &tiglHandle));
         logOutput = t.log();
         std::string comparisonString = "The use of the cpacsVersion node right at /cpacs/header/ is deprecated since CPACS version 3.5.\n" \
-                "This value has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
+                "This node has to be moved exclusively into the /cpacs/header/versionInfos[]/versionInfo node to be supported by future TiGL versions.\n" \
                 "More information can be found in the CPACS documentation.";
         ASSERT_TRUE((logOutput.find(comparisonString)) != std::string::npos);
     } //scope


### PR DESCRIPTION
## Description
The use of the node cpacsVersion right within the CPACS path /cpacs/header/ is deprecated according to CPACS 3.5. Hence, print a deprecation warning if it is still used.

Fixes #1126.

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
