### PR TITLE
use FitCurveOptimal to improve approximation quality of approximated point list profiles

### DIFF
--- a/src/fuselage/CCPACSFuselageProfile.cpp
+++ b/src/fuselage/CCPACSFuselageProfile.cpp
@@ -276,7 +276,8 @@ void CCPACSFuselageProfile::BuildWiresPointList(WireCache& cache) const
 
                 auto paramsVec = computeParams(occPoints, paramsMap, 0.5);
 
-                CTiglApproxResult approxResult = approx.FitCurve(paramsVec, approxErrFct);
+                int max_iter = 5;
+                CTiglApproxResult approxResult = approx.FitCurveOptimal(paramsVec, max_iter, approxErrFct);
 
                 spline = approxResult.curve;
                 errApproxCalc = approxResult.error;

--- a/src/geometry/CTiglApproximateBsplineWire.cpp
+++ b/src/geometry/CTiglApproximateBsplineWire.cpp
@@ -139,9 +139,11 @@ TopoDS_Wire CTiglApproximateBsplineWire::BuildWire(const CPointContainer& points
             approx.InterpolatePoint(idxInt-1, false);
         }
 
-        CTiglApproxResult approxResult = approx.FitCurve(std::vector<double>(), approxErrFct);
+        int max_iter = 5;
+        CTiglApproxResult approxResult = approx.FitCurveOptimal(std::vector<double>(), max_iter, approxErrFct);
 
         hcurve = approxResult.curve;
+
         m_approxErr = approxResult.error;
         m_usedNrPoles = hcurve->NbPoles();
 

--- a/src/geometry/CTiglBSplineApproxInterp.cpp
+++ b/src/geometry/CTiglBSplineApproxInterp.cpp
@@ -234,7 +234,7 @@ CTiglApproxResult CTiglBSplineApproxInterp::FitCurve(const std::vector<double>& 
     return solve(parms, OccFArray(knots)->Array1(), OccIArray(mults)->Array1(), calcErrorFct);
 }
 
-CTiglApproxResult CTiglBSplineApproxInterp::FitCurveOptimal(const std::vector<double>& initialParms, int maxIter) const
+CTiglApproxResult CTiglBSplineApproxInterp::FitCurveOptimal(const std::vector<double>& initialParms, int maxIter, CalcPointVecErrorFct calcErrorFct) const
 {
     std::vector<double> parms;
     // compute initial parameters, if initialParms emtpy
@@ -262,14 +262,14 @@ CTiglApproxResult CTiglBSplineApproxInterp::FitCurveOptimal(const std::vector<do
     int iteration = 0;
 
     // solve system
-    CTiglApproxResult result = solve(parms, occKnots->Array1(), occMults->Array1());
+    CTiglApproxResult result = solve(parms, occKnots->Array1(), occMults->Array1(), calcErrorFct);
     double old_error = result.error * 2.;
 
     while(result.error > 0 && (old_error - result.error) / std::max(result.error, 1e-6) > 1e-3 && iteration < maxIter) {
         old_error = result.error;
 
         optimizeParameters(result.curve, parms);
-        result = solve(parms, occKnots->Array1(), occMults->Array1());
+        result = solve(parms, occKnots->Array1(), occMults->Array1(), calcErrorFct);
 
         iteration++;
     }

--- a/src/geometry/CTiglBSplineApproxInterp.h
+++ b/src/geometry/CTiglBSplineApproxInterp.h
@@ -60,7 +60,7 @@ public:
 
     /// Fits the curve by optimizing the parameters.
     /// Important: Parameters of points that are interpolated are not optimized
-    TIGL_EXPORT CTiglApproxResult FitCurveOptimal(const std::vector<double>& initialParms = std::vector<double>(), int maxIter=10) const;
+    TIGL_EXPORT CTiglApproxResult FitCurveOptimal(const std::vector<double>& initialParms = std::vector<double>(), int maxIter=10, CalcPointVecErrorFct calcErrorFct=calcPointVecErrorMax) const;
 
 private:
     ProjectResult projectOnCurve(const gp_Pnt& pnt, const Handle(Geom_Curve)& curve, double initial_Parm) const;

--- a/tests/unittests/tiglWingProfile.cpp
+++ b/tests/unittests/tiglWingProfile.cpp
@@ -208,7 +208,7 @@ TEST(WingProfileApproximation, approxInterpProfiles)
     auto* wireAlgo = dynamic_cast<tigl::CTiglApproximateBsplineWire*>(wingProfilePointList->GetWireAlgo());
     double approxErr = wireAlgo->GetApproxErr();
 
-    EXPECT_NEAR(approxErr, 0.00218717, 1e-8);
+    EXPECT_NEAR(approxErr, 0.0012563542066345885, 1e-8);
 
     // Broken combination of pole number and interpolation indices
     tigl::CCPACSWingProfile& profileApproxInterpBroken = config.GetWingProfile("NACA1309_ApproxInterp_Broken");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Addresses #1320. Switching to FitCurveOptimal results in a much better control point distribution. Not adding a release note entry as it doesn't add any functionality on top of #1277, which has a release note entry already.

This PR does not fix the issue of excessive knot insertion in the pre-processing of the profile curves before lofting. 

## How Has This Been Tested?

Tested on a variant of the BWB model in the digital hangar. Approximation quality is greatly improved.

## Screenshots, that help to understand the changes(if applicable):

<img width="1408" height="532" alt="image" src="https://github.com/user-attachments/assets/231a9c89-2770-4d19-b9bd-8b5fef6c3ccd" />

<img width="1677" height="790" alt="image" src="https://github.com/user-attachments/assets/de3a5766-057f-4d1e-a489-8aff0eaa705a" />


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
