### PR TITLE
Fix Draw Rotorcraft

### DIFF
--- a/TIGLCreator/src/TIGLCreatorDocument.cpp
+++ b/TIGLCreator/src/TIGLCreatorDocument.cpp
@@ -2788,17 +2788,21 @@ void TIGLCreatorDocument::drawRotorBladeShells(const QString& Uid)
 void TIGLCreatorDocument::drawRotorByUID(const QString& uid)
 {
     removeAirfoil();
-    START_COMMAND()
-    tigl::CCPACSRotor& rotor = GetConfiguration().GetRotor(uid.toStdString());
-    if (!app->getScene()->GetShapeManager().HasShapeEntry(uid.toStdString())) {
+    QString rotorUid = dlgGetRotorSelection(uid);
+    if (rotorUid == "") {
+        return;
+    }
 
+    START_COMMAND()
+    tigl::CCPACSRotor& rotor = GetConfiguration().GetRotor(rotorUid.toStdString());
+    if (!app->getScene()->GetShapeManager().HasShapeEntry(rotorUid.toStdString())) {
         // Draw segment loft
         app->getScene()->displayShape(rotor.GetLoft(), true, Quantity_NOC_RotorCol);
 
         // Draw rotor disk
         TopoDS_Shape rotorDisk = rotor.GetRotorDisk()->Shape();
         auto shape = app->getScene()->displayShape(rotorDisk, true, Quantity_NOC_RotorCol, 0.9);
-        app->getScene()->GetShapeManager().addObject(uid.toStdString(), shape);
+        app->getScene()->GetShapeManager().addObject(rotorUid.toStdString(), shape);
 
         if (rotor.GetSymmetryAxis() == TIGL_NO_SYMMETRY) {
             return;
@@ -2806,7 +2810,7 @@ void TIGLCreatorDocument::drawRotorByUID(const QString& uid)
 
         // Draw mirrored rotor
         shape = app->getScene()->displayShape(rotor.GetMirroredLoft()->Shape(), false, Quantity_NOC_MirrRotorCol);
-        app->getScene()->GetShapeManager().addObject(uid.toStdString(), shape);
+        app->getScene()->GetShapeManager().addObject(rotorUid.toStdString(), shape);
 
         // Draw mirrored rotor disk
         gp_Ax2 mirrorPlane;
@@ -2825,10 +2829,10 @@ void TIGLCreatorDocument::drawRotorByUID(const QString& uid)
         const TopoDS_Shape& mirrRotorDisk = myBRepTransformation.Shape();
 
         shape = app->getScene()->displayShape(mirrRotorDisk, true, Quantity_NOC_MirrRotorCol, 0.9);
-        app->getScene()->GetShapeManager().addObject(uid.toStdString(), shape);
+        app->getScene()->GetShapeManager().addObject(rotorUid.toStdString(), shape);
     }
     else {
-        IObjectList objects = app->getScene()->GetShapeManager().GetIObjectsFromShapeName(uid.toStdString());
+        IObjectList objects = app->getScene()->GetShapeManager().GetIObjectsFromShapeName(rotorUid.toStdString());
         for (auto& obj : objects) {
             app->getScene()->getContext()->Display(obj, Standard_False);
         }

--- a/TIGLCreator/src/TIGLCreatorWindow.ui
+++ b/TIGLCreator/src/TIGLCreatorWindow.ui
@@ -177,8 +177,6 @@
      <property name="title">
       <string>Rotorcraft</string>
      </property>
-     <addaction name="drawRotorsAction"/>
-     <addaction name="showRotorPropertiesAction"/>
     </widget>
     <widget class="QMenu" name="menuRotorBlades">
      <property name="title">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR removes two moved functions from the old spot in the UI an fixed the draw Rotor options, when used from the toolbar. There was no check for a Uid. 
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots, that help to understand the changes(if applicable):


## Checklist:

<!--- Our Continuous Integration Workflow will automatically check if all unit tests run without failure -->
<!--- Our Continuous Integration Workflow will automatically check if the code coverage decreases -->
<!--- The following tasks must be performed manually by the contributor and checked by the reviewer -->

<!--- Go over all the following points, and put an `x` in all the boxes in the "Finished" column that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

| Task                                                    | Finished                                                  | Reviewer Approved          |
|---------------------------------------------------------|-----------------------------------------------------------|----------------------------|
| At least one test for the new functionality was added.  | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| New classes have been added to the Python interface.    | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| The code is properly documented with doxygen docstrings | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
| Changes are documented at the top of ChangeLog.md       | <ul><li>- [ ] yes </li><li>- [ ] does not apply</li></ul> | <ul><li>- [ ] OK</li></ul> |
