### PR TITLE
Replace QDoubleSpinBox by QLineEdit

### DIFF
--- a/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.cpp
+++ b/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.cpp
@@ -23,7 +23,6 @@
 #include <QGroupBox>
 #include <QGridLayout>
 #include <QLabel>
-#include <QDoubleSpinBox>
 #include <QDialogButtonBox>
 
 TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
@@ -34,7 +33,7 @@ TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
     , dx(new QDoubleSpinBox())
     , dy(new QDoubleSpinBox())
     , dz(new QDoubleSpinBox())
-    , concentration(new QDoubleSpinBox())
+    , concentration(new TIGLDoubleLineEdit())
 {
     setWindowTitle("Add a spotlight");
 
@@ -69,7 +68,8 @@ TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
     dx->setValue(1.);
     dy->setValue(1.);
     dz->setValue(1.);
-    concentration->setValue(0.5);
+
+    concentration->setValue(0.5, 2);
 
     // The main layout is vertical with a horizontal layout on top
     // and the dialog buttons below
@@ -149,5 +149,15 @@ tigl::CTiglPoint TIGLCreatorAddSpotlightDialog::getDirection() const
 
 double TIGLCreatorAddSpotlightDialog::getConcentration() const
 {
-    return concentration->value();
+    double value = concentration->text().toDouble();
+
+    // Probably not needed anymore
+    // Intention of this part is to round the user input to some defined decimal places
+    /*if(auto *validator = qobject_cast<const QDoubleValidator*>(concentration->validator())) {
+        int maxDecimals = validator->decimals();
+
+        double factorRounding = std::pow(10., maxDecimals);
+        value = std::round(value * factorRounding) / factorRounding;
+    }*/
+    return value;
 }

--- a/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.h
+++ b/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.h
@@ -21,9 +21,9 @@
 
 #include <QDialog>
 #include <CTiglPoint.h>
-
-
-class QDoubleSpinBox;
+#include <QDoubleSpinBox>
+#include <QLabel>
+#include <TIGLDoubleLineEdit.h>
 
 class TIGLCreatorAddSpotlightDialog : public QDialog
 {
@@ -43,7 +43,7 @@ private:
     QDoubleSpinBox* dx;
     QDoubleSpinBox* dy;
     QDoubleSpinBox* dz;
-    QDoubleSpinBox* concentration;
+    TIGLDoubleLineEdit* concentration;
 };
 
 #endif // TIGLCREATORADDSPOTLIGHTDIALOG_H

--- a/TIGLCreator/src/TIGLCreatorApp.cpp
+++ b/TIGLCreator/src/TIGLCreatorApp.cpp
@@ -60,6 +60,8 @@ TIGLCreatorApp::TIGLCreatorApp(int& argc, char* argv[])
     setlocale(LC_NUMERIC, "C");
 #endif
 
+    QLocale::setDefault(QLocale(QLocale::English));
+
     mainwindow.reset(new TIGLCreatorWindow);
 
     for (int iarg = 0; iarg < argc; ++iarg) {

--- a/TIGLCreator/src/TIGLDoubleLineEdit.cpp
+++ b/TIGLCreator/src/TIGLDoubleLineEdit.cpp
@@ -1,0 +1,45 @@
+/*
+* Copyright (C) 2025 German Aerospace Center (DLR/SC)
+*
+* Created: 2025-11-04 Sven Goldberg <Sven.Goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <TIGLDoubleLineEdit.h>
+#include <TIGLDoubleValidator.h>
+#include <QString>
+
+TIGLDoubleLineEdit::TIGLDoubleLineEdit() 
+    : QLineEdit()
+{}
+
+TIGLDoubleLineEdit::TIGLDoubleLineEdit(double minValue, double maxValue, double value, int nrDecimalsPrint) 
+    : QLineEdit()
+{
+    this->setRange(minValue, maxValue);
+    this->setValue(value, nrDecimalsPrint);
+}
+
+void TIGLDoubleLineEdit::setRange(double minValue, double maxValue)
+{
+    // Do no explicitely forbid a specific number of decimals
+    // As a value has to be set, we decided to choose a large value here
+    // For some Qt reasons, the number of decimals places must not be arbitrary large
+    this->setValidator(new TIGLDoubleValidator(minValue, maxValue, 300., this));
+}
+
+void TIGLDoubleLineEdit::setValue(double value, int nrDecimalsPrint)
+{
+    this->setText(QString::number(value, 'f', nrDecimalsPrint));
+}

--- a/TIGLCreator/src/TIGLDoubleLineEdit.h
+++ b/TIGLCreator/src/TIGLDoubleLineEdit.h
@@ -1,0 +1,38 @@
+/*
+* Copyright (C) 2025 German Aerospace Center (DLR/SC)
+*
+* Created: 2025-11-04 Sven Goldberg <Sven.Goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TIGLDOUBLELINEEDIT_H
+#define TIGLDOUBLELINEEDIT_H
+
+#include <QLineEdit>
+
+class TIGLDoubleLineEdit : public QLineEdit
+{
+    Q_OBJECT
+
+public:
+    TIGLDoubleLineEdit();
+    TIGLDoubleLineEdit(double minValue, double maxValue, double value, int nrDecimalsPrint);
+
+    void setRange(double minValue, double maxValue);
+
+    void setValue(double value, int nrDecimalsPrint);
+
+};
+
+#endif // TIGLDOUBLELINEEDIT_H

--- a/TIGLCreator/src/TIGLDoubleValidator.cpp
+++ b/TIGLCreator/src/TIGLDoubleValidator.cpp
@@ -1,0 +1,46 @@
+/*
+* Copyright (C) 2025 German Aerospace Center (DLR/SC)
+*
+* Created: 2025-11-04 Sven Goldberg <Sven.Goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "TIGLDoubleValidator.h"
+
+TIGLDoubleValidator::TIGLDoubleValidator(double bottom, double top, int decimals, QObject *parent)
+    : QDoubleValidator(bottom, top, decimals, parent)
+{}
+
+TIGLDoubleValidator::State TIGLDoubleValidator::validate(QString &input, int &pos) const {
+    Q_UNUSED(pos);
+
+    // Allow empty input and number with leading "."
+    if (input.isEmpty() || input == ".") {
+        return Intermediate;
+    }
+    // A leading "-" is only allowed if the range includes negative values
+    if (bottom() < 0 && input == "-") {
+        return Intermediate;
+    }
+
+    bool valueValid = false;
+    double value = input.toDouble(&valueValid);
+
+    // Input that is not convertible to a C++ double or lies outside the defined range is invalid
+    if (!valueValid || value < bottom() || value > top()) {
+        return Invalid;
+    }
+
+    return Intermediate;
+}

--- a/TIGLCreator/src/TIGLDoubleValidator.h
+++ b/TIGLCreator/src/TIGLDoubleValidator.h
@@ -1,0 +1,37 @@
+/*
+* Copyright (C) 2025 German Aerospace Center (DLR/SC)
+*
+* Created: 2025-11-04 Sven Goldberg <Sven.Goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TIGLDOUBLEVALIDATOR_H
+#define TIGLDOUBLEVALIDATOR_H
+
+#include <QDoubleValidator>
+#include <QString>
+
+
+class TIGLDoubleValidator : public QDoubleValidator
+{
+    Q_OBJECT
+
+public:
+    TIGLDoubleValidator(double bottom, double top, int decimals, QObject *parent = nullptr);
+
+    // Defines valid status of String inputs
+    State validate(QString &input, int &pos) const override;
+};
+
+#endif // TIGLDOUBLEVALIDATOR_H


### PR DESCRIPTION
This is a draft PR, do not merge!
## General information
This PR's base branch is branch that should be merged into main, as well. I started working there and did not see any advantage to move to another one for this example case... 
Only one input field is changed, namely the "concentration" input of the `add-lightsource`-dialog. The window can be found under "View->Display->Add a spotlight". Here, the direct contrast can be seen to the currently used `QDoubleSpinBox`.

Now, to the
## Implementation:
This is a suggestion for the replacement of the `QDoubleSpinBox` by a customized version of the `QLineEdit` for every occurrence within the TiGLCreator. We discussed internally that we want to find another solution for user input of double values

Since the `QLineEdit` is for text in general and not specified for number input, some restrictions and special calls are needed. For convenience, they are put into the derived class [`TIGLDoubleLineEdit`](https://github.com/DLR-SC/tigl/blob/replaceQtSpinBoxes/TIGLCreator/src/TIGLDoubleLineEdit.h). This allows easier access of this object when it is used for double input.

Moreoever, the `QLineEdit` (or its derived class) needs a validator object to only allow wanted input. This object, e.g., automatically blocks input that cannot be converted into a `double`. For some reasons, the implemented value-range control did not work for me. So, I implemented a customized `validate()` function. This is used by the Qt object `QDoubleValidator`. In order to customize the function, I derived the class [`TIGLDoubleValidator`](https://github.com/DLR-SC/tigl/blob/replaceQtSpinBoxes/TIGLCreator/src/TIGLDoubleValidator.h) and overwrote the function to only allow string input that can be converted into double within a developer-defined value range.

What do you all think about the suggestion @joergbrech @merakulix @ole-alb @AntonReiswich ?