### PR TITLE
Fix issue when changing symmetry plane of a wing in CPACS Creator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ Changelog
 
 Changes since last release
 -------------
+
+27/08/2025
+- Fix hard crash when changing the symmetry axis of a wing in TiGL Creator (#1143)
+
 05/08/2025
 - Deprecation warning
   - The use of the node cpacsVersion right within the CPACS path /cpacs/header/ is deprecated according to CPACS 3.5. Hence, now a deprecation warning is printed if it is still used (issue #1126).

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
@@ -68,21 +68,31 @@ void ModificatorWingWidget::init()
         &SymmetryComboBoxWidget::currentIndexChanged,
         this,
         [=](){
-            // changing the wing's symmetry axis, also changes span, aspect ratio and area
-            auto previous_sym = tiglWing->GetSymmetryAxis();
-            tiglWing->SetSymmetryAxis(ui->symmetry->getSymmetry());
+            try {
+                // changing the wing's symmetry axis, also changes span, aspect ratio and area
+                auto previous_sym = tiglWing->GetSymmetryAxis();
+                tiglWing->SetSymmetryAxis(ui->symmetry->getSymmetry());
 
-            internalSpan = tiglWing->GetWingHalfSpan();
-            ui->spinBoxSpan->setValue(internalSpan);
-            internalAR = tiglWing->GetAspectRatio();
-            ui->spinBoxAR->setValue(internalAR);
-            internalArea = tiglWing->GetReferenceArea();
-            ui->spinBoxArea->setValue(internalArea);
-            updateSweepAccordingChordValue();
-            updateDihedralAccordingChordValue();
+                internalSpan = tiglWing->GetWingHalfSpan();
+                ui->spinBoxSpan->setValue(internalSpan);
+                internalAR = tiglWing->GetAspectRatio();
+                ui->spinBoxAR->setValue(internalAR);
+                internalArea = tiglWing->GetReferenceArea();
+                ui->spinBoxArea->setValue(internalArea);
+                updateSweepAccordingChordValue();
+                updateDihedralAccordingChordValue();
 
-            // reset symmetry axis. We only want to log this change in in the apply function.
-            tiglWing->SetSymmetryAxis(previous_sym);
+                // reset symmetry axis. We only want to log this change in in the apply function.
+                tiglWing->SetSymmetryAxis(previous_sym);
+            } catch (...) {
+                TIGLViewerErrorDialog errDialog(this);
+                errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                             .arg("Failed to apply the settings")
+                                             .arg("An unknown exception occured."));
+                errDialog.setWindowTitle("Error");
+                errDialog.exec();
+                return false;
+            }
         }
     );
 }

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
@@ -62,6 +62,27 @@ void ModificatorWingWidget::init()
 
     connect(ui->spinBoxSweepChord, SIGNAL(valueChanged(double)), this, SLOT(updateSweepAccordingChordValue(double)) );
     connect(ui->spinBoxDihedralChord, SIGNAL(valueChanged(double)), this, SLOT(updateDihedralAccordingChordValue(double)) );
+
+    connect(
+        ui->symmetry,
+        &SymmetryComboBoxWidget::currentIndexChanged,
+        this,
+        [=](){
+            // changing the wing's symmetry axis, also changes span, aspect ratio and area
+            auto previous_sym = tiglWing->GetSymmetryAxis();
+            tiglWing->SetSymmetryAxis(ui->symmetry->getSymmetry());
+
+            internalSpan = tiglWing->GetWingHalfSpan();
+            ui->spinBoxSpan->setValue(internalSpan);
+            internalAR = tiglWing->GetAspectRatio();
+            ui->spinBoxAR->setValue(internalAR);
+            internalArea = tiglWing->GetReferenceArea();
+            ui->spinBoxArea->setValue(internalArea);
+
+            // reset symmetry axis. We only want to log this change in in the apply function.
+            tiglWing->SetSymmetryAxis(previous_sym);
+        }
+    );
 }
 
 
@@ -202,6 +223,7 @@ bool ModificatorWingWidget::apply()
     if (symmetryHasChanged) {
         ui->symmetry->setInternalFromGUI();
         tiglWing->SetSymmetryAxis(ui->symmetry->getInternalSymmetry());
+
         wasModified = true; 
     }
 

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
@@ -82,7 +82,7 @@ void ModificatorWingWidget::init()
                 updateSweepAccordingChordValue();
                 updateDihedralAccordingChordValue();
 
-                // reset symmetry axis. We only want to log this change in in the apply function.
+                // reset symmetry axis. We only want to log this change in the apply function.
                 tiglWing->SetSymmetryAxis(previous_sym);
             } catch (...) {
                 TIGLViewerErrorDialog errDialog(this);

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
@@ -209,116 +209,126 @@ bool ModificatorWingWidget::apply()
     bool wasModified = false;
 
     try {
+        try {
 
-        if (rootLEHasChanged) {
-            ui->rootLE->setInternalFromGUI();
-            tigl::CTiglPoint newRootLE = ui->rootLE->getInternalPoint();
-            tiglWing->SetRootLEPosition(newRootLE);
-            wasModified = true;
-        }
-
-        if (rotationHasChanged) {
-            ui->rotation->setInternalFromGUI();
-            tigl::CTiglPoint newRot = ui->rotation->getInternalPoint();
-            tiglWing->SetRotation(newRot);
-            wasModified = true;
-        }
-
-        if (symmetryHasChanged) {
-            ui->symmetry->setInternalFromGUI();
-            tiglWing->SetSymmetryAxis(ui->symmetry->getInternalSymmetry());
-
-            wasModified = true;
-        }
-
-        if (sweepHasChanged) {
-            internalSweep      = ui->spinBoxSweep->value();
-            internalSweepChord = ui->spinBoxSweepChord->value();
-            tiglWing->SetSweep(internalSweep, internalDihedralChord);
-            wasModified = true;
-        }
-
-        if (dihedralHasChanged) {
-            internalDihedral      = ui->spinBoxDihedral->value();
-            internalDihedralChord = ui->spinBoxDihedralChord->value();
-            tiglWing->SetDihedral(internalDihedral, internalDihedralChord);
-            wasModified = true;
-        }
-
-        if (areaXYHasChanged) {
-            internalArea = ui->spinBoxArea->value();
-            if (ui->checkBoxIsSpanConstant->isChecked()) {
-                tiglWing->SetAreaKeepSpan(internalArea);
+            if (rootLEHasChanged) {
+                ui->rootLE->setInternalFromGUI();
+                tigl::CTiglPoint newRootLE = ui->rootLE->getInternalPoint();
+                tiglWing->SetRootLEPosition(newRootLE);
                 wasModified = true;
             }
-            else if (ui->checkBoxIsARConstant->isChecked()) {
-                tiglWing->SetAreaKeepAR(internalArea);
+
+            if (rotationHasChanged) {
+                ui->rotation->setInternalFromGUI();
+                tigl::CTiglPoint newRot = ui->rotation->getInternalPoint();
+                tiglWing->SetRotation(newRot);
                 wasModified = true;
             }
-            else {
-                LOG(ERROR) << "ModificatorWingWidget: set area called, but not correct "
-                              "constant checkbox set";
+
+            if (symmetryHasChanged) {
+                ui->symmetry->setInternalFromGUI();
+                tiglWing->SetSymmetryAxis(ui->symmetry->getInternalSymmetry());
+
+                wasModified = true;
             }
+
+            if (sweepHasChanged) {
+                internalSweep      = ui->spinBoxSweep->value();
+                internalSweepChord = ui->spinBoxSweepChord->value();
+                tiglWing->SetSweep(internalSweep, internalDihedralChord);
+                wasModified = true;
+            }
+
+            if (dihedralHasChanged) {
+                internalDihedral      = ui->spinBoxDihedral->value();
+                internalDihedralChord = ui->spinBoxDihedralChord->value();
+                tiglWing->SetDihedral(internalDihedral, internalDihedralChord);
+                wasModified = true;
+            }
+
+            if (areaXYHasChanged) {
+                internalArea = ui->spinBoxArea->value();
+                if (ui->checkBoxIsSpanConstant->isChecked()) {
+                    tiglWing->SetAreaKeepSpan(internalArea);
+                    wasModified = true;
+                }
+                else if (ui->checkBoxIsARConstant->isChecked()) {
+                    tiglWing->SetAreaKeepAR(internalArea);
+                    wasModified = true;
+                }
+                else {
+                    LOG(ERROR) << "ModificatorWingWidget: set area called, but not correct "
+                                  "constant checkbox set";
+                }
+            }
+
+            if (spanHasChanged) {
+                internalSpan = ui->spinBoxSpan->value();
+                if (ui->checkBoxIsAreaConstant->isChecked()) {
+                    tiglWing->SetHalfSpanKeepArea(internalSpan);
+                    wasModified = true;
+                }
+                else if (ui->checkBoxIsARConstant->isChecked()) {
+                    tiglWing->SetHalfSpanKeepAR(internalSpan);
+                    wasModified = true;
+                }
+                else {
+                    LOG(ERROR) << "ModificatorWingWidget: set span called, but not correct "
+                                  "constant checkbox set";
+                }
+            }
+
+            if (arHasChanged) {
+                internalAR = ui->spinBoxAR->value();
+                if (ui->checkBoxIsAreaConstant->isChecked()) {
+                    tiglWing->SetARKeepArea(internalAR);
+                    wasModified = true;
+                }
+                else if (ui->checkBoxIsSpanConstant->isChecked()) {
+                    tiglWing->SetARKeepSpan(internalAR);
+                    wasModified = true;
+                }
+                else {
+                    LOG(ERROR) << "ModificatorWingWidget: set AR called, but not correct "
+                                  "constant checkbox set";
+                }
+            }
+
+
+            if (profileHasChanged) {
+                internalProfile = ui->profileComboBox->currentText();
+
+                if (!profilesDB->hasProfileConfigSuffix(internalProfile)) {
+                    profilesDB->copyProfileFromLocalToConfig(internalProfile);
+                }
+                tiglWing->SetAllAirfoils(profilesDB->removeSuffix(internalProfile).toStdString());
+                wasModified = true;
+
+            }
+
+            if (wasModified) {
+                reset();
+            }
+
         }
-
-        if (spanHasChanged) {
-            internalSpan = ui->spinBoxSpan->value();
-            if (ui->checkBoxIsAreaConstant->isChecked()) {
-                tiglWing->SetHalfSpanKeepArea(internalSpan);
-                wasModified = true;
-            }
-            else if (ui->checkBoxIsARConstant->isChecked()) {
-                tiglWing->SetHalfSpanKeepAR(internalSpan);
-                wasModified = true;
-            }
-            else {
-                LOG(ERROR) << "ModificatorWingWidget: set span called, but not correct "
-                              "constant checkbox set";
-            }
+        catch (const tigl::CTiglError &err) {
+            TIGLViewerErrorDialog errDialog(this);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                         .arg("Failed to apply the settings")
+                                         .arg(err.what()));
+            errDialog.setWindowTitle("Error");
+            errDialog.setDetailsText(err.what());
+            errDialog.exec();
+            return false;
         }
-
-        if (arHasChanged) {
-            internalAR = ui->spinBoxAR->value();
-            if (ui->checkBoxIsAreaConstant->isChecked()) {
-                tiglWing->SetARKeepArea(internalAR);
-                wasModified = true;
-            }
-            else if (ui->checkBoxIsSpanConstant->isChecked()) {
-                tiglWing->SetARKeepSpan(internalAR);
-                wasModified = true;
-            }
-            else {
-                LOG(ERROR) << "ModificatorWingWidget: set AR called, but not correct "
-                              "constant checkbox set";
-            }
-        }
-
-
-        if (profileHasChanged) {
-            internalProfile = ui->profileComboBox->currentText();
-
-            if (!profilesDB->hasProfileConfigSuffix(internalProfile)) {
-                profilesDB->copyProfileFromLocalToConfig(internalProfile);
-            }
-            tiglWing->SetAllAirfoils(profilesDB->removeSuffix(internalProfile).toStdString());
-            wasModified = true;
-
-        }
-
-    }
-    catch (const tigl::CTiglError &err) {
+    } catch (...) {
         TIGLViewerErrorDialog errDialog(this);
         errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
                                      .arg("Failed to apply the settings")
-                                     .arg(err.what()));
+                                     .arg("An unknown exception occured."));
         errDialog.setWindowTitle("Error");
-        errDialog.setDetailsText(err.what());
         errDialog.exec();
         return false;
-    }
-
-    if (wasModified) {
-        reset();
     }
 
     return wasModified;

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
@@ -208,108 +208,113 @@ bool ModificatorWingWidget::apply()
 
     bool wasModified = false;
 
-    if (rootLEHasChanged) {
-        ui->rootLE->setInternalFromGUI();
-        tigl::CTiglPoint newRootLE = ui->rootLE->getInternalPoint();
-        tiglWing->SetRootLEPosition(newRootLE);
-        wasModified = true;
-    }
+    try {
 
-    if (rotationHasChanged) {
-        ui->rotation->setInternalFromGUI();
-        tigl::CTiglPoint newRot = ui->rotation->getInternalPoint();
-        tiglWing->SetRotation(newRot);
-        wasModified = true;
-    }
-
-    if (symmetryHasChanged) {
-        ui->symmetry->setInternalFromGUI();
-        tiglWing->SetSymmetryAxis(ui->symmetry->getInternalSymmetry());
-
-        wasModified = true; 
-    }
-
-    if (sweepHasChanged) {
-        internalSweep      = ui->spinBoxSweep->value();
-        internalSweepChord = ui->spinBoxSweepChord->value();
-        tiglWing->SetSweep(internalSweep, internalDihedralChord);
-        wasModified = true;
-    }
-
-    if (dihedralHasChanged) {
-        internalDihedral      = ui->spinBoxDihedral->value();
-        internalDihedralChord = ui->spinBoxDihedralChord->value();
-        tiglWing->SetDihedral(internalDihedral, internalDihedralChord);
-        wasModified = true;
-    }
-
-    if (areaXYHasChanged) {
-        internalArea = ui->spinBoxArea->value();
-        if (ui->checkBoxIsSpanConstant->isChecked()) {
-            tiglWing->SetAreaKeepSpan(internalArea);
+        if (rootLEHasChanged) {
+            ui->rootLE->setInternalFromGUI();
+            tigl::CTiglPoint newRootLE = ui->rootLE->getInternalPoint();
+            tiglWing->SetRootLEPosition(newRootLE);
             wasModified = true;
         }
-        else if (ui->checkBoxIsARConstant->isChecked()) {
-            tiglWing->SetAreaKeepAR(internalArea);
-            wasModified = true;
-        }
-        else {
-            LOG(ERROR) << "ModificatorWingWidget: set area called, but not correct "
-                          "constant checkbox set";
-        }
-    }
 
-    if (spanHasChanged) {
-        internalSpan = ui->spinBoxSpan->value();
-        if (ui->checkBoxIsAreaConstant->isChecked()) {
-            tiglWing->SetHalfSpanKeepArea(internalSpan);
+        if (rotationHasChanged) {
+            ui->rotation->setInternalFromGUI();
+            tigl::CTiglPoint newRot = ui->rotation->getInternalPoint();
+            tiglWing->SetRotation(newRot);
             wasModified = true;
         }
-        else if (ui->checkBoxIsARConstant->isChecked()) {
-            tiglWing->SetHalfSpanKeepAR(internalSpan);
-            wasModified = true;
-        }
-        else {
-            LOG(ERROR) << "ModificatorWingWidget: set span called, but not correct "
-                          "constant checkbox set";
-        }
-    }
 
-    if (arHasChanged) {
-        internalAR = ui->spinBoxAR->value();
-        if (ui->checkBoxIsAreaConstant->isChecked()) {
-            tiglWing->SetARKeepArea(internalAR);
+        if (symmetryHasChanged) {
+            ui->symmetry->setInternalFromGUI();
+            tiglWing->SetSymmetryAxis(ui->symmetry->getInternalSymmetry());
+
             wasModified = true;
         }
-        else if (ui->checkBoxIsSpanConstant->isChecked()) {
-            tiglWing->SetARKeepSpan(internalAR);
+
+        if (sweepHasChanged) {
+            internalSweep      = ui->spinBoxSweep->value();
+            internalSweepChord = ui->spinBoxSweepChord->value();
+            tiglWing->SetSweep(internalSweep, internalDihedralChord);
             wasModified = true;
         }
-        else {
-            LOG(ERROR) << "ModificatorWingWidget: set AR called, but not correct "
-                          "constant checkbox set";
+
+        if (dihedralHasChanged) {
+            internalDihedral      = ui->spinBoxDihedral->value();
+            internalDihedralChord = ui->spinBoxDihedralChord->value();
+            tiglWing->SetDihedral(internalDihedral, internalDihedralChord);
+            wasModified = true;
         }
-    }
+
+        if (areaXYHasChanged) {
+            internalArea = ui->spinBoxArea->value();
+            if (ui->checkBoxIsSpanConstant->isChecked()) {
+                tiglWing->SetAreaKeepSpan(internalArea);
+                wasModified = true;
+            }
+            else if (ui->checkBoxIsARConstant->isChecked()) {
+                tiglWing->SetAreaKeepAR(internalArea);
+                wasModified = true;
+            }
+            else {
+                LOG(ERROR) << "ModificatorWingWidget: set area called, but not correct "
+                              "constant checkbox set";
+            }
+        }
+
+        if (spanHasChanged) {
+            internalSpan = ui->spinBoxSpan->value();
+            if (ui->checkBoxIsAreaConstant->isChecked()) {
+                tiglWing->SetHalfSpanKeepArea(internalSpan);
+                wasModified = true;
+            }
+            else if (ui->checkBoxIsARConstant->isChecked()) {
+                tiglWing->SetHalfSpanKeepAR(internalSpan);
+                wasModified = true;
+            }
+            else {
+                LOG(ERROR) << "ModificatorWingWidget: set span called, but not correct "
+                              "constant checkbox set";
+            }
+        }
+
+        if (arHasChanged) {
+            internalAR = ui->spinBoxAR->value();
+            if (ui->checkBoxIsAreaConstant->isChecked()) {
+                tiglWing->SetARKeepArea(internalAR);
+                wasModified = true;
+            }
+            else if (ui->checkBoxIsSpanConstant->isChecked()) {
+                tiglWing->SetARKeepSpan(internalAR);
+                wasModified = true;
+            }
+            else {
+                LOG(ERROR) << "ModificatorWingWidget: set AR called, but not correct "
+                              "constant checkbox set";
+            }
+        }
 
 
-    if (profileHasChanged) {
-        internalProfile = ui->profileComboBox->currentText();
-        try {
+        if (profileHasChanged) {
+            internalProfile = ui->profileComboBox->currentText();
+
             if (!profilesDB->hasProfileConfigSuffix(internalProfile)) {
                 profilesDB->copyProfileFromLocalToConfig(internalProfile);
             }
             tiglWing->SetAllAirfoils(profilesDB->removeSuffix(internalProfile).toStdString());
             wasModified = true;
+
         }
-        catch (const tigl::CTiglError &err) {
-            TIGLViewerErrorDialog errDialog(this);
-            errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
-                                         .arg("Fail to set the profile")
-                                         .arg(err.what()));
-            errDialog.setWindowTitle("Error");
-            errDialog.setDetailsText(err.what());
-            errDialog.exec();
-        }
+
+    }
+    catch (const tigl::CTiglError &err) {
+        TIGLViewerErrorDialog errDialog(this);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                     .arg("Failed to apply the settings")
+                                     .arg(err.what()));
+        errDialog.setWindowTitle("Error");
+        errDialog.setDetailsText(err.what());
+        errDialog.exec();
+        return false;
     }
 
     if (wasModified) {

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.cpp
@@ -78,6 +78,8 @@ void ModificatorWingWidget::init()
             ui->spinBoxAR->setValue(internalAR);
             internalArea = tiglWing->GetReferenceArea();
             ui->spinBoxArea->setValue(internalArea);
+            updateSweepAccordingChordValue();
+            updateDihedralAccordingChordValue();
 
             // reset symmetry axis. We only want to log this change in in the apply function.
             tiglWing->SetSymmetryAxis(previous_sym);

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.ui
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.ui
@@ -317,7 +317,7 @@
         <number>3</number>
        </property>
        <property name="minimum">
-        <double>0.010000000000000</double>
+        <double>0.000000000000000</double>
        </property>
        <property name="maximum">
         <double>99999999999999998278261272554585856747747644714015897553975120217811154108416.000000000000000</double>
@@ -427,7 +427,7 @@
         <number>3</number>
        </property>
        <property name="minimum">
-        <double>0.010000000000000</double>
+        <double>0.000000000000000</double>
        </property>
        <property name="maximum">
         <double>1000000000000000013287555072.000000000000000</double>

--- a/TIGLViewer/src/modificators/ModificatorWingWidget.ui
+++ b/TIGLViewer/src/modificators/ModificatorWingWidget.ui
@@ -84,10 +84,10 @@
         <number>3</number>
        </property>
        <property name="minimum">
-        <double>-89.000000000000000</double>
+        <double>-90.000000000000000</double>
        </property>
        <property name="maximum">
-        <double>89.000000000000000</double>
+        <double>90.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -194,10 +194,10 @@
         <number>3</number>
        </property>
        <property name="minimum">
-        <double>-89.000000000000000</double>
+        <double>-90.000000000000000</double>
        </property>
        <property name="maximum">
-        <double>89.000000000000000</double>
+        <double>90.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/TIGLViewer/src/modificators/SymmetryComboBoxWidget.cpp
+++ b/TIGLViewer/src/modificators/SymmetryComboBoxWidget.cpp
@@ -34,6 +34,15 @@ SymmetryComboBoxWidget::SymmetryComboBoxWidget(QWidget* parent)
     ui->comboBox->addItem("no-symmetry");
 
     setInternal(TiglSymmetryAxis::TIGL_NO_SYMMETRY);
+
+    connect(
+        ui->comboBox,
+        &QComboBox::currentTextChanged,
+        this,
+        [=](const QString&){
+            emit currentIndexChanged();
+        }
+    );
 }
 
 QString SymmetryComboBoxWidget::TiglSymmetryAxisToQString(TiglSymmetryAxis symmetryAxis)
@@ -96,7 +105,7 @@ void SymmetryComboBoxWidget::setInternalFromGUI()
 
 bool SymmetryComboBoxWidget::hasChanged()
 {
-    if (internalSymmetry == QStringToTiglAxis(ui->comboBox->currentText())) {
+    if (internalSymmetry == getSymmetry()) {
         return false;
     }
     else {
@@ -107,4 +116,9 @@ bool SymmetryComboBoxWidget::hasChanged()
 TiglSymmetryAxis SymmetryComboBoxWidget::getInternalSymmetry()
 {
     return internalSymmetry;
+}
+
+TiglSymmetryAxis SymmetryComboBoxWidget::getSymmetry()
+{
+    return QStringToTiglAxis(ui->comboBox->currentText());
 }

--- a/TIGLViewer/src/modificators/SymmetryComboBoxWidget.h
+++ b/TIGLViewer/src/modificators/SymmetryComboBoxWidget.h
@@ -37,12 +37,17 @@ public slots:
     void setGUIFromInternal();
     void setInternalFromGUI();
 
+signals:
+    void currentIndexChanged();
+
 public:
     explicit SymmetryComboBoxWidget(QWidget* parent = nullptr);
     ~SymmetryComboBoxWidget();
 
     void setInternal(TiglSymmetryAxis symmetryAxis);
 
+
+    TiglSymmetryAxis getSymmetry();
     TiglSymmetryAxis getInternalSymmetry();
 
     bool hasChanged();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #1143

## Description

The problem is that changing the symmetry plane of a wing has an influence on the reference area, sweep, dihedral and aspect ratio. When the symmetry axis is changed, the spinboxes for setting the top area, aspect ratio, etc. are not changed, but the values are recalculated internally. From this difference, the ModificatorWingWidget deduces that e.g. the aspect ratio has changed and calls the associated function, actually changing the geometry. For some choices the calculated reference area is nonsensical, e.g. 0. When applying the change, TiGL crashes.

--------------------

Now, before we call ModificatorWingWidget::apply, we connect the combobox of the symmetry with a function that recalculates the reference area, sweep, dihedral and aspect ratio and sets the comboboxes appropriately. With this change, the ModificatorWingWidget will see that only the symmetry has changed and will not update the geometry of the wing. 

An additional issue was, that in some choices of the symmetry plane we get dihedrals and sweeps of 90 degrees and reference areas of 0 degrees, which are stored internally. The combobox limits do not allow this and clamp the value of the combobox. In consequence, there is an inconsistency between the combobox values for area, dihedral and span and ModificatorWingWidget deduces that the values were changed. This has been fixed by lifting the limits of the comboboxes so as to ensure that there is no inconsistency between the comboboxes value and the internally stored values.

The hard crash was caused because for some choices the top area was zero. Setting the top area to zero gives a CTiglError, which was not caught by the GUI. Now we have a big try-catch block in ModificatorWingWidget::apply to catch any error before applying the values.

## How Has This Been Tested?

Debugger, Manual testing in the GUI.

## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
