### PR TITLE
Add function setObjectsColorRGB to TiGLCreator scripting engine

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Changes since last release
 ----------------
 2025/09/26
 -General changes
+  - Add `Color` class and `setObjectsColor`/`setObjectsColorRGB` functions to the TiGLCreator scripting console to set object colors without needing a native QColor object ([#1222](https://github.com/DLR-SC/tigl/issues/1222))
   - CPACS Export: Choose more meaningful marker for mirrored objects uIDs [#1289](https://github.com/DLR-SC/tigl/issues/1289)
   - Add leading edge devices (LED) to TiGL and TiGLcreator [#1101](https://github.com/DLR-SC/tigl/issues/1101)
   - Always display the borders of the control surfaces on the wing

--- a/TIGLCreator/src/TIGLCreatorContext.cpp
+++ b/TIGLCreator/src/TIGLCreatorContext.cpp
@@ -593,6 +593,11 @@ void TIGLCreatorContext::setObjectsColor(const QColor& color)
     }
 }
 
+void TIGLCreatorContext::setObjectsColorRGB(int r, int g, int b, int a)
+{
+    setObjectsColor(QColor(r, g, b, a));
+}
+
 void TIGLCreatorContext::setFaceBoundariesEnabled(bool enabled) {
     if (myContext && myContext->DefaultDrawer()) {
         myContext->DefaultDrawer()->SetFaceBoundaryDraw(enabled);

--- a/TIGLCreator/src/TIGLCreatorContext.h
+++ b/TIGLCreator/src/TIGLCreatorContext.h
@@ -129,6 +129,7 @@ public slots:
     void setObjectsTexture(const QString& filename);
     void setReflectionlinesEnabled(bool);
     void setObjectsColor(const QColor &color);
+    void setObjectsColorRGB(int r, int g, int b, int a = 255);
     void setFaceBoundariesEnabled(bool enabled);
 
 signals:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #1222

Problem: `app.scene.setObjectsColor(color)` exists as a script-accessible slot, but there was no way to construct a `QColor` from the TiGLCreator console (QtScript). Users had no workaround.

Workaround: Add a `setObjectsColorRGB` function to the scripting engine that allows specifying RGB values directly.

Usage examples in the TiGLCreator console:

```
app.scene.setObjectsColorRGB(255, 0, 0)          // red
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manully in the GUI

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
