### PR TITLE
Allow naming new sections

### DIFF
--- a/TIGLViewer/src/modificators/ModificatorSectionsWidget.cpp
+++ b/TIGLViewer/src/modificators/ModificatorSectionsWidget.cpp
@@ -62,6 +62,7 @@ void ModificatorSectionsWidget::execNewConnectedElementDialog()
     NewConnectedElementDialog newElementDialog(elementUIDsQList, this);
     if (newElementDialog.exec() == QDialog::Accepted) {
         std::string startUID                    = newElementDialog.getStartUID().toStdString();
+        std::string sectionName                 = newElementDialog.getSectionName().toStdString();
         NewConnectedElementDialog::Where where  = newElementDialog.getWhere();
         std::optional<double> eta               = newElementDialog.getEta();
         try {
@@ -69,28 +70,28 @@ void ModificatorSectionsWidget::execNewConnectedElementDialog()
                 auto elementUIDBefore = createConnectedElement->GetElementUIDBeforeNewElement(startUID);
                 if (elementUIDBefore) {
                     if (eta) { // Security check. Should be set if elementUIDBefore is true
-                        createConnectedElement->CreateNewConnectedElementBetween(*elementUIDBefore, startUID, *eta);
+                        createConnectedElement->CreateNewConnectedElementBetween(*elementUIDBefore, startUID, *eta, sectionName);
                     }
                     else {
                         throw tigl::CTiglError("No eta value set!");
                     }
                 }
                 else {
-                    createConnectedElement->CreateNewConnectedElementBefore(startUID);
+                    createConnectedElement->CreateNewConnectedElementBefore(startUID, sectionName);
                 }
             }
             else if (where == NewConnectedElementDialog::After) {
                 auto elementUIDAfter = createConnectedElement->GetElementUIDAfterNewElement(startUID);
                 if (elementUIDAfter) {
                     if (eta) { // Security check. Should be set if elementUIDAfter is true
-                        createConnectedElement->CreateNewConnectedElementBetween(startUID, *elementUIDAfter, *eta);
+                        createConnectedElement->CreateNewConnectedElementBetween(startUID, *elementUIDAfter, *eta, sectionName);
                     }
                     else {
                         throw tigl::CTiglError("No eta value set!");
                     }
                 }
                 else {
-                    createConnectedElement->CreateNewConnectedElementAfter(startUID);
+                    createConnectedElement->CreateNewConnectedElementAfter(startUID, sectionName);
                 }
             }
         }

--- a/TIGLViewer/src/modificators/ModificatorSectionsWidget.h
+++ b/TIGLViewer/src/modificators/ModificatorSectionsWidget.h
@@ -40,16 +40,16 @@ struct ElementModificatorInterface
             [&t](std::string str){ return t.GetElementUIDAfterNewElement(str); }
             )
         , CreateNewConnectedElementAfter(
-            [&t](std::string str){ return t.CreateNewConnectedElementAfter(str); }
+            [&t](std::string str, std::string name){ return t.CreateNewConnectedElementAfter(str, name); }
             )
         , GetElementUIDBeforeNewElement(
             [&t](std::string str){ return t.GetElementUIDBeforeNewElement(str); }
             )
         , CreateNewConnectedElementBefore(
-            [&t](std::string str){ return t.CreateNewConnectedElementBefore(str); }
+            [&t](std::string str, std::string name){ return t.CreateNewConnectedElementBefore(str, name); }
             )
         , CreateNewConnectedElementBetween(
-            [&t](std::string str1, std::string str2, double param){ return t.CreateNewConnectedElementBetween(str1, str2, param); }
+            [&t](std::string str1, std::string str2, double param, std::string name){ return t.CreateNewConnectedElementBetween(str1, str2, param, name); }
             )
         , DeleteConnectedElement(
             [&t](std::string str){ return t.DeleteConnectedElement(str); }
@@ -60,10 +60,10 @@ struct ElementModificatorInterface
     {}
 
     std::function<std::optional<std::string>(std::string)> GetElementUIDAfterNewElement;
-    std::function<void(std::string)> CreateNewConnectedElementAfter;
+    std::function<void(std::string, std::string)> CreateNewConnectedElementAfter;
     std::function<std::optional<std::string>(std::string)> GetElementUIDBeforeNewElement;
-    std::function<void(std::string)> CreateNewConnectedElementBefore;
-    std::function<void(std::string, std::string, double param)> CreateNewConnectedElementBetween;
+    std::function<void(std::string, std::string)> CreateNewConnectedElementBefore;
+    std::function<void(std::string, std::string, double param, std::string)> CreateNewConnectedElementBetween;
     std::function<void(std::string)> DeleteConnectedElement;
     std::function<std::vector<std::string>()> GetOrderedConnectedElement;
 };

--- a/TIGLViewer/src/modificators/NewConnectedElementDialog.cpp
+++ b/TIGLViewer/src/modificators/NewConnectedElementDialog.cpp
@@ -43,7 +43,22 @@ NewConnectedElementDialog::NewConnectedElementDialog(QStringList connectedElemen
         SLOT(activate_eta())
     );
 
+     connect(
+        ui->comboBoxStartUID,
+        SIGNAL(currentIndexChanged(int)),
+        this,
+        SLOT(updateDefaultName())
+    );
+
+    connect(
+        ui->comboBoxWhere,
+        SIGNAL(currentIndexChanged(int)),
+        this,
+        SLOT(updateDefaultName())
+    );
+
     activate_eta();
+    updateDefaultName();
 }
 
 void NewConnectedElementDialog::activate_eta()
@@ -61,6 +76,23 @@ void NewConnectedElementDialog::activate_eta()
         ui->eta_spinbox->setEnabled(false);
     }
 }
+
+void NewConnectedElementDialog::updateDefaultName()
+{
+    QString uid = ui->comboBoxStartUID->currentText();
+    QString where = ui->comboBoxWhere->currentText();
+
+    QString defaultName = QString("%1_%2").arg(uid, where);
+
+    // Only update if the user hasn’t typed a custom name
+    if (ui->lineEditName->text().isEmpty() ||
+        ui->lineEditName->text().endsWith("Before") ||
+        ui->lineEditName->text().endsWith("After")) 
+    {
+        ui->lineEditName->setText(defaultName);
+    }
+}
+
 
 NewConnectedElementDialog::~NewConnectedElementDialog()
 {
@@ -90,3 +122,10 @@ std::optional<double> NewConnectedElementDialog::getEta() const
         return std::nullopt;
     }
 }
+
+QString NewConnectedElementDialog::getSectionName() const
+{
+    return ui->lineEditName->text();
+}
+
+

--- a/TIGLViewer/src/modificators/NewConnectedElementDialog.h
+++ b/TIGLViewer/src/modificators/NewConnectedElementDialog.h
@@ -54,10 +54,13 @@ public:
      */
     Where getWhere() const;
 
+    QString getSectionName() const;
+
     std::optional<double> getEta() const;
 
 private slots:
     void activate_eta();
+    void updateDefaultName();
 
 private:
     Ui::NewConnectedElementDialog* ui;

--- a/TIGLViewer/src/modificators/NewConnectedElementDialog.ui
+++ b/TIGLViewer/src/modificators/NewConnectedElementDialog.ui
@@ -15,6 +15,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLineEdit" name="lineEditName">
+     <property name="text">
+      <string></string>
+     </property>
+     <property name="placeholderText">
+      <string>Enter name...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Chose where you want to create the new section. </string>

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -747,7 +747,7 @@ void CCPACSFuselage::SetFuselageHelper(CTiglFuselageHelper& cache) const
     cache.SetFuselage(const_cast<CCPACSFuselage*>(this));
 }
 
-void CCPACSFuselage::CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta)
+void CCPACSFuselage::CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta, std::string sectionName)
 {
     if(0.0001 > eta || eta > 0.9999)
     {
@@ -777,7 +777,7 @@ void CCPACSFuselage::CreateNewConnectedElementBetween(std::string startElementUI
 
     // create new section and element
     CTiglUIDManager& uidManager = GetUIDManager();
-    std::string baseUID = uidManager.MakeUIDUnique(startElement->GetSectionUID() + "Bis" );
+    std::string baseUID = uidManager.MakeUIDUnique(sectionName);
     CCPACSFuselageSection& newSection = GetSections().CreateSection(baseUID, startElement->GetProfileUID());
     CTiglFuselageSectionElement* newElement = newSection.GetSectionElement(1).GetCTiglSectionElement();
 
@@ -806,7 +806,7 @@ std::optional<std::string> CCPACSFuselage::GetElementUIDAfterNewElement(std::str
     return *(++it);
 }
 
-void CCPACSFuselage::CreateNewConnectedElementAfter(std::string startElementUID)
+void CCPACSFuselage::CreateNewConnectedElementAfter(std::string startElementUID, std::string sectionName)
 {
     auto elementUIDAfter = GetElementUIDAfterNewElement(startElementUID);
     if (elementUIDAfter) {
@@ -846,7 +846,7 @@ void CCPACSFuselage::CreateNewConnectedElementAfter(std::string startElementUID)
             area = scaleF * area;
         }
         std::string profileUID = startElement->GetProfileUID();
-        std::string sectionUID = startElement->GetSectionUID() + "After";
+        std::string sectionUID =  GetUIDManager().MakeUIDUnique(sectionName);
 
 
         CCPACSFuselageSection& newSection = GetSections().CreateSection(sectionUID, profileUID);
@@ -881,7 +881,7 @@ std::optional<std::string> CCPACSFuselage::GetElementUIDBeforeNewElement(std::st
     return *(--it);
 }
 
-void CCPACSFuselage::CreateNewConnectedElementBefore(std::string startElementUID)
+void CCPACSFuselage::CreateNewConnectedElementBefore(std::string startElementUID, std::string sectionName)
 {
     auto elementUIDBefore = GetElementUIDBeforeNewElement(startElementUID);
     if (elementUIDBefore) {
@@ -920,7 +920,7 @@ void CCPACSFuselage::CreateNewConnectedElementBefore(std::string startElementUID
             area = scaleF * area;
         }
         std::string profileUID = startElement->GetProfileUID();
-        std::string sectionUID = startElement->GetSectionUID() + "Before";
+        std::string sectionUID =  GetUIDManager().MakeUIDUnique(sectionName);
 
 
         CCPACSFuselageSection& newSection = GetSections().CreateSection(sectionUID, profileUID);

--- a/src/fuselage/CCPACSFuselage.h
+++ b/src/fuselage/CCPACSFuselage.h
@@ -172,7 +172,7 @@ public:
      *
      * @param startElementUID
      */
-    TIGL_EXPORT void CreateNewConnectedElementAfter(std::string startElementUID);
+    TIGL_EXPORT void CreateNewConnectedElementAfter(std::string startElementUID, std::string sectionName = "defaultName");
 
     TIGL_EXPORT std::optional<std::string> GetElementUIDBeforeNewElement(std::string startElementUID);
 
@@ -184,7 +184,7 @@ public:
      *
      * @param startElementUID
      */
-    TIGL_EXPORT void CreateNewConnectedElementBefore(std::string startElementUID);
+    TIGL_EXPORT void CreateNewConnectedElementBefore(std::string startElementUID, std::string sectionName = "defaultName");
 
     /**
      * Create a new section, a new element and place the new element between the startElement and the endElement.
@@ -194,7 +194,7 @@ public:
      * @param endElementUID
      * @param eta
      */
-    TIGL_EXPORT void CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta = 0.5);
+    TIGL_EXPORT void CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta = 0.5, std::string sectionName = "defaultName");
 
     TIGL_EXPORT void DeleteConnectedElement(std::string elementUID);
 

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -1405,7 +1405,7 @@ void CCPACSWing::SetARKeepArea(double newAR)
     SetHalfSpanKeepArea(newSpan);
 }
 
-void CCPACSWing::CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta)
+void CCPACSWing::CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta, std::string sectionName)
 {
 
     if(0.0001 > eta || eta > 0.9999)
@@ -1436,7 +1436,7 @@ void CCPACSWing::CreateNewConnectedElementBetween(std::string startElementUID, s
 
     // create new section and element
     CTiglUIDManager &uidManager = GetUIDManager();
-    std::string baseUID = uidManager.MakeUIDUnique(startElement->GetSectionUID() + "Bis");
+    std::string baseUID = uidManager.MakeUIDUnique(sectionName);
     CCPACSWingSection &newSection = GetSections().CreateSection(baseUID, startElement->GetProfileUID());
     CTiglWingSectionElement *newElement = newSection.GetSectionElement(1).GetCTiglSectionElement();
 
@@ -1465,7 +1465,7 @@ std::optional<std::string> CCPACSWing::GetElementUIDAfterNewElement(std::string 
     return *(++it);
 }
 
-void CCPACSWing::CreateNewConnectedElementAfter(std::string startElementUID)
+void CCPACSWing::CreateNewConnectedElementAfter(std::string startElementUID, std::string sectionName)
 {
     auto elementUIDAfter = GetElementUIDAfterNewElement(startElementUID);
     if (elementUIDAfter) {
@@ -1504,7 +1504,7 @@ void CCPACSWing::CreateNewConnectedElementAfter(std::string startElementUID)
             area = scaleF * area;
         }
         std::string profileUID = startElement->GetProfileUID();
-        std::string sectionUID = startElement->GetSectionUID() + "After";
+        std::string sectionUID =  GetUIDManager().MakeUIDUnique(sectionName);
 
 
         CCPACSWingSection& newSection = GetSections().CreateSection(sectionUID, profileUID);
@@ -1539,7 +1539,7 @@ std::optional<std::string> CCPACSWing::GetElementUIDBeforeNewElement(std::string
     return *(--it);
 }
 
-void CCPACSWing::CreateNewConnectedElementBefore(std::string startElementUID)
+void CCPACSWing::CreateNewConnectedElementBefore(std::string startElementUID, std::string sectionName)
 {
 
     auto elementUIDBefore = GetElementUIDBeforeNewElement(startElementUID);
@@ -1579,7 +1579,7 @@ void CCPACSWing::CreateNewConnectedElementBefore(std::string startElementUID)
             area = scaleF * area;
         }
         std::string profileUID = startElement->GetProfileUID();
-        std::string sectionUID = startElement->GetSectionUID() + "Before";
+        std::string sectionUID =  GetUIDManager().MakeUIDUnique(sectionName);
 
 
         CCPACSWingSection& newSection = GetSections().CreateSection(sectionUID, profileUID);

--- a/src/wing/CCPACSWing.h
+++ b/src/wing/CCPACSWing.h
@@ -484,7 +484,7 @@ public:
      *
      * @param startElementUID
      */
-    TIGL_EXPORT void CreateNewConnectedElementAfter(std::string startElementUID);
+    TIGL_EXPORT void CreateNewConnectedElementAfter(std::string startElementUID, std::string sectionName = "defaultName");
 
     TIGL_EXPORT std::optional<std::string> GetElementUIDBeforeNewElement(std::string startElementUID);
 
@@ -496,7 +496,7 @@ public:
      *
      * @param startElementUID
      */
-    TIGL_EXPORT void CreateNewConnectedElementBefore(std::string startElementUID);
+    TIGL_EXPORT void CreateNewConnectedElementBefore(std::string startElementUID, std::string sectionName = "defaultName");
 
     /**
      * Create a new section, a new element and place the new element between the startElement and the endElement.
@@ -506,7 +506,7 @@ public:
      * @param endElementUID
      * @param eta
      */
-    TIGL_EXPORT void CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta = 0.5);
+    TIGL_EXPORT void CreateNewConnectedElementBetween(std::string startElementUID, std::string endElementUID, double eta = 0.5, std::string sectionName = "defaultName");
 
     /**
      * Delete the connected element.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When adding fuselages and wings, a user can choose a uid of the new fuselage/wing. A default name is displayed and doesn't have to changed by the user. If changed the new name will be the name of the section. If the chosen uid is not unique it will be made unique by the uidmanager. 


Closes #1141 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
