### PR TITLE
Resolve inconsistent naming of the executable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ Changelog
 
 Changes since last release
 -------------
+22/09/2025
+- Fixes
+  - Fix #1186: Resolve inconsistent naming of executable in source code. This caused the system to create two different registry entries.
 
 10/09/2025
 - General changes

--- a/TIGLCreator/src/TIGLCreatorSettings.cpp
+++ b/TIGLCreator/src/TIGLCreatorSettings.cpp
@@ -191,7 +191,7 @@ bool TIGLCreatorSettings::drawFaceBoundaries() const
 
 void TIGLCreatorSettings::loadSettings()
 {
-    QSettings settings("DLR SC-HPC", "TiGLCreator3");
+    QSettings settings("DLR SC-HPC", "TiGLCreator");
 
     _tesselationAccuracy   = settings.value("tesselation_accuracy"  , tesselationAccuracy()).toDouble();
     _triangulationAccuracy = settings.value("triangulation_accuracy", triangulationAccuracy()).toDouble();
@@ -224,7 +224,7 @@ void TIGLCreatorSettings::loadSettings()
 
 void TIGLCreatorSettings::storeSettings()
 {
-    QSettings settings("DLR SC-HPC", "TiGLCreator3");
+    QSettings settings("DLR SC-HPC", "TiGLCreator");
 
     settings.setValue("tesselation_accuracy"  , tesselationAccuracy());
     settings.setValue("triangulation_accuracy", triangulationAccuracy());

--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -483,7 +483,7 @@ void TIGLCreatorWindow::setCurrentFile(const QString& fileName)
         watcher->addPath(currentFile.absoluteFilePath());
         QObject::connect(watcher, SIGNAL(fileChanged(QString)), openTimer, SLOT(start()));
 
-        QSettings settings("DLR SC-HPC", "TiGL-Creator");
+        QSettings settings("DLR SC-HPC", "TiGLCreator");
         QStringList files = settings.value("recentFileList").toStringList();
         files.removeAll(fileName);
         files.prepend(fileName);
@@ -503,7 +503,7 @@ void TIGLCreatorWindow::setCurrentFile(const QString& fileName)
 
 void TIGLCreatorWindow::loadSettings()
 {
-    QSettings settings("DLR SC-HPC", "TiGL-Creator");
+    QSettings settings("DLR SC-HPC", "TiGLCreator");
 
     bool showConsole = settings.value("show_console",QVariant(true)).toBool();
     bool showTree = settings.value("show_tree",QVariant(true)).toBool();
@@ -531,7 +531,7 @@ void TIGLCreatorWindow::loadSettings()
 
 void TIGLCreatorWindow::saveSettings()
 {
-    QSettings settings("DLR SC-HPC", "TiGL-Creator");
+    QSettings settings("DLR SC-HPC", "TiGLCreator");
 
     bool showConsole = consoleDockWidget->isVisible();
     settings.setValue("show_console", showConsole);
@@ -1054,7 +1054,7 @@ void TIGLCreatorWindow::createMenus()
 
 void TIGLCreatorWindow::updateRecentFileActions()
 {
-    QSettings settings("DLR SC-HPC", "TiGL-Creator");
+    QSettings settings("DLR SC-HPC", "TiGLCreator");
     QStringList files = settings.value("recentFileList").toStringList();
 
     int numRecentFiles = qMin(files.size(), (int)MaxRecentFiles);


### PR DESCRIPTION
## Description
Fixes #1186.

After the merge from tigl and cpacs-creator (especially merging the names), the new naming was inconsistent at some places. That results in 2 different registry entries. This PR resolves this by giving one consistent name.

## Checklist:
| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
