### PR TITLE
Catch invalid or missing uid for transformation element

### DIFF
--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -139,9 +139,17 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
     unHighlight();
     if (item->getType() == "transformation") {
         tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
-        tigl::CCPACSTransformation& transformation =
-            uidManager.ResolveObject<tigl::CCPACSTransformation>(item->getUid());
-        modificatorContainerWidget->setTransformationModificator(transformation, doc->GetConfiguration());
+        if(item->getUid().empty()){
+            LOG(WARNING) << "The 'transformation'-element you are trying to access has no UID and is not editable. If you want to be able to edit add UID." << std::endl;
+        } else {
+            try{
+                tigl::CCPACSTransformation& transformation =
+                    uidManager.ResolveObject<tigl::CCPACSTransformation>(item->getUid());
+                modificatorContainerWidget->setTransformationModificator(transformation, doc->GetConfiguration());
+            } catch (tigl::CTiglError& ex) {
+                LOG(ERROR) << ex.what() << std::endl;
+            }
+        }
     }
     else if (item->getType() == "fuselage") {
         tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Catch the error responsible for the crash and add a warning that informs whether uid is missing or invalid.

## Description
<!--- Describe your changes in detail -->
Since it is not trivial to access an object that has an optional uid we provide a quick fix with a warning, informing the user to add a uid if she wants to edit the element.

In TiGL we have two options to access CPACSElements: 
1. Use the uid manager - Accessing objects with optional UID empty is not yet implemented and not trivial to be implemented, since well... there is no unique identifier, and the xpath is variable.
2. Which leaves accessing the object via parent, which is right now only solvable during runtime via adding a lot of code baggage, and probably also not a solution to all the kinds of cpacs elements.
<!--- Why is this change required? What problem does it solve? -->

This fix, as said, informs the user, to add a UID to the 'transformation' element, if he likes to edit this element, no crash happening anymore.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1236 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually in the GUI. Warning is printed, the tree shows a transformation dummy, which is neither readable nor editable (hence the object information is not accessible).

## Screenshots, that help to understand the changes(if applicable):
<img width="689" height="118" alt="image" src="https://github.com/user-attachments/assets/1e43e0b6-d89e-4255-b95b-90223c71f21d" />

<img width="763" height="579" alt="image" src="https://github.com/user-attachments/assets/8893f34e-c458-4f22-be25-2039f46b3c09" />


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
