### PR TITLE
temporarily disable macos CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -65,12 +65,12 @@ jobs:
             pixienv: "default"
             documentation: "OFF"
             package: "OFF"
-          - os: "macos-13"
-            config: "Release"
-            pixienv: "occt-static"
-            documentation: "OFF"
-            # create macos package (dmg) only on release and scheduled (nightly) builds due to time constraints of macos runners
-            package: ${{ ( (github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))) && 'ON') || 'OFF' }}
+          #- os: "macos-13"
+          #  config: "Release"
+          #  pixienv: "occt-static"
+          #  documentation: "OFF"
+          #  # create macos package (dmg) only on release and scheduled (nightly) builds due to time constraints of macos runners
+          #  package: ${{ ( (github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))) && 'ON') || 'OFF' }}
     uses: ./.github/workflows/build-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR temporarily (!!!) disables MacOS CI, which is failing currently, see #1273. Updating occt, occt-static and all dependencies to a new MacOS version is a pain, and since we are migrating to conda-forge anyway (#1286) not worth the hassle. Once the build-chain is setup for conda-forge, we should re-enable MacOS builds and tests in CI
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

CI

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
