### PR TITLE
Update Python example from CPACS Creator

### DIFF
--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -17,7 +17,7 @@ install(FILES
 
 
 install(FILES
-        data/empty.cpacs3.xml
+        data/empty.cpacs.xml
         DESTINATION share/doc/tigl3/examples/data
         COMPONENT docu
         )

--- a/examples/python/create_space_ship.py
+++ b/examples/python/create_space_ship.py
@@ -4,7 +4,7 @@ import tigl3
 import tigl3.tigl3wrapper
 import tigl3.configuration
 import tigl3.geometry
-import OCC.gp
+from OCC.Core.gp import gp_Pnt
 
 
 def create_fuselage(aircraft, uid):
@@ -57,10 +57,10 @@ def create_round_wing(aircraft,diameter, uid):
     # rotation between each section 
     deltaRotX = 180.0  / (numberOfSection - 1.0)
     
-    # Normaly, we should use CTiglPoint instead of gp.gp_Pnt
+    # Normaly, we should use CTiglPoint instead of gp_Pnt
     # but there is for the moment a small issue in the binding of CTiglTransformation class
-    firstPosition = OCC.gp.gp_Pnt(0,0,-diameter/2.0);  
-    firstNormal = OCC.gp.gp_Pnt(0,-1,0);
+    firstPosition = gp_Pnt(0,0,-diameter/2.0);  
+    firstNormal = gp_Pnt(0,-1,0);
 
     wings = aircraft.get_wings();
     # create the wing

--- a/examples/python/create_space_ship.py
+++ b/examples/python/create_space_ship.py
@@ -98,7 +98,7 @@ def create_round_wing(aircraft,diameter, uid):
 
 def create_space_ship():
 
-    filename = "./data/empty.cpacs3.xml"
+    filename = "./data/empty.cpacs.xml"
     # Open the file using tixi 
     tixi_h = tixi3.tixi3wrapper.Tixi3()
     tixi_h.open(filename)

--- a/examples/python/create_space_ship.py
+++ b/examples/python/create_space_ship.py
@@ -3,7 +3,7 @@ import tixi3.tixi3wrapper
 import tigl3
 import tigl3.tigl3wrapper
 import tigl3.configuration
-import tigl3.geometry
+from tigl3.geometry import CTiglPoint, CTiglTransformation
 from OCC.Core.gp import gp_Pnt
 
 
@@ -36,17 +36,17 @@ def create_fuselage(aircraft, uid):
     # Here we set the height and width of the section 2,3,4,18,19,20,21    
     for idx in (2,3,4,5,18,19,20,21) :
         s = fuselage.get_section(idx)
-        e = s.get_section_element(1);
-        ce = e.get_ctigl_section_element();
+        e = s.get_section_element(1)
+        ce = e.get_ctigl_section_element()
         ce.set_height(1.5)
         ce.set_width(2.3)
 
     # Here we set the area of the section the extremity  
     for idx in (1,22) :
         s = fuselage.get_section(idx)
-        e = s.get_section_element(1);
-        ce = e.get_ctigl_section_element();
-        ce.set_area(0);
+        e = s.get_section_element(1)
+        ce = e.get_ctigl_section_element()
+        ce.set_area(0)
         
     return fuselage
     
@@ -59,39 +59,39 @@ def create_round_wing(aircraft,diameter, uid):
     
     # Normaly, we should use CTiglPoint instead of gp_Pnt
     # but there is for the moment a small issue in the binding of CTiglTransformation class
-    firstPosition = gp_Pnt(0,0,-diameter/2.0);  
-    firstNormal = gp_Pnt(0,-1,0);
+    firstPosition = gp_Pnt(0,0,-diameter/2.0)  
+    firstNormal = gp_Pnt(0,-1,0)
 
-    wings = aircraft.get_wings();
+    wings = aircraft.get_wings()
     # create the wing
-    wings.create_wing(uid, numberOfSection , "NACA0006");
-    wing = wings.get_wing(uid);
+    wings.create_wing(uid, numberOfSection , "NACA0006")
+    wing = wings.get_wing(uid)
    
    
-    rot =  tigl3.geometry.CTiglTransformation();
+    rot =  CTiglTransformation()
     # set the wing section elements
     for idx  in range(1,wing.get_section_count() + 1) :
-        rotX = (idx - 1) * deltaRotX;
-        rot.set_identity();
-        rot.add_rotation_x(rotX);
+        rotX = (idx - 1) * deltaRotX
+        rot.set_identity()
+        rot.add_rotation_x(rotX)
 
-        p = rot.transform(firstPosition);
-        n = rot.transform(firstNormal);
+        p = rot.transform(firstPosition)
+        n = rot.transform(firstNormal)
 
-        s = wing.get_section(idx);
-        e = s.get_section_element(1);
-        ce = e.get_ctigl_section_element();
+        s = wing.get_section(idx)
+        e = s.get_section_element(1)
+        ce = e.get_ctigl_section_element()
 
-        ce.set_center(tigl3.geometry.CTiglPoint(p.X(), p.Y(), p.Z()));
-        ce.set_normal(tigl3.geometry.CTiglPoint(n.X(), n.Y(), n.Z()));
+        ce.set_center(CTiglPoint(p.X(), p.Y(), p.Z()))
+        ce.set_normal(CTiglPoint(n.X(), n.Y(), n.Z()))
         if rotX >= 90:
-            ce.set_rotation_around_normal(180);
+            ce.set_rotation_around_normal(180)
 
     # set symmetry of the wing 
     sym = tigl3.geometry.TIGL_X_Z_PLANE 
     wing.set_symmetry(sym)
     
-    return wing;
+    return wing
 
 
 
@@ -124,23 +124,23 @@ def create_space_ship():
     wing1 = create_round_wing(aircraft, 13, "Wing1")
     # All the function of the CCPACSWing class is available for the wing2 object
     # Especially, we can set the root leading edge position of the wing.
-    wing1_position = wing1.get_root_leposition();
+    wing1_position = wing1.get_root_leposition()
     wing1_position.x = 2
     wing1.set_root_leposition(wing1_position)
   
     # The following function use internal python api to creare a wing 
     wing2 = create_round_wing(aircraft, 23, "Wing2")
-    wing2_position = wing2.get_root_leposition();
+    wing2_position = wing2.get_root_leposition()
     wing2_position.x = 10
     wing2.set_root_leposition(wing2_position)
     
     wing3 = create_round_wing(aircraft, 13, "Wing3")
-    wing3_position = wing3.get_root_leposition();
+    wing3_position = wing3.get_root_leposition()
     wing3_position.x = 18
     wing3.set_root_leposition(wing3_position)
 
     aircraft.write_cpacs(aircraft.get_uid())
-    config_as_string = tixi_h.exportDocumentAsString();
+    config_as_string = tixi_h.exportDocumentAsString()
     text_file = open("./out.xml", "w")
     text_file.write(config_as_string)
     text_file.close()

--- a/examples/python/create_space_ship.py
+++ b/examples/python/create_space_ship.py
@@ -57,8 +57,6 @@ def create_round_wing(aircraft,diameter, uid):
     # rotation between each section 
     deltaRotX = 180.0  / (numberOfSection - 1.0)
     
-    # Normaly, we should use CTiglPoint instead of gp_Pnt
-    # but there is for the moment a small issue in the binding of CTiglTransformation class
     firstPosition = gp_Pnt(0,0,-diameter/2.0)  
     firstNormal = gp_Pnt(0,-1,0)
 

--- a/examples/python/data/empty.cpacs.xml
+++ b/examples/python/data/empty.cpacs.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cpacs.googlecode.com/files/CPACS_21_Schema.xsd">
-  <header>
-    <name>Empty</name>
-    <description>Empty aircraft</description>
-    <creator>Malo Drougard</creator>
-    <timestamp>2019-02-27T15:12:47</timestamp>
-    <version>0.2</version>
-    <cpacsVersion>3.0</cpacsVersion>
-    <updates>
-    </updates>
+  <header xsi:type="headerType">
+    <name>Empty aircraft</name>
+    <version>1.0.0</version>
+    <versionInfos>
+      <versionInfo version="1.0.0">
+        <cpacsVersion>3.0</cpacsVersion>
+        <creator>Malo Drougard</creator>
+        <description>Empty aircraft</description>
+        <timestamp>2019-02-27T15:12:47</timestamp>
+      </versionInfo>
+    </versionInfos>
   </header>
   <vehicles>
     <aircraft>
@@ -23,10 +25,8 @@
             <z>0</z>
           </point>
         </reference>
-	<fuselages>
-	</fuselages>
-	<wings>  
-	</wings>
+        <fuselages/>
+        <wings/>
       </model>
     </aircraft>
     <profiles>
@@ -65,6 +65,5 @@
     </fuselageProfiles>
     </profiles>
   </vehicles>
-  <toolspecific>
-  </toolspecific>
+  <toolspecific/>
 </cpacs>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #1183. The code comment is not correct IMHO. CTiglTransformation::Transform does not have an overload for CTiglPoint. I am not sure why the code comment was there, so I removed it. The code works as is.

## How Has This Been Tested?

I built the python bindings and tested it locally.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
