### PR TITLE
always display control surfcaes

### DIFF
--- a/TIGLCreator/src/TIGLCreatorDocument.cpp
+++ b/TIGLCreator/src/TIGLCreatorDocument.cpp
@@ -827,15 +827,14 @@ void TIGLCreatorDocument::drawConfiguration(bool withDuctCutouts)
                     if (!pcs->GetControlSurfaces() || pcs->GetControlSurfaces()->ControlSurfaceCount() == 0) {
                         continue;
                     }
-                    Quantity_Color grey(0.5, 0.5, 0.5, Quantity_TOC_RGB);
                     if (auto& teds = pcs->GetControlSurfaces()->GetTrailingEdgeDevices()) {
                         for (auto& ted : teds->GetTrailingEdgeDevices()) {
-                            app->getScene()->displayShape(ted->GetLoft(), true, grey);
+                            app->getScene()->displayShape(ted->GetLoft(), true, getDefaultShapeColor(), 1);
                         }
                     }
                     if (auto& leds = pcs->GetControlSurfaces()->GetLeadingEdgeDevices()) {
                         for (auto& led : leds->GetLeadingEdgeDevices()) {
-                            app->getScene()->displayShape(led->GetLoft(), true, grey);
+                            app->getScene()->displayShape(led->GetLoft(), true, getDefaultShapeColor(), 1);
                         }
                     }
                 }
@@ -1010,15 +1009,14 @@ void TIGLCreatorDocument::drawWing()
             if (!pcs->GetControlSurfaces() || pcs->GetControlSurfaces()->ControlSurfaceCount() == 0) {
                 continue;
             }
-            Quantity_Color grey(0.5, 0.5, 0.5, Quantity_TOC_RGB);
             if (auto& teds = pcs->GetControlSurfaces()->GetTrailingEdgeDevices()) {
                 for (auto& ted : teds->GetTrailingEdgeDevices()) {
-                    app->getScene()->displayShape(ted->GetLoft(), true, grey);
+                    app->getScene()->displayShape(ted->GetLoft(), true, getDefaultShapeColor(), 1);
                 }
             }
             if (auto& leds = pcs->GetControlSurfaces()->GetLeadingEdgeDevices()) {
                 for (auto& led : leds->GetLeadingEdgeDevices()) {
-                    app->getScene()->displayShape(led->GetLoft(), true, grey);
+                    app->getScene()->displayShape(led->GetLoft(), true, getDefaultShapeColor(), 1);
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #1225 

Always display the control surfaces when the whole aircraft or just the wings are displayed in the tiglecreator. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
