### PR TITLE
Fix #1191

### DIFF
--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -509,9 +509,9 @@ void TIGLCreatorWindow::loadSettings()
     bool showTree = settings.value("show_tree",QVariant(true)).toBool();
     bool showModificator = settings.value("show_modificator",QVariant(true)).toBool();
 
-    bool floatConsole = settings.value("float_console",QVariant(true)).toBool();
-    bool floatTree = settings.value("float_tree",QVariant(true)).toBool();
-    bool floatModificator = settings.value("float_modificator",QVariant(true)).toBool();
+    bool floatConsole = settings.value("float_console",QVariant(false)).toBool();
+    bool floatTree = settings.value("float_tree",QVariant(false)).toBool();
+    bool floatModificator = settings.value("float_modificator",QVariant(false)).toBool();
 
     restoreGeometry(settings.value("MainWindowGeom").toByteArray());
     restoreState(settings.value("MainWindowState").toByteArray());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #1191. The default value for the "floating" state is set in the TiGLCreatorWindow settings. Per default it is set to true. This is now changed to false.

## How Has This Been Tested?

A clean registry and clean install under windows. 

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
