### PR TITLE
Fix floating windows at first start after clean build

### DIFF
--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -509,9 +509,9 @@ void TIGLCreatorWindow::loadSettings()
     bool showTree = settings.value("show_tree",QVariant(true)).toBool();
     bool showModificator = settings.value("show_modificator",QVariant(true)).toBool();
 
-    bool floatConsole = settings.value("float_console",QVariant(true)).toBool();
-    bool floatTree = settings.value("float_tree",QVariant(true)).toBool();
-    bool floatModificator = settings.value("float_modificator",QVariant(true)).toBool();
+    bool floatConsole = settings.value("float_console",QVariant(false)).toBool();
+    bool floatTree = settings.value("float_tree",QVariant(false)).toBool();
+    bool floatModificator = settings.value("float_modificator",QVariant(false)).toBool();
 
     restoreGeometry(settings.value("MainWindowGeom").toByteArray());
     restoreState(settings.value("MainWindowState").toByteArray());


### PR DESCRIPTION
Fix #1192.

When the TiGLCreator is locally build from scratch and no registry entry exists yet, the editor, tree and console window are floating and not connected to the main window. This PR fixes the behaviour.

## Checklist:

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
