### PR TITLE
Fix #1209: fix invalidation logic of CTiglSectionElement

### DIFF
--- a/src/fuselage/CCPACSFuselageSection.cpp
+++ b/src/fuselage/CCPACSFuselageSection.cpp
@@ -40,6 +40,11 @@ void CCPACSFuselageSection::InvalidateImpl(const boost::optional<std::string>& s
 {
     // forward invalidation to section elements, these are the objects which are referenced
     m_elements.Invalidate(GetUID());
+
+    // propagate invalidation to the fuselage
+    if (GetNextUIDParent() && GetNextUIDParent()->GetNextUIDParent()) {
+        GetNextUIDParent()->GetNextUIDParent()->Invalidate();
+    }
 }
 
 // Read CPACS section elements

--- a/src/fuselage/CCPACSFuselageSectionElement.cpp
+++ b/src/fuselage/CCPACSFuselageSectionElement.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
 * Copyright (C) 2007-2013 German Aerospace Center (DLR/SC)
 *
 * Created: 2010-08-13 Markus Litz <Markus.Litz@dlr.de>
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 /**
-* @file 
+* @file
 * @brief  Implementation of CPACS fuselage section element handling routines.
 */
 

--- a/src/fuselage/CTiglFuselageSectionElement.cpp
+++ b/src/fuselage/CTiglFuselageSectionElement.cpp
@@ -193,11 +193,6 @@ tigl::CCPACSTransformation& tigl::CTiglFuselageSectionElement::GetSectionCCPACST
     return section->GetTransformation();
 }
 
-void tigl::CTiglFuselageSectionElement::InvalidateParent()
-{
-    fuselage->Invalidate();
-}
-
 tigl::CTiglPoint tigl::CTiglFuselageSectionElement::GetStdDirForProfileUnitZ(TiglCoordinateSystem referenceCS)  const
 {
     CTiglPoint normal = GetNormal(referenceCS);

--- a/src/fuselage/CTiglFuselageSectionElement.h
+++ b/src/fuselage/CTiglFuselageSectionElement.h
@@ -74,8 +74,6 @@ protected:
 
     CCPACSTransformation& GetSectionCCPACSTransformation() override;
 
-    void InvalidateParent() override;
-
     /**
      * Return the conventional direction for the unit vector z of the profile.
      *

--- a/src/geometry/CTiglSectionElement.cpp
+++ b/src/geometry/CTiglSectionElement.cpp
@@ -181,7 +181,7 @@ void tigl::CTiglSectionElement::SetWidth(double newWidth, TiglCoordinateSystem r
         elementScaling.x = 0;
         elementScaling.y = 0;
         storedElementTransformation.setScaling(elementScaling);
-        InvalidateParent();
+        Invalidate();
         return;
 
     }
@@ -224,7 +224,7 @@ void tigl::CTiglSectionElement::SetHeight(double newHeight, TiglCoordinateSystem
         CTiglPoint elementScaling                         = storedElementTransformation.getScaling();
         elementScaling.z                                  = 0;
         storedElementTransformation.setScaling(elementScaling);
-        InvalidateParent();
+        Invalidate();
         return;
     }
 
@@ -263,7 +263,7 @@ void tigl::CTiglSectionElement::SetArea(double newArea, TiglCoordinateSystem ref
     if (isNear(newArea, 0, 0.0001)) {
         CCPACSTransformation& storedElementTransformation = GetElementCCPACSTransformation();
         storedElementTransformation.setScaling(CTiglPoint(0, 0, 0));
-        InvalidateParent();
+        Invalidate();
         return;
     }
 
@@ -334,10 +334,18 @@ void tigl::CTiglSectionElement::SetPSETransformations(const tigl::CTiglTransform
     CCPACSPositionings& positionings = GetPositionings();
     positionings.SetPositioningTransformation(GetSectionUID(), trans, false );
 
-    InvalidateParent();
+    Invalidate();
 
 }
 
+void tigl::CTiglSectionElement::Invalidate()
+{
+    // we need to explicitly invalidate the transformations
+    // this propagates invalidation the section and element,
+    // and transitively to the fuselage/wing
+    GetElementCCPACSTransformation().Invalidate();
+    GetSectionCCPACSTransformation().Invalidate();
+}
 
 
 void tigl::CTiglSectionElement::SetPSETransformationsUseSimpleDecomposition(
@@ -376,7 +384,7 @@ void tigl::CTiglSectionElement::SetPSETransformationsUseSimpleDecomposition(
     CCPACSPositionings& positionings = GetPositionings();
     positionings.SetPositioningTransformation(GetSectionUID(), CTiglPoint(trans[0], trans[1], trans[2]), false );
 
-    InvalidateParent();
+    Invalidate();
 
 }
 
@@ -410,7 +418,7 @@ void tigl::CTiglSectionElement::SetElementAndSectionScalingToNoneZero()
     }
     storedSectionTransformation.setScaling(sectionScaling);
 
-    InvalidateParent();
+    Invalidate();
 }
 
 

--- a/src/geometry/CTiglSectionElement.h
+++ b/src/geometry/CTiglSectionElement.h
@@ -215,8 +215,8 @@ protected:
     // Retrieve the stored "CCPACSTransformation" of the section transformation;
     virtual CCPACSTransformation& GetSectionCCPACSTransformation() = 0;
 
-    // Invalidate the fuselage or the wing
-    virtual void InvalidateParent() = 0;
+    // Invalidate internal data of the section and element. IMPORTANT: Invalidation must be propagated to parent fuselage/wing
+    virtual void Invalidate();
 
     /**
      * If element or section transformation contains near zero scaling,

--- a/src/wing/CCPACSWingSection.cpp
+++ b/src/wing/CCPACSWingSection.cpp
@@ -31,6 +31,11 @@ void CCPACSWingSection::InvalidateImpl(const boost::optional<std::string>& sourc
 {
     // forward invalidation to section elements, these are the objects which are referenced
     m_elements.Invalidate(GetUID());
+
+    // propagate invalidation to the wing
+    if (GetNextUIDParent() && GetNextUIDParent()->GetNextUIDParent()) {
+        GetNextUIDParent()->GetNextUIDParent()->Invalidate();
+    }
 }
 
 // Get profile count for this section

--- a/src/wing/CTiglWingSectionElement.cpp
+++ b/src/wing/CTiglWingSectionElement.cpp
@@ -191,11 +191,6 @@ tigl::CTiglPoint tigl::CTiglWingSectionElement::GetChordPoint(double xsi, TiglCo
     return GetTotalTransformation(referenceCS) * airfoilChordPoint;
 }
 
-void tigl::CTiglWingSectionElement::InvalidateParent()
-{
-    wing->Invalidate();
-}
-
 tigl::CCPACSTransformation& tigl::CTiglWingSectionElement::GetElementCCPACSTransformation()
 {
     return element->GetTransformation();

--- a/src/wing/CTiglWingSectionElement.h
+++ b/src/wing/CTiglWingSectionElement.h
@@ -95,8 +95,6 @@ protected:
      */
     CTiglPoint GetStdDirForProfileUnitZ(TiglCoordinateSystem referenceCS) const override;
 
-    void InvalidateParent() override;
-
 private:
     CCPACSWingSectionElement* element;
     CCPACSWingSection* section;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #1209 

There was an issue with the internal invalidation of caches. When a transformation of a section was modified, this invalidated the parent, i.e. the fuselage and the wing. When the wing and the fuselages get rebuild, the section wires are recalculated from the transformation matrices, that are still in cache and should be invalidated. 

Therefore I changed the invalidation logic of CTiglSectionElement to invalidate these transformations and made sure that the invalidation of the transformations is properly propagated to the parents (elements, sections, wing/fuselage).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
