### PR TITLE
Alos display mirrored control devices

### DIFF
--- a/src/control_devices/CCPACSLeadingEdgeDevice.cpp
+++ b/src/control_devices/CCPACSLeadingEdgeDevice.cpp
@@ -201,6 +201,12 @@ TiglGeometricComponentIntent CCPACSLeadingEdgeDevice::GetComponentIntent() const
     return TIGL_INTENT_OUTER_AERO_SURFACE | TIGL_INTENT_PHYSICAL;
 }
 
+// Use symmetry from the parent wing
+TiglSymmetryAxis CCPACSLeadingEdgeDevice::GetSymmetryAxis() const
+{
+    return Wing().GetSymmetryAxis();
+}
+
 PNamedShape CCPACSLeadingEdgeDevice::GetCutOutShape(void) const
 {
     return *m_cutoutShape;

--- a/src/control_devices/CCPACSLeadingEdgeDevice.h
+++ b/src/control_devices/CCPACSLeadingEdgeDevice.h
@@ -58,6 +58,8 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const override;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const override;
     TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const override;
+    
+    TIGL_EXPORT TiglSymmetryAxis GetSymmetryAxis() const override;
 
 private:
     struct HingePoints {

--- a/src/control_devices/CCPACSTrailingEdgeDevice.cpp
+++ b/src/control_devices/CCPACSTrailingEdgeDevice.cpp
@@ -200,6 +200,12 @@ TiglGeometricComponentIntent CCPACSTrailingEdgeDevice::GetComponentIntent() cons
     return TIGL_INTENT_OUTER_AERO_SURFACE | TIGL_INTENT_PHYSICAL;
 }
 
+// Use symmetry from the parent wing
+TiglSymmetryAxis CCPACSTrailingEdgeDevice::GetSymmetryAxis() const
+{
+    return Wing().GetSymmetryAxis();
+}
+
 PNamedShape CCPACSTrailingEdgeDevice::GetCutOutShape(void) const
 {
     return *m_cutoutShape;

--- a/src/control_devices/CCPACSTrailingEdgeDevice.h
+++ b/src/control_devices/CCPACSTrailingEdgeDevice.h
@@ -58,6 +58,8 @@ public:
     TIGL_EXPORT std::string GetDefaultedUID() const override;
     TIGL_EXPORT TiglGeometricComponentType GetComponentType() const override;
     TIGL_EXPORT TiglGeometricComponentIntent GetComponentIntent() const override;
+    
+    TIGL_EXPORT TiglSymmetryAxis GetSymmetryAxis() const override;
 
 private:
     struct HingePoints {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a small fix to also display the control devices on the mirrored wing, by using the wings symmetry.

Closes #1268 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
