### PR TITLE
Fix LE point parameter when approximating point list profiles

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Changes since last release
 ----------------
 2025/09/26
 -General changes
+  - Wing profile B-spline approximation: pass prescribed leading edge parameter (from CPACS `parameterMap` or default 0.5) to the approximation step. This ensures consistent knot vectors across lofted profiles, fixing lofting failures with approximated point list profiles.
   - TiGL is now able to approximate profile point lists. The user can define an index list refering to points that should still be interpolated [#1276](https://github.com/DLR-SC/tigl/issues/1276).
   - Add `Color` class and `setObjectsColor`/`setObjectsColorRGB` functions to the TiGLCreator scripting console to set object colors without needing a native QColor object ([#1222](https://github.com/DLR-SC/tigl/issues/1222))
   - CPACS Export: Choose more meaningful marker for mirrored objects uIDs [#1289](https://github.com/DLR-SC/tigl/issues/1289)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,6 @@ Changes since last release
 ----------------
 2025/09/26
 -General changes
-  - Wing profile B-spline approximation: pass prescribed leading edge parameter (from CPACS `parameterMap` or default 0.5) to the approximation step. This ensures consistent knot vectors across lofted profiles, fixing lofting failures with approximated point list profiles.
   - TiGL is now able to approximate profile point lists. The user can define an index list refering to points that should still be interpolated [#1276](https://github.com/DLR-SC/tigl/issues/1276).
   - Add `Color` class and `setObjectsColor`/`setObjectsColorRGB` functions to the TiGLCreator scripting console to set object colors without needing a native QColor object ([#1222](https://github.com/DLR-SC/tigl/issues/1222))
   - CPACS Export: Choose more meaningful marker for mirrored objects uIDs [#1289](https://github.com/DLR-SC/tigl/issues/1289)

--- a/src/geometry/CTiglApproximateBsplineWire.cpp
+++ b/src/geometry/CTiglApproximateBsplineWire.cpp
@@ -53,6 +53,22 @@ CTiglApproximateBsplineWire::CTiglApproximateBsplineWire(double tolerance, const
     , m_interpolatedPointsIndices(interpolatedPointsIndices)
 {}
 
+CTiglApproximateBsplineWire::CTiglApproximateBsplineWire(int nrControlPoints, const std::string approxErrStr, std::vector<double> interpolatedPointsIndices, std::vector<double> initialParams)
+    : continuity(_C0)
+    , m_approximationSettings(nrControlPoints)
+    , m_approxErrStr(approxErrStr)
+    , m_interpolatedPointsIndices(interpolatedPointsIndices)
+    , m_initialParams(initialParams)
+{}
+
+CTiglApproximateBsplineWire::CTiglApproximateBsplineWire(double tolerance, const std::string approxErrStr, std::vector<double> interpolatedPointsIndices, std::vector<double> initialParams)
+    : continuity(_C0)
+    , m_approximationSettings(tolerance)
+    , m_approxErrStr(approxErrStr)
+    , m_interpolatedPointsIndices(interpolatedPointsIndices)
+    , m_initialParams(initialParams)
+{}
+
 // Destructor
 CTiglApproximateBsplineWire::~CTiglApproximateBsplineWire()
 {
@@ -140,7 +156,7 @@ TopoDS_Wire CTiglApproximateBsplineWire::BuildWire(const CPointContainer& points
         }
 
         int max_iter = 5;
-        CTiglApproxResult approxResult = approx.FitCurveOptimal(std::vector<double>(), max_iter, approxErrFct);
+        CTiglApproxResult approxResult = approx.FitCurveOptimal(m_initialParams, max_iter, approxErrFct);
 
         hcurve = approxResult.curve;
 

--- a/src/geometry/CTiglApproximateBsplineWire.h
+++ b/src/geometry/CTiglApproximateBsplineWire.h
@@ -43,6 +43,14 @@ public:
     TIGL_EXPORT CTiglApproximateBsplineWire(double tolerance, const std::string approxErrStr="RMSE",
                                             std::vector<double> interpolatedPointsIndices=std::vector<double>{});
 
+    TIGL_EXPORT CTiglApproximateBsplineWire(int nrControlPoints, const std::string approxErrStr,
+                                            std::vector<double> interpolatedPointsIndices,
+                                            std::vector<double> initialParams);
+
+    TIGL_EXPORT CTiglApproximateBsplineWire(double tolerance, const std::string approxErrStr,
+                                            std::vector<double> interpolatedPointsIndices,
+                                            std::vector<double> initialParams);
+
     // Destructor
     TIGL_EXPORT ~CTiglApproximateBsplineWire() override;
 
@@ -96,6 +104,8 @@ private:
     mutable double m_approxErr; // Approximation error according to chosen computation method
 
     std::vector<double> m_interpolatedPointsIndices; // Contains indices of points that should still be interpolated
+
+    std::vector<double> m_initialParams; // Initial parameter values for approximation
 };
 
 } // end namespace tigl

--- a/src/wing/CTiglWingProfilePointList.cpp
+++ b/src/wing/CTiglWingProfilePointList.cpp
@@ -134,7 +134,9 @@ CTiglWingProfilePointList::CTiglWingProfilePointList(const CCPACSWingProfile& pr
             hpoints->SetValue(static_cast<Standard_Integer>(i + 1), coordinates[i].Get_gp_Pnt());
         }
 
-        tigl::ParamMap paramsMap;
+        ParamMap paramsMap;
+        auto le_idx = static_cast<unsigned int>(lePointIdx);
+        auto le_in_params_map = false;
         if (cpacsPointList.GetParameterMap()) {
             const auto& cpacsMap = cpacsPointList.GetParameterMap().value();
             auto params = cpacsMap.GetParamAsVector();
@@ -143,12 +145,17 @@ CTiglWingProfilePointList::CTiglWingProfilePointList(const CCPACSWingProfile& pr
                 throw CTiglError("Number of parameters does not match number of indices");
             }
             for (size_t i = 0; i < params.size(); ++i) {
+                if (idx[i] == le_idx) {
+                    le_in_params_map = true;
+                }
                 paramsMap[idx[i]] = params[i];
             }
         }
-        paramsMap[static_cast<unsigned int>(lePointIdx)] = c_prescribedLEParam;
+        if (!le_in_params_map) {
+            paramsMap[le_idx] = c_prescribedLEParam;
+        }
 
-        m_initialParams = tigl::computeParams(hpoints, paramsMap, c_prescribedLEParam);
+        m_initialParams = computeParams(hpoints, paramsMap, c_prescribedLEParam);
 
         if (approxSettings->GetControlPointNumber_choice1()) {
             int nrControlPoints = *(approxSettings->GetControlPointNumber_choice1());

--- a/src/wing/CTiglWingProfilePointList.cpp
+++ b/src/wing/CTiglWingProfilePointList.cpp
@@ -39,6 +39,8 @@
 #include "CCPACSNacelleProfile.h"
 #include "tiglcommonfunctions.h"
 #include "CCPACSCurvePointListXYZ.h"
+#include "CTiglInterpolatePointsWithKinks.h"
+#include "CTiglBSplineAlgorithms.h"
 
 #include "gp_Pnt2d.hxx"
 #include "gp_Vec2d.hxx"
@@ -84,6 +86,7 @@ namespace tigl
 
 const double CTiglWingProfilePointList::c_trailingEdgeRelGap = 1E-2;
 const double CTiglWingProfilePointList::c_blendingDistance = 0.1;
+const double CTiglWingProfilePointList::c_prescribedLEParam = 0.5;
 
 // Constructor
 CTiglWingProfilePointList::CTiglWingProfilePointList(const CCPACSWingProfile& profile, const CCPACSCurvePointListXYZ& cpacsPointList)
@@ -126,13 +129,34 @@ CTiglWingProfilePointList::CTiglWingProfilePointList(const CCPACSWingProfile& pr
             interpPointsIndices.push_back(lePointIdx+1);
         }
 
+        Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, static_cast<Standard_Integer>(coordinates.size()));
+        for (size_t i = 0; i < coordinates.size(); ++i) {
+            hpoints->SetValue(static_cast<Standard_Integer>(i + 1), coordinates[i].Get_gp_Pnt());
+        }
+
+        tigl::ParamMap paramsMap;
+        if (cpacsPointList.GetParameterMap()) {
+            const auto& cpacsMap = cpacsPointList.GetParameterMap().value();
+            auto params = cpacsMap.GetParamAsVector();
+            auto idx = cpacsMap.GetPointIndexAsVector();
+            if (idx.size() != params.size()) {
+                throw CTiglError("Number of parameters does not match number of indices");
+            }
+            for (size_t i = 0; i < params.size(); ++i) {
+                paramsMap[idx[i]] = params[i];
+            }
+        }
+        paramsMap[static_cast<unsigned int>(lePointIdx)] = c_prescribedLEParam;
+
+        m_initialParams = tigl::computeParams(hpoints, paramsMap, c_prescribedLEParam);
+
         if (approxSettings->GetControlPointNumber_choice1()) {
             int nrControlPoints = *(approxSettings->GetControlPointNumber_choice1());
-            profileWireAlgo = std::make_unique<CTiglApproximateBsplineWire>(nrControlPoints, approxErrStr, interpPointsIndices);
+            profileWireAlgo = std::make_unique<CTiglApproximateBsplineWire>(nrControlPoints, approxErrStr, interpPointsIndices, m_initialParams);
         }
         else if (approxSettings->GetMaximumError_choice2()) {
             double tolerance = *(approxSettings->GetMaximumError_choice2());
-            profileWireAlgo = std::make_unique<CTiglApproximateBsplineWire>(tolerance, approxErrStr, interpPointsIndices);
+            profileWireAlgo = std::make_unique<CTiglApproximateBsplineWire>(tolerance, approxErrStr, interpPointsIndices, m_initialParams);
         }
         else {
             throw CTiglError("CTiglWingProfilePointList: Invalid Definition of approximationSettings in profile " + profileUID);
@@ -254,7 +278,14 @@ void CTiglWingProfilePointList::BuildWiresImpl(WireCache& cache, bool closed) co
     curve = new Geom_TrimmedCurve(curve, u1, u2);
 
     // Get Leading edge parameter on curve
-    double lep_par = GeomAPI_ProjectPointOnCurve(lePoint, curve).LowerDistanceParameter();
+    // Use stored initial param for consistent lofting (avoids projection variability between profiles)
+    double lep_par;
+    if (!m_initialParams.empty() && lePointIdx < m_initialParams.size()) {
+        lep_par = m_initialParams[lePointIdx];
+    }
+    else {
+        lep_par = GeomAPI_ProjectPointOnCurve(lePoint, curve).LowerDistanceParameter();
+    }
 
     // upper and lower curve
     Handle(Geom_TrimmedCurve) lowerCurve = new Geom_TrimmedCurve(curve, curve->FirstParameter(), lep_par);

--- a/src/wing/CTiglWingProfilePointList.cpp
+++ b/src/wing/CTiglWingProfilePointList.cpp
@@ -39,8 +39,6 @@
 #include "CCPACSNacelleProfile.h"
 #include "tiglcommonfunctions.h"
 #include "CCPACSCurvePointListXYZ.h"
-#include "CTiglInterpolatePointsWithKinks.h"
-#include "CTiglBSplineAlgorithms.h"
 
 #include "gp_Pnt2d.hxx"
 #include "gp_Vec2d.hxx"

--- a/src/wing/CTiglWingProfilePointList.h
+++ b/src/wing/CTiglWingProfilePointList.h
@@ -125,6 +125,8 @@ private:
     static const double       c_trailingEdgeRelGap;
     // constant blending distance for opening/closing trailing edge
     static const double       c_blendingDistance;
+    // constant prescribed parameter value for leading edge point
+    static const double       c_prescribedLEParam;
 
     const std::vector<CTiglPoint>&      coordinates;     /**< Coordinates of a wing profile element */
     std::unique_ptr<ITiglWireAlgorithm> profileWireAlgo; /**< Pointer to wire algorithm (e.g. CTiglInterpolateBsplineWire) */
@@ -133,6 +135,7 @@ private:
     gp_Pnt lePoint;     // Leading edge point
     size_t lePointIdx;  // Leading edge point idx (0-based)
     gp_Pnt tePoint;     // Trailing edge point
+    std::vector<double> m_initialParams; /**< Initial parameter values for B-spline approximation (used for consistent knot vectors in lofting) */
 
     Cache<WireCache, CTiglWingProfilePointList> wireCacheOpened;
     Cache<WireCache, CTiglWingProfilePointList> wireCacheClosed;

--- a/tests/unittests/tiglWingProfile.cpp
+++ b/tests/unittests/tiglWingProfile.cpp
@@ -208,7 +208,7 @@ TEST(WingProfileApproximation, approxInterpProfiles)
     auto* wireAlgo = dynamic_cast<tigl::CTiglApproximateBsplineWire*>(wingProfilePointList->GetWireAlgo());
     double approxErr = wireAlgo->GetApproxErr();
 
-    EXPECT_NEAR(approxErr, 0.0012563542066345885, 1e-8);
+    EXPECT_NEAR(approxErr, 0.0012975978942703363, 1e-8);
 
     // Broken combination of pole number and interpolation indices
     tigl::CCPACSWingProfile& profileApproxInterpBroken = config.GetWingProfile("NACA1309_ApproxInterp_Broken");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1320. Depends on #1329.  This PR addresses an issue of excessive knot insertion due to incompatible B-Splines after approximation. If we have several point list profiles that are all interpolated analogously with the same number of control and interpolation points, we end up with a set of profiles that all share the same knot vector. But because the curves differ slightly geometrically, the LE point (selected from the point list and projected onto the approximated curve) will have a different parameter for each curve. This in turn means that after trimming the profile curves into a lower and an upper curve, the individual upper curves (resp. lower curves) will have slightly different knot vectors, forcing the lofting algorithm to perform knot insertion. This produces overly complex surfaces with cluttered control points. 

To fix this, the leading edge point is fixed at parameter 0.5 for all curves, unless otherwise specified in the CPACS parameter map. With this change, all approximated profiles will not only share the same knot vector, they will be trimmed at the same parameter and thus upper and lower curves will have consistent knot vectors. In this special case, no knot insertion is necessary.

 - Adds a new ctor to `CTiglApproximateBsplineWire` that accepts a vector of initial parameters associated with the interpolatedPointIndices. These are passed on to `CTiglBSplineApproxInterp`.
 - In `CTiglWingProfilePointList` we first read out the parameter map of the point list (if any) to pass the parameter to the new `CTiglApproximateBsplineWire`. If the leading edge point is not part of the parameter map, it is added with a default value of 0.5 before approximation.
 - Before trimming the approximated curve into an upper and lower curve, we first check if the leading edge point index is in the parameters map as it should. In this case, we trim at that parameter. We still use the old implementation of projecting the LE point onto the approximated curve as a fall back if the LE point index is not in the parameter map. 

Note: There is one unit test, that checks the actual approximation error, even though the algorithm has a fixed set of control points. Changes to the approximation procedure like the ones from this PR will result in a different numerical error. Therefore the test is not very robust and the expected value needs to be manually changed with every PR touching this code.

I haven't addd a Changelog entry as this can be seen as part of #1277.

## How Has This Been Tested?

Visual inspection in TiGLCreator as well as the following diagnostic script: [le_point_diagnostic_script.zip](https://github.com/user-attachments/files/29046709/le_point_diagnostic_script.zip). It checks the knot vectors of the original interpolated profiles and approximated profiles and prints the control points of the wing faces.

Without approximation we have 93840 control points for the BWB wing geometry. With approximation we have 1080 control points, so a reduction by the factor of 100, all the while having mean root square errors < 0.0004.

Expand the following to see the log output including the root mean square error of each approximation:
<details>
 <summary>Log Output of opening the digital hangar BWB with approximated point lists</summary>
 
  ```
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_0' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000380403.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_1' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000380155.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_2' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000379965.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_3' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000375334.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_4' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.00060664.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_5' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000469788.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_6' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000338091.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_7' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000343901.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_8' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.00034473.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_9' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000345552.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_10' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000342483.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_11' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000344877.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_12' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000346296.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_13' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000347849.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_14' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.00035082.
  WRN 06/17 09:20:50 CTiglWingProfilePointList.cpp:261] The profile 'VELA_15' is created by approximating the point list using 32 poles. This leads to a root mean square error of 0.000355246.
  ```
</details>

## Screenshots, that help to understand the changes(if applicable):

<img width="1247" height="587" alt="image" src="https://github.com/user-attachments/assets/a3edd924-1a92-49fb-b98d-ac32ce93d062" />

<img width="1758" height="836" alt="image" src="https://github.com/user-attachments/assets/e34da845-ac8b-45ce-9d3d-762f621f5091" />


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
