### PR TITLE
Fix an issue with an instant crash for invalid xml in TiGLCreator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ Changes since last release
   - The function `app.openFile` in the TiGLCreator scripting engine now accepts a configuration uid. [#1309](https://github.com/DLR-SC/tigl/pull/1309)
 
 - Fixes
+  - Fix hard crash for invalid xml files ([#1322](https://github.com/DLR-SC/tigl/pull/1322))
   - Fix many CMake and compiler warnings ([#1307](https://github.com/DLR-SC/tigl/pull/1307))
   - Make all shapes non-transparent again by default ([#1258](https://github.com/DLR-SC/tigl/issues/1258))
   - Update modificator widget's references after undo/redo action. Fixes ([#1240](https://github.com/DLR-SC/tigl/issues/1240))

--- a/pixi.toml
+++ b/pixi.toml
@@ -82,9 +82,9 @@ configure = { cmd = [
 ]}
 generate = { cmd = """
     git submodule update --init --recursive
-    && cd thirdparty/cpacs_gen
-    && cmake -GNinja -S. -Bbuild -DTIGL_PATH=../.. 
-    && cmake --build build --target generate
+    cd thirdparty/cpacs_gen
+    cmake -GNinja -S . -Bbuild -DTIGL_PATH=../.. 
+    cmake --build build --target generate
 """}
 build = { cmd = "cmake --build . {{ extra_args }}", cwd = "build", args= [ { "arg" = "extra_args", "default" = "-j"}]}
 install = { cmd = "cmake --build . --target install {{ extra_args }}", cwd = "build", args= [ { "arg" = "extra_args", "default" = "-j"}] }
@@ -103,6 +103,7 @@ tiglcreator = { cmd = "./tiglcreator", cwd = "build/install/bin"}
 "occt-static" = ["base", "opencascade-static"]
 # python-internal feature builds the internal python bindings of the C++ core using swig
 "python-internal" = ["base", "python-internal"]
+
 
 [feature.coverage.tasks]
 # The coverage feature builds in debug mode and runs the tests with coverage flags enabled

--- a/src/generated/CPACSAircraftControlElement.cpp
+++ b/src/generated/CPACSAircraftControlElement.cpp
@@ -88,7 +88,7 @@ namespace generated
     void CPACSAircraftControlElement::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element controlDeviceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlDeviceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlDeviceUID")) {
             m_controlDeviceUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/controlDeviceUID");
             if (m_controlDeviceUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element controlDeviceUID is present but empty at xpath " << xpath;
@@ -97,12 +97,12 @@ namespace generated
         }
 
         // read element controlParameter
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlParameter")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlParameter")) {
             m_controlParameter_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/controlParameter");
         }
 
         // read element controlDistributorUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlDistributorUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlDistributorUID")) {
             m_controlDistributorUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/controlDistributorUID");
             if (m_controlDistributorUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element controlDistributorUID is present but empty at xpath " << xpath;
@@ -111,7 +111,7 @@ namespace generated
         }
 
         // read element commandInput
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/commandInput")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/commandInput")) {
             m_commandInput_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/commandInput");
         }
 

--- a/src/generated/CPACSAircraftModel.cpp
+++ b/src/generated/CPACSAircraftModel.cpp
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSAlignmentCrossBeam.cpp
+++ b/src/generated/CPACSAlignmentCrossBeam.cpp
@@ -105,27 +105,27 @@ namespace generated
         }
 
         // read element offset1LocX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/offset1LocX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/offset1LocX")) {
             m_offset1LocX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/offset1LocX");
         }
 
         // read element offset2LocX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/offset2LocX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/offset2LocX")) {
             m_offset2LocX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/offset2LocX");
         }
 
         // read element rotationLocX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotationLocX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotationLocX")) {
             m_rotationLocX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotationLocX");
         }
 
         // read element translationLocY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/translationLocY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/translationLocY")) {
             m_translationLocY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/translationLocY");
         }
 
         // read element translationLocZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/translationLocZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/translationLocZ")) {
             m_translationLocZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/translationLocZ");
         }
 

--- a/src/generated/CPACSAlignmentStringFrame.cpp
+++ b/src/generated/CPACSAlignmentStringFrame.cpp
@@ -89,17 +89,17 @@ namespace generated
         }
 
         // read element rotationLocX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotationLocX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotationLocX")) {
             m_rotationLocX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotationLocX");
         }
 
         // read element translationLocY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/translationLocY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/translationLocY")) {
             m_translationLocY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/translationLocY");
         }
 
         // read element translationLocZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/translationLocZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/translationLocZ")) {
             m_translationLocZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/translationLocZ");
         }
 

--- a/src/generated/CPACSAlignmentStructMember.cpp
+++ b/src/generated/CPACSAlignmentStructMember.cpp
@@ -89,22 +89,22 @@ namespace generated
         }
 
         // read element offsetLocX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/offsetLocX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/offsetLocX")) {
             m_offsetLocX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/offsetLocX");
         }
 
         // read element rotationLocX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotationLocX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotationLocX")) {
             m_rotationLocX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotationLocX");
         }
 
         // read element translationLocY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/translationLocY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/translationLocY")) {
             m_translationLocY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/translationLocY");
         }
 
         // read element translationLocZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/translationLocZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/translationLocZ")) {
             m_translationLocZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/translationLocZ");
         }
 

--- a/src/generated/CPACSApproximationSettings.cpp
+++ b/src/generated/CPACSApproximationSettings.cpp
@@ -74,12 +74,12 @@ namespace generated
         }
 
         // read element controlPointNumber
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlPointNumber")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlPointNumber")) {
             m_controlPointNumber_choice1 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/controlPointNumber");
         }
 
         // read element maximumError
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/maximumError")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/maximumError")) {
             m_maximumError_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/maximumError");
         }
 

--- a/src/generated/CPACSAxle.cpp
+++ b/src/generated/CPACSAxle.cpp
@@ -113,7 +113,7 @@ namespace generated
         }
 
         // read element length
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/length")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/length")) {
             m_length = tixi::TixiGetElement<double>(tixiHandle, xpath + "/length");
         }
         else {
@@ -129,7 +129,7 @@ namespace generated
         }
 
         // read element numberOfWheels
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/numberOfWheels")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/numberOfWheels")) {
             m_numberOfWheels = tixi::TixiGetElement<int>(tixiHandle, xpath + "/numberOfWheels");
         }
         else {
@@ -137,7 +137,7 @@ namespace generated
         }
 
         // read element sideOfFirstWheel
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sideOfFirstWheel")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sideOfFirstWheel")) {
             m_sideOfFirstWheel = stringToCPACSAxle_sideOfFirstWheel(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sideOfFirstWheel"));
         }
         else {

--- a/src/generated/CPACSAxleAssembly.cpp
+++ b/src/generated/CPACSAxleAssembly.cpp
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element posOnBogie
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/posOnBogie")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/posOnBogie")) {
             m_posOnBogie = tixi::TixiGetElement<double>(tixiHandle, xpath + "/posOnBogie");
         }
         else {

--- a/src/generated/CPACSBeamCrossSection.cpp
+++ b/src/generated/CPACSBeamCrossSection.cpp
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element area
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/area")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/area")) {
             m_area = tixi::TixiGetElement<double>(tixiHandle, xpath + "/area");
         }
         else {
@@ -102,7 +102,7 @@ namespace generated
         }
 
         // read element xMin
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xMin")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xMin")) {
             m_xMin = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xMin");
         }
         else {
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element xMax
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xMax")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xMax")) {
             m_xMax = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xMax");
         }
         else {
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element yMin
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/yMin")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/yMin")) {
             m_yMin = tixi::TixiGetElement<double>(tixiHandle, xpath + "/yMin");
         }
         else {
@@ -126,7 +126,7 @@ namespace generated
         }
 
         // read element yMax
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/yMax")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/yMax")) {
             m_yMax = tixi::TixiGetElement<double>(tixiHandle, xpath + "/yMax");
         }
         else {

--- a/src/generated/CPACSBeamStiffness.cpp
+++ b/src/generated/CPACSBeamStiffness.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element EA
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/EA")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/EA")) {
             m_EA = tixi::TixiGetElement<double>(tixiHandle, xpath + "/EA");
         }
         else {
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element EIxx
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/EIxx")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/EIxx")) {
             m_EIxx = tixi::TixiGetElement<double>(tixiHandle, xpath + "/EIxx");
         }
         else {
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element EIyy
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/EIyy")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/EIyy")) {
             m_EIyy = tixi::TixiGetElement<double>(tixiHandle, xpath + "/EIyy");
         }
         else {
@@ -120,7 +120,7 @@ namespace generated
         }
 
         // read element EIxy
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/EIxy")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/EIxy")) {
             m_EIxy = tixi::TixiGetElement<double>(tixiHandle, xpath + "/EIxy");
         }
         else {
@@ -128,7 +128,7 @@ namespace generated
         }
 
         // read element GIt
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/GIt")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/GIt")) {
             m_GIt = tixi::TixiGetElement<double>(tixiHandle, xpath + "/GIt");
         }
         else {
@@ -136,7 +136,7 @@ namespace generated
         }
 
         // read element G
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/G")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/G")) {
             m_G = tixi::TixiGetElement<double>(tixiHandle, xpath + "/G");
         }
         else {
@@ -144,7 +144,7 @@ namespace generated
         }
 
         // read element It
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/It")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/It")) {
             m_It = tixi::TixiGetElement<double>(tixiHandle, xpath + "/It");
         }
         else {

--- a/src/generated/CPACSBogie.cpp
+++ b/src/generated/CPACSBogie.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element length
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/length")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/length")) {
             m_length = tixi::TixiGetElement<double>(tixiHandle, xpath + "/length");
         }
         else {
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element tiltAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/tiltAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/tiltAngle")) {
             m_tiltAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/tiltAngle");
         }
         else {

--- a/src/generated/CPACSBoundingBox.cpp
+++ b/src/generated/CPACSBoundingBox.cpp
@@ -87,7 +87,7 @@ namespace generated
     void CPACSBoundingBox::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element deltaX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaX")) {
             m_deltaX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaX");
         }
         else {
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element deltaY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaY")) {
             m_deltaY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaY");
         }
         else {
@@ -103,7 +103,7 @@ namespace generated
         }
 
         // read element deltaZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaZ")) {
             m_deltaZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaZ");
         }
         else {

--- a/src/generated/CPACSBoundingElementUIDs.cpp
+++ b/src/generated/CPACSBoundingElementUIDs.cpp
@@ -95,7 +95,7 @@ namespace generated
     void CPACSBoundingElementUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element boundingElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/boundingElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/boundingElementUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/boundingElementUID", m_boundingElementUIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_boundingElementUIDs.begin(); it != m_boundingElementUIDs.end(); ++it) {

--- a/src/generated/CPACSBoundingElementUIDs.cpp
+++ b/src/generated/CPACSBoundingElementUIDs.cpp
@@ -95,7 +95,7 @@ namespace generated
     void CPACSBoundingElementUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element boundingElementUID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/boundingElementUID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/boundingElementUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/boundingElementUID", m_boundingElementUIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_boundingElementUIDs.begin(); it != m_boundingElementUIDs.end(); ++it) {

--- a/src/generated/CPACSCap.cpp
+++ b/src/generated/CPACSCap.cpp
@@ -155,7 +155,7 @@ namespace generated
     void CPACSCap::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element area
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/area")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/area")) {
             m_area = tixi::TixiGetElement<double>(tixiHandle, xpath + "/area");
         }
         else {

--- a/src/generated/CPACSCargoContainerElement.cpp
+++ b/src/generated/CPACSCargoContainerElement.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element contour
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/contour")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/contour")) {
             m_contour = stringToCPACSCargoContainerElement_contour(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/contour"));
         }
         else {
@@ -125,7 +125,7 @@ namespace generated
         }
 
         // read element deltaX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaX")) {
             m_deltaX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaX");
         }
         else {
@@ -133,7 +133,7 @@ namespace generated
         }
 
         // read element deltaY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaY")) {
             m_deltaY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaY");
         }
         else {
@@ -141,12 +141,12 @@ namespace generated
         }
 
         // read element deltaYBase
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaYBase")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaYBase")) {
             m_deltaYBase = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaYBase");
         }
 
         // read element deltaZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaZ")) {
             m_deltaZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaZ");
         }
         else {
@@ -154,7 +154,7 @@ namespace generated
         }
 
         // read element deltaZKink
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaZKink")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaZKink")) {
             m_deltaZKink = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaZKink");
         }
 

--- a/src/generated/CPACSCellPositioningChordwise.cpp
+++ b/src/generated/CPACSCellPositioningChordwise.cpp
@@ -81,7 +81,7 @@ namespace generated
     void CPACSCellPositioningChordwise::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sparUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sparUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sparUID")) {
             m_sparUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sparUID");
             if (m_sparUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element sparUID is present but empty at xpath " << xpath;
@@ -90,17 +90,17 @@ namespace generated
         }
 
         // read element contourCoordinate
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/contourCoordinate")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/contourCoordinate")) {
             m_contourCoordinate_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/contourCoordinate");
         }
 
         // read element xsi1
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi1")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi1")) {
             m_xsi1_choice3 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi1");
         }
 
         // read element xsi2
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi2")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi2")) {
             m_xsi2_choice3 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi2");
         }
 

--- a/src/generated/CPACSCellPositioningSpanwise.cpp
+++ b/src/generated/CPACSCellPositioningSpanwise.cpp
@@ -81,7 +81,7 @@ namespace generated
     void CPACSCellPositioningSpanwise::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element contourCoordinate
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/contourCoordinate")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/contourCoordinate")) {
             m_contourCoordinate_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/contourCoordinate");
         }
 
@@ -108,12 +108,12 @@ namespace generated
         }
 
         // read element ribNumber
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribNumber")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribNumber")) {
             m_ribNumber_choice3 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/ribNumber");
         }
 
         // read element ribDefinitionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribDefinitionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribDefinitionUID")) {
             m_ribDefinitionUID_choice3 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribDefinitionUID");
             if (m_ribDefinitionUID_choice3->empty()) {
                 LOG(WARNING) << "Optional element ribDefinitionUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSCompartment.cpp
+++ b/src/generated/CPACSCompartment.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element designVolume
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/designVolume")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/designVolume")) {
             m_designVolume = tixi::TixiGetElement<double>(tixiHandle, xpath + "/designVolume");
         }
 

--- a/src/generated/CPACSCompartmentGeometry.cpp
+++ b/src/generated/CPACSCompartmentGeometry.cpp
@@ -95,7 +95,7 @@ namespace generated
     void CPACSCompartmentGeometry::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element boundaryElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/boundaryElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/boundaryElementUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/boundaryElementUID", m_boundaryElementUIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_boundaryElementUIDs.begin(); it != m_boundaryElementUIDs.end(); ++it) {

--- a/src/generated/CPACSCompartmentGeometry.cpp
+++ b/src/generated/CPACSCompartmentGeometry.cpp
@@ -95,7 +95,7 @@ namespace generated
     void CPACSCompartmentGeometry::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element boundaryElementUID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/boundaryElementUID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/boundaryElementUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/boundaryElementUID", m_boundaryElementUIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_boundaryElementUIDs.begin(); it != m_boundaryElementUIDs.end(); ++it) {

--- a/src/generated/CPACSComponentSegment.cpp
+++ b/src/generated/CPACSComponentSegment.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element fromElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromElementUID")) {
             m_fromElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromElementUID");
             if (m_fromElementUID.empty()) {
                 LOG(WARNING) << "Required element fromElementUID is empty at xpath " << xpath;
@@ -130,7 +130,7 @@ namespace generated
         }
 
         // read element toElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toElementUID")) {
             m_toElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/toElementUID");
             if (m_toElementUID.empty()) {
                 LOG(WARNING) << "Required element toElementUID is empty at xpath " << xpath;

--- a/src/generated/CPACSComposite.cpp
+++ b/src/generated/CPACSComposite.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element offset
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/offset")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/offset")) {
             m_offset = tixi::TixiGetElement<double>(tixiHandle, xpath + "/offset");
         }
 

--- a/src/generated/CPACSCompositeLayer.cpp
+++ b/src/generated/CPACSCompositeLayer.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSCompositeLayer::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -91,7 +91,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element thickness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/thickness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/thickness")) {
             m_thickness = tixi::TixiGetElement<double>(tixiHandle, xpath + "/thickness");
         }
         else {
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element phi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/phi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/phi")) {
             m_phi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/phi");
         }
         else {
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID.empty()) {
                 LOG(WARNING) << "Required element materialUID is empty at xpath " << xpath;

--- a/src/generated/CPACSContourReference.cpp
+++ b/src/generated/CPACSContourReference.cpp
@@ -103,7 +103,7 @@ namespace generated
     void CPACSContourReference::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element airfoilUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/airfoilUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/airfoilUID")) {
             m_airfoilUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/airfoilUID");
             if (m_airfoilUID.empty()) {
                 LOG(WARNING) << "Required element airfoilUID is empty at xpath " << xpath;
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element rotX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotX")) {
             m_rotX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotX");
         }
         else {
@@ -123,7 +123,7 @@ namespace generated
         }
 
         // read element scalY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/scalY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/scalY")) {
             m_scalY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/scalY");
         }
         else {
@@ -131,7 +131,7 @@ namespace generated
         }
 
         // read element scalZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/scalZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/scalZ")) {
             m_scalZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/scalZ");
         }
         else {

--- a/src/generated/CPACSControlSurfaceAirfoil.cpp
+++ b/src/generated/CPACSControlSurfaceAirfoil.cpp
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element airfoilUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/airfoilUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/airfoilUID")) {
             m_airfoilUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/airfoilUID");
             if (m_airfoilUID.empty()) {
                 LOG(WARNING) << "Required element airfoilUID is empty at xpath " << xpath;
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element rotX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotX")) {
             m_rotX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotX");
         }
         else {
@@ -120,7 +120,7 @@ namespace generated
         }
 
         // read element rotZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotZ")) {
             m_rotZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotZ");
         }
         else {
@@ -128,7 +128,7 @@ namespace generated
         }
 
         // read element scalY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/scalY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/scalY")) {
             m_scalY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/scalY");
         }
         else {
@@ -136,7 +136,7 @@ namespace generated
         }
 
         // read element scalZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/scalZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/scalZ")) {
             m_scalZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/scalZ");
         }
         else {

--- a/src/generated/CPACSControlSurfaceBorderLeadingEdge.cpp
+++ b/src/generated/CPACSControlSurfaceBorderLeadingEdge.cpp
@@ -115,12 +115,12 @@ namespace generated
         }
 
         // read element xsiTEUpper
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiTEUpper")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiTEUpper")) {
             m_xsiTEUpper_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiTEUpper");
         }
 
         // read element xsiTELower
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiTELower")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiTELower")) {
             m_xsiTELower_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiTELower");
         }
 

--- a/src/generated/CPACSControlSurfaceHingePoint.cpp
+++ b/src/generated/CPACSControlSurfaceHingePoint.cpp
@@ -86,7 +86,7 @@ namespace generated
     void CPACSControlSurfaceHingePoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element hingeXsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/hingeXsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/hingeXsi")) {
             m_hingeXsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/hingeXsi");
         }
         else {
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element hingeRelHeight
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/hingeRelHeight")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/hingeRelHeight")) {
             m_hingeRelHeight = tixi::TixiGetElement<double>(tixiHandle, xpath + "/hingeRelHeight");
         }
         else {

--- a/src/generated/CPACSControlSurfaceSkinCutOut.cpp
+++ b/src/generated/CPACSControlSurfaceSkinCutOut.cpp
@@ -87,7 +87,7 @@ namespace generated
     void CPACSControlSurfaceSkinCutOut::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sparUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sparUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sparUID")) {
             m_sparUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sparUID");
             if (m_sparUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element sparUID is present but empty at xpath " << xpath;
@@ -96,12 +96,12 @@ namespace generated
         }
 
         // read element xsiInnerBorder
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiInnerBorder")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiInnerBorder")) {
             m_xsiInnerBorder_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiInnerBorder");
         }
 
         // read element xsiOuterBorder
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiOuterBorder")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiOuterBorder")) {
             m_xsiOuterBorder_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiOuterBorder");
         }
 

--- a/src/generated/CPACSControlSurfaceSkinCutOutBorder.cpp
+++ b/src/generated/CPACSControlSurfaceSkinCutOutBorder.cpp
@@ -87,7 +87,7 @@ namespace generated
     void CPACSControlSurfaceSkinCutOutBorder::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element ribDefinitionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribDefinitionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribDefinitionUID")) {
             m_ribDefinitionUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribDefinitionUID");
             if (m_ribDefinitionUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element ribDefinitionUID is present but empty at xpath " << xpath;
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element ribNumber
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribNumber")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribNumber")) {
             m_ribNumber_choice1 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/ribNumber");
         }
 

--- a/src/generated/CPACSControlSurfaceStep.cpp
+++ b/src/generated/CPACSControlSurfaceStep.cpp
@@ -85,7 +85,7 @@ namespace generated
     void CPACSControlSurfaceStep::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element controlParameter
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlParameter")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlParameter")) {
             m_controlParameter = tixi::TixiGetElement<double>(tixiHandle, xpath + "/controlParameter");
         }
         else {
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element hingeLineRotation
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/hingeLineRotation")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/hingeLineRotation")) {
             m_hingeLineRotation = tixi::TixiGetElement<double>(tixiHandle, xpath + "/hingeLineRotation");
         }
 

--- a/src/generated/CPACSControlSurfaceTrackType.cpp
+++ b/src/generated/CPACSControlSurfaceTrackType.cpp
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element trackType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/trackType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/trackType")) {
             m_trackType = stringToCPACSControlSurfaceTrackType_trackType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/trackType"));
         }
         else {
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element trackSubType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/trackSubType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/trackSubType")) {
             m_trackSubType = stringToCPACSControlSurfaceTrackType_trackSubType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/trackSubType"));
         }
 

--- a/src/generated/CPACSCrossBeamAssemblyPosition.cpp
+++ b/src/generated/CPACSCrossBeamAssemblyPosition.cpp
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element structuralElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementUID")) {
             m_structuralElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementUID");
             if (m_structuralElementUID.empty()) {
                 LOG(WARNING) << "Required element structuralElementUID is empty at xpath " << xpath;
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element frameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/frameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/frameUID")) {
             m_frameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/frameUID");
             if (m_frameUID.empty()) {
                 LOG(WARNING) << "Required element frameUID is empty at xpath " << xpath;
@@ -124,7 +124,7 @@ namespace generated
         }
 
         // read element positionZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/positionZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/positionZ")) {
             m_positionZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/positionZ");
         }
         else {

--- a/src/generated/CPACSCrossBeamStrutAssemblyPosition.cpp
+++ b/src/generated/CPACSCrossBeamStrutAssemblyPosition.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element structuralElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementUID")) {
             m_structuralElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementUID");
             if (m_structuralElementUID.empty()) {
                 LOG(WARNING) << "Required element structuralElementUID is empty at xpath " << xpath;
@@ -113,7 +113,7 @@ namespace generated
         }
 
         // read element frameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/frameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/frameUID")) {
             m_frameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/frameUID");
             if (m_frameUID.empty()) {
                 LOG(WARNING) << "Required element frameUID is empty at xpath " << xpath;
@@ -125,7 +125,7 @@ namespace generated
         }
 
         // read element crossBeamUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/crossBeamUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/crossBeamUID")) {
             m_crossBeamUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/crossBeamUID");
             if (m_crossBeamUID.empty()) {
                 LOG(WARNING) << "Required element crossBeamUID is empty at xpath " << xpath;
@@ -137,7 +137,7 @@ namespace generated
         }
 
         // read element positionYAtCrossBeam
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/positionYAtCrossBeam")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/positionYAtCrossBeam")) {
             m_positionYAtCrossBeam = tixi::TixiGetElement<double>(tixiHandle, xpath + "/positionYAtCrossBeam");
         }
         else {
@@ -145,7 +145,7 @@ namespace generated
         }
 
         // read element angleX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/angleX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/angleX")) {
             m_angleX = tixi::TixiGetElement<double>(tixiHandle, xpath + "/angleX");
         }
 

--- a/src/generated/CPACSCst2D.cpp
+++ b/src/generated/CPACSCst2D.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element upperN1
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/upperN1")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/upperN1")) {
             m_upperN1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/upperN1");
         }
         else {
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element upperN2
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/upperN2")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/upperN2")) {
             m_upperN2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/upperN2");
         }
         else {
@@ -121,7 +121,7 @@ namespace generated
         }
 
         // read element lowerN1
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/lowerN1")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/lowerN1")) {
             m_lowerN1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/lowerN1");
         }
         else {
@@ -129,7 +129,7 @@ namespace generated
         }
 
         // read element lowerN2
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/lowerN2")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/lowerN2")) {
             m_lowerN2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/lowerN2");
         }
         else {
@@ -145,7 +145,7 @@ namespace generated
         }
 
         // read element trailingEdgeThickness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/trailingEdgeThickness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/trailingEdgeThickness")) {
             m_trailingEdgeThickness = tixi::TixiGetElement<double>(tixiHandle, xpath + "/trailingEdgeThickness");
         }
 

--- a/src/generated/CPACSCurvePoint.cpp
+++ b/src/generated/CPACSCurvePoint.cpp
@@ -77,7 +77,7 @@ namespace generated
     void CPACSCurvePoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element eta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/eta")) {
             m_eta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta");
         }
         else {
@@ -85,7 +85,7 @@ namespace generated
         }
 
         // read element referenceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceUID")) {
             m_referenceUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceUID");
             if (m_referenceUID.empty()) {
                 LOG(WARNING) << "Required element referenceUID is empty at xpath " << xpath;

--- a/src/generated/CPACSCutOut.cpp
+++ b/src/generated/CPACSCutOut.cpp
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -103,7 +103,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -111,7 +111,7 @@ namespace generated
         }
 
         // read element width
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/width")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/width")) {
             m_width = tixi::TixiGetElement<double>(tixiHandle, xpath + "/width");
         }
         else {
@@ -119,7 +119,7 @@ namespace generated
         }
 
         // read element height
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/height")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/height")) {
             m_height = tixi::TixiGetElement<double>(tixiHandle, xpath + "/height");
         }
         else {
@@ -127,7 +127,7 @@ namespace generated
         }
 
         // read element filletRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/filletRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/filletRadius")) {
             m_filletRadius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/filletRadius");
         }
         else {
@@ -135,7 +135,7 @@ namespace generated
         }
 
         // read element reinforcementElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/reinforcementElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/reinforcementElementUID")) {
             m_reinforcementElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/reinforcementElementUID");
             if (m_reinforcementElementUID->empty()) {
                 LOG(WARNING) << "Optional element reinforcementElementUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSCutOutControlPoint.cpp
+++ b/src/generated/CPACSCutOutControlPoint.cpp
@@ -68,7 +68,7 @@ namespace generated
     void CPACSCutOutControlPoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element relHeight
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relHeight")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relHeight")) {
             m_relHeight = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relHeight");
         }
         else {
@@ -76,7 +76,7 @@ namespace generated
         }
 
         // read element xsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi")) {
             m_xsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi");
         }
         else {

--- a/src/generated/CPACSCutOutProfile.cpp
+++ b/src/generated/CPACSCutOutProfile.cpp
@@ -89,7 +89,7 @@ namespace generated
     void CPACSCutOutProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element profileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/profileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/profileUID")) {
             m_profileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/profileUID");
             if (m_profileUID.empty()) {
                 LOG(WARNING) << "Required element profileUID is empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element rotZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotZ")) {
             m_rotZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotZ");
         }
         else {

--- a/src/generated/CPACSDeckComponent2DBase.cpp
+++ b/src/generated/CPACSDeckComponent2DBase.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element deckElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deckElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deckElementUID")) {
             m_deckElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/deckElementUID");
             if (m_deckElementUID.empty()) {
                 LOG(WARNING) << "Required element deckElementUID is empty at xpath " << xpath;

--- a/src/generated/CPACSDeckElementBase.cpp
+++ b/src/generated/CPACSDeckElementBase.cpp
@@ -171,7 +171,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSDeckElementMass.cpp
+++ b/src/generated/CPACSDeckElementMass.cpp
@@ -139,7 +139,7 @@ namespace generated
         }
 
         // read element mass
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/mass")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/mass")) {
             m_mass = tixi::TixiGetElement<double>(tixiHandle, xpath + "/mass");
         }
         else {

--- a/src/generated/CPACSDeckStructuralMount.cpp
+++ b/src/generated/CPACSDeckStructuralMount.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element componentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/componentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/componentUID")) {
             m_componentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/componentUID");
             if (m_componentUID.empty()) {
                 LOG(WARNING) << "Required element componentUID is empty at xpath " << xpath;

--- a/src/generated/CPACSDoorAssemblyPosition.cpp
+++ b/src/generated/CPACSDoorAssemblyPosition.cpp
@@ -102,7 +102,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,12 +118,12 @@ namespace generated
         }
 
         // read element doorType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/doorType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/doorType")) {
             m_doorType = stringToCPACSDoorAssemblyPosition_doorType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/doorType"));
         }
 
         // read element doorElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/doorElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/doorElementUID")) {
             m_doorElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/doorElementUID");
             if (m_doorElementUID.empty()) {
                 LOG(WARNING) << "Required element doorElementUID is empty at xpath " << xpath;
@@ -135,7 +135,7 @@ namespace generated
         }
 
         // read element startFrameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startFrameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startFrameUID")) {
             m_startFrameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startFrameUID");
             if (m_startFrameUID.empty()) {
                 LOG(WARNING) << "Required element startFrameUID is empty at xpath " << xpath;
@@ -147,7 +147,7 @@ namespace generated
         }
 
         // read element endFrameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endFrameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endFrameUID")) {
             m_endFrameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/endFrameUID");
             if (m_endFrameUID.empty()) {
                 LOG(WARNING) << "Required element endFrameUID is empty at xpath " << xpath;
@@ -159,7 +159,7 @@ namespace generated
         }
 
         // read element startStringerUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startStringerUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startStringerUID")) {
             m_startStringerUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startStringerUID");
             if (m_startStringerUID.empty()) {
                 LOG(WARNING) << "Required element startStringerUID is empty at xpath " << xpath;
@@ -171,7 +171,7 @@ namespace generated
         }
 
         // read element endStringerUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endStringerUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endStringerUID")) {
             m_endStringerUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/endStringerUID");
             if (m_endStringerUID.empty()) {
                 LOG(WARNING) << "Required element endStringerUID is empty at xpath " << xpath;
@@ -183,22 +183,22 @@ namespace generated
         }
 
         // read element zBase
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/zBase")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/zBase")) {
             m_zBase = tixi::TixiGetElement<double>(tixiHandle, xpath + "/zBase");
         }
 
         // read element minWidth
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/minWidth")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/minWidth")) {
             m_minWidth = tixi::TixiGetElement<double>(tixiHandle, xpath + "/minWidth");
         }
 
         // read element minHeight
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/minHeight")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/minHeight")) {
             m_minHeight = tixi::TixiGetElement<double>(tixiHandle, xpath + "/minHeight");
         }
 
         // read element ySign
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ySign")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ySign")) {
             m_ySign = tixi::TixiGetElement<int>(tixiHandle, xpath + "/ySign");
         }
 

--- a/src/generated/CPACSDoorCutOut.cpp
+++ b/src/generated/CPACSDoorCutOut.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -114,12 +114,12 @@ namespace generated
         }
 
         // read element filletRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/filletRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/filletRadius")) {
             m_filletRadius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/filletRadius");
         }
 
         // read element dssDesignUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/dssDesignUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/dssDesignUID")) {
             m_dssDesignUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/dssDesignUID");
             if (m_dssDesignUID->empty()) {
                 LOG(WARNING) << "Optional element dssDesignUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSDoorSurroundStructurePosition.cpp
+++ b/src/generated/CPACSDoorSurroundStructurePosition.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element framesGapFront
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/framesGapFront")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/framesGapFront")) {
             m_framesGapFront = tixi::TixiGetElement<int>(tixiHandle, xpath + "/framesGapFront");
         }
         else {
@@ -123,7 +123,7 @@ namespace generated
         }
 
         // read element framesGapRear
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/framesGapRear")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/framesGapRear")) {
             m_framesGapRear = tixi::TixiGetElement<int>(tixiHandle, xpath + "/framesGapRear");
         }
         else {
@@ -131,7 +131,7 @@ namespace generated
         }
 
         // read element stringersGapPrimary
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/stringersGapPrimary")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/stringersGapPrimary")) {
             m_stringersGapPrimary = tixi::TixiGetElement<int>(tixiHandle, xpath + "/stringersGapPrimary");
         }
         else {
@@ -139,7 +139,7 @@ namespace generated
         }
 
         // read element stringersGapSecondary
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/stringersGapSecondary")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/stringersGapSecondary")) {
             m_stringersGapSecondary = tixi::TixiGetElement<int>(tixiHandle, xpath + "/stringersGapSecondary");
         }
         else {

--- a/src/generated/CPACSDoubleConstraintBase.cpp
+++ b/src/generated/CPACSDoubleConstraintBase.cpp
@@ -75,7 +75,7 @@ namespace generated
         }
 
         // read simpleContent 
-        if (tixi::TixiCheckElement(tixiHandle, xpath)) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath)) {
             m_value = tixi::TixiGetElement<double>(tixiHandle, xpath);
         }
         else {

--- a/src/generated/CPACSDuct.cpp
+++ b/src/generated/CPACSDuct.cpp
@@ -102,7 +102,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -113,7 +113,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSDuctAssembly.cpp
+++ b/src/generated/CPACSDuctAssembly.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSEllipsoidDome.cpp
+++ b/src/generated/CPACSEllipsoidDome.cpp
@@ -67,7 +67,7 @@ namespace generated
     void CPACSEllipsoidDome::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element halfAxisFraction
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/halfAxisFraction")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/halfAxisFraction")) {
             m_halfAxisFraction = tixi::TixiGetElement<double>(tixiHandle, xpath + "/halfAxisFraction");
         }
         else {

--- a/src/generated/CPACSEngine.cpp
+++ b/src/generated/CPACSEngine.cpp
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -114,7 +114,7 @@ namespace generated
         }
 
         // read element thrust00Scaling
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/thrust00Scaling")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/thrust00Scaling")) {
             m_thrust00Scaling = tixi::TixiGetElement<double>(tixiHandle, xpath + "/thrust00Scaling");
         }
 

--- a/src/generated/CPACSEnginePosition.cpp
+++ b/src/generated/CPACSEnginePosition.cpp
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -116,7 +116,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -124,7 +124,7 @@ namespace generated
         }
 
         // read element engineUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/engineUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/engineUID")) {
             m_engineUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/engineUID");
             if (m_engineUID.empty()) {
                 LOG(WARNING) << "Required element engineUID is empty at xpath " << xpath;
@@ -136,7 +136,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID.empty()) {
                 LOG(WARNING) << "Required element parentUID is empty at xpath " << xpath;

--- a/src/generated/CPACSEnginePylon.cpp
+++ b/src/generated/CPACSEnginePylon.cpp
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -120,7 +120,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID.empty()) {
                 LOG(WARNING) << "Required element parentUID is empty at xpath " << xpath;

--- a/src/generated/CPACSEnvironment.cpp
+++ b/src/generated/CPACSEnvironment.cpp
@@ -75,7 +75,7 @@ namespace generated
     void CPACSEnvironment::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element atmosphericModel
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/atmosphericModel")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/atmosphericModel")) {
             m_atmosphericModel = stringToCPACSAtmosphericModel(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/atmosphericModel"));
         }
         else {
@@ -83,7 +83,7 @@ namespace generated
         }
 
         // read element deltaTemperature
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/deltaTemperature")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/deltaTemperature")) {
             m_deltaTemperature = tixi::TixiGetElement<double>(tixiHandle, xpath + "/deltaTemperature");
         }
 

--- a/src/generated/CPACSEtaIsoLine.cpp
+++ b/src/generated/CPACSEtaIsoLine.cpp
@@ -211,7 +211,7 @@ namespace generated
     void CPACSEtaIsoLine::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element eta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/eta")) {
             m_eta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta");
         }
         else {
@@ -219,7 +219,7 @@ namespace generated
         }
 
         // read element referenceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceUID")) {
             m_referenceUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceUID");
             if (m_referenceUID.empty()) {
                 LOG(WARNING) << "Required element referenceUID is empty at xpath " << xpath;

--- a/src/generated/CPACSEtaXsiPoint.cpp
+++ b/src/generated/CPACSEtaXsiPoint.cpp
@@ -118,7 +118,7 @@ namespace generated
     void CPACSEtaXsiPoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element eta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/eta")) {
             m_eta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta");
         }
         else {
@@ -126,7 +126,7 @@ namespace generated
         }
 
         // read element xsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi")) {
             m_xsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi");
         }
         else {
@@ -134,7 +134,7 @@ namespace generated
         }
 
         // read element referenceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceUID")) {
             m_referenceUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceUID");
             if (m_referenceUID.empty()) {
                 LOG(WARNING) << "Required element referenceUID is empty at xpath " << xpath;

--- a/src/generated/CPACSEtaXsiRelHeightPoint.cpp
+++ b/src/generated/CPACSEtaXsiRelHeightPoint.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSEtaXsiRelHeightPoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element eta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/eta")) {
             m_eta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta");
         }
         else {
@@ -91,7 +91,7 @@ namespace generated
         }
 
         // read element xsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi")) {
             m_xsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi");
         }
         else {
@@ -99,12 +99,12 @@ namespace generated
         }
 
         // read element relHeight
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relHeight")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relHeight")) {
             m_relHeight = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relHeight");
         }
 
         // read element referenceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceUID")) {
             m_referenceUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceUID");
             if (m_referenceUID.empty()) {
                 LOG(WARNING) << "Required element referenceUID is empty at xpath " << xpath;

--- a/src/generated/CPACSFuelTank.cpp
+++ b/src/generated/CPACSFuelTank.cpp
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -116,7 +116,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -124,7 +124,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSFuelTankVolume.cpp
+++ b/src/generated/CPACSFuelTankVolume.cpp
@@ -61,7 +61,7 @@ namespace generated
     void CPACSFuelTankVolume::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element optimalVolume
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/optimalVolume")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/optimalVolume")) {
             m_optimalVolume = tixi::TixiGetElement<double>(tixiHandle, xpath + "/optimalVolume");
         }
         else {
@@ -69,22 +69,22 @@ namespace generated
         }
 
         // read element usableVolume
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/usableVolume")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/usableVolume")) {
             m_usableVolume_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/usableVolume");
         }
 
         // read element realVolume
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/realVolume")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/realVolume")) {
             m_realVolume_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/realVolume");
         }
 
         // read element useableVolumeFactor
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/useableVolumeFactor")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/useableVolumeFactor")) {
             m_useableVolumeFactor_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/useableVolumeFactor");
         }
 
         // read element realVolumeFactor
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/realVolumeFactor")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/realVolumeFactor")) {
             m_realVolumeFactor_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/realVolumeFactor");
         }
 

--- a/src/generated/CPACSFuselage.cpp
+++ b/src/generated/CPACSFuselage.cpp
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -125,7 +125,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSFuselageElement.cpp
+++ b/src/generated/CPACSFuselageElement.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element profileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/profileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/profileUID")) {
             m_profileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/profileUID");
             if (m_profileUID.empty()) {
                 LOG(WARNING) << "Required element profileUID is empty at xpath " << xpath;

--- a/src/generated/CPACSFuselageSection.cpp
+++ b/src/generated/CPACSFuselageSection.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSFuselageSegment.cpp
+++ b/src/generated/CPACSFuselageSegment.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element fromElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromElementUID")) {
             m_fromElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromElementUID");
             if (m_fromElementUID.empty()) {
                 LOG(WARNING) << "Required element fromElementUID is empty at xpath " << xpath;
@@ -130,7 +130,7 @@ namespace generated
         }
 
         // read element toElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toElementUID")) {
             m_toElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/toElementUID");
             if (m_toElementUID.empty()) {
                 LOG(WARNING) << "Required element toElementUID is empty at xpath " << xpath;

--- a/src/generated/CPACSGalleyElement.cpp
+++ b/src/generated/CPACSGalleyElement.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSGenericGeometricComponent.cpp
+++ b/src/generated/CPACSGenericGeometricComponent.cpp
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -116,7 +116,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -124,7 +124,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSGenericSystem.cpp
+++ b/src/generated/CPACSGenericSystem.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -120,7 +120,7 @@ namespace generated
         }
 
         // read element geometricBaseType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/geometricBaseType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/geometricBaseType")) {
             m_geometricBaseType = stringToCPACSGenericSystem_geometricBaseType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/geometricBaseType"));
         }
 

--- a/src/generated/CPACSGlobalBeamProperties.cpp
+++ b/src/generated/CPACSGlobalBeamProperties.cpp
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID.empty()) {
                 LOG(WARNING) << "Required element materialUID is empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element source
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/source")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/source")) {
             m_source = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/source");
             if (m_source.empty()) {
                 LOG(WARNING) << "Required element source is empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element consistancy
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/consistancy")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/consistancy")) {
             m_consistancy = tixi::TixiGetElement<bool>(tixiHandle, xpath + "/consistancy");
         }
         else {
@@ -164,7 +164,7 @@ namespace generated
         }
 
         // read element beamSpecificMass
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/beamSpecificMass")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/beamSpecificMass")) {
             m_beamSpecificMass = tixi::TixiGetElement<double>(tixiHandle, xpath + "/beamSpecificMass");
         }
 

--- a/src/generated/CPACSGlobalFlightPoint.cpp
+++ b/src/generated/CPACSGlobalFlightPoint.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -116,7 +116,7 @@ namespace generated
         }
 
         // read element altitude
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/altitude")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/altitude")) {
             m_altitude = tixi::TixiGetElement<double>(tixiHandle, xpath + "/altitude");
         }
         else {
@@ -124,17 +124,17 @@ namespace generated
         }
 
         // read element machNumber
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/machNumber")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/machNumber")) {
             m_machNumber_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/machNumber");
         }
 
         // read element calibratedAirSpeed
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/calibratedAirSpeed")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/calibratedAirSpeed")) {
             m_calibratedAirSpeed_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/calibratedAirSpeed");
         }
 
         // read element trueAirSpeed
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/trueAirSpeed")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/trueAirSpeed")) {
             m_trueAirSpeed_choice3 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/trueAirSpeed");
         }
 

--- a/src/generated/CPACSGuideCurve.cpp
+++ b/src/generated/CPACSGuideCurve.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element guideCurveProfileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/guideCurveProfileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/guideCurveProfileUID")) {
             m_guideCurveProfileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/guideCurveProfileUID");
             if (m_guideCurveProfileUID.empty()) {
                 LOG(WARNING) << "Required element guideCurveProfileUID is empty at xpath " << xpath;
@@ -128,7 +128,7 @@ namespace generated
         }
 
         // read element fromGuideCurveUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromGuideCurveUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromGuideCurveUID")) {
             m_fromGuideCurveUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromGuideCurveUID");
             if (m_fromGuideCurveUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element fromGuideCurveUID is present but empty at xpath " << xpath;
@@ -137,17 +137,17 @@ namespace generated
         }
 
         // read element continuity
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/continuity")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/continuity")) {
             m_continuity_choice1 = stringToCPACSGuideCurve_continuity(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/continuity"));
         }
 
         // read element fromRelativeCircumference
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromRelativeCircumference")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromRelativeCircumference")) {
             m_fromRelativeCircumference_choice2_1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fromRelativeCircumference");
         }
 
         // read element fromParameter
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromParameter")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromParameter")) {
             m_fromParameter_choice2_2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fromParameter");
         }
 
@@ -163,12 +163,12 @@ namespace generated
         }
 
         // read element toRelativeCircumference
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toRelativeCircumference")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toRelativeCircumference")) {
             m_toRelativeCircumference_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/toRelativeCircumference");
         }
 
         // read element toParameter
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toParameter")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toParameter")) {
             m_toParameter_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/toParameter");
         }
 

--- a/src/generated/CPACSGuideCurveProfileGeometry.cpp
+++ b/src/generated/CPACSGuideCurveProfileGeometry.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSHeader.cpp
+++ b/src/generated/CPACSHeader.cpp
@@ -67,7 +67,7 @@ namespace generated
     void CPACSHeader::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -78,7 +78,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -86,7 +86,7 @@ namespace generated
         }
 
         // read element version
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/version")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/version")) {
             m_version = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/version");
             if (m_version.empty()) {
                 LOG(WARNING) << "Required element version is empty at xpath " << xpath;
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element cpacsVersion
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/cpacsVersion")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/cpacsVersion")) {
             m_cpacsVersion = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/cpacsVersion");
             if (m_cpacsVersion->empty()) {
                 LOG(WARNING) << "Optional element cpacsVersion is present but empty at xpath " << xpath;

--- a/src/generated/CPACSInternalPressure.cpp
+++ b/src/generated/CPACSInternalPressure.cpp
@@ -88,7 +88,7 @@ namespace generated
     void CPACSInternalPressure::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element referenceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceUID")) {
             m_referenceUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceUID");
             if (m_referenceUID.empty()) {
                 LOG(WARNING) << "Required element referenceUID is empty at xpath " << xpath;
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element pressure
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/pressure")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/pressure")) {
             m_pressure = tixi::TixiGetElement<double>(tixiHandle, xpath + "/pressure");
         }
         else {

--- a/src/generated/CPACSIsotensoidDome.cpp
+++ b/src/generated/CPACSIsotensoidDome.cpp
@@ -67,7 +67,7 @@ namespace generated
     void CPACSIsotensoidDome::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element polarOpeningRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/polarOpeningRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/polarOpeningRadius")) {
             m_polarOpeningRadius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/polarOpeningRadius");
         }
         else {

--- a/src/generated/CPACSLandingGearBase.cpp
+++ b/src/generated/CPACSLandingGearBase.cpp
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -112,7 +112,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -120,7 +120,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;
@@ -151,17 +151,17 @@ namespace generated
         }
 
         // read element totalLength
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/totalLength")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/totalLength")) {
             m_totalLength_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/totalLength");
         }
 
         // read element staticSuspensionTravel
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/staticSuspensionTravel")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/staticSuspensionTravel")) {
             m_staticSuspensionTravel_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/staticSuspensionTravel");
         }
 
         // read element compressedSuspensionTravel
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/compressedSuspensionTravel")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/compressedSuspensionTravel")) {
             m_compressedSuspensionTravel_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/compressedSuspensionTravel");
         }
 

--- a/src/generated/CPACSLandingGearBrakingState.cpp
+++ b/src/generated/CPACSLandingGearBrakingState.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element controlParameterBraked
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlParameterBraked")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlParameterBraked")) {
             m_controlParameterBraked = tixi::TixiGetElement<double>(tixiHandle, xpath + "/controlParameterBraked");
         }
         else {
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element controlParameterReleased
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlParameterReleased")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlParameterReleased")) {
             m_controlParameterReleased = tixi::TixiGetElement<double>(tixiHandle, xpath + "/controlParameterReleased");
         }
         else {

--- a/src/generated/CPACSLandingGearControl.cpp
+++ b/src/generated/CPACSLandingGearControl.cpp
@@ -78,7 +78,7 @@ namespace generated
     void CPACSLandingGearControl::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element retractAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/retractAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/retractAngle")) {
             m_retractAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/retractAngle");
         }
 
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element offset
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/offset")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/offset")) {
             m_offset = tixi::TixiGetElement<double>(tixiHandle, xpath + "/offset");
         }
 

--- a/src/generated/CPACSLandingGearExtensionFunctionStep.cpp
+++ b/src/generated/CPACSLandingGearExtensionFunctionStep.cpp
@@ -62,7 +62,7 @@ namespace generated
     void CPACSLandingGearExtensionFunctionStep::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element stepType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/stepType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/stepType")) {
             m_stepType = stringToCPACSLandingGearExtensionFunctionStep_stepType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/stepType"));
         }
         else {
@@ -70,7 +70,7 @@ namespace generated
         }
 
         // read element controlParameter
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlParameter")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlParameter")) {
             m_controlParameter = tixi::TixiGetElement<double>(tixiHandle, xpath + "/controlParameter");
         }
         else {
@@ -78,7 +78,7 @@ namespace generated
         }
 
         // read element extensionAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/extensionAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/extensionAngle")) {
             m_extensionAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/extensionAngle");
         }
         else {

--- a/src/generated/CPACSLandingGearSteeringFunctionStep.cpp
+++ b/src/generated/CPACSLandingGearSteeringFunctionStep.cpp
@@ -62,7 +62,7 @@ namespace generated
     void CPACSLandingGearSteeringFunctionStep::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element stepType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/stepType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/stepType")) {
             m_stepType = stringToCPACSLandingGearSteeringFunctionStep_stepType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/stepType"));
         }
         else {
@@ -70,7 +70,7 @@ namespace generated
         }
 
         // read element controlParameter
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/controlParameter")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/controlParameter")) {
             m_controlParameter = tixi::TixiGetElement<double>(tixiHandle, xpath + "/controlParameter");
         }
         else {
@@ -78,7 +78,7 @@ namespace generated
         }
 
         // read element steeringAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/steeringAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/steeringAngle")) {
             m_steeringAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/steeringAngle");
         }
         else {

--- a/src/generated/CPACSLandingGearStrutAttachment.cpp
+++ b/src/generated/CPACSLandingGearStrutAttachment.cpp
@@ -82,7 +82,7 @@ namespace generated
     void CPACSLandingGearStrutAttachment::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sparSegmentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sparSegmentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sparSegmentUID")) {
             m_sparSegmentUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sparSegmentUID");
             if (m_sparSegmentUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element sparSegmentUID is present but empty at xpath " << xpath;
@@ -124,7 +124,7 @@ namespace generated
         }
 
         // read element ribDefinitionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribDefinitionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribDefinitionUID")) {
             m_ribDefinitionUID_choice5 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribDefinitionUID");
             if (m_ribDefinitionUID_choice5->empty()) {
                 LOG(WARNING) << "Optional element ribDefinitionUID is present but empty at xpath " << xpath;
@@ -133,7 +133,7 @@ namespace generated
         }
 
         // read element ribNumber
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribNumber")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribNumber")) {
             m_ribNumber_choice5 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/ribNumber");
         }
 

--- a/src/generated/CPACSLateralCap.cpp
+++ b/src/generated/CPACSLateralCap.cpp
@@ -92,7 +92,7 @@ namespace generated
     void CPACSLateralCap::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element area
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/area")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/area")) {
             m_area = tixi::TixiGetElement<double>(tixiHandle, xpath + "/area");
         }
         else {
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element placement
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/placement")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/placement")) {
             m_placement = stringToCPACSLateralCap_placement(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/placement"));
         }
         else {

--- a/src/generated/CPACSLeadingEdgeDevice.cpp
+++ b/src/generated/CPACSLeadingEdgeDevice.cpp
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -111,7 +111,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -119,7 +119,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID.empty()) {
                 LOG(WARNING) << "Required element parentUID is empty at xpath " << xpath;

--- a/src/generated/CPACSLeadingEdgeHollow.cpp
+++ b/src/generated/CPACSLeadingEdgeHollow.cpp
@@ -79,7 +79,7 @@ namespace generated
     void CPACSLeadingEdgeHollow::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element relHeightTE
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relHeightTE")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relHeightTE")) {
             m_relHeightTE = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relHeightTE");
         }
         else {
@@ -87,7 +87,7 @@ namespace generated
         }
 
         // read element xsiTE
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiTE")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiTE")) {
             m_xsiTE = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiTE");
         }
         else {

--- a/src/generated/CPACSLeadingEdgeShape.cpp
+++ b/src/generated/CPACSLeadingEdgeShape.cpp
@@ -81,7 +81,7 @@ namespace generated
     void CPACSLeadingEdgeShape::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element relHeightLE
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relHeightLE")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relHeightLE")) {
             m_relHeightLE = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relHeightLE");
         }
         else {
@@ -89,7 +89,7 @@ namespace generated
         }
 
         // read element xsiUpperSkin
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiUpperSkin")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiUpperSkin")) {
             m_xsiUpperSkin = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiUpperSkin");
         }
         else {
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element xsiLowerSkin
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsiLowerSkin")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsiLowerSkin")) {
             m_xsiLowerSkin = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsiLowerSkin");
         }
         else {

--- a/src/generated/CPACSLinkToFile.cpp
+++ b/src/generated/CPACSLinkToFile.cpp
@@ -80,7 +80,7 @@ namespace generated
         }
 
         // read simpleContent 
-        if (tixi::TixiCheckElement(tixiHandle, xpath)) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath)) {
             m_value = tixi::TixiGetElement<std::string>(tixiHandle, xpath);
             if (m_value.empty()) {
                 LOG(WARNING) << "Required element  is empty at xpath " << xpath;

--- a/src/generated/CPACSLongFloorBeamPosition.cpp
+++ b/src/generated/CPACSLongFloorBeamPosition.cpp
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element structuralElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementUID")) {
             m_structuralElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementUID");
             if (m_structuralElementUID.empty()) {
                 LOG(WARNING) << "Required element structuralElementUID is empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element crossBeamUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/crossBeamUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/crossBeamUID")) {
             m_crossBeamUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/crossBeamUID");
             if (m_crossBeamUID.empty()) {
                 LOG(WARNING) << "Required element crossBeamUID is empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element positionY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/positionY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/positionY")) {
             m_positionY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/positionY");
         }
         else {
@@ -137,12 +137,12 @@ namespace generated
         }
 
         // read element continuity
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/continuity")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/continuity")) {
             m_continuity = stringToCPACSContinuity(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/continuity"));
         }
 
         // read element interpolation
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/interpolation")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/interpolation")) {
             m_interpolation = stringToCPACSInterpolation(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/interpolation"));
         }
 

--- a/src/generated/CPACSMainActuator.cpp
+++ b/src/generated/CPACSMainActuator.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element actuatorUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/actuatorUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/actuatorUID")) {
             m_actuatorUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/actuatorUID");
             if (m_actuatorUID.empty()) {
                 LOG(WARNING) << "Required element actuatorUID is empty at xpath " << xpath;

--- a/src/generated/CPACSMassInertia.cpp
+++ b/src/generated/CPACSMassInertia.cpp
@@ -63,7 +63,7 @@ namespace generated
     void CPACSMassInertia::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element Jxx
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/Jxx")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/Jxx")) {
             m_Jxx = tixi::TixiGetElement<double>(tixiHandle, xpath + "/Jxx");
         }
         else {
@@ -71,7 +71,7 @@ namespace generated
         }
 
         // read element Jyy
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/Jyy")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/Jyy")) {
             m_Jyy = tixi::TixiGetElement<double>(tixiHandle, xpath + "/Jyy");
         }
         else {
@@ -79,7 +79,7 @@ namespace generated
         }
 
         // read element Jzz
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/Jzz")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/Jzz")) {
             m_Jzz = tixi::TixiGetElement<double>(tixiHandle, xpath + "/Jzz");
         }
         else {
@@ -87,17 +87,17 @@ namespace generated
         }
 
         // read element Jxy
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/Jxy")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/Jxy")) {
             m_Jxy = tixi::TixiGetElement<double>(tixiHandle, xpath + "/Jxy");
         }
 
         // read element Jxz
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/Jxz")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/Jxz")) {
             m_Jxz = tixi::TixiGetElement<double>(tixiHandle, xpath + "/Jxz");
         }
 
         // read element Jyz
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/Jyz")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/Jyz")) {
             m_Jyz = tixi::TixiGetElement<double>(tixiHandle, xpath + "/Jyz");
         }
 

--- a/src/generated/CPACSMaterialDefinition.cpp
+++ b/src/generated/CPACSMaterialDefinition.cpp
@@ -188,7 +188,7 @@ namespace generated
     void CPACSMaterialDefinition::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element compositeUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/compositeUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/compositeUID")) {
             m_compositeUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/compositeUID");
             if (m_compositeUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element compositeUID is present but empty at xpath " << xpath;
@@ -197,17 +197,17 @@ namespace generated
         }
 
         // read element orthotropyDirection
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/orthotropyDirection")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/orthotropyDirection")) {
             m_orthotropyDirection_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/orthotropyDirection");
         }
 
         // read element thicknessScaling
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/thicknessScaling")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/thicknessScaling")) {
             m_thicknessScaling_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/thicknessScaling");
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element materialUID is present but empty at xpath " << xpath;
@@ -216,7 +216,7 @@ namespace generated
         }
 
         // read element thickness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/thickness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/thickness")) {
             m_thickness_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/thickness");
         }
 

--- a/src/generated/CPACSMaterialDefinitionForProfileBased.cpp
+++ b/src/generated/CPACSMaterialDefinitionForProfileBased.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSMaterialDefinitionForProfileBased::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sheetUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sheetUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sheetUID")) {
             m_sheetUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sheetUID");
             if (m_sheetUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element sheetUID is present but empty at xpath " << xpath;
@@ -92,17 +92,17 @@ namespace generated
         }
 
         // read element standardProfileSheetID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/standardProfileSheetID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/standardProfileSheetID")) {
             m_standardProfileSheetID_choice2 = stringToCPACSMaterialDefinitionForProfileBased_standardProfileSheetID(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/standardProfileSheetID"));
         }
 
         // read element length
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/length")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/length")) {
             m_length_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/length");
         }
 
         // read element compositeUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/compositeUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/compositeUID")) {
             m_compositeUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/compositeUID");
             if (m_compositeUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element compositeUID is present but empty at xpath " << xpath;
@@ -111,17 +111,17 @@ namespace generated
         }
 
         // read element orthotropyDirection
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/orthotropyDirection")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/orthotropyDirection")) {
             m_orthotropyDirection_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/orthotropyDirection");
         }
 
         // read element thicknessScaling
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/thicknessScaling")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/thicknessScaling")) {
             m_thicknessScaling_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/thicknessScaling");
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element materialUID is present but empty at xpath " << xpath;
@@ -130,7 +130,7 @@ namespace generated
         }
 
         // read element thickness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/thickness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/thickness")) {
             m_thickness_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/thickness");
         }
 

--- a/src/generated/CPACSMaterialDefinitionForProfileBasedPoint.cpp
+++ b/src/generated/CPACSMaterialDefinitionForProfileBasedPoint.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSMaterialDefinitionForProfileBasedPoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element pointUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/pointUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/pointUID")) {
             m_pointUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/pointUID");
             if (m_pointUID->empty()) {
                 LOG(WARNING) << "Optional element pointUID is present but empty at xpath " << xpath;
@@ -92,7 +92,7 @@ namespace generated
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID.empty()) {
                 LOG(WARNING) << "Required element materialUID is empty at xpath " << xpath;
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element crossSectionArea
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/crossSectionArea")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/crossSectionArea")) {
             m_crossSectionArea = tixi::TixiGetElement<double>(tixiHandle, xpath + "/crossSectionArea");
         }
         else {
@@ -112,12 +112,12 @@ namespace generated
         }
 
         // read element optionalAux1
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/optionalAux1")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/optionalAux1")) {
             m_optionalAux1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/optionalAux1");
         }
 
         // read element optionalAux2
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/optionalAux2")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/optionalAux2")) {
             m_optionalAux2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/optionalAux2");
         }
 

--- a/src/generated/CPACSNacaProfile.cpp
+++ b/src/generated/CPACSNacaProfile.cpp
@@ -60,7 +60,7 @@ namespace generated
     void CPACSNacaProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element naca4DigitCode
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/naca4DigitCode")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/naca4DigitCode")) {
             m_naca4DigitCode_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/naca4DigitCode");
             if (m_naca4DigitCode_choice1->empty()) {
                 LOG(WARNING) << "Optional element naca4DigitCode is present but empty at xpath " << xpath;
@@ -68,7 +68,7 @@ namespace generated
         }
 
         // read element naca5DigitCode
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/naca5DigitCode")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/naca5DigitCode")) {
             m_naca5DigitCode_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/naca5DigitCode");
             if (m_naca5DigitCode_choice2->empty()) {
                 LOG(WARNING) << "Optional element naca5DigitCode is present but empty at xpath " << xpath;
@@ -76,7 +76,7 @@ namespace generated
         }
 
         // read element trailingEdgeThickness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/trailingEdgeThickness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/trailingEdgeThickness")) {
             m_trailingEdgeThickness = tixi::TixiGetElement<double>(tixiHandle, xpath + "/trailingEdgeThickness");
         }
 

--- a/src/generated/CPACSNacelleCenterCowl.cpp
+++ b/src/generated/CPACSNacelleCenterCowl.cpp
@@ -93,7 +93,7 @@ namespace generated
         }
 
         // read element xOffset
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xOffset")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xOffset")) {
             m_xOffset = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xOffset");
         }
         else {
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element curveUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/curveUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/curveUID")) {
             m_curveUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/curveUID");
             if (m_curveUID.empty()) {
                 LOG(WARNING) << "Required element curveUID is empty at xpath " << xpath;

--- a/src/generated/CPACSNacelleGuideCurve.cpp
+++ b/src/generated/CPACSNacelleGuideCurve.cpp
@@ -90,7 +90,7 @@ namespace generated
     void CPACSNacelleGuideCurve::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element guideCurveProfileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/guideCurveProfileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/guideCurveProfileUID")) {
             m_guideCurveProfileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/guideCurveProfileUID");
             if (m_guideCurveProfileUID.empty()) {
                 LOG(WARNING) << "Required element guideCurveProfileUID is empty at xpath " << xpath;
@@ -121,7 +121,7 @@ namespace generated
         }
 
         // read element startSectionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startSectionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startSectionUID")) {
             m_startSectionUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startSectionUID");
             if (m_startSectionUID.empty()) {
                 LOG(WARNING) << "Required element startSectionUID is empty at xpath " << xpath;
@@ -133,7 +133,7 @@ namespace generated
         }
 
         // read element fromZeta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromZeta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromZeta")) {
             m_fromZeta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fromZeta");
         }
         else {
@@ -141,7 +141,7 @@ namespace generated
         }
 
         // read element toZeta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toZeta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toZeta")) {
             m_toZeta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/toZeta");
         }
         else {

--- a/src/generated/CPACSNacelleSection.cpp
+++ b/src/generated/CPACSNacelleSection.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -126,7 +126,7 @@ namespace generated
         }
 
         // read element profileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/profileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/profileUID")) {
             m_profileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/profileUID");
             if (m_profileUID.empty()) {
                 LOG(WARNING) << "Required element profileUID is empty at xpath " << xpath;

--- a/src/generated/CPACSOuterCutOutProfile.cpp
+++ b/src/generated/CPACSOuterCutOutProfile.cpp
@@ -88,7 +88,7 @@ namespace generated
     void CPACSOuterCutOutProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element profileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/profileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/profileUID")) {
             m_profileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/profileUID");
             if (m_profileUID.empty()) {
                 LOG(WARNING) << "Required element profileUID is empty at xpath " << xpath;
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element rotZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotZ")) {
             m_rotZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotZ");
         }
         else {

--- a/src/generated/CPACSPiston.cpp
+++ b/src/generated/CPACSPiston.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element length
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/length")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/length")) {
             m_length = tixi::TixiGetElement<double>(tixiHandle, xpath + "/length");
         }
         else {
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element maxSpringDeflection
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/maxSpringDeflection")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/maxSpringDeflection")) {
             m_maxSpringDeflection = tixi::TixiGetElement<double>(tixiHandle, xpath + "/maxSpringDeflection");
         }
         else {
@@ -123,7 +123,7 @@ namespace generated
         }
 
         // read element compressedExternalLength
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/compressedExternalLength")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/compressedExternalLength")) {
             m_compressedExternalLength = tixi::TixiGetElement<double>(tixiHandle, xpath + "/compressedExternalLength");
         }
         else {

--- a/src/generated/CPACSPoint.cpp
+++ b/src/generated/CPACSPoint.cpp
@@ -168,17 +168,17 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
 
         // read element y
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/y")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/y")) {
             m_y = tixi::TixiGetElement<double>(tixiHandle, xpath + "/y");
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
 

--- a/src/generated/CPACSPointAbsRel.cpp
+++ b/src/generated/CPACSPointAbsRel.cpp
@@ -113,17 +113,17 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
 
         // read element y
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/y")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/y")) {
             m_y = tixi::TixiGetElement<double>(tixiHandle, xpath + "/y");
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
 

--- a/src/generated/CPACSPointPerformanceDefinition.cpp
+++ b/src/generated/CPACSPointPerformanceDefinition.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element segmentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/segmentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/segmentUID")) {
             m_segmentUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/segmentUID");
             if (m_segmentUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element segmentUID is present but empty at xpath " << xpath;
@@ -126,17 +126,17 @@ namespace generated
         }
 
         // read element massFraction
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/massFraction")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/massFraction")) {
             m_massFraction_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/massFraction");
         }
 
         // read element fuelFraction
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fuelFraction")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fuelFraction")) {
             m_fuelFraction_choice3 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/fuelFraction");
         }
 
         // read element typeOfPointPerformance
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/typeOfPointPerformance")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/typeOfPointPerformance")) {
             m_typeOfPointPerformance = stringToCPACSPointPerformanceDefinition_typeOfPointPerformance(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/typeOfPointPerformance"));
         }
         else {

--- a/src/generated/CPACSPointPerformanceRequirements.cpp
+++ b/src/generated/CPACSPointPerformanceRequirements.cpp
@@ -60,32 +60,32 @@ namespace generated
     void CPACSPointPerformanceRequirements::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sustainedLoadFactor
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sustainedLoadFactor")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sustainedLoadFactor")) {
             m_sustainedLoadFactor = tixi::TixiGetElement<double>(tixiHandle, xpath + "/sustainedLoadFactor");
         }
 
         // read element instantaneousLoadFactor
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/instantaneousLoadFactor")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/instantaneousLoadFactor")) {
             m_instantaneousLoadFactor = tixi::TixiGetElement<double>(tixiHandle, xpath + "/instantaneousLoadFactor");
         }
 
         // read element specificExcessPower
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/specificExcessPower")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/specificExcessPower")) {
             m_specificExcessPower = tixi::TixiGetElement<double>(tixiHandle, xpath + "/specificExcessPower");
         }
 
         // read element rollRate
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rollRate")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rollRate")) {
             m_rollRate = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rollRate");
         }
 
         // read element rollAccelerationOnset
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rollAccelerationOnset")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rollAccelerationOnset")) {
             m_rollAccelerationOnset = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rollAccelerationOnset");
         }
 
         // read element rollAccelerationStop
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rollAccelerationStop")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rollAccelerationStop")) {
             m_rollAccelerationStop = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rollAccelerationStop");
         }
 

--- a/src/generated/CPACSPointX.cpp
+++ b/src/generated/CPACSPointX.cpp
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
         else {

--- a/src/generated/CPACSPointXY.cpp
+++ b/src/generated/CPACSPointXY.cpp
@@ -146,7 +146,7 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
         else {
@@ -154,7 +154,7 @@ namespace generated
         }
 
         // read element y
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/y")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/y")) {
             m_y = tixi::TixiGetElement<double>(tixiHandle, xpath + "/y");
         }
         else {

--- a/src/generated/CPACSPointXYZ.cpp
+++ b/src/generated/CPACSPointXYZ.cpp
@@ -89,7 +89,7 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
         else {
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element y
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/y")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/y")) {
             m_y = tixi::TixiGetElement<double>(tixiHandle, xpath + "/y");
         }
         else {
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
         else {

--- a/src/generated/CPACSPointXZ.cpp
+++ b/src/generated/CPACSPointXZ.cpp
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
         else {
@@ -102,7 +102,7 @@ namespace generated
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
         else {

--- a/src/generated/CPACSPointZ.cpp
+++ b/src/generated/CPACSPointZ.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
         else {

--- a/src/generated/CPACSPosExcl0DoubleBase.cpp
+++ b/src/generated/CPACSPosExcl0DoubleBase.cpp
@@ -136,7 +136,7 @@ namespace generated
         }
 
         // read simpleContent 
-        if (tixi::TixiCheckElement(tixiHandle, xpath)) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath)) {
             m_value = tixi::TixiGetElement<double>(tixiHandle, xpath);
         }
         else {

--- a/src/generated/CPACSPosExcl0IntBase.cpp
+++ b/src/generated/CPACSPosExcl0IntBase.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read simpleContent 
-        if (tixi::TixiCheckElement(tixiHandle, xpath)) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath)) {
             m_value = tixi::TixiGetElement<int>(tixiHandle, xpath);
         }
         else {

--- a/src/generated/CPACSPositioning.cpp
+++ b/src/generated/CPACSPositioning.cpp
@@ -102,7 +102,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -113,7 +113,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -121,7 +121,7 @@ namespace generated
         }
 
         // read element length
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/length")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/length")) {
             m_length = tixi::TixiGetElement<double>(tixiHandle, xpath + "/length");
         }
         else {
@@ -129,7 +129,7 @@ namespace generated
         }
 
         // read element sweepAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sweepAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sweepAngle")) {
             m_sweepAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/sweepAngle");
         }
         else {
@@ -137,7 +137,7 @@ namespace generated
         }
 
         // read element dihedralAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/dihedralAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/dihedralAngle")) {
             m_dihedralAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/dihedralAngle");
         }
         else {
@@ -145,7 +145,7 @@ namespace generated
         }
 
         // read element fromSectionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromSectionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromSectionUID")) {
             m_fromSectionUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromSectionUID");
             if (m_fromSectionUID->empty()) {
                 LOG(WARNING) << "Optional element fromSectionUID is present but empty at xpath " << xpath;
@@ -154,7 +154,7 @@ namespace generated
         }
 
         // read element toSectionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toSectionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toSectionUID")) {
             m_toSectionUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/toSectionUID");
             if (m_toSectionUID.empty()) {
                 LOG(WARNING) << "Required element toSectionUID is empty at xpath " << xpath;

--- a/src/generated/CPACSPressureBulkhead.cpp
+++ b/src/generated/CPACSPressureBulkhead.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element sheetElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sheetElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sheetElementUID")) {
             m_sheetElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sheetElementUID");
             if (m_sheetElementUID.empty()) {
                 LOG(WARNING) << "Required element sheetElementUID is empty at xpath " << xpath;
@@ -129,12 +129,12 @@ namespace generated
         }
 
         // read element reinforcementNumberVertical
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/reinforcementNumberVertical")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/reinforcementNumberVertical")) {
             m_reinforcementNumberVertical_choice1 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/reinforcementNumberVertical");
         }
 
         // read element structuralElementVerticalUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementVerticalUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementVerticalUID")) {
             m_structuralElementVerticalUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementVerticalUID");
             if (m_structuralElementVerticalUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element structuralElementVerticalUID is present but empty at xpath " << xpath;
@@ -143,12 +143,12 @@ namespace generated
         }
 
         // read element reinforcementNumberHorizontal
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/reinforcementNumberHorizontal")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/reinforcementNumberHorizontal")) {
             m_reinforcementNumberHorizontal_choice1 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/reinforcementNumberHorizontal");
         }
 
         // read element structuralElementHorizontalUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementHorizontalUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementHorizontalUID")) {
             m_structuralElementHorizontalUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementHorizontalUID");
             if (m_structuralElementHorizontalUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element structuralElementHorizontalUID is present but empty at xpath " << xpath;
@@ -157,22 +157,22 @@ namespace generated
         }
 
         // read element bulkheadCalotteRadiusAtFrame
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/bulkheadCalotteRadiusAtFrame")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/bulkheadCalotteRadiusAtFrame")) {
             m_bulkheadCalotteRadiusAtFrame_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/bulkheadCalotteRadiusAtFrame");
         }
 
         // read element maxFlectionDepth
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/maxFlectionDepth")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/maxFlectionDepth")) {
             m_maxFlectionDepth_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/maxFlectionDepth");
         }
 
         // read element reinforcementNumberRadial
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/reinforcementNumberRadial")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/reinforcementNumberRadial")) {
             m_reinforcementNumberRadial_choice2 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/reinforcementNumberRadial");
         }
 
         // read element structuralElementRadialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementRadialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementRadialUID")) {
             m_structuralElementRadialUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementRadialUID");
             if (m_structuralElementRadialUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element structuralElementRadialUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSPressureBulkheadAssemblyPosition.cpp
+++ b/src/generated/CPACSPressureBulkheadAssemblyPosition.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element frameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/frameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/frameUID")) {
             m_frameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/frameUID");
             if (m_frameUID.empty()) {
                 LOG(WARNING) << "Required element frameUID is empty at xpath " << xpath;
@@ -111,7 +111,7 @@ namespace generated
         }
 
         // read element pressureBulkheadElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/pressureBulkheadElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/pressureBulkheadElementUID")) {
             m_pressureBulkheadElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/pressureBulkheadElementUID");
             if (m_pressureBulkheadElementUID.empty()) {
                 LOG(WARNING) << "Required element pressureBulkheadElementUID is empty at xpath " << xpath;

--- a/src/generated/CPACSProfileBasedStructuralElement.cpp
+++ b/src/generated/CPACSProfileBasedStructuralElement.cpp
@@ -101,7 +101,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -133,12 +133,12 @@ namespace generated
         }
 
         // read element standardProfileType
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/standardProfileType")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/standardProfileType")) {
             m_standardProfileType_choice2_1 = stringToCPACSProfileBasedStructuralElement_standardProfileType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/standardProfileType"));
         }
 
         // read element structuralProfileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralProfileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralProfileUID")) {
             m_structuralProfileUID_choice2_2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralProfileUID");
             if (m_structuralProfileUID_choice2_2->empty()) {
                 LOG(WARNING) << "Optional element structuralProfileUID is present but empty at xpath " << xpath;
@@ -152,7 +152,7 @@ namespace generated
         }
 
         // read element referencePointUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referencePointUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referencePointUID")) {
             m_referencePointUID_choice2_2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referencePointUID");
             if (m_referencePointUID_choice2_2->empty()) {
                 LOG(WARNING) << "Optional element referencePointUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSProfileGeometry.cpp
+++ b/src/generated/CPACSProfileGeometry.cpp
@@ -125,7 +125,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -136,7 +136,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSProfileGeometry2D.cpp
+++ b/src/generated/CPACSProfileGeometry2D.cpp
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -121,7 +121,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSRectangleProfile.cpp
+++ b/src/generated/CPACSRectangleProfile.cpp
@@ -67,7 +67,7 @@ namespace generated
     void CPACSRectangleProfile::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element cornerRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/cornerRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/cornerRadius")) {
             m_cornerRadius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/cornerRadius");
         }
 

--- a/src/generated/CPACSRelativeStrutPosition.cpp
+++ b/src/generated/CPACSRelativeStrutPosition.cpp
@@ -82,7 +82,7 @@ namespace generated
     void CPACSRelativeStrutPosition::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element strutUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/strutUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/strutUID")) {
             m_strutUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/strutUID");
             if (m_strutUID.empty()) {
                 LOG(WARNING) << "Required element strutUID is empty at xpath " << xpath;
@@ -94,7 +94,7 @@ namespace generated
         }
 
         // read element relativePosition
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relativePosition")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relativePosition")) {
             m_relativePosition = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relativePosition");
         }
         else {

--- a/src/generated/CPACSRibRotation.cpp
+++ b/src/generated/CPACSRibRotation.cpp
@@ -67,7 +67,7 @@ namespace generated
     void CPACSRibRotation::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element ribRotationReference
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribRotationReference")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribRotationReference")) {
             m_ribRotationReference = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribRotationReference");
             if (m_ribRotationReference->empty()) {
                 LOG(WARNING) << "Optional element ribRotationReference is present but empty at xpath " << xpath;
@@ -75,7 +75,7 @@ namespace generated
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
         else {

--- a/src/generated/CPACSRivet.cpp
+++ b/src/generated/CPACSRivet.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -113,7 +113,7 @@ namespace generated
         }
 
         // read element tensileStrength
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/tensileStrength")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/tensileStrength")) {
             m_tensileStrength = tixi::TixiGetElement<double>(tixiHandle, xpath + "/tensileStrength");
         }
         else {
@@ -121,7 +121,7 @@ namespace generated
         }
 
         // read element shearStrength
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/shearStrength")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/shearStrength")) {
             m_shearStrength = tixi::TixiGetElement<double>(tixiHandle, xpath + "/shearStrength");
         }
         else {

--- a/src/generated/CPACSRotationCurve.cpp
+++ b/src/generated/CPACSRotationCurve.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element referenceSectionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceSectionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceSectionUID")) {
             m_referenceSectionUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceSectionUID");
             if (m_referenceSectionUID.empty()) {
                 LOG(WARNING) << "Required element referenceSectionUID is empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element startZeta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startZeta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startZeta")) {
             m_startZeta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/startZeta");
         }
         else {
@@ -117,7 +117,7 @@ namespace generated
         }
 
         // read element endZeta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endZeta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endZeta")) {
             m_endZeta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/endZeta");
         }
         else {
@@ -125,7 +125,7 @@ namespace generated
         }
 
         // read element startZetaBlending
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startZetaBlending")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startZetaBlending")) {
             m_startZetaBlending = tixi::TixiGetElement<double>(tixiHandle, xpath + "/startZetaBlending");
         }
         else {
@@ -133,7 +133,7 @@ namespace generated
         }
 
         // read element endZetaBlending
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endZetaBlending")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endZetaBlending")) {
             m_endZetaBlending = tixi::TixiGetElement<double>(tixiHandle, xpath + "/endZetaBlending");
         }
         else {
@@ -141,7 +141,7 @@ namespace generated
         }
 
         // read element curveProfileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/curveProfileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/curveProfileUID")) {
             m_curveProfileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/curveProfileUID");
             if (m_curveProfileUID.empty()) {
                 LOG(WARNING) << "Required element curveProfileUID is empty at xpath " << xpath;

--- a/src/generated/CPACSRotor.cpp
+++ b/src/generated/CPACSRotor.cpp
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -116,7 +116,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -124,7 +124,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;
@@ -133,12 +133,12 @@ namespace generated
         }
 
         // read element type
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/type")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/type")) {
             m_type = stringToCPACSRotor_type(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/type"));
         }
 
         // read element nominalRotationsPerMinute
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/nominalRotationsPerMinute")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/nominalRotationsPerMinute")) {
             m_nominalRotationsPerMinute = tixi::TixiGetElement<double>(tixiHandle, xpath + "/nominalRotationsPerMinute");
         }
 

--- a/src/generated/CPACSRotorBladeAttachment.cpp
+++ b/src/generated/CPACSRotorBladeAttachment.cpp
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -125,7 +125,7 @@ namespace generated
         }
 
         // read element numberOfBlades
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/numberOfBlades")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/numberOfBlades")) {
             m_numberOfBlades_choice2 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/numberOfBlades");
         }
 
@@ -141,7 +141,7 @@ namespace generated
         }
 
         // read element rotorBladeUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotorBladeUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotorBladeUID")) {
             m_rotorBladeUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/rotorBladeUID");
             if (m_rotorBladeUID.empty()) {
                 LOG(WARNING) << "Required element rotorBladeUID is empty at xpath " << xpath;

--- a/src/generated/CPACSRotorHub.cpp
+++ b/src/generated/CPACSRotorHub.cpp
@@ -90,7 +90,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -98,7 +98,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element type
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/type")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/type")) {
             m_type = stringToTiglRotorHubType(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/type"));
         }
 

--- a/src/generated/CPACSRotorHubHinge.cpp
+++ b/src/generated/CPACSRotorHubHinge.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -120,7 +120,7 @@ namespace generated
         }
 
         // read element type
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/type")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/type")) {
             m_type = stringToCPACSRotorHubHinge_type(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/type"));
         }
         else {
@@ -128,22 +128,22 @@ namespace generated
         }
 
         // read element neutralPosition
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/neutralPosition")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/neutralPosition")) {
             m_neutralPosition = tixi::TixiGetElement<double>(tixiHandle, xpath + "/neutralPosition");
         }
 
         // read element staticStiffness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/staticStiffness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/staticStiffness")) {
             m_staticStiffness = tixi::TixiGetElement<double>(tixiHandle, xpath + "/staticStiffness");
         }
 
         // read element dynamicStiffness
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/dynamicStiffness")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/dynamicStiffness")) {
             m_dynamicStiffness = tixi::TixiGetElement<double>(tixiHandle, xpath + "/dynamicStiffness");
         }
 
         // read element damping
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/damping")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/damping")) {
             m_damping = tixi::TixiGetElement<double>(tixiHandle, xpath + "/damping");
         }
 

--- a/src/generated/CPACSRotorcraftModel.cpp
+++ b/src/generated/CPACSRotorcraftModel.cpp
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSSeatElement.cpp
+++ b/src/generated/CPACSSeatElement.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSSheet.cpp
+++ b/src/generated/CPACSSheet.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name->empty()) {
                 LOG(WARNING) << "Optional element name is present but empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element fromPointUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromPointUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromPointUID")) {
             m_fromPointUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromPointUID");
             if (m_fromPointUID.empty()) {
                 LOG(WARNING) << "Required element fromPointUID is empty at xpath " << xpath;
@@ -127,7 +127,7 @@ namespace generated
         }
 
         // read element continuityAtP1
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/continuityAtP1")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/continuityAtP1")) {
             m_continuityAtP1 = stringToCPACSContinuityAtP(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/continuityAtP1"));
         }
 
@@ -143,7 +143,7 @@ namespace generated
         }
 
         // read element toPointUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toPointUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toPointUID")) {
             m_toPointUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/toPointUID");
             if (m_toPointUID.empty()) {
                 LOG(WARNING) << "Required element toPointUID is empty at xpath " << xpath;
@@ -155,7 +155,7 @@ namespace generated
         }
 
         // read element continuityAtP2
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/continuityAtP2")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/continuityAtP2")) {
             m_continuityAtP2 = stringToCPACSContinuityAtP(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/continuityAtP2"));
         }
 

--- a/src/generated/CPACSSheet3D.cpp
+++ b/src/generated/CPACSSheet3D.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSSheetPoints.cpp
+++ b/src/generated/CPACSSheetPoints.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSSheetPoints::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sheetPointUID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sheetPointUID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sheetPointUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/sheetPointUID", m_sheetPointUIDs, 3, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_sheetPointUIDs.begin(); it != m_sheetPointUIDs.end(); ++it) {

--- a/src/generated/CPACSSheetPoints.cpp
+++ b/src/generated/CPACSSheetPoints.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSSheetPoints::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sheetPointUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sheetPointUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sheetPointUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/sheetPointUID", m_sheetPointUIDs, 3, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_sheetPointUIDs.begin(); it != m_sheetPointUIDs.end(); ++it) {

--- a/src/generated/CPACSSkin.cpp
+++ b/src/generated/CPACSSkin.cpp
@@ -112,7 +112,7 @@ namespace generated
     void CPACSSkin::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element standardSheetElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/standardSheetElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/standardSheetElementUID")) {
             m_standardSheetElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/standardSheetElementUID");
             if (m_standardSheetElementUID->empty()) {
                 LOG(WARNING) << "Optional element standardSheetElementUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSSkinSegment.cpp
+++ b/src/generated/CPACSSkinSegment.cpp
@@ -102,7 +102,7 @@ namespace generated
         }
 
         // read element sheetElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sheetElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sheetElementUID")) {
             m_sheetElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sheetElementUID");
             if (m_sheetElementUID.empty()) {
                 LOG(WARNING) << "Required element sheetElementUID is empty at xpath " << xpath;
@@ -114,7 +114,7 @@ namespace generated
         }
 
         // read element startFrameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startFrameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startFrameUID")) {
             m_startFrameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startFrameUID");
             if (m_startFrameUID.empty()) {
                 LOG(WARNING) << "Required element startFrameUID is empty at xpath " << xpath;
@@ -126,7 +126,7 @@ namespace generated
         }
 
         // read element endFrameUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endFrameUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endFrameUID")) {
             m_endFrameUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/endFrameUID");
             if (m_endFrameUID.empty()) {
                 LOG(WARNING) << "Required element endFrameUID is empty at xpath " << xpath;
@@ -138,7 +138,7 @@ namespace generated
         }
 
         // read element startStringerUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startStringerUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startStringerUID")) {
             m_startStringerUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startStringerUID");
             if (m_startStringerUID.empty()) {
                 LOG(WARNING) << "Required element startStringerUID is empty at xpath " << xpath;
@@ -150,7 +150,7 @@ namespace generated
         }
 
         // read element endStringerUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endStringerUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endStringerUID")) {
             m_endStringerUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/endStringerUID");
             if (m_endStringerUID->empty()) {
                 LOG(WARNING) << "Optional element endStringerUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSSparCell.cpp
+++ b/src/generated/CPACSSparCell.cpp
@@ -156,7 +156,7 @@ namespace generated
         }
 
         // read element rotation
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotation")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotation")) {
             m_rotation = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotation");
         }
         else {

--- a/src/generated/CPACSSparCrossSection.cpp
+++ b/src/generated/CPACSSparCrossSection.cpp
@@ -150,7 +150,7 @@ namespace generated
         }
 
         // read element rotation
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/rotation")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/rotation")) {
             m_rotation = tixi::TixiGetElement<double>(tixiHandle, xpath + "/rotation");
         }
         else {

--- a/src/generated/CPACSSparPositionUIDs.cpp
+++ b/src/generated/CPACSSparPositionUIDs.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSSparPositionUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sparPositionUID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sparPositionUID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sparPositionUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/sparPositionUID", m_sparPositionUIDs, 2, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_sparPositionUIDs.begin(); it != m_sparPositionUIDs.end(); ++it) {

--- a/src/generated/CPACSSparPositionUIDs.cpp
+++ b/src/generated/CPACSSparPositionUIDs.cpp
@@ -83,7 +83,7 @@ namespace generated
     void CPACSSparPositionUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element sparPositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sparPositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sparPositionUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/sparPositionUID", m_sparPositionUIDs, 2, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_sparPositionUIDs.begin(); it != m_sparPositionUIDs.end(); ++it) {

--- a/src/generated/CPACSSparSegment.cpp
+++ b/src/generated/CPACSSparSegment.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSStringVectorBase.cpp
+++ b/src/generated/CPACSStringVectorBase.cpp
@@ -223,7 +223,7 @@ namespace generated
         }
 
         // read simpleContent 
-        if (tixi::TixiCheckElement(tixiHandle, xpath)) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath)) {
             m_value = tixi::TixiGetElement<std::string>(tixiHandle, xpath);
             if (m_value.empty()) {
                 LOG(WARNING) << "Required element  is empty at xpath " << xpath;

--- a/src/generated/CPACSStringerFramePosition.cpp
+++ b/src/generated/CPACSStringerFramePosition.cpp
@@ -115,7 +115,7 @@ namespace generated
         }
 
         // read element structuralElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementUID")) {
             m_structuralElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementUID");
             if (m_structuralElementUID.empty()) {
                 LOG(WARNING) << "Required element structuralElementUID is empty at xpath " << xpath;
@@ -127,12 +127,12 @@ namespace generated
         }
 
         // read element positionX
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/positionX")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/positionX")) {
             m_positionX_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/positionX");
         }
 
         // read element sectionElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sectionElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sectionElementUID")) {
             m_sectionElementUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sectionElementUID");
             if (m_sectionElementUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element sectionElementUID is present but empty at xpath " << xpath;
@@ -141,7 +141,7 @@ namespace generated
         }
 
         // read element referenceY
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceY")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceY")) {
             m_referenceY = tixi::TixiGetElement<double>(tixiHandle, xpath + "/referenceY");
         }
         else {
@@ -149,7 +149,7 @@ namespace generated
         }
 
         // read element referenceZ
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceZ")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceZ")) {
             m_referenceZ = tixi::TixiGetElement<double>(tixiHandle, xpath + "/referenceZ");
         }
         else {
@@ -157,7 +157,7 @@ namespace generated
         }
 
         // read element referenceAngle
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceAngle")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceAngle")) {
             m_referenceAngle = tixi::TixiGetElement<double>(tixiHandle, xpath + "/referenceAngle");
         }
         else {
@@ -176,12 +176,12 @@ namespace generated
         }
 
         // read element continuity
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/continuity")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/continuity")) {
             m_continuity = stringToCPACSContinuity(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/continuity"));
         }
 
         // read element interpolation
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/interpolation")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/interpolation")) {
             m_interpolation = stringToCPACSInterpolation(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/interpolation"));
         }
 

--- a/src/generated/CPACSStringerFramePositionUIDs.cpp
+++ b/src/generated/CPACSStringerFramePositionUIDs.cpp
@@ -89,7 +89,7 @@ namespace generated
     void CPACSStringerFramePositionUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element stringerFramePositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/stringerFramePositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/stringerFramePositionUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/stringerFramePositionUID", m_stringerFramePositionUIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_stringerFramePositionUIDs.begin(); it != m_stringerFramePositionUIDs.end(); ++it) {

--- a/src/generated/CPACSStringerFramePositionUIDs.cpp
+++ b/src/generated/CPACSStringerFramePositionUIDs.cpp
@@ -89,7 +89,7 @@ namespace generated
     void CPACSStringerFramePositionUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element stringerFramePositionUID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/stringerFramePositionUID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/stringerFramePositionUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/stringerFramePositionUID", m_stringerFramePositionUIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_stringerFramePositionUIDs.begin(); it != m_stringerFramePositionUIDs.end(); ++it) {

--- a/src/generated/CPACSStructuralProfile.cpp
+++ b/src/generated/CPACSStructuralProfile.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSStructuralProfile3D.cpp
+++ b/src/generated/CPACSStructuralProfile3D.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSStructuralWallElement.cpp
+++ b/src/generated/CPACSStructuralWallElement.cpp
@@ -92,7 +92,7 @@ namespace generated
         }
 
         // read element sheetElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sheetElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sheetElementUID")) {
             m_sheetElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sheetElementUID");
             if (m_sheetElementUID.empty()) {
                 LOG(WARNING) << "Required element sheetElementUID is empty at xpath " << xpath;

--- a/src/generated/CPACSStrut.cpp
+++ b/src/generated/CPACSStrut.cpp
@@ -89,12 +89,12 @@ namespace generated
     void CPACSStrut::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element radius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/radius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/radius")) {
             m_radius_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/radius");
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element materialUID is present but empty at xpath " << xpath;
@@ -103,12 +103,12 @@ namespace generated
         }
 
         // read element innerRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/innerRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/innerRadius")) {
             m_innerRadius_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/innerRadius");
         }
 
         // read element structuralElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementUID")) {
             m_structuralElementUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementUID");
             if (m_structuralElementUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element structuralElementUID is present but empty at xpath " << xpath;
@@ -128,7 +128,7 @@ namespace generated
         }
 
         // read element length
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/length")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/length")) {
             m_length = tixi::TixiGetElement<double>(tixiHandle, xpath + "/length");
         }
         else {

--- a/src/generated/CPACSStrutAssembly.cpp
+++ b/src/generated/CPACSStrutAssembly.cpp
@@ -137,7 +137,7 @@ namespace generated
         }
 
         // read element mainStrutRelativePosition
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/mainStrutRelativePosition")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/mainStrutRelativePosition")) {
             m_mainStrutRelativePosition = tixi::TixiGetElement<double>(tixiHandle, xpath + "/mainStrutRelativePosition");
         }
         else {
@@ -189,7 +189,7 @@ namespace generated
         }
 
         // read element actuatorUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/actuatorUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/actuatorUID")) {
             m_actuatorUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/actuatorUID");
             if (m_actuatorUID->empty()) {
                 LOG(WARNING) << "Optional element actuatorUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSStrutProperties.cpp
+++ b/src/generated/CPACSStrutProperties.cpp
@@ -128,12 +128,12 @@ namespace generated
     void CPACSStrutProperties::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element radius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/radius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/radius")) {
             m_radius_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/radius");
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element materialUID is present but empty at xpath " << xpath;
@@ -142,12 +142,12 @@ namespace generated
         }
 
         // read element innerRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/innerRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/innerRadius")) {
             m_innerRadius_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/innerRadius");
         }
 
         // read element structuralElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralElementUID")) {
             m_structuralElementUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralElementUID");
             if (m_structuralElementUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element structuralElementUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSSuperEllipseProfile.cpp
+++ b/src/generated/CPACSSuperEllipseProfile.cpp
@@ -103,7 +103,7 @@ namespace generated
         }
 
         // read element lowerHeightFraction
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/lowerHeightFraction")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/lowerHeightFraction")) {
             m_lowerHeightFraction = tixi::TixiGetElement<double>(tixiHandle, xpath + "/lowerHeightFraction");
         }
         else {

--- a/src/generated/CPACSTorisphericalDome.cpp
+++ b/src/generated/CPACSTorisphericalDome.cpp
@@ -68,7 +68,7 @@ namespace generated
     void CPACSTorisphericalDome::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element dishRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/dishRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/dishRadius")) {
             m_dishRadius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/dishRadius");
         }
         else {
@@ -76,7 +76,7 @@ namespace generated
         }
 
         // read element knuckleRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/knuckleRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/knuckleRadius")) {
             m_knuckleRadius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/knuckleRadius");
         }
         else {

--- a/src/generated/CPACSTrackActuator.cpp
+++ b/src/generated/CPACSTrackActuator.cpp
@@ -93,7 +93,7 @@ namespace generated
         }
 
         // read element actuatorUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/actuatorUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/actuatorUID")) {
             m_actuatorUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/actuatorUID");
             if (m_actuatorUID.empty()) {
                 LOG(WARNING) << "Required element actuatorUID is empty at xpath " << xpath;

--- a/src/generated/CPACSTrackJointCoordinates.cpp
+++ b/src/generated/CPACSTrackJointCoordinates.cpp
@@ -68,7 +68,7 @@ namespace generated
     void CPACSTrackJointCoordinates::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = stringToCPACSTrackJointCoordinates_name(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name"));
         }
         else {
@@ -76,7 +76,7 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
         else {
@@ -84,12 +84,12 @@ namespace generated
         }
 
         // read element dy
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/dy")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/dy")) {
             m_dy = tixi::TixiGetElement<double>(tixiHandle, xpath + "/dy");
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
         else {

--- a/src/generated/CPACSTrackSecondaryStructure.cpp
+++ b/src/generated/CPACSTrackSecondaryStructure.cpp
@@ -87,7 +87,7 @@ namespace generated
     void CPACSTrackSecondaryStructure::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID.empty()) {
                 LOG(WARNING) << "Required element materialUID is empty at xpath " << xpath;

--- a/src/generated/CPACSTrackStrut.cpp
+++ b/src/generated/CPACSTrackStrut.cpp
@@ -88,7 +88,7 @@ namespace generated
     void CPACSTrackStrut::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = stringToCPACSTrackStrut_name(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name"));
         }
         else {
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element materialUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/materialUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/materialUID")) {
             m_materialUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/materialUID");
             if (m_materialUID.empty()) {
                 LOG(WARNING) << "Required element materialUID is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element profileUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/profileUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/profileUID")) {
             m_profileUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/profileUID");
             if (m_profileUID.empty()) {
                 LOG(WARNING) << "Required element profileUID is empty at xpath " << xpath;

--- a/src/generated/CPACSTrailingEdgeDevice.cpp
+++ b/src/generated/CPACSTrailingEdgeDevice.cpp
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -111,7 +111,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -119,7 +119,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID.empty()) {
                 LOG(WARNING) << "Required element parentUID is empty at xpath " << xpath;

--- a/src/generated/CPACSUIDSequence.cpp
+++ b/src/generated/CPACSUIDSequence.cpp
@@ -99,7 +99,7 @@ namespace generated
     void CPACSUIDSequence::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element uID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/uID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/uID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/uID", m_uIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_uIDs.begin(); it != m_uIDs.end(); ++it) {

--- a/src/generated/CPACSUIDSequence.cpp
+++ b/src/generated/CPACSUIDSequence.cpp
@@ -99,7 +99,7 @@ namespace generated
     void CPACSUIDSequence::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element uID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/uID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/uID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/uID", m_uIDs, 1, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_uIDs.begin(); it != m_uIDs.end(); ++it) {

--- a/src/generated/CPACSVehicleConfiguration.cpp
+++ b/src/generated/CPACSVehicleConfiguration.cpp
@@ -95,7 +95,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSVersionInfo.cpp
+++ b/src/generated/CPACSVersionInfo.cpp
@@ -78,7 +78,7 @@ namespace generated
         }
 
         // read element cpacsVersion
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/cpacsVersion")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/cpacsVersion")) {
             m_cpacsVersion = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/cpacsVersion");
             if (m_cpacsVersion.empty()) {
                 LOG(WARNING) << "Required element cpacsVersion is empty at xpath " << xpath;
@@ -89,7 +89,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description.empty()) {
                 LOG(WARNING) << "Required element description is empty at xpath " << xpath;
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element timestamp
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/timestamp")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/timestamp")) {
             m_timestamp = tixi::TixiGetElement<std::time_t>(tixiHandle, xpath + "/timestamp");
         }
         else {
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element creator
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/creator")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/creator")) {
             m_creator = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/creator");
             if (m_creator.empty()) {
                 LOG(WARNING) << "Required element creator is empty at xpath " << xpath;

--- a/src/generated/CPACSVessel.cpp
+++ b/src/generated/CPACSVessel.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -145,12 +145,12 @@ namespace generated
         }
 
         // read element cylinderRadius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/cylinderRadius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/cylinderRadius")) {
             m_cylinderRadius_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/cylinderRadius");
         }
 
         // read element cylinderLength
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/cylinderLength")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/cylinderLength")) {
             m_cylinderLength_choice2 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/cylinderLength");
         }
 
@@ -188,7 +188,7 @@ namespace generated
         }
 
         // read element burstPressure
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/burstPressure")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/burstPressure")) {
             m_burstPressure = tixi::TixiGetElement<double>(tixiHandle, xpath + "/burstPressure");
         }
 

--- a/src/generated/CPACSWallPosition.cpp
+++ b/src/generated/CPACSWallPosition.cpp
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element bulkheadUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/bulkheadUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/bulkheadUID")) {
             m_bulkheadUID_choice1 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/bulkheadUID");
             if (m_bulkheadUID_choice1->empty()) {
                 LOG(WARNING) << "Optional element bulkheadUID is present but empty at xpath " << xpath;
@@ -109,7 +109,7 @@ namespace generated
         }
 
         // read element wallSegmentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/wallSegmentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/wallSegmentUID")) {
             m_wallSegmentUID_choice2 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/wallSegmentUID");
             if (m_wallSegmentUID_choice2->empty()) {
                 LOG(WARNING) << "Optional element wallSegmentUID is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element fuselageSectionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fuselageSectionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fuselageSectionUID")) {
             m_fuselageSectionUID_choice3 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fuselageSectionUID");
             if (m_fuselageSectionUID_choice3->empty()) {
                 LOG(WARNING) << "Optional element fuselageSectionUID is present but empty at xpath " << xpath;
@@ -127,7 +127,7 @@ namespace generated
         }
 
         // read element sectionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/sectionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/sectionUID")) {
             m_sectionUID_choice4 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/sectionUID");
             if (m_sectionUID_choice4->empty()) {
                 LOG(WARNING) << "Optional element sectionUID is present but empty at xpath " << xpath;
@@ -136,12 +136,12 @@ namespace generated
         }
 
         // read element x
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/x")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/x")) {
             m_x_choice5 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/x");
         }
 
         // read element y
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/y")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/y")) {
             m_y = tixi::TixiGetElement<double>(tixiHandle, xpath + "/y");
         }
         else {
@@ -149,7 +149,7 @@ namespace generated
         }
 
         // read element z
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/z")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/z")) {
             m_z = tixi::TixiGetElement<double>(tixiHandle, xpath + "/z");
         }
         else {

--- a/src/generated/CPACSWallPositionUIDs.cpp
+++ b/src/generated/CPACSWallPositionUIDs.cpp
@@ -95,7 +95,7 @@ namespace generated
     void CPACSWallPositionUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element wallPositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/wallPositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/wallPositionUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/wallPositionUID", m_wallPositionUIDs, 2, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_wallPositionUIDs.begin(); it != m_wallPositionUIDs.end(); ++it) {

--- a/src/generated/CPACSWallPositionUIDs.cpp
+++ b/src/generated/CPACSWallPositionUIDs.cpp
@@ -95,7 +95,7 @@ namespace generated
     void CPACSWallPositionUIDs::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element wallPositionUID
-        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/wallPositionUID")) {
+        if (tixi::TixiCheckElement(tixiHandle, xpath + "/wallPositionUID")) {
             tixi::TixiReadElements(tixiHandle, xpath + "/wallPositionUID", m_wallPositionUIDs, 2, tixi::xsdUnbounded);
             if (m_uidMgr) {
                 for (std::vector<std::string>::iterator it = m_wallPositionUIDs.begin(); it != m_wallPositionUIDs.end(); ++it) {

--- a/src/generated/CPACSWallSegment.cpp
+++ b/src/generated/CPACSWallSegment.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element phi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/phi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/phi")) {
             m_phi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/phi");
         }
         else {
@@ -105,17 +105,17 @@ namespace generated
         }
 
         // read element doubleSidedExtrusion
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/doubleSidedExtrusion")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/doubleSidedExtrusion")) {
             m_doubleSidedExtrusion = tixi::TixiGetElement<bool>(tixiHandle, xpath + "/doubleSidedExtrusion");
         }
 
         // read element flushConnectionStart
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/flushConnectionStart")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/flushConnectionStart")) {
             m_flushConnectionStart = tixi::TixiGetElement<bool>(tixiHandle, xpath + "/flushConnectionStart");
         }
 
         // read element flushConnectionEnd
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/flushConnectionEnd")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/flushConnectionEnd")) {
             m_flushConnectionEnd = tixi::TixiGetElement<bool>(tixiHandle, xpath + "/flushConnectionEnd");
         }
 
@@ -131,7 +131,7 @@ namespace generated
         }
 
         // read element structuralWallElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/structuralWallElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/structuralWallElementUID")) {
             m_structuralWallElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/structuralWallElementUID");
             if (m_structuralWallElementUID->empty()) {
                 LOG(WARNING) << "Optional element structuralWallElementUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSWeb.cpp
+++ b/src/generated/CPACSWeb.cpp
@@ -106,7 +106,7 @@ namespace generated
         }
 
         // read element relPos
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relPos")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relPos")) {
             m_relPos = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relPos");
         }
         else {

--- a/src/generated/CPACSWheel.cpp
+++ b/src/generated/CPACSWheel.cpp
@@ -92,7 +92,7 @@ namespace generated
         }
 
         // read element radius
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/radius")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/radius")) {
             m_radius = tixi::TixiGetElement<double>(tixiHandle, xpath + "/radius");
         }
         else {
@@ -100,7 +100,7 @@ namespace generated
         }
 
         // read element width
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/width")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/width")) {
             m_width = tixi::TixiGetElement<double>(tixiHandle, xpath + "/width");
         }
         else {
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element braked
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/braked")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/braked")) {
             m_braked = tixi::TixiGetElement<bool>(tixiHandle, xpath + "/braked");
         }
         else {

--- a/src/generated/CPACSWing.cpp
+++ b/src/generated/CPACSWing.cpp
@@ -119,7 +119,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -130,7 +130,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -138,7 +138,7 @@ namespace generated
         }
 
         // read element parentUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/parentUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/parentUID")) {
             m_parentUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/parentUID");
             if (m_parentUID->empty()) {
                 LOG(WARNING) << "Optional element parentUID is present but empty at xpath " << xpath;

--- a/src/generated/CPACSWingAttachmentPositioning.cpp
+++ b/src/generated/CPACSWingAttachmentPositioning.cpp
@@ -67,7 +67,7 @@ namespace generated
     void CPACSWingAttachmentPositioning::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element relHeight
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/relHeight")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/relHeight")) {
             m_relHeight = tixi::TixiGetElement<double>(tixiHandle, xpath + "/relHeight");
         }
         else {
@@ -75,12 +75,12 @@ namespace generated
         }
 
         // read element eta
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/eta")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/eta")) {
             m_eta = tixi::TixiGetElement<double>(tixiHandle, xpath + "/eta");
         }
 
         // read element xsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi")) {
             m_xsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi");
         }
 

--- a/src/generated/CPACSWingElement.cpp
+++ b/src/generated/CPACSWingElement.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element airfoilUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/airfoilUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/airfoilUID")) {
             m_airfoilUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/airfoilUID");
             if (m_airfoilUID.empty()) {
                 LOG(WARNING) << "Required element airfoilUID is empty at xpath " << xpath;

--- a/src/generated/CPACSWingRibCell.cpp
+++ b/src/generated/CPACSWingRibCell.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element fromRib
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromRib")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromRib")) {
             m_fromRib = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromRib");
             if (m_fromRib.empty()) {
                 LOG(WARNING) << "Required element fromRib is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element toRib
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toRib")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toRib")) {
             m_toRib = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/toRib");
             if (m_toRib.empty()) {
                 LOG(WARNING) << "Required element toRib is empty at xpath " << xpath;

--- a/src/generated/CPACSWingRibExplicitPositioning.cpp
+++ b/src/generated/CPACSWingRibExplicitPositioning.cpp
@@ -104,7 +104,7 @@ namespace generated
         }
 
         // read element startSparPositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startSparPositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startSparPositionUID")) {
             m_startSparPositionUID_choice3 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startSparPositionUID");
             if (m_startSparPositionUID_choice3->empty()) {
                 LOG(WARNING) << "Optional element startSparPositionUID is present but empty at xpath " << xpath;
@@ -135,7 +135,7 @@ namespace generated
         }
 
         // read element endSparPositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endSparPositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endSparPositionUID")) {
             m_endSparPositionUID_choice3 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/endSparPositionUID");
             if (m_endSparPositionUID_choice3->empty()) {
                 LOG(WARNING) << "Optional element endSparPositionUID is present but empty at xpath " << xpath;
@@ -144,7 +144,7 @@ namespace generated
         }
 
         // read element ribStart
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribStart")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribStart")) {
             m_ribStart = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribStart");
             if (m_ribStart.empty()) {
                 LOG(WARNING) << "Required element ribStart is empty at xpath " << xpath;
@@ -155,7 +155,7 @@ namespace generated
         }
 
         // read element ribEnd
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribEnd")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribEnd")) {
             m_ribEnd = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribEnd");
             if (m_ribEnd.empty()) {
                 LOG(WARNING) << "Required element ribEnd is empty at xpath " << xpath;

--- a/src/generated/CPACSWingRibPoint.cpp
+++ b/src/generated/CPACSWingRibPoint.cpp
@@ -82,7 +82,7 @@ namespace generated
     void CPACSWingRibPoint::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element ribDefinitionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribDefinitionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribDefinitionUID")) {
             m_ribDefinitionUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribDefinitionUID");
             if (m_ribDefinitionUID.empty()) {
                 LOG(WARNING) << "Required element ribDefinitionUID is empty at xpath " << xpath;
@@ -94,12 +94,12 @@ namespace generated
         }
 
         // read element ribNumber
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribNumber")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribNumber")) {
             m_ribNumber = tixi::TixiGetElement<int>(tixiHandle, xpath + "/ribNumber");
         }
 
         // read element xsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi")) {
             m_xsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi");
         }
         else {

--- a/src/generated/CPACSWingRibsDefinition.cpp
+++ b/src/generated/CPACSWingRibsDefinition.cpp
@@ -96,7 +96,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -107,7 +107,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSWingRibsPositioning.cpp
+++ b/src/generated/CPACSWingRibsPositioning.cpp
@@ -105,7 +105,7 @@ namespace generated
         }
 
         // read element startSparPositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/startSparPositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/startSparPositionUID")) {
             m_startSparPositionUID_choice3 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/startSparPositionUID");
             if (m_startSparPositionUID_choice3->empty()) {
                 LOG(WARNING) << "Optional element startSparPositionUID is present but empty at xpath " << xpath;
@@ -136,7 +136,7 @@ namespace generated
         }
 
         // read element endSparPositionUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/endSparPositionUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/endSparPositionUID")) {
             m_endSparPositionUID_choice3 = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/endSparPositionUID");
             if (m_endSparPositionUID_choice3->empty()) {
                 LOG(WARNING) << "Optional element endSparPositionUID is present but empty at xpath " << xpath;
@@ -145,7 +145,7 @@ namespace generated
         }
 
         // read element ribStart
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribStart")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribStart")) {
             m_ribStart = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribStart");
             if (m_ribStart.empty()) {
                 LOG(WARNING) << "Required element ribStart is empty at xpath " << xpath;
@@ -156,7 +156,7 @@ namespace generated
         }
 
         // read element ribEnd
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribEnd")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribEnd")) {
             m_ribEnd = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribEnd");
             if (m_ribEnd.empty()) {
                 LOG(WARNING) << "Required element ribEnd is empty at xpath " << xpath;
@@ -167,17 +167,17 @@ namespace generated
         }
 
         // read element spacing
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/spacing")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/spacing")) {
             m_spacing_choice1 = tixi::TixiGetElement<double>(tixiHandle, xpath + "/spacing");
         }
 
         // read element numberOfRibs
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/numberOfRibs")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/numberOfRibs")) {
             m_numberOfRibs_choice2 = tixi::TixiGetElement<int>(tixiHandle, xpath + "/numberOfRibs");
         }
 
         // read element ribReference
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribReference")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribReference")) {
             m_ribReference = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribReference");
             if (m_ribReference.empty()) {
                 LOG(WARNING) << "Required element ribReference is empty at xpath " << xpath;
@@ -188,7 +188,7 @@ namespace generated
         }
 
         // read element ribCrossingBehaviour
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/ribCrossingBehaviour")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/ribCrossingBehaviour")) {
             m_ribCrossingBehaviour = stringToCPACSRibCrossingBehaviour(tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/ribCrossingBehaviour"));
         }
         else {

--- a/src/generated/CPACSWingSection.cpp
+++ b/src/generated/CPACSWingSection.cpp
@@ -97,7 +97,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -108,7 +108,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;

--- a/src/generated/CPACSWingSegment.cpp
+++ b/src/generated/CPACSWingSegment.cpp
@@ -99,7 +99,7 @@ namespace generated
         }
 
         // read element name
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/name")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/name")) {
             m_name = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/name");
             if (m_name.empty()) {
                 LOG(WARNING) << "Required element name is empty at xpath " << xpath;
@@ -110,7 +110,7 @@ namespace generated
         }
 
         // read element description
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/description")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/description")) {
             m_description = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/description");
             if (m_description->empty()) {
                 LOG(WARNING) << "Optional element description is present but empty at xpath " << xpath;
@@ -118,7 +118,7 @@ namespace generated
         }
 
         // read element fromElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/fromElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/fromElementUID")) {
             m_fromElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/fromElementUID");
             if (m_fromElementUID.empty()) {
                 LOG(WARNING) << "Required element fromElementUID is empty at xpath " << xpath;
@@ -130,7 +130,7 @@ namespace generated
         }
 
         // read element toElementUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/toElementUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/toElementUID")) {
             m_toElementUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/toElementUID");
             if (m_toElementUID.empty()) {
                 LOG(WARNING) << "Required element toElementUID is empty at xpath " << xpath;

--- a/src/generated/CPACSXsiIsoLine.cpp
+++ b/src/generated/CPACSXsiIsoLine.cpp
@@ -115,7 +115,7 @@ namespace generated
     void CPACSXsiIsoLine::ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
     {
         // read element xsi
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/xsi")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/xsi")) {
             m_xsi = tixi::TixiGetElement<double>(tixiHandle, xpath + "/xsi");
         }
         else {
@@ -123,7 +123,7 @@ namespace generated
         }
 
         // read element referenceUID
-        if (tixi::TixiCheckElement(tixiHandle, xpath + "/referenceUID")) {
+        if (tixi::TixiCheckElementHasTextContent(tixiHandle, xpath + "/referenceUID")) {
             m_referenceUID = tixi::TixiGetElement<std::string>(tixiHandle, xpath + "/referenceUID");
             if (m_referenceUID.empty()) {
                 LOG(WARNING) << "Required element referenceUID is empty at xpath " << xpath;

--- a/src/generated/TixiHelper.h
+++ b/src/generated/TixiHelper.h
@@ -175,6 +175,20 @@ namespace tixi
         TixiSaveElementsInternal(tixiHandle, xpath, children, writer);
     }
 
+    inline bool TixiCheckElementHasTextContent(const TixiDocumentHandle& tixiHandle, const std::string& xpath)
+    {
+        if (!TixiCheckElement(tixiHandle, xpath)) {
+            return false;
+        }
+        try {
+            std::string text = TixiGetTextElement(tixiHandle, xpath);
+            return !text.empty();
+        }
+        catch (const TixiError&) {
+            return false;
+        }
+    }
+
     inline void TixiCreateSequenceElementIfNotExists(const TixiDocumentHandle& tixiHandle, const std::string& xpath, const std::vector<std::string>& childElemOrder)
     {
         // in case element already exists, nothing left to do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #994. If you add an xml node without content, TIGL crashes. The reason is that in the generated code, only existence of tixi elements is checked, not if the tixi element has any text contents. 

To fix this, we need to fix the check in the generated code and regenerate all the files. Therefore this PR depends on https://github.com/DLR-SC/cpacs_tigl_gen/pull/9 to be merged first. The changes in this PR are just regenerated src files with the updated cpacs_gen version.

To Do: 
 - [x] Make sure that the submodule points to the latest commit of master once https://github.com/DLR-SC/cpacs_tigl_gen/pull/9 is merged.

## How Has This Been Tested?

Since this is a TiGLCreator issue it was only tested manually with the TiGLCreator. The test file in the issue description logs an error, but the geometry can be generated and TiGLCreator does not crash anymore.

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [x] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
