### PR TITLE
Fix #628 Context Menus in Tree View

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Changes since last release
 
 10/09/2025
 - General changes
+  - Sections can now be added or deleted using a context menu in the CPACS Tree View ([#628](https://github.com/DLR-SC/tigl/issues/628))
   - [#1141](https://github.com/DLR-SC/tigl/issues/1141) Add the option to set a custom name when a new section is added into fuselages or wings. This user dialog is included within the new-section-dialog.
   - When adding new sections to wings or fuselages, the sections are reordered from root to tip (resp. nose to rear) according to the segments ([#1139](https://github.com/DLR-SC/tigl/issues/1139))
 

--- a/TIGLCreator/src/CPACSAbstractModel.cpp
+++ b/TIGLCreator/src/CPACSAbstractModel.cpp
@@ -63,11 +63,20 @@ QVariant CPACSAbstractModel::data(const QModelIndex& index, int role) const
         return QVariant();
     }
 
-    if (role != Qt::DisplayRole) {
+    if (role != Qt::DisplayRole && role !=Qt::UserRole) {
         return QVariant();
     }
+
     cpcr::CPACSTreeItem* item = getItem(index);
     QVariant data;
+
+    if (role == Qt::UserRole) {
+        // we use Qt::UserRole to mark eligable parents for context menus in the tree view
+        // For now, these are fuselage sections and wing setions
+        data = (item->getType() == "sections");
+        return data;
+    }
+
     if (index.column() == 0) { // combine uid and type
         data = QString(item->getUid().c_str());
         if (data == "") {

--- a/TIGLCreator/src/CPACSAbstractModel.h
+++ b/TIGLCreator/src/CPACSAbstractModel.h
@@ -80,7 +80,6 @@ public:
     // Return the index of the first cpacs element that is of the "model" type
     QModelIndex getAircraftModelIndex();
 
-protected:
     // return the item for the given index
     // empty index is considered as the root index!
     cpcr::CPACSTreeItem* getItem(QModelIndex index) const;

--- a/TIGLCreator/src/CPACSFilterModel.cpp
+++ b/TIGLCreator/src/CPACSFilterModel.cpp
@@ -40,6 +40,11 @@ cpcr::CPACSTreeItem* CPACSFilterModel::getItemFromSelection(const QItemSelection
     return cpacsModel->getItemFromSelection(mapSelectionToSource(newSelection));
 }
 
+cpcr::CPACSTreeItem *CPACSFilterModel::getItem(QModelIndex index) const
+{
+    return cpacsModel->getItem(mapToSource(index));
+}
+
 bool CPACSFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
 {
 

--- a/TIGLCreator/src/CPACSFilterModel.h
+++ b/TIGLCreator/src/CPACSFilterModel.h
@@ -74,6 +74,7 @@ public:
     };
 
     cpcr::CPACSTreeItem* getItemFromSelection(const QItemSelection& newSelection);
+    cpcr::CPACSTreeItem* getItem(QModelIndex index) const;
 
     /**
      * @return Return the index of the first cpacs element that is of the "model" type

--- a/TIGLCreator/src/CPACSTreeView.cpp
+++ b/TIGLCreator/src/CPACSTreeView.cpp
@@ -38,10 +38,7 @@ void CPACSTreeView::onContextMenuDone()
 
 void CPACSTreeView::onCustomContextMenuRequested(const QPoint &pos)
 {
-    // remember that a custom context menu was requested. We want to paint
-    // the line until we get the signal that the context menu was closed
-    contextMenuRequested = true;
-
+    contextMenuRequested = false;
     QModelIndex index = indexAt(pos);
     if (!index.isValid()){
         return;
@@ -51,6 +48,10 @@ void CPACSTreeView::onCustomContextMenuRequested(const QPoint &pos)
     if (!parent.isValid() || !parent.data(Qt::UserRole).toBool()) {
         return;
     }
+
+    // remember that a custom context menu was requested. We want to paint
+    // the line until we get the signal that the context menu was closed
+    contextMenuRequested = true;
 
     QRect rect = visualRect(index);
     QPoint globalPos = viewport()->mapToGlobal(pos);

--- a/TIGLCreator/src/CPACSTreeView.cpp
+++ b/TIGLCreator/src/CPACSTreeView.cpp
@@ -23,9 +23,16 @@
 
 CPACSTreeView::CPACSTreeView(QWidget *parent)
  : QTreeView(parent)
+ , contextMenuRequested(false)
 {
     setMouseTracking(true);
     setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(this, &QTreeView::customContextMenuRequested, this, [=](){ contextMenuRequested = true; });
+}
+
+void CPACSTreeView::onContextMenuDone()
+{
+    contextMenuRequested = false;
 }
 
 void CPACSTreeView::mouseMoveEvent(QMouseEvent *event)
@@ -45,6 +52,20 @@ void CPACSTreeView::paintEvent(QPaintEvent *event)
 {
     QTreeView::paintEvent(event);
 
+    QPainter p(viewport());
+    p.setPen(QPen(Qt::lightGray, 2));
+
+    auto paint = [&](){
+        p.drawLine(line);                  // draw line between elements
+        // To Do: Loose focus of hovered item
+    };
+
+    // keep the visual feedback of selected gap while context menu is open
+    if (contextMenuRequested) {
+        paint();
+        return;
+    }
+
     if (hoverPos.isNull()) {
         return;
     }
@@ -61,12 +82,15 @@ void CPACSTreeView::paintEvent(QPaintEvent *event)
         return;
     }
 
-    QPainter p(viewport());
-    p.setPen(QPen(Qt::blue, 2));
-
     if (hoverPos.y() < rect.top() + 4) {
-        p.drawLine(rect.left(), rect.top(), rect.right(), rect.top());
+        left = QPoint(rect.left(), rect.top());
+        right = QPoint(rect.right(), rect.top());
+        line = QLine(left, right);
+        paint();
     } else if (hoverPos.y() > rect.bottom() - 4) {
-        p.drawLine(rect.left(), rect.bottom(), rect.right(), rect.bottom());
+        left = QPoint(rect.left(), rect.bottom());
+        right = QPoint(rect.right(), rect.bottom());
+        line = QLine(left, right);
+        paint();
     }
 }

--- a/TIGLCreator/src/CPACSTreeView.cpp
+++ b/TIGLCreator/src/CPACSTreeView.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 DLR
+ *
+ * Created: 2025 Jan Kleinert <jan.kleinert@dlr.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CPACSTreeView.h"
+
+#include <QMouseEvent>
+#include <QPainter>
+
+CPACSTreeView::CPACSTreeView(QWidget *parent)
+ : QTreeView(parent)
+{
+    setMouseTracking(true);
+    setContextMenuPolicy(Qt::CustomContextMenu);
+}
+
+void CPACSTreeView::mouseMoveEvent(QMouseEvent *event)
+{
+    hoverPos = event->pos();
+    QWidget::mouseMoveEvent(event);
+    update();
+}
+
+void CPACSTreeView::leaveEvent(QEvent*)
+{
+    hoverPos = QPoint();
+    update();
+}
+
+void CPACSTreeView::paintEvent(QPaintEvent *event)
+{
+    QTreeView::paintEvent(event);
+
+    if (hoverPos.isNull()) {
+        return;
+    }
+
+    QModelIndex index = indexAt(hoverPos);
+    if (!index.isValid()){
+        return;
+    }
+
+    QRect rect = visualRect(index);
+
+    QModelIndex parent = index.parent();
+    if (!parent.isValid() || !parent.data(Qt::UserRole).toBool()) {
+        return;
+    }
+
+    QPainter p(viewport());
+    p.setPen(QPen(Qt::blue, 2));
+
+    if (hoverPos.y() < rect.top() + 4) {
+        p.drawLine(rect.left(), rect.top(), rect.right(), rect.top());
+    } else if (hoverPos.y() > rect.bottom() - 4) {
+        p.drawLine(rect.left(), rect.bottom(), rect.right(), rect.bottom());
+    }
+}

--- a/TIGLCreator/src/CPACSTreeView.h
+++ b/TIGLCreator/src/CPACSTreeView.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 DLR
+ *
+ * Created: 2025 Jan Kleinert <jan.kleinert@dlr.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <QTreeWidget>
+#include <optional>
+
+namespace Ui
+{
+class CPACSTreeView;
+}
+
+/**
+ * @brief This class inherits QTreeView.
+ *
+ * The purpose of the customization is special painting for
+ * hovering a mouse between two tree elements. This is useful
+ * for context menus.
+ *
+ * @author Jan Kleinert
+ */
+class CPACSTreeView : public QTreeView
+{
+    Q_OBJECT
+
+public:
+    explicit CPACSTreeView(QWidget* parent = nullptr);
+
+protected:
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+
+    QPoint hoverPos;
+};

--- a/TIGLCreator/src/CPACSTreeView.h
+++ b/TIGLCreator/src/CPACSTreeView.h
@@ -42,12 +42,16 @@ class CPACSTreeView : public QTreeView
 public:
     explicit CPACSTreeView(QWidget* parent = nullptr);
 
+public slots:
+    void onContextMenuDone();
+
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
 
 private:
-
+    bool contextMenuRequested;
+    QLine line; // remember the line between two elements
     QPoint hoverPos;
 };

--- a/TIGLCreator/src/CPACSTreeView.h
+++ b/TIGLCreator/src/CPACSTreeView.h
@@ -42,8 +42,19 @@ class CPACSTreeView : public QTreeView
 public:
     explicit CPACSTreeView(QWidget* parent = nullptr);
 
+    enum class Where
+    {
+        Before,
+        At,
+        After
+    };
+
+signals:
+    void customContextMenuRequestedForItem(QPoint globalPos, Where where, QModelIndex);
+
 public slots:
     void onContextMenuDone();
+    void onCustomContextMenuRequested(const QPoint &pos);
 
 protected:
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -51,7 +62,8 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    bool contextMenuRequested;
-    QLine line; // remember the line between two elements
-    QPoint hoverPos;
+    int margin;                 // margin for hovering between elements
+    bool contextMenuRequested;  // keep visual feedback alive as long as context menu is open
+    QLine line;                 // remember the line between two elements
+    QPoint hoverPos;            // remember hover position
 };

--- a/TIGLCreator/src/CPACSTreeView.h
+++ b/TIGLCreator/src/CPACSTreeView.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <QTreeWidget>
-#include <optional>
 
 namespace Ui
 {

--- a/TIGLCreator/src/CPACSTreeWidget.cpp
+++ b/TIGLCreator/src/CPACSTreeWidget.cpp
@@ -19,9 +19,7 @@
 #include "CPACSTreeWidget.h"
 #include "ui_CPACSTreeWidget.h"
 #include "CTiglLogging.h"
-
 #include<QMenu>
-#include <QDebug>
 
 CPACSTreeWidget::CPACSTreeWidget(QWidget* parent)
     : QWidget(parent)
@@ -68,6 +66,7 @@ void CPACSTreeWidget::onCustomContextMenuRequested(QPoint const& globalPos, CPAC
 
     if (parent == nullptr || parent->getType() != "sections") {
         // context menus only supported for children of sections
+        emit contextMenuClosed();
         return;
     }
 

--- a/TIGLCreator/src/CPACSTreeWidget.cpp
+++ b/TIGLCreator/src/CPACSTreeWidget.cpp
@@ -64,13 +64,19 @@ void CPACSTreeWidget::onCustomContextMenuRequested(QPoint const& globalPos, CPAC
     QString uid = QString::fromStdString(item->getUid());
     QString type = QString::fromStdString(item->getType());
 
-    int item_idx = item->positionRelativelyToParent();
-    cpcr::CPACSTreeItem* item_parent = item->getParent();
-    auto siblings = item_parent->getChildren();
+    cpcr::CPACSTreeItem* parent = item->getParent();
+
+    if (parent == nullptr || parent->getType() != "sections") {
+        // context menus only supported for children of sections
+        return;
+    }
 
     if (where == CPACSTreeView::Where::At) {
         QMenu menu;
-        menu.addAction(QStringLiteral("Delete %1 %2").arg(type, uid));
+        QAction* delete_action = menu.addAction(QStringLiteral("Delete %1 %2").arg(type, uid));
+        connect(delete_action, &QAction::triggered, this, [&](){
+            emit deleteElementRequested(item);
+        });
         menu.exec(globalPos);
     } else {
         QMenu menu;

--- a/TIGLCreator/src/CPACSTreeWidget.cpp
+++ b/TIGLCreator/src/CPACSTreeWidget.cpp
@@ -75,18 +75,16 @@ void CPACSTreeWidget::onCustomContextMenuRequested(QPoint const& globalPos, CPAC
         QMenu menu;
         QAction* delete_action = menu.addAction(QStringLiteral("Delete %1 %2").arg(type, uid));
         connect(delete_action, &QAction::triggered, this, [&](){
-            emit deleteElementRequested(item);
+            emit deleteSectionRequested(item);
         });
         delete_action->setDisabled(parent->getChildren().size() <= 2); // At least two sections required
         menu.exec(globalPos);
     } else {
         QMenu menu;
-        menu.addAction(QStringLiteral("Add %1").arg(type));
-        if (where == CPACSTreeView::Where::Before) {
-            // action: Open dialog and set values of comboboxes appropriately
-        } else if (where == CPACSTreeView::Where::After) {
-            // action: Open dialog and set values of comboboxes appropriately
-        }
+        QAction* add_action = menu.addAction(QStringLiteral("Add %1").arg(type));
+        connect(add_action, &QAction::triggered, this, [&](){
+            emit addSectionRequested(where, item);
+        });
         menu.exec(globalPos);
     }
     emit contextMenuClosed();

--- a/TIGLCreator/src/CPACSTreeWidget.cpp
+++ b/TIGLCreator/src/CPACSTreeWidget.cpp
@@ -77,6 +77,7 @@ void CPACSTreeWidget::onCustomContextMenuRequested(QPoint const& globalPos, CPAC
         connect(delete_action, &QAction::triggered, this, [&](){
             emit deleteElementRequested(item);
         });
+        delete_action->setDisabled(parent->getChildren().size() <= 2); // At least two sections required
         menu.exec(globalPos);
     } else {
         QMenu menu;

--- a/TIGLCreator/src/CPACSTreeWidget.cpp
+++ b/TIGLCreator/src/CPACSTreeWidget.cpp
@@ -72,11 +72,17 @@ void CPACSTreeWidget::onCustomContextMenuRequested(QPoint const& globalPos, CPAC
 
     if (where == CPACSTreeView::Where::At) {
         QMenu menu;
+        menu.setToolTipsVisible(true);
         QAction* delete_action = menu.addAction(QStringLiteral("Delete %1 %2").arg(type, uid));
         connect(delete_action, &QAction::triggered, this, [&](){
             emit deleteSectionRequested(item);
         });
-        delete_action->setDisabled(parent->getChildren().size() <= 2); // At least two sections required
+        if (parent->getChildren().size() <= 2) {
+            // At least two sections required
+            delete_action->setDisabled(true);
+            delete_action->setToolTip("Section deletion not allowed: At least two sections are required.");
+        }
+
         menu.exec(globalPos);
     } else {
         QMenu menu;

--- a/TIGLCreator/src/CPACSTreeWidget.cpp
+++ b/TIGLCreator/src/CPACSTreeWidget.cpp
@@ -80,7 +80,8 @@ void CPACSTreeWidget::onCustomContextMenuRequested(QPoint const& globalPos, CPAC
         menu.exec(globalPos);
     } else {
         QMenu menu;
-        QAction* add_action = menu.addAction(QStringLiteral("Add %1").arg(type));
+        QString where_str = (where == CPACSTreeView::Where::Before)? "before" : "after";
+        QAction* add_action = menu.addAction(QStringLiteral("Add %1 %2 %3").arg(type, where_str, uid));
         connect(add_action, &QAction::triggered, this, [&](){
             emit addSectionRequested(where, item);
         });

--- a/TIGLCreator/src/CPACSTreeWidget.h
+++ b/TIGLCreator/src/CPACSTreeWidget.h
@@ -23,6 +23,7 @@
 #include <QTreeView>
 #include "CPACSTree.h"
 #include "CPACSFilterModel.h"
+#include "CPACSTreeView.h"
 
 namespace Ui
 {
@@ -58,7 +59,7 @@ signals:
 
 private slots:
 
-    void onCustomContextMenuRequested(QPoint const& pos);
+    void onCustomContextMenuRequested(QPoint const& globalPos, CPACSTreeView::Where where, QModelIndex index);
 
     void onSelectionChanged(const QItemSelection& newSelection, const QItemSelection& oldSelection);
 
@@ -94,8 +95,6 @@ public:
     QString getSelectedUID();
 
 private:
-
-    void showInsertMenu(QPoint const& globalPos);//, QTreeWidgetItem* above, QTreeWidgetItem* below);
 
     void setTreeViewColumnsDisplay();
 

--- a/TIGLCreator/src/CPACSTreeWidget.h
+++ b/TIGLCreator/src/CPACSTreeWidget.h
@@ -56,6 +56,7 @@ signals:
 
     void newSelectedTreeItem(cpcr::CPACSTreeItem*);
     void contextMenuClosed(); // signals the CPACSTreeView to update its paintEvent
+    void deleteElementRequested(cpcr::CPACSTreeItem*);
 
 private slots:
 
@@ -103,9 +104,6 @@ private:
     cpcr::CPACSTree tree;
     CPACSFilterModel* filterModel;
     QItemSelectionModel* selectionModel;
-
-    // needed for the context menu between two tree entries
-    QPoint hoverPos;
 };
 
 #endif // CPACSTREEWIDGET_H

--- a/TIGLCreator/src/CPACSTreeWidget.h
+++ b/TIGLCreator/src/CPACSTreeWidget.h
@@ -54,6 +54,7 @@ class CPACSTreeWidget : public QWidget
 signals:
 
     void newSelectedTreeItem(cpcr::CPACSTreeItem*);
+    void contextMenuClosed(); // signals the CPACSTreeView to update its paintEvent
 
 private slots:
 

--- a/TIGLCreator/src/CPACSTreeWidget.h
+++ b/TIGLCreator/src/CPACSTreeWidget.h
@@ -57,6 +57,8 @@ signals:
 
 private slots:
 
+    void onCustomContextMenuRequested(QPoint const& pos);
+
     void onSelectionChanged(const QItemSelection& newSelection, const QItemSelection& oldSelection);
 
     void setNewSearch(const QString newText);
@@ -92,6 +94,8 @@ public:
 
 private:
 
+    void showInsertMenu(QPoint const& globalPos);//, QTreeWidgetItem* above, QTreeWidgetItem* below);
+
     void setTreeViewColumnsDisplay();
 
     Ui::CPACSTreeWidget* ui;
@@ -99,6 +103,9 @@ private:
     cpcr::CPACSTree tree;
     CPACSFilterModel* filterModel;
     QItemSelectionModel* selectionModel;
+
+    // needed for the context menu between two tree entries
+    QPoint hoverPos;
 };
 
 #endif // CPACSTREEWIDGET_H

--- a/TIGLCreator/src/CPACSTreeWidget.h
+++ b/TIGLCreator/src/CPACSTreeWidget.h
@@ -56,7 +56,8 @@ signals:
 
     void newSelectedTreeItem(cpcr::CPACSTreeItem*);
     void contextMenuClosed(); // signals the CPACSTreeView to update its paintEvent
-    void deleteElementRequested(cpcr::CPACSTreeItem*);
+    void deleteSectionRequested(cpcr::CPACSTreeItem* item);
+    void addSectionRequested(CPACSTreeView::Where where, cpcr::CPACSTreeItem* item);
 
 private slots:
 

--- a/TIGLCreator/src/CPACSTreeWidget.ui
+++ b/TIGLCreator/src/CPACSTreeWidget.ui
@@ -36,7 +36,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QTreeView" name="treeView">
+    <widget class="CPACSTreeView" name="treeView">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -56,6 +56,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CPACSTreeView</class>
+   <extends>QTreeView</extends>
+   <header>CPACSTreeView.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/TIGLCreator/src/ModificatorManager.h
+++ b/TIGLCreator/src/ModificatorManager.h
@@ -72,7 +72,8 @@ public slots:
     void unHighlight();
 
     // signals from treewidget (delete or add section)
-    void onDeleteSectionRequested(cpcr::CPACSTreeItem*);
+    void onDeleteSectionRequested(cpcr::CPACSTreeItem* item);
+    void onAddSectionRequested(CPACSTreeView::Where where, cpcr::CPACSTreeItem* item);
 
 public:
     ModificatorManager(CPACSTreeWidget* treeWidget, ModificatorContainerWidget* modificatorContainerWidget,  TIGLCreatorContext* scene,  QUndoStack* undoStack);
@@ -126,7 +127,7 @@ private:
      */
     Ui::ElementModificatorInterface resolve(std::string const& uid) const;
 
-    std::string const& sectionUidToElementUid(std::string const& uid) const;
+    std::string sectionUidToElementUid(std::string const& uid) const;
 
     TIGLCreatorDocument* doc;
 

--- a/TIGLCreator/src/ModificatorManager.h
+++ b/TIGLCreator/src/ModificatorManager.h
@@ -71,6 +71,9 @@ public slots:
     void highlight(tigl::CCPACSPositioning &positioning, const tigl::CTiglTransformation& parentTransformation);
     void unHighlight();
 
+    // signals from treewidget (delete or add section)
+    void onDeleteSectionRequested(cpcr::CPACSTreeItem*);
+
 public:
     ModificatorManager(CPACSTreeWidget* treeWidget, ModificatorContainerWidget* modificatorContainerWidget,  TIGLCreatorContext* scene,  QUndoStack* undoStack);
 
@@ -114,6 +117,15 @@ protected:
     }
 
 private:
+
+    /**
+     * @brief resolve resolves the ElementModificatorInterface based on the uid
+     * The ElementModificatorInterface can handle either wings or fuselages
+     * @param uid of a wing or a fuselage
+     * @return the interface
+     */
+    Ui::ElementModificatorInterface resolve(std::string const& uid) const;
+
     TIGLCreatorDocument* doc;
 
     CPACSTreeWidget* treeWidget;

--- a/TIGLCreator/src/ModificatorManager.h
+++ b/TIGLCreator/src/ModificatorManager.h
@@ -126,6 +126,8 @@ private:
      */
     Ui::ElementModificatorInterface resolve(std::string const& uid) const;
 
+    std::string const& sectionUidToElementUid(std::string const& uid) const;
+
     TIGLCreatorDocument* doc;
 
     CPACSTreeWidget* treeWidget;

--- a/TIGLCreator/src/TIGLCreatorWindow.ui
+++ b/TIGLCreator/src/TIGLCreatorWindow.ui
@@ -63,8 +63,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>783</width>
-     <height>20</height>
+     <width>1458</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="fileMenu">

--- a/TIGLCreator/src/modificators/ElementModificatorInterface.h
+++ b/TIGLCreator/src/modificators/ElementModificatorInterface.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 DLR
+ *
+ * Created: 2025 Jan Kleinert <jan.kleinert@dlr.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #pragma once
+
+ #include <functional>
+
+ namespace Ui
+ {
+    // Interface-like structure to account for different possible object types whose member variables may be adapted by the TiGLCreator.
+    //
+    // It is currently used for CCPACSFuselage and CCPACSWing.
+    // Could be extended by Duct, Pylon, Tank, etc. in the future (observe: The respective classes need to define the listed functions).
+    struct ElementModificatorInterface
+    {
+        // Here, functions are defined as member variables calling the 'right' (depending on present data type) function from CCPACSFuselage, CCPACSWing, etc. via lambdas
+        template <typename T>
+        ElementModificatorInterface(T&& t)
+            : GetElementUIDAfterNewElement(
+                [&t](std::string str){ return t.GetElementUIDAfterNewElement(str); }
+                )
+            , CreateNewConnectedElementAfter(
+                [&t](std::string str, std::string name){ return t.CreateNewConnectedElementAfter(str, name); }
+                )
+            , GetElementUIDBeforeNewElement(
+                [&t](std::string str){ return t.GetElementUIDBeforeNewElement(str); }
+                )
+            , CreateNewConnectedElementBefore(
+                [&t](std::string str, std::string name){ return t.CreateNewConnectedElementBefore(str, name); }
+                )
+            , CreateNewConnectedElementBetween(
+                [&t](std::string str1, std::string str2, double param, std::string name){ return t.CreateNewConnectedElementBetween(str1, str2, param, name); }
+                )
+            , DeleteConnectedElement(
+                [&t](std::string str){ return t.DeleteConnectedElement(str); }
+                )
+            , GetOrderedConnectedElement(
+                [&t](){ return t.GetOrderedConnectedElement(); }
+                )
+        {}
+
+        std::function<std::optional<std::string>(std::string)> GetElementUIDAfterNewElement;
+        std::function<void(std::string, std::string)> CreateNewConnectedElementAfter;
+        std::function<std::optional<std::string>(std::string)> GetElementUIDBeforeNewElement;
+        std::function<void(std::string, std::string)> CreateNewConnectedElementBefore;
+        std::function<void(std::string, std::string, double param, std::string)> CreateNewConnectedElementBetween;
+        std::function<void(std::string)> DeleteConnectedElement;
+        std::function<std::vector<std::string>()> GetOrderedConnectedElement;
+    };
+}

--- a/TIGLCreator/src/modificators/ModificatorSectionsWidget.cpp
+++ b/TIGLCreator/src/modificators/ModificatorSectionsWidget.cpp
@@ -43,6 +43,9 @@ ModificatorSectionsWidget::~ModificatorSectionsWidget()
 void ModificatorSectionsWidget::setCreateConnectedElement(Ui::ElementModificatorInterface const& element)
 {
     createConnectedElement = element;
+
+    // at least two sections required
+    ui->deleteConnectedElementBtn->setDisabled(element.GetOrderedConnectedElement().size() <= 2);
 }
 
 void ModificatorSectionsWidget::execNewConnectedElementDialog()
@@ -105,6 +108,7 @@ void ModificatorSectionsWidget::execNewConnectedElementDialog()
             return;
         }
         emit undoCommandRequired();
+        ui->deleteConnectedElementBtn->setDisabled(createConnectedElement->GetOrderedConnectedElement().size() <= 2);
     }
 }
 

--- a/TIGLCreator/src/modificators/ModificatorSectionsWidget.cpp
+++ b/TIGLCreator/src/modificators/ModificatorSectionsWidget.cpp
@@ -64,49 +64,7 @@ void ModificatorSectionsWidget::execNewConnectedElementDialog()
 
     NewConnectedElementDialog newElementDialog(elementUIDsQList, this);
     if (newElementDialog.exec() == QDialog::Accepted) {
-        std::string startUID                    = newElementDialog.getStartUID().toStdString();
-        std::string sectionName                 = newElementDialog.getSectionName().toStdString();
-        NewConnectedElementDialog::Where where  = newElementDialog.getWhere();
-        std::optional<double> eta               = newElementDialog.getEta();
-        try {
-            if (where == NewConnectedElementDialog::Before) {
-                auto elementUIDBefore = createConnectedElement->GetElementUIDBeforeNewElement(startUID);
-                if (elementUIDBefore) {
-                    if (eta) { // Security check. Should be set if elementUIDBefore is true
-                        createConnectedElement->CreateNewConnectedElementBetween(*elementUIDBefore, startUID, *eta, sectionName);
-                    }
-                    else {
-                        throw tigl::CTiglError("No eta value set!");
-                    }
-                }
-                else {
-                    createConnectedElement->CreateNewConnectedElementBefore(startUID, sectionName);
-                }
-            }
-            else if (where == NewConnectedElementDialog::After) {
-                auto elementUIDAfter = createConnectedElement->GetElementUIDAfterNewElement(startUID);
-                if (elementUIDAfter) {
-                    if (eta) { // Security check. Should be set if elementUIDAfter is true
-                        createConnectedElement->CreateNewConnectedElementBetween(startUID, *elementUIDAfter, *eta, sectionName);
-                    }
-                    else {
-                        throw tigl::CTiglError("No eta value set!");
-                    }
-                }
-                else {
-                    createConnectedElement->CreateNewConnectedElementAfter(startUID, sectionName);
-                }
-            }
-        }
-        catch (const tigl::CTiglError& err) {
-            TIGLCreatorErrorDialog errDialog(this);
-            errDialog.setMessage(
-                QString("<b>%1</b><br /><br />%2").arg("Fail to create the new connected element ").arg(err.what()));
-            errDialog.setWindowTitle("Error");
-            errDialog.setDetailsText(err.what());
-            errDialog.exec();
-            return;
-        }
+        newElementDialog.applySelection(*createConnectedElement);
         emit undoCommandRequired();
         ui->deleteConnectedElementBtn->setDisabled(createConnectedElement->GetOrderedConnectedElement().size() <= 2);
     }

--- a/TIGLCreator/src/modificators/ModificatorSectionsWidget.cpp
+++ b/TIGLCreator/src/modificators/ModificatorSectionsWidget.cpp
@@ -43,9 +43,23 @@ ModificatorSectionsWidget::~ModificatorSectionsWidget()
 void ModificatorSectionsWidget::setCreateConnectedElement(Ui::ElementModificatorInterface const& element)
 {
     createConnectedElement = element;
+    update_delete_section_button_disabled_state();
+}
 
+void ModificatorSectionsWidget::update_delete_section_button_disabled_state()
+{
+    if (createConnectedElement == std::nullopt) {
+        return;
+    }
     // at least two sections required
-    ui->deleteConnectedElementBtn->setDisabled(element.GetOrderedConnectedElement().size() <= 2);
+    if (createConnectedElement->GetOrderedConnectedElement().size() <= 2) {
+        ui->deleteConnectedElementBtn->setDisabled(true);
+        ui->deleteConnectedElementBtn->setToolTip("Section deletion not allowed: At least two sections are required.");
+    } else
+    {
+        ui->deleteConnectedElementBtn->setDisabled(false);
+        ui->deleteConnectedElementBtn->setToolTip("");
+    }
 }
 
 void ModificatorSectionsWidget::execNewConnectedElementDialog()
@@ -65,8 +79,8 @@ void ModificatorSectionsWidget::execNewConnectedElementDialog()
     NewConnectedElementDialog newElementDialog(elementUIDsQList, this);
     if (newElementDialog.exec() == QDialog::Accepted) {
         newElementDialog.applySelection(*createConnectedElement);
+        update_delete_section_button_disabled_state();
         emit undoCommandRequired();
-        ui->deleteConnectedElementBtn->setDisabled(createConnectedElement->GetOrderedConnectedElement().size() <= 2);
     }
 }
 

--- a/TIGLCreator/src/modificators/ModificatorSectionsWidget.h
+++ b/TIGLCreator/src/modificators/ModificatorSectionsWidget.h
@@ -49,6 +49,10 @@ public:
     void setCreateConnectedElement(Ui::ElementModificatorInterface const& element);
 
 private:
+
+    // disables the selection deletion, if we have two or less sections
+    void update_delete_section_button_disabled_state();
+
     Ui::ModificatorSectionsWidget* ui;
     // std::optional used here to account for empty initializiation of member variable in construtor (ptr and nullptr used before)
     std::optional<Ui::ElementModificatorInterface> createConnectedElement;

--- a/TIGLCreator/src/modificators/ModificatorSectionsWidget.h
+++ b/TIGLCreator/src/modificators/ModificatorSectionsWidget.h
@@ -24,51 +24,10 @@
 #include <optional>
 #include "CCPACSFuselage.h"
 #include "CCPACSWing.h"
+#include "ElementModificatorInterface.h"
 
 namespace Ui
 {
-
-// Interface-like structure to account for different possible object types whose member variables may be adapted by the TiGLCreator.
-//
-// It is currently used for CCPACSFuselage and CCPACSWing.
-// Could be extended by Duct, Pylon, Tank, etc. in the future (observe: The respective classes need to define the listed functions).
-struct ElementModificatorInterface
-{
-    // Here, functions are defined as member variables calling the 'right' (depending on present data type) function from CCPACSFuselage, CCPACSWing, etc. via lambdas
-    template <typename T>
-    ElementModificatorInterface(T&& t)
-        : GetElementUIDAfterNewElement(
-            [&t](std::string str){ return t.GetElementUIDAfterNewElement(str); }
-            )
-        , CreateNewConnectedElementAfter(
-            [&t](std::string str, std::string name){ return t.CreateNewConnectedElementAfter(str, name); }
-            )
-        , GetElementUIDBeforeNewElement(
-            [&t](std::string str){ return t.GetElementUIDBeforeNewElement(str); }
-            )
-        , CreateNewConnectedElementBefore(
-            [&t](std::string str, std::string name){ return t.CreateNewConnectedElementBefore(str, name); }
-            )
-        , CreateNewConnectedElementBetween(
-             [&t](std::string str1, std::string str2, double param, std::string name){ return t.CreateNewConnectedElementBetween(str1, str2, param, name); }
-            )
-        , DeleteConnectedElement(
-            [&t](std::string str){ return t.DeleteConnectedElement(str); }
-            )
-        , GetOrderedConnectedElement(
-            [&t](){ return t.GetOrderedConnectedElement(); }
-            )
-    {}
-
-    std::function<std::optional<std::string>(std::string)> GetElementUIDAfterNewElement;
-    std::function<void(std::string, std::string)> CreateNewConnectedElementAfter;
-    std::function<std::optional<std::string>(std::string)> GetElementUIDBeforeNewElement;
-    std::function<void(std::string, std::string)> CreateNewConnectedElementBefore;
-    std::function<void(std::string, std::string, double param, std::string)> CreateNewConnectedElementBetween;
-    std::function<void(std::string)> DeleteConnectedElement;
-    std::function<std::vector<std::string>()> GetOrderedConnectedElement;
-};
-
 class ModificatorSectionsWidget;
 }
 

--- a/TIGLCreator/src/modificators/NewConnectedElementDialog.cpp
+++ b/TIGLCreator/src/modificators/NewConnectedElementDialog.cpp
@@ -19,6 +19,7 @@
 #include "NewConnectedElementDialog.h"
 #include "TIGLCreatorErrorDialog.h"
 #include "ui_NewConnectedElementDialog.h"
+#include "CTiglError.h"
 #include <QString>
 
 NewConnectedElementDialog::NewConnectedElementDialog(QStringList connectedElements, QWidget* parent)

--- a/TIGLCreator/src/modificators/NewConnectedElementDialog.h
+++ b/TIGLCreator/src/modificators/NewConnectedElementDialog.h
@@ -22,7 +22,7 @@
 #include <QDialog>
 #include <QString>
 #include <optional>
-#include "ModificatorSectionsWidget.h" //To Do: Move ElementModificatorInterface to its own header?
+#include "ElementModificatorInterface.h"
 
 namespace Ui
 {

--- a/TIGLCreator/src/modificators/NewConnectedElementDialog.h
+++ b/TIGLCreator/src/modificators/NewConnectedElementDialog.h
@@ -22,6 +22,7 @@
 #include <QDialog>
 #include <QString>
 #include <optional>
+#include "ModificatorSectionsWidget.h" //To Do: Move ElementModificatorInterface to its own header?
 
 namespace Ui
 {
@@ -47,15 +48,19 @@ public:
      * @return
      */
     QString getStartUID() const;
+    void setStartUID(QString const& text);
 
     /**
      * Return if the new connected element should be created before or after the reference element.
      * @return
      */
     Where getWhere() const;
+    void setWhere(Where where);
 
     std::optional<double> getEta() const;
     QString getSectionName() const;
+
+    void applySelection(Ui::ElementModificatorInterface& interface);
 
 private slots:
     void activate_eta();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #628. 

We have two new context menus that can be activated in the CPACS Tree View: 
 1. If a section is right-clicked, a context menu with the option to delete the section shows up. Upon clicking the section is deleted.
 2. If the area between two sections is right-clicked, a context menu with the option to add a section shows up. Upon clicking the NewConnectedElementDialog opens up, with the "Where" and "startUid" comboboxes set appropriately. 

To assist the user, mouse hovering will show a line, if the mouse hovers over an area between two elements.

### Implementation details

 - Previously, the `CPACSTreeWidget` held a `QTreeView` to display the CPACS Tree. Now this `QTreeView` is subclassed (`CPACSTreeView`) to customize the mouse hovering behavior (drawing a white line between items, if the mouse hovers there). This special hover-behavior is enabled only for the children of nodes that have the name "sections". This is set by the `CPACSAbstractModel` by setting an appropriate `Qt::UserRole` to these `CPACSTreeItem`s.
 - `CPACSTreeView` emits signals if a context menu was requested (right-click). This signal contains the information of the global position for opening the context menu, but also the item and an enum value `Where`, that can be `Before`, `At` and `After`. 
 - `CPACSTreeWidget` connects to these signals and opens the context menus in the slot. It notifies the `ModificatorManager` of the request for deletion or insertion. `ModificatorManager` then handles the deletion and insertion accordingly.

In addition to these changes, I disabled deletion of sections, if there are two or less. A wing or a fuselage must have at least two sections.

## How Has This Been Tested?

With the GUI only.

## Screenshots, that help to understand the changes(if applicable):

### Add a section
<img width="697" alt="grafik" src="https://github.com/user-attachments/assets/3179f97c-380f-4b54-854b-30c165d312ca" />

### Delete a section
<img width="697" alt="grafik" src="https://github.com/user-attachments/assets/b813c55a-a318-4afb-a2c9-3439ca99f705" />



## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
