### PR TITLE
Prevent TiGLCreator crash when drawing systems with invalid geometry

### DIFF
--- a/TIGLCreator/src/TIGLCreatorDocument.cpp
+++ b/TIGLCreator/src/TIGLCreatorDocument.cpp
@@ -2335,13 +2335,19 @@ void TIGLCreatorDocument::drawSystems()
     // Draw all generic systems
     for (int gs = 1; gs <= GetConfiguration().GetGenericSystemCount(); gs++) {
         tigl::CCPACSGenericSystem& genericSystem = GetConfiguration().GetGenericSystem(gs);
-        app->getScene()->displayShape(genericSystem.GetLoft(), true, getDefaultShapeColor());
 
-        if (genericSystem.GetSymmetryAxis() == TIGL_NO_SYMMETRY) {
-            continue;
+        try {
+            app->getScene()->displayShape(genericSystem.GetLoft(), true, getDefaultShapeColor());
+
+            if (genericSystem.GetSymmetryAxis() != TIGL_NO_SYMMETRY) {
+                app->getScene()->displayShape(genericSystem.GetMirroredLoft()->Shape(), true,
+                                              getDefaultShapeSymmetryColor());
+            }
         }
-
-        app->getScene()->displayShape(genericSystem.GetMirroredLoft()->Shape(), true, getDefaultShapeSymmetryColor());
+        catch (const tigl::CTiglError& err) {
+            const QString uid = QString::fromStdString(genericSystem.GetUID());
+            displayError("Cannot display \"" + uid + "\": " + err.what());
+        }
     }
 }
 


### PR DESCRIPTION
# Prevent TiGLCreator crash when drawing systems with invalid geometry

## Description

This PR fixes a TiGLCreator crash that occurred when using **Draw → Aircraft → Draw Systems** while one of the generic systems contained invalid geometry, for example an external geometry referencing a missing STEP file.

Drawing a component through the CPACS tree already handled `CTiglError` exceptions and displayed an error message. However, `TIGLCreatorDocument::drawSystems()` did not catch these exceptions, causing the application to terminate when geometry construction failed.

The drawing of each generic system is now wrapped in a `try`/`catch` block. Invalid systems display an error message instead of crashing TiGLCreator, while the remaining valid systems can still be processed.

Fixes #1303.

## How Has This Been Tested?

The change was tested manually in TiGLCreator using `simpletest-systems.cpacs.xml`.

The following cases were verified:

- Drawing systems with the referenced `nacelle.stp` file missing now shows an error message instead of crashing TiGLCreator.
- The error message identifies the affected generic system.

## Screenshots, that help to understand the changes:

<img width="876" height="759" alt="image" src="https://github.com/user-attachments/assets/a1ae3924-29c3-402d-a6db-41d79b86aaf8" />

## Checklist:

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [x] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
