### PR TITLE
Choose a unique marker for mirrored shapes in export files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Changes since last release
 ----------------
 2025/09/26
 -General changes
+  - CPACS Export: Choose more meaningful marker for mirrored objects uIDs [#1289](https://github.com/DLR-SC/tigl/issues/1289)
   - Add leading edge devices (LED) to TiGL and TiGLcreator [#1101](https://github.com/DLR-SC/tigl/issues/1101)
   - Always display the borders of the control surfaces on the wing
   - TiGLCreator: Add option to display the control point net of all faces of a geometric component for debugging purposes [#1260](https://github.com/DLR-SC/tigl/pull/1260)

--- a/src/geometry/CTiglAbstractGeometricComponent.cpp
+++ b/src/geometry/CTiglAbstractGeometricComponent.cpp
@@ -81,9 +81,9 @@ PNamedShape CTiglAbstractGeometricComponent::GetMirroredLoft() const
     PNamedShape mirroredShape = trafo.Transform(GetLoft());
 
     std::string mirrorName = mirroredShape->Name();
-    mirrorName += "M";
+    mirrorName += ":mirrored";
     std::string mirrorShortName = mirroredShape->ShortName();
-    mirrorShortName += "M";
+    mirrorShortName += ":mirrored";
     mirroredShape->SetName(mirrorName.c_str());
     mirroredShape->SetShortName(mirrorShortName.c_str());
     return mirroredShape;


### PR DESCRIPTION
Fix #1289


| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
