### PR TITLE
Fix #1172

### DIFF
--- a/TIGLCreator/src/modificators/ModificatorWingWidget.cpp
+++ b/TIGLCreator/src/modificators/ModificatorWingWidget.cpp
@@ -91,7 +91,6 @@ void ModificatorWingWidget::init()
                                              .arg("An unknown exception occured."));
                 errDialog.setWindowTitle("Error");
                 errDialog.exec();
-                return false;
             }
         }
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #1172.

I introduced a copy-paste error. The slot should be a void function, but I had a return false. My best guess is, that qt cast the function pointer to a wrong type, which internally caused the memory issue, but I am not sure. 


## How Has This Been Tested?

On my machine, removing the return statement fixes the issue.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
