### PR TITLE
Python test cosmetics

### DIFF
--- a/tests/python/test_decks.py
+++ b/tests/python/test_decks.py
@@ -38,13 +38,11 @@ class TestDeckBindings(unittest.TestCase):
         if not cls.CPACS_FILE.is_file():
             raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}")
 
-        # Load the read-only CPACS configuration once for all tests.
         cls.tixi = Tixi3()
         cls.tigl = Tigl3()
         cls._tixi_is_open = False
         cls._tigl_is_open = False
 
-        # Register cleanup before opening native resources.
         cls.addClassCleanup(cls._close_configuration)
 
         tixi_result = cls.tixi.open(str(cls.CPACS_FILE))
@@ -66,7 +64,6 @@ class TestDeckBindings(unittest.TestCase):
 
     @classmethod
     def _close_configuration(cls) -> None:
-        # Close TiGL before releasing its underlying TiXI document.
         try:
             if cls._tigl_is_open:
                 cls.tigl.close()

--- a/tests/python/test_decks.py
+++ b/tests/python/test_decks.py
@@ -16,49 +16,96 @@
 # limitations under the License.
 #############################################################################
 
+from pathlib import Path
 import unittest
 
-from tigl3.tigl3wrapper import *
-from tixi3.tixi3wrapper import *
 from tigl3 import configuration, geometry
+from tigl3.tigl3wrapper import Tigl3
+from tixi3.tixi3wrapper import Tixi3
 
-from OCC.Core.Bnd import Bnd_Box
-from OCC.Core.BRepBndLib import brepbndlib_Add
 
+class TestDeckBindings(unittest.TestCase):
+    CPACS_FILE = Path("TestData/simpletest-decks.cpacs.xml")
+    CONFIGURATION_UID = "testAircraft"
 
-class Decks(unittest.TestCase):
+    DECK_UID = "deck"
+    COMPONENT_UID = "classDivider"
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        if not cls.CPACS_FILE.is_file():
+            raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}")
+
+        # Load the read-only CPACS configuration once for all tests.
         cls.tixi = Tixi3()
         cls.tigl = Tigl3()
+        cls._tixi_is_open = False
+        cls._tigl_is_open = False
 
-        cls.assertIsNone = staticmethod(unittest.TestCase().assertIsNone)
-        cls.assertIsNone(cls.tixi.open("TestData/simpletest-decks.cpacs.xml"))
-        cls.assertIsNone(cls.tigl.open(cls.tixi, "testAircraft"))
+        # Register cleanup before opening native resources.
+        cls.addClassCleanup(cls._close_configuration)
 
-        mgr = configuration.CCPACSConfigurationManager.get_instance()
-        cls.config = mgr.get_configuration(cls.tigl._handle.value)
-        cls.uid_mgr = cls.config.get_uidmanager()
+        tixi_result = cls.tixi.open(str(cls.CPACS_FILE))
+        if tixi_result is not None:
+            raise AssertionError(f"Tixi3.open() unexpectedly returned {tixi_result!r}")
+        cls._tixi_is_open = True
+
+        tigl_result = cls.tigl.open(cls.tixi, cls.CONFIGURATION_UID)
+        if tigl_result is not None:
+            raise AssertionError(f"Tigl3.open() unexpectedly returned {tigl_result!r}")
+        cls._tigl_is_open = True
+
+        manager = configuration.CCPACSConfigurationManager.get_instance()
+        cls.aircraft_config = manager.get_configuration(cls.tigl._handle.value)
+        cls.uid_manager = cls.aircraft_config.get_uidmanager()
+
+        cls.deck = cls.uid_manager.get_geometric_component(cls.DECK_UID)
+        cls.component = cls.uid_manager.get_geometric_component(cls.COMPONENT_UID)
 
     @classmethod
-    def tearDownClass(cls):
-        cls.tigl.close()
-        cls.tixi.close()
+    def _close_configuration(cls) -> None:
+        # Close TiGL before releasing its underlying TiXI document.
+        try:
+            if cls._tigl_is_open:
+                cls.tigl.close()
+        finally:
+            if cls._tixi_is_open:
+                cls.tixi.close()
 
-    def test_deck(self):
-
-        deck = self.uid_mgr.get_geometric_component("deck")
-        self.assertIsInstance(deck, geometry.ITiglGeometricComponent)
-        self.assertIsInstance(deck, configuration.CCPACSDeck)
-
-        # Cabin geometry
-        cabinGeometry = deck.get_cabin_geometry()
-        self.assertIsInstance(cabinGeometry, configuration.CPACSCabinGeometry)
+    def test_factory_types(self) -> None:
+        # The SWIG factory must expose the concrete C++ runtime types.
         self.assertIsInstance(
-            cabinGeometry.get_contours(), configuration.CPACSCabinGeometryContours
+            self.deck,
+            geometry.ITiglGeometricComponent,
         )
-        contour = cabinGeometry.get_contours().get_contour(1)
+        self.assertIsInstance(
+            self.deck,
+            configuration.CCPACSDeck,
+        )
+        self.assertIsInstance(
+            self.component,
+            configuration.CCPACSDeckComponentBase,
+        )
+
+    def test_cabin_geometry(self) -> None:
+        cabin_geometry = self.deck.get_cabin_geometry()
+
+        self.assertIsInstance(
+            cabin_geometry,
+            configuration.CPACSCabinGeometry,
+        )
+
+        contours = cabin_geometry.get_contours()
+
+        self.assertIsInstance(
+            contours,
+            configuration.CPACSCabinGeometryContours,
+        )
+
+        contour = contours.get_contour(1)
+
         self.assertIsInstance(
             contour,
             configuration.CPACSCabinGeometryContour,
@@ -68,121 +115,178 @@ class Decks(unittest.TestCase):
             configuration.CPACSDoubleVectorBase,
         )
 
-        # Deck components
-        self.assertIsInstance(deck.get_seat_modules(), configuration.CPACSSeatModules)
+    def test_component_containers(self) -> None:
+        seat_modules = self.deck.get_seat_modules()
+
         self.assertIsInstance(
-            deck.get_seat_modules().get_seat_module(1),
+            seat_modules,
+            configuration.CPACSSeatModules,
+        )
+        self.assertIsInstance(
+            seat_modules.get_seat_module(1),
             configuration.CCPACSDeckComponentBase,
         )
 
+        sidewall_panels = self.deck.get_sidewall_panels()
+
         self.assertIsInstance(
-            deck.get_sidewall_panels(), configuration.CPACSSidewallPanels
+            sidewall_panels,
+            configuration.CPACSSidewallPanels,
         )
         self.assertIsInstance(
-            deck.get_sidewall_panels().get_sidewall_panel(1),
+            sidewall_panels.get_sidewall_panel(1),
             configuration.CCPACSDeckComponentBase,
         )
 
+        luggage_compartments = self.deck.get_luggage_compartments()
+
         self.assertIsInstance(
-            deck.get_luggage_compartments(), configuration.CPACSLuggageCompartments
+            luggage_compartments,
+            configuration.CPACSLuggageCompartments,
         )
         self.assertIsInstance(
-            deck.get_luggage_compartments().get_luggage_compartment(1),
+            luggage_compartments.get_luggage_compartment(1),
             configuration.CCPACSDeckComponentBase,
         )
 
+        ceiling_panels = self.deck.get_ceiling_panels()
+
         self.assertIsInstance(
-            deck.get_ceiling_panels(), configuration.CPACSCeilingPanels
+            ceiling_panels,
+            configuration.CPACSCeilingPanels,
         )
         self.assertIsInstance(
-            deck.get_ceiling_panels().get_ceiling_panel(1),
+            ceiling_panels.get_ceiling_panel(1),
             configuration.CCPACSDeckComponentBase,
         )
 
-        self.assertIsInstance(deck.get_galleys(), configuration.CPACSGalleys)
+        galleys = self.deck.get_galleys()
+
         self.assertIsInstance(
-            deck.get_galleys().get_galley(1),
+            galleys,
+            configuration.CPACSGalleys,
+        )
+        self.assertIsInstance(
+            galleys.get_galley(1),
             configuration.CCPACSDeckComponentBase,
         )
 
+        floor_modules = self.deck.get_generic_floor_modules()
+
         self.assertIsInstance(
-            deck.get_generic_floor_modules(), configuration.CPACSGenericFloorModules
+            floor_modules,
+            configuration.CPACSGenericFloorModules,
         )
         self.assertIsInstance(
-            deck.get_generic_floor_modules().get_generic_floor_module(1),
+            floor_modules.get_generic_floor_module(1),
             configuration.CCPACSDeckComponentBase,
         )
 
-        self.assertIsInstance(deck.get_lavatories(), configuration.CPACSLavatories)
+        lavatories = self.deck.get_lavatories()
+
         self.assertIsInstance(
-            deck.get_lavatories().get_lavatory(1),
+            lavatories,
+            configuration.CPACSLavatories,
+        )
+        self.assertIsInstance(
+            lavatories.get_lavatory(1),
             configuration.CCPACSDeckComponentBase,
         )
 
+        class_dividers = self.deck.get_class_dividers()
+
         self.assertIsInstance(
-            deck.get_class_dividers(), configuration.CPACSClassDividers
+            class_dividers,
+            configuration.CPACSClassDividers,
         )
         self.assertIsInstance(
-            deck.get_class_dividers().get_class_divider(1),
+            class_dividers.get_class_divider(1),
             configuration.CCPACSDeckComponentBase,
         )
 
+        cargo_containers = self.deck.get_cargo_containers()
+
         self.assertIsInstance(
-            deck.get_cargo_containers(), configuration.CPACSCargoContainers
+            cargo_containers,
+            configuration.CPACSCargoContainers,
         )
         self.assertIsInstance(
-            deck.get_cargo_containers().get_cargo_container(1),
+            cargo_containers.get_cargo_container(1),
             configuration.CCPACSDeckComponentBase,
         )
+
+    def test_plural_getters_hidden(self) -> None:
+        # Generated vector getters are intentionally hidden from Python.
+        with self.assertRaises(AttributeError):
+            self.deck.get_seat_modules().get_seat_modules()
 
         with self.assertRaises(AttributeError):
-            deck.get_seat_modules().get_seat_modules()
-        with self.assertRaises(AttributeError):
-            deck.get_sidewall_panels().get_sidewall_panels()
-        with self.assertRaises(AttributeError):
-            deck.get_luggage_compartments().get_luggage_compartments()
-        with self.assertRaises(AttributeError):
-            deck.get_ceiling_panels().get_ceiling_panels()
-        with self.assertRaises(AttributeError):
-            deck.get_galleys().get_galleys()
-        with self.assertRaises(AttributeError):
-            deck.get_generic_floor_modules().get_generic_floor_modules()
-        with self.assertRaises(AttributeError):
-            deck.get_lavatories().get_lavatorys()
-        with self.assertRaises(AttributeError):
-            deck.get_class_dividers().get_class_dividers()
-        with self.assertRaises(AttributeError):
-            deck.get_cargo_containers().get_cargo_containers()
+            self.deck.get_sidewall_panels().get_sidewall_panels()
 
-    def test_deckComponentBase(self):
+        with self.assertRaises(AttributeError):
+            self.deck.get_luggage_compartments().get_luggage_compartments()
 
-        component = self.uid_mgr.get_geometric_component("classDivider")
+        with self.assertRaises(AttributeError):
+            self.deck.get_ceiling_panels().get_ceiling_panels()
+
+        with self.assertRaises(AttributeError):
+            self.deck.get_galleys().get_galleys()
+
+        with self.assertRaises(AttributeError):
+            (self.deck.get_generic_floor_modules().get_generic_floor_modules())
+
+        with self.assertRaises(AttributeError):
+            self.deck.get_lavatories().get_lavatorys()
+
+        with self.assertRaises(AttributeError):
+            self.deck.get_class_dividers().get_class_dividers()
+
+        with self.assertRaises(AttributeError):
+            self.deck.get_cargo_containers().get_cargo_containers()
+
+    def test_component_accessors(self) -> None:
         self.assertIsInstance(
-            component,
-            configuration.CCPACSDeckComponentBase,
-        )
-
-        self.assertIsInstance(component.get_mass(), float)
-        self.assertIsInstance(
-            component.get_center_of_gravity_global(), geometry.CTiglPoint
+            self.component.get_mass(),
+            float,
         )
         self.assertIsInstance(
-            component.get_center_of_gravity_local(), geometry.CTiglPoint
+            self.component.get_center_of_gravity_global(),
+            geometry.CTiglPoint,
         )
         self.assertIsInstance(
-            component.get_mass_inertia_local(), configuration.CTiglMassInertia
+            self.component.get_center_of_gravity_local(),
+            geometry.CTiglPoint,
         )
-
-        self.assertIsInstance(component.get_component_intent(), int)
-        self.assertIsInstance(component.get_component_representation(), int)
-        self.assertIsInstance(component.get_component_representation_as_string(), str)
-        self.assertIsInstance(component.get_component_type(), int)
+        self.assertIsInstance(
+            self.component.get_mass_inertia_local(),
+            configuration.CTiglMassInertia,
+        )
 
         self.assertIsInstance(
-            component.get_configuration(), configuration.CCPACSConfiguration
+            self.component.get_component_intent(),
+            int,
+        )
+        self.assertIsInstance(
+            self.component.get_component_representation(),
+            int,
+        )
+        self.assertIsInstance(
+            self.component.get_component_representation_as_string(),
+            str,
+        )
+        self.assertIsInstance(
+            self.component.get_component_type(),
+            int,
         )
 
-        self.assertIsInstance(component.get_defaulted_uid(), str)
+        self.assertIsInstance(
+            self.component.get_configuration(),
+            configuration.CCPACSConfiguration,
+        )
+        self.assertIsInstance(
+            self.component.get_defaulted_uid(),
+            str,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/python/test_fuelTanks.py
+++ b/tests/python/test_fuelTanks.py
@@ -16,249 +16,380 @@
 # limitations under the License.
 #############################################################################
 
+from pathlib import Path
 import unittest
-
-from tigl3.tigl3wrapper import *
-from tixi3.tixi3wrapper import *
-from tigl3 import configuration
 
 from OCC.Core.TopoDS import TopoDS_Face
 
+from tigl3 import configuration
+from tigl3.tigl3wrapper import Tigl3
+from tixi3.tixi3wrapper import Tixi3
 
-class FuelTanks(unittest.TestCase):
 
-    def setUp(self):
-        self.tixi = Tixi3()
-        self.tigl = Tigl3()
-        self.assertIsNone(self.tixi.open("TestData/simpletest-fuelTanks.cpacs.xml"))
-        self.assertIsNone(self.tigl.open(self.tixi, ""))
+class TestFuelTanks(unittest.TestCase):
+    CPACS_FILE = Path("TestData/simpletest-fuelTanks.cpacs.xml")
 
-        mgr = configuration.CCPACSConfigurationManager.get_instance()
-        self.config = mgr.get_configuration(self.tigl._handle.value)
-        uid_mgr = self.config.get_uidmanager()
+    TANK_UID = "tank1"
+    SEGMENT_VESSEL_UID = "tank1_outerVessel"
+    GUIDE_VESSEL_UID = "tank2_outerVessel"
+    SPHERICAL_VESSEL_UID = "tank3_sphericalDome"
+    ELLIPSOID_VESSEL_UID = "tank3_ellipsoidDome1"
+    TORISPHERICAL_VESSEL_UID = "tank4_torisphericalDome"
+    ISOTENSOID_VESSEL_UID = "tank5_isotensoidDome"
 
-        self.fuelTank = uid_mgr.get_geometric_component("tank1")
-        self.vessel_segments = uid_mgr.get_geometric_component("tank1_outerVessel")
-        self.vessel_guides = uid_mgr.get_geometric_component("tank2_outerVessel")
-        self.vessel_spherical = uid_mgr.get_geometric_component("tank3_sphericalDome")
-        self.vessel_ellipsoid1 = uid_mgr.get_geometric_component("tank3_ellipsoidDome1")
-        self.vessel_ellipsoid2 = uid_mgr.get_geometric_component("tank3_ellipsoidDome1")
-        self.vessel_torispherical = uid_mgr.get_geometric_component(
-            "tank4_torisphericalDome"
+    GEOMETRY_TOLERANCE = 1e-2
+    POINT_TOLERANCE = 1e-5
+
+    INVALID_VESSEL_TYPE_MESSAGE = (
+        "This method is only available for vessels with segments. " "No segment found."
+    )
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        if not cls.CPACS_FILE.is_file():
+            raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}")
+
+        cls.tixi = Tixi3()
+        cls.tigl = Tigl3()
+        cls._tixi_is_open = False
+        cls._tigl_is_open = False
+
+        cls.addClassCleanup(cls._close_configuration)
+
+        tixi_result = cls.tixi.open(str(cls.CPACS_FILE))
+        if tixi_result is not None:
+            raise AssertionError(f"Tixi3.open() unexpectedly returned {tixi_result!r}")
+        cls._tixi_is_open = True
+
+        tigl_result = cls.tigl.open(cls.tixi, "")
+        if tigl_result is not None:
+            raise AssertionError(f"Tigl3.open() unexpectedly returned {tigl_result!r}")
+        cls._tigl_is_open = True
+
+        manager = configuration.CCPACSConfigurationManager.get_instance()
+        cls.aircraft_config = manager.get_configuration(cls.tigl._handle.value)
+        cls.uid_manager = cls.aircraft_config.get_uidmanager()
+
+        cls.fuel_tank = cls.uid_manager.get_geometric_component(cls.TANK_UID)
+        cls.segment_vessel = cls.uid_manager.get_geometric_component(
+            cls.SEGMENT_VESSEL_UID
         )
-        self.vessel_isotensoid = uid_mgr.get_geometric_component("tank5_isotensoidDome")
-
-        self.tank_type_exception_msg = (
-            "This method is only available for vessels with segments. No segment found."
+        cls.guide_vessel = cls.uid_manager.get_geometric_component(cls.GUIDE_VESSEL_UID)
+        cls.spherical_vessel = cls.uid_manager.get_geometric_component(
+            cls.SPHERICAL_VESSEL_UID
+        )
+        cls.ellipsoid_vessel = cls.uid_manager.get_geometric_component(
+            cls.ELLIPSOID_VESSEL_UID
+        )
+        cls.torispherical_vessel = cls.uid_manager.get_geometric_component(
+            cls.TORISPHERICAL_VESSEL_UID
+        )
+        cls.isotensoid_vessel = cls.uid_manager.get_geometric_component(
+            cls.ISOTENSOID_VESSEL_UID
         )
 
-    def tearDown(self):
-        self.tigl.close()
-        self.tixi.close()
+    @classmethod
+    def _close_configuration(cls) -> None:
+        try:
+            if cls._tigl_is_open:
+                cls.tigl.close()
+        finally:
+            if cls._tixi_is_open:
+                cls.tixi.close()
 
-    def test_configuration(self):
-
-        tank1_uID = "tank1"
-        self.assertEqual(self.config.get_fuel_tank_count(), 8)
+    def test_configuration(self) -> None:
+        self.assertEqual(
+            self.aircraft_config.get_fuel_tank_count(),
+            8,
+        )
         self.assertIsInstance(
-            self.config.get_fuel_tank(1), configuration.CPACSFuelTank
+            self.aircraft_config.get_fuel_tank(1),
+            configuration.CPACSFuelTank,
         )
         self.assertIsInstance(
-            self.config.get_fuel_tank(tank1_uID),
+            self.aircraft_config.get_fuel_tank(self.TANK_UID),
             configuration.CCPACSFuelTank,
         )
         self.assertEqual(
-            self.config.get_fuel_tank_index(tank1_uID),
+            self.aircraft_config.get_fuel_tank_index(self.TANK_UID),
             1,
         )
         self.assertIsInstance(
-            self.config.get_fuel_tanks(), configuration.CPACSFuelTanks
+            self.aircraft_config.get_fuel_tanks(),
+            configuration.CPACSFuelTanks,
         )
 
-    def test_fuelTanks(self):
-        # Test custom class methods:
-        fuelTanks = self.fuelTank.get_parent()
-        tank1_uID = "tank1"
+    def test_fuel_tanks(self) -> None:
+        fuel_tanks = self.fuel_tank.get_parent()
 
-        ## Test accessability of childs:
-        self.assertIsInstance(fuelTanks.get_fuel_tank(1), configuration.CCPACSFuelTank)
-        self.assertEqual(fuelTanks.get_fuel_tank(1).get_defaulted_uid(), tank1_uID)
         self.assertIsInstance(
-            fuelTanks.get_fuel_tank(tank1_uID),
+            fuel_tanks,
+            configuration.CPACSFuelTanks,
+        )
+        self.assertIsInstance(
+            fuel_tanks.get_fuel_tank(1),
+            configuration.CCPACSFuelTank,
+        )
+        self.assertEqual(
+            fuel_tanks.get_fuel_tank(1).get_defaulted_uid(),
+            self.TANK_UID,
+        )
+        self.assertIsInstance(
+            fuel_tanks.get_fuel_tank(self.TANK_UID),
             configuration.CPACSFuelTank,
         )
         self.assertEqual(
-            fuelTanks.get_fuel_tank_index(tank1_uID),
+            fuel_tanks.get_fuel_tank_index(self.TANK_UID),
             1,
         )
-        self.assertEqual(fuelTanks.get_fuel_tank_count(), 8)
+        self.assertEqual(
+            fuel_tanks.get_fuel_tank_count(),
+            8,
+        )
 
-        # Test availability of generated class:
-        self.assertIsInstance(fuelTanks, configuration.CPACSFuelTanks)
-
-    def test_genericFuelTank(self):
-        # Test custom class methods:
-        self.assertIsInstance(self.fuelTank.get_vessels(), configuration.CPACSVessels)
-
-        # Test availability of generated class:
-        self.assertEqual(self.fuelTank.get_name(), "Simple tank 1")
-
-    def test_vessels(self):
-        # Test custom class methods:
-        vessels = self.vessel_segments.get_parent()
-        vessel1_uID = "tank1_outerVessel"
-
-        ## Test accessability of childs:
-        self.assertIsInstance(vessels.get_vessel(1), configuration.CPACSVessel)
-        self.assertEqual(vessels.get_vessel(1).get_defaulted_uid(), vessel1_uID)
+    def test_fuel_tank(self) -> None:
         self.assertIsInstance(
-            vessels.get_vessel(vessel1_uID), configuration.CPACSVessel
+            self.fuel_tank.get_vessels(),
+            configuration.CPACSVessels,
         )
         self.assertEqual(
-            vessels.get_vessel_index(vessel1_uID),
+            self.fuel_tank.get_name(),
+            "Simple tank 1",
+        )
+
+    def test_vessels(self) -> None:
+        vessels = self.segment_vessel.get_parent()
+
+        self.assertIsInstance(
+            vessels.get_vessel(1),
+            configuration.CPACSVessel,
+        )
+        self.assertEqual(
+            vessels.get_vessel(1).get_defaulted_uid(),
+            self.SEGMENT_VESSEL_UID,
+        )
+        self.assertIsInstance(
+            vessels.get_vessel(self.SEGMENT_VESSEL_UID),
+            configuration.CPACSVessel,
+        )
+        self.assertEqual(
+            vessels.get_vessel_index(self.SEGMENT_VESSEL_UID),
             1,
         )
-        self.assertEqual(vessels.get_vessel_count(), 2)
-
-        # Test availability of generated class:
-        self.assertIsInstance(vessels.get_parent(), configuration.CPACSFuelTank)
-
-    def test_vessel_general(self):
-
-        # Custom class methods
         self.assertEqual(
-            self.vessel_segments.get_configuration().get_uid(), "testAircraft"
+            vessels.get_vessel_count(),
+            2,
         )
-        self.assertEqual(self.vessel_segments.get_defaulted_uid(), "tank1_outerVessel")
 
-        # Generated class methods
         self.assertIsInstance(
-            self.vessel_segments.get_configuration(),
+            vessels.get_parent(),
+            configuration.CPACSFuelTank,
+        )
+
+    def test_vessel_accessors(self) -> None:
+        vessel_configuration = self.segment_vessel.get_configuration()
+
+        self.assertEqual(
+            vessel_configuration.get_uid(),
+            "testAircraft",
+        )
+        self.assertIsInstance(
+            vessel_configuration,
             configuration.CCPACSConfiguration,
         )
-
-        self.assertEqual(self.vessel_segments.get_name(), "Outer vessel")
-
-    def test_vessel_type_info(self):
-
-        self.assertTrue(self.vessel_segments.is_vessel_via_segments())
-        self.assertFalse(self.vessel_segments.is_vessel_via_design_parameters())
-        self.assertFalse(self.vessel_spherical.is_vessel_via_segments())
-        self.assertTrue(self.vessel_spherical.is_vessel_via_design_parameters())
-
-        self.assertFalse(self.vessel_segments.has_spherical_dome())
-        self.assertFalse(self.vessel_segments.has_ellipsoid_dome())
-        self.assertFalse(self.vessel_segments.has_torispherical_dome())
-        self.assertFalse(self.vessel_segments.has_isotensoid_dome())
-
-        self.assertTrue(self.vessel_spherical.has_spherical_dome())
-        self.assertTrue(self.vessel_spherical.has_ellipsoid_dome())
-        self.assertFalse(self.vessel_spherical.has_torispherical_dome())
-        self.assertFalse(self.vessel_spherical.has_isotensoid_dome())
-
-        self.assertFalse(self.vessel_ellipsoid1.has_spherical_dome())
-        self.assertTrue(self.vessel_ellipsoid1.has_ellipsoid_dome())
-        self.assertFalse(self.vessel_ellipsoid1.has_torispherical_dome())
-        self.assertFalse(self.vessel_ellipsoid1.has_isotensoid_dome())
-
-        self.assertFalse(self.vessel_torispherical.has_spherical_dome())
-        self.assertFalse(self.vessel_torispherical.has_ellipsoid_dome())
-        self.assertTrue(self.vessel_torispherical.has_torispherical_dome())
-        self.assertFalse(self.vessel_torispherical.has_isotensoid_dome())
-
-        self.assertFalse(self.vessel_isotensoid.has_spherical_dome())
-        self.assertFalse(self.vessel_isotensoid.has_ellipsoid_dome())
-        self.assertFalse(self.vessel_isotensoid.has_torispherical_dome())
-        self.assertTrue(self.vessel_isotensoid.has_isotensoid_dome())
-
-    def test_vessel_sections(self):
-        vessel_segments = self.vessel_segments
-        vessel_parametric = self.vessel_spherical
-
-        self.assertEqual(vessel_segments.get_section_count(), 3)
-        self.assertEqual(vessel_parametric.get_section_count(), 0)
-
-        self.assertIsInstance(
-            vessel_segments.get_section(1), configuration.CCPACSFuselageSection
+        self.assertEqual(
+            self.segment_vessel.get_defaulted_uid(),
+            self.SEGMENT_VESSEL_UID,
         )
-        with self.assertRaises(RuntimeError) as context:
-            vessel_parametric.get_section(1)
-        self.assertEqual(str(context.exception), self.tank_type_exception_msg)
-
-        self.assertIsInstance(
-            vessel_segments.get_section_face("outerVessel_section3"), TopoDS_Face
+        self.assertEqual(
+            self.segment_vessel.get_name(),
+            "Outer vessel",
         )
-        with self.assertRaises(RuntimeError) as context:
-            vessel_parametric.get_section_face("outerVessel_section3")
-        self.assertEqual(str(context.exception), self.tank_type_exception_msg)
 
-    def test_vessel_segments(self):
-        vessel_segments = self.vessel_segments
-        vessel_parametric = self.vessel_spherical
+    def test_vessel_types(self) -> None:
+        self.assertTrue(self.segment_vessel.is_vessel_via_segments())
+        self.assertFalse(self.segment_vessel.is_vessel_via_design_parameters())
+        self.assertFalse(self.spherical_vessel.is_vessel_via_segments())
+        self.assertTrue(self.spherical_vessel.is_vessel_via_design_parameters())
 
-        self.assertEqual(vessel_segments.get_segment_count(), 2)
-        self.assertEqual(vessel_parametric.get_segment_count(), 0)
+        self.assertFalse(self.segment_vessel.has_spherical_dome())
+        self.assertFalse(self.segment_vessel.has_ellipsoid_dome())
+        self.assertFalse(self.segment_vessel.has_torispherical_dome())
+        self.assertFalse(self.segment_vessel.has_isotensoid_dome())
 
-        self.assertIsInstance(
-            vessel_segments.get_segment(1), configuration.CCPACSFuselageSegment
+        self.assertTrue(self.spherical_vessel.has_spherical_dome())
+        self.assertTrue(self.spherical_vessel.has_ellipsoid_dome())
+        self.assertFalse(self.spherical_vessel.has_torispherical_dome())
+        self.assertFalse(self.spherical_vessel.has_isotensoid_dome())
+
+        self.assertFalse(self.ellipsoid_vessel.has_spherical_dome())
+        self.assertTrue(self.ellipsoid_vessel.has_ellipsoid_dome())
+        self.assertFalse(self.ellipsoid_vessel.has_torispherical_dome())
+        self.assertFalse(self.ellipsoid_vessel.has_isotensoid_dome())
+
+        self.assertFalse(self.torispherical_vessel.has_spherical_dome())
+        self.assertFalse(self.torispherical_vessel.has_ellipsoid_dome())
+        self.assertTrue(self.torispherical_vessel.has_torispherical_dome())
+        self.assertFalse(self.torispherical_vessel.has_isotensoid_dome())
+
+        self.assertFalse(self.isotensoid_vessel.has_spherical_dome())
+        self.assertFalse(self.isotensoid_vessel.has_ellipsoid_dome())
+        self.assertFalse(self.isotensoid_vessel.has_torispherical_dome())
+        self.assertTrue(self.isotensoid_vessel.has_isotensoid_dome())
+
+    def test_vessel_sections(self) -> None:
+        self.assertEqual(
+            self.segment_vessel.get_section_count(),
+            3,
         )
-        with self.assertRaises(RuntimeError) as context:
-            vessel_parametric.get_segment(1)
-        self.assertEqual(str(context.exception), self.tank_type_exception_msg)
+        self.assertEqual(
+            self.spherical_vessel.get_section_count(),
+            0,
+        )
+        self.assertIsInstance(
+            self.segment_vessel.get_section(1),
+            configuration.CCPACSFuselageSection,
+        )
 
-    def test_vessel_guide_curves(self):
-        point = self.vessel_guides.get_guide_curve_points()[1]
-        self.assertAlmostEqual(round(point.X(), 2), 3.5, 1e-2)
-        self.assertAlmostEqual(round(point.Y(), 2), 0.0, 1e-5)
-        self.assertAlmostEqual(round(point.Z(), 2), -0.65, 1e-2)
         with self.assertRaises(RuntimeError) as context:
-            self.vessel_spherical.get_guide_curve_points()[1]
-        self.assertEqual(str(context.exception), self.tank_type_exception_msg)
+            self.spherical_vessel.get_section(1)
 
         self.assertEqual(
-            self.vessel_guides.get_guide_curve_segment(
-                "tank2_seg1_upper"
-            ).get_guide_curve_profile_uid(),
-            "gc_upper",
+            str(context.exception),
+            self.INVALID_VESSEL_TYPE_MESSAGE,
         )
+
+        self.assertIsInstance(
+            self.segment_vessel.get_section_face("outerVessel_section3"),
+            TopoDS_Face,
+        )
+
         with self.assertRaises(RuntimeError) as context:
-            self.vessel_spherical.get_guide_curve_segment("tank2_seg1_upper")
-        self.assertEqual(str(context.exception), self.tank_type_exception_msg)
+            self.spherical_vessel.get_section_face("outerVessel_section3")
 
-    def test_vessel_loft_evaluation(self):
-        vessel_segments = self.vessel_segments
-        vessel_parametric = self.vessel_spherical
+        self.assertEqual(
+            str(context.exception),
+            self.INVALID_VESSEL_TYPE_MESSAGE,
+        )
 
-        self.assertAlmostEqual(round(vessel_segments.get_geometric_volume(), 2), 6.57)
-        self.assertAlmostEqual(round(vessel_parametric.get_geometric_volume(), 2), 18.1)
+    def test_vessel_segments(self) -> None:
+        self.assertEqual(
+            self.segment_vessel.get_segment_count(),
+            2,
+        )
+        self.assertEqual(
+            self.spherical_vessel.get_segment_count(),
+            0,
+        )
+        self.assertIsInstance(
+            self.segment_vessel.get_segment(1),
+            configuration.CCPACSFuselageSegment,
+        )
 
-        self.assertAlmostEqual(round(vessel_segments.get_surface_area(), 2), 19.94)
-        self.assertAlmostEqual(round(vessel_parametric.get_surface_area(), 2), 36.19)
+        with self.assertRaises(RuntimeError) as context:
+            self.spherical_vessel.get_segment(1)
+
+        self.assertEqual(
+            str(context.exception),
+            self.INVALID_VESSEL_TYPE_MESSAGE,
+        )
+
+    def test_guide_curves(self) -> None:
+        point = self.guide_vessel.get_guide_curve_points()[1]
 
         self.assertAlmostEqual(
-            round(vessel_segments.get_circumference(1, 0.5), 2), 7.43
+            point.X(),
+            3.5,
+            delta=self.GEOMETRY_TOLERANCE,
         )
+        self.assertAlmostEqual(
+            point.Y(),
+            0.0,
+            delta=self.POINT_TOLERANCE,
+        )
+        self.assertAlmostEqual(
+            point.Z(),
+            -0.65,
+            delta=self.GEOMETRY_TOLERANCE,
+        )
+
         with self.assertRaises(RuntimeError) as context:
-            vessel_parametric.get_circumference(1, 0.5)
-        self.assertEqual(str(context.exception), self.tank_type_exception_msg)
+            self.spherical_vessel.get_guide_curve_points()
 
-    def test_structure(self):
-        structure_with_walls = self.vessel_isotensoid.get_structure()
-        structure_with_stringer_frames = self.vessel_segments.get_structure()
+        self.assertEqual(
+            str(context.exception),
+            self.INVALID_VESSEL_TYPE_MESSAGE,
+        )
 
-        # Test availability of generated class:
+        guide_curve_segment = self.guide_vessel.get_guide_curve_segment(
+            "tank2_seg1_upper"
+        )
+
+        self.assertEqual(
+            guide_curve_segment.get_guide_curve_profile_uid(),
+            "gc_upper",
+        )
+
+        with self.assertRaises(RuntimeError) as context:
+            self.spherical_vessel.get_guide_curve_segment("tank2_seg1_upper")
+
+        self.assertEqual(
+            str(context.exception),
+            self.INVALID_VESSEL_TYPE_MESSAGE,
+        )
+
+    def test_loft_evaluation(self) -> None:
+        self.assertAlmostEqual(
+            self.segment_vessel.get_geometric_volume(),
+            6.57,
+            delta=self.GEOMETRY_TOLERANCE,
+        )
+        self.assertAlmostEqual(
+            self.spherical_vessel.get_geometric_volume(),
+            18.1,
+            delta=self.GEOMETRY_TOLERANCE,
+        )
+        self.assertAlmostEqual(
+            self.segment_vessel.get_surface_area(),
+            19.94,
+            delta=self.GEOMETRY_TOLERANCE,
+        )
+        self.assertAlmostEqual(
+            self.spherical_vessel.get_surface_area(),
+            36.19,
+            delta=self.GEOMETRY_TOLERANCE,
+        )
+        self.assertAlmostEqual(
+            self.segment_vessel.get_circumference(1, 0.5),
+            7.43,
+            delta=self.GEOMETRY_TOLERANCE,
+        )
+
+        with self.assertRaises(RuntimeError) as context:
+            self.spherical_vessel.get_circumference(1, 0.5)
+
+        self.assertEqual(
+            str(context.exception),
+            self.INVALID_VESSEL_TYPE_MESSAGE,
+        )
+
+    def test_structure(self) -> None:
+        wall_structure = self.isotensoid_vessel.get_structure()
+        reinforced_structure = self.segment_vessel.get_structure()
+
         self.assertIsInstance(
-            structure_with_stringer_frames.get_frames(),
+            reinforced_structure.get_frames(),
             configuration.CCPACSFramesAssembly,
         )
-
         self.assertIsInstance(
-            structure_with_stringer_frames.get_stringers(),
+            reinforced_structure.get_stringers(),
             configuration.CCPACSStringersAssembly,
         )
-
         self.assertIsInstance(
-            structure_with_walls.get_walls(), configuration.CCPACSWalls
+            wall_structure.get_walls(),
+            configuration.CCPACSWalls,
         )
 
 

--- a/tests/python/test_fuelTanks.py
+++ b/tests/python/test_fuelTanks.py
@@ -72,6 +72,7 @@ class TestFuelTanks(unittest.TestCase):
         cls.aircraft_config = manager.get_configuration(cls.tigl._handle.value)
         cls.uid_manager = cls.aircraft_config.get_uidmanager()
 
+        # Cache representative segment-based and parametric vessels.
         cls.fuel_tank = cls.uid_manager.get_geometric_component(cls.TANK_UID)
         cls.segment_vessel = cls.uid_manager.get_geometric_component(
             cls.SEGMENT_VESSEL_UID
@@ -104,6 +105,8 @@ class TestFuelTanks(unittest.TestCase):
             self.aircraft_config.get_fuel_tank_count(),
             8,
         )
+
+        # Verify the index- and UID-based overloads exposed by SWIG.
         self.assertIsInstance(
             self.aircraft_config.get_fuel_tank(1),
             configuration.CPACSFuelTank,
@@ -209,11 +212,13 @@ class TestFuelTanks(unittest.TestCase):
         )
 
     def test_vessel_types(self) -> None:
+        # Vessel geometry uses either segments or parametric design data.
         self.assertTrue(self.segment_vessel.is_vessel_via_segments())
         self.assertFalse(self.segment_vessel.is_vessel_via_design_parameters())
         self.assertFalse(self.spherical_vessel.is_vessel_via_segments())
         self.assertTrue(self.spherical_vessel.is_vessel_via_design_parameters())
 
+        # A spherical dome is an ellipsoid with a half-axis fraction of 1.
         self.assertFalse(self.segment_vessel.has_spherical_dome())
         self.assertFalse(self.segment_vessel.has_ellipsoid_dome())
         self.assertFalse(self.segment_vessel.has_torispherical_dome())
@@ -240,6 +245,7 @@ class TestFuelTanks(unittest.TestCase):
         self.assertTrue(self.isotensoid_vessel.has_isotensoid_dome())
 
     def test_vessel_sections(self) -> None:
+        # Parametric vessels have no sections and reject section-only access.
         self.assertEqual(
             self.segment_vessel.get_section_count(),
             3,
@@ -261,6 +267,7 @@ class TestFuelTanks(unittest.TestCase):
             self.INVALID_VESSEL_TYPE_MESSAGE,
         )
 
+        # Section faces are reconstructed from segment boundary wires.
         self.assertIsInstance(
             self.segment_vessel.get_section_face("outerVessel_section3"),
             TopoDS_Face,
@@ -275,6 +282,7 @@ class TestFuelTanks(unittest.TestCase):
         )
 
     def test_vessel_segments(self) -> None:
+        # Parametric vessels have no segments and reject segment access.
         self.assertEqual(
             self.segment_vessel.get_segment_count(),
             2,
@@ -376,6 +384,7 @@ class TestFuelTanks(unittest.TestCase):
         )
 
     def test_structure(self) -> None:
+        # Vessel structures expose optional frame, stringer, and wall assemblies.
         wall_structure = self.isotensoid_vessel.get_structure()
         reinforced_structure = self.segment_vessel.get_structure()
 

--- a/tests/python/test_naca4profile.py
+++ b/tests/python/test_naca4profile.py
@@ -1,48 +1,109 @@
+from pathlib import Path
+import unittest
+
+from OCC.Core.gp import gp_Vec2d
+from OCC.Core.TopoDS import TopoDS_Edge
+
 from tixi3.tixi3wrapper import Tixi3
 from tigl3.tigl3wrapper import Tigl3
-import tigl3.configuration
-import unittest
-import os
-import sys
-from OCC.Core.TopoDS import TopoDS_Edge
-from OCC.Core.gp import gp_Vec2d
-from tigl3.configuration import CTiglNACA4Calculator
+from tigl3.configuration import (
+    CCPACSConfigurationManager_get_instance,
+    CPACSNacaProfile,
+    CTiglNACA4Calculator,
+)
 
 
 class TestNACA(unittest.TestCase):
-    def setUp(self):
-        self.tixi_h = Tixi3()
-        self.tigl_h = Tigl3()
-        self.assertIsNone(self.tixi_h.open("TestData/naca_test.cpacs.xml"))
-        self.assertIsNone(self.tigl_h.open(self.tixi_h, ""))
-        mgr = tigl3.configuration.CCPACSConfigurationManager_get_instance()
-        self.aircraft_config = mgr.get_configuration(self.tigl_h._handle.value)
-        
+    CPACS_FILE = Path("TestData/naca_test.cpacs.xml")
+    PROFILE_UID = "NACA0012"
+    ABS_TOLERANCE = 1e-6
 
-    def tearDown(self):
-        self.tigl_h.close()
-        self.tixi_h.close()
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
 
-    def test_nacaAircraftElements_0012(self):
-        profiles = self.aircraft_config.get_wing_profiles()
-        self.wing_profile = profiles.get_profile("NACA0012")
-        choice = self.wing_profile.get_naca_profile_choice4()
-        assert isinstance(self.wing_profile.get_naca_profile_choice4(), tigl3.configuration.CPACSNacaProfile)
-        upper_wire = self.wing_profile.get_upper_wire()
-        assert isinstance(upper_wire, TopoDS_Edge)
-        lower_wire = self.wing_profile.get_lower_wire()
-        assert isinstance(lower_wire, TopoDS_Edge)
-        trailing_edge = self.wing_profile.get_trailing_edge()
-        assert isinstance(trailing_edge, TopoDS_Edge)
+        if not cls.CPACS_FILE.is_file():
+            raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}.")
 
+        cls.tixi = Tixi3()
+        cls.tigl = Tigl3()
+        cls._tixi_is_open = False
+        cls._tigl_is_open = False
+
+        cls.addClassCleanup(cls._close_configuration)
+
+        tixi_result = cls.tixi.open(str(cls.CPACS_FILE))
+        if tixi_result is not None:
+            raise AssertionError(f"Tixi3.open() unexpectedly returned {tixi_result!r}")
+        cls._tixi_is_open = True
+
+        tigl_result = cls.tigl.open(cls.tixi, "")
+        if tigl_result is not None:
+            raise AssertionError(f"Tigl3.open() unexpectedly returned {tigl_result!r}")
+        cls._tigl_is_open = True
+
+        manager = CCPACSConfigurationManager_get_instance()
+        cls.aircraft_config = manager.get_configuration(cls.tigl._handle.value)
+
+        profiles = cls.aircraft_config.get_wing_profiles()
+        cls.wing_profile = profiles.get_profile(cls.PROFILE_UID)
+
+    @classmethod
+    def _close_configuration(cls) -> None:
+        try:
+            if cls._tigl_is_open:
+                cls.tigl.close()
+        finally:
+            if cls._tixi_is_open:
+                cls.tixi.close()
+
+    def test_profile_type(self) -> None:
+        naca_profile = self.wing_profile.get_naca_profile_choice4()
+
+        self.assertIsInstance(naca_profile, CPACSNacaProfile)
+
+    def test_edges(self) -> None:
+        self.assertIsInstance(
+            self.wing_profile.get_upper_wire(),
+            TopoDS_Edge,
+        )
+        self.assertIsInstance(
+            self.wing_profile.get_lower_wire(),
+            TopoDS_Edge,
+        )
+        self.assertIsInstance(
+            self.wing_profile.get_trailing_edge(),
+            TopoDS_Edge,
+        )
+
+    def test_trailing_edge_point(self) -> None:
         upper_point = self.wing_profile.get_upper_point(1.0)
-        point = upper_point.Z()
-        self.assertAlmostEqual(point, 0, delta=1e-6)
 
-        calculator = tigl3.configuration.CTiglNACA4Calculator(0,0,9, 0.000945)
-        assert isinstance(calculator, CTiglNACA4Calculator)
-        calculator_upper_curve = calculator.upper_curve(0.5)
-        assert isinstance(calculator_upper_curve, gp_Vec2d)
-        
+        self.assertAlmostEqual(
+            upper_point.Z(),
+            0.0,
+            delta=self.ABS_TOLERANCE,
+        )
+
+    def test_upper_curve_type(self) -> None:
+        max_camber = 0
+        camber_position = 0
+        thickness = 9
+        trailing_edge_thickness = 0.000945
+
+        calculator = CTiglNACA4Calculator(
+            max_camber,
+            camber_position,
+            thickness,
+            trailing_edge_thickness,
+        )
+
+        self.assertIsInstance(calculator, CTiglNACA4Calculator)
+
+        upper_curve_point = calculator.upper_curve(0.5)
+
+        self.assertIsInstance(upper_curve_point, gp_Vec2d)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_systems.py
+++ b/tests/python/test_systems.py
@@ -4,169 +4,274 @@
 # Licensed under the Apache License, Version 2.0
 #############################################################################
 
+from pathlib import Path
 import unittest
 
-from tigl3.tigl3wrapper import *
-from tixi3.tixi3wrapper import *
 from tigl3 import configuration, geometry
+from tigl3.tigl3wrapper import Tigl3
+from tixi3.tixi3wrapper import Tixi3
 
 
-class SystemsBindings(unittest.TestCase):
+class TestSystemsBindings(unittest.TestCase):
+    CPACS_FILE = Path("TestData/simpletest-systems.cpacs.xml")
+    CONFIGURATION_UID = "testAircraft"
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        if not cls.CPACS_FILE.is_file():
+            raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}")
+
         cls.tixi = Tixi3()
         cls.tigl = Tigl3()
+        cls._tixi_is_open = False
+        cls._tigl_is_open = False
 
-        cls.assertIsNone = staticmethod(unittest.TestCase().assertIsNone)
-        cls.assertIsNone(cls.tixi.open("TestData/simpletest-systems.cpacs.xml"))
-        cls.assertIsNone(cls.tigl.open(cls.tixi, "testAircraft"))
+        cls.addClassCleanup(cls._close_configuration)
 
-        mgr = configuration.CCPACSConfigurationManager.get_instance()
-        cls.config = mgr.get_configuration(cls.tigl._handle.value)
-        cls.uid_mgr = cls.config.get_uidmanager()
+        tixi_result = cls.tixi.open(str(cls.CPACS_FILE))
+        if tixi_result is not None:
+            raise AssertionError(f"Tixi3.open() unexpectedly returned {tixi_result!r}")
+        cls._tixi_is_open = True
+
+        tigl_result = cls.tigl.open(cls.tixi, cls.CONFIGURATION_UID)
+        if tigl_result is not None:
+            raise AssertionError(f"Tigl3.open() unexpectedly returned {tigl_result!r}")
+        cls._tigl_is_open = True
+
+        manager = configuration.CCPACSConfigurationManager.get_instance()
+        cls.aircraft_config = manager.get_configuration(cls.tigl._handle.value)
+        cls.uid_manager = cls.aircraft_config.get_uidmanager()
 
     @classmethod
-    def tearDownClass(cls):
-        cls.tigl.close()
-        cls.tixi.close()
+    def _close_configuration(cls) -> None:
+        try:
+            if cls._tigl_is_open:
+                cls.tigl.close()
+        finally:
+            if cls._tixi_is_open:
+                cls.tixi.close()
 
-    def test_uid_manager_factory_returns_concrete_types(self):
-        system = self.uid_mgr.get_geometric_component("genSys")
-        component = self.uid_mgr.get_geometric_component("cuboid_1")
+    def test_factory_types(self) -> None:
+        system = self.uid_manager.get_geometric_component("genSys")
+        component = self.uid_manager.get_geometric_component("cuboid_1")
 
-        self.assertIsInstance(system, geometry.ITiglGeometricComponent)
-        self.assertIsInstance(system, configuration.CCPACSGenericSystem)
+        self.assertIsInstance(
+            system,
+            geometry.ITiglGeometricComponent,
+        )
+        self.assertIsInstance(
+            system,
+            configuration.CCPACSGenericSystem,
+        )
+        self.assertIsInstance(
+            component,
+            geometry.ITiglGeometricComponent,
+        )
+        self.assertIsInstance(
+            component,
+            configuration.CCPACSComponent,
+        )
 
-        self.assertIsInstance(component, geometry.ITiglGeometricComponent)
-        self.assertIsInstance(component, configuration.CCPACSComponent)
-
-    def test_system_accessors(self):
-        system = self.uid_mgr.get_geometric_component("genSys")
+    def test_system_accessors(self) -> None:
+        system = self.uid_manager.get_geometric_component("genSys")
 
         self.assertEqual(system.get_uid(), "genSys")
         self.assertEqual(system.get_defaulted_uid(), "genSys")
         self.assertEqual(system.get_name(), "Generic System")
         self.assertIsInstance(
-            system.get_configuration(), configuration.CCPACSConfiguration
+            system.get_configuration(),
+            configuration.CCPACSConfiguration,
         )
 
         components = system.get_components()
+
         self.assertIsNotNone(components)
         self.assertEqual(components.get_component_count(), 24)
         self.assertIsInstance(
-            components.get_component(1), configuration.CCPACSComponent
+            components.get_component(1),
+            configuration.CCPACSComponent,
         )
 
-        # curated Python API: generated plural getter is intentionally hidden
+        # The generated plural getter is intentionally hidden from Python.
         with self.assertRaises(AttributeError):
             components.get_components()
 
-        # smoke-check wrapped system methods without reproducing C++ numerics
-        self.assertIsInstance(system.get_mass_all_components(), float)
-        self.assertIsInstance(system.get_mass_positioned_components(), float)
-        self.assertIsInstance(system.get_center_of_gravity(), geometry.CTiglPoint)
+        self.assertIsInstance(
+            system.get_mass_all_components(),
+            float,
+        )
+        self.assertIsInstance(
+            system.get_mass_positioned_components(),
+            float,
+        )
+        self.assertIsInstance(
+            system.get_center_of_gravity(),
+            geometry.CTiglPoint,
+        )
 
         shape = system.get_loft()
+
         self.assertIsNotNone(shape)
         self.assertGreater(shape.get_face_count(), 0)
 
-    def test_component_accessors(self):
-        component = self.uid_mgr.get_geometric_component("cuboid_2")
+    def test_component_accessors(self) -> None:
+        component = self.uid_manager.get_geometric_component("cuboid_2")
 
-        self.assertIsInstance(component.get_component_intent(), int)
-        self.assertIsInstance(component.get_component_type(), int)
-        self.assertIsInstance(component.get_component_representation(), int)
-        self.assertEqual(component.get_component_representation_as_string(), "envelope")
+        self.assertIsInstance(
+            component.get_component_intent(),
+            int,
+        )
+        self.assertIsInstance(
+            component.get_component_type(),
+            int,
+        )
+        self.assertIsInstance(
+            component.get_component_representation(),
+            int,
+        )
+        self.assertEqual(
+            component.get_component_representation_as_string(),
+            "envelope",
+        )
 
         self.assertIsInstance(component.get_mass(), float)
         self.assertTrue(component.is_positioned())
+
         self.assertIsInstance(
-            component.get_center_of_gravity_local(), geometry.CTiglPoint
+            component.get_center_of_gravity_local(),
+            geometry.CTiglPoint,
         )
         self.assertIsInstance(
-            component.get_center_of_gravity_global(), geometry.CTiglPoint
+            component.get_center_of_gravity_global(),
+            geometry.CTiglPoint,
+        )
+        self.assertIsInstance(
+            component.get_centroid_local(),
+            geometry.CTiglPoint,
+        )
+        self.assertIsInstance(
+            component.get_centroid_global(),
+            geometry.CTiglPoint,
         )
 
-        self.assertIsInstance(component.get_centroid_local(), geometry.CTiglPoint)
-        self.assertIsInstance(component.get_centroid_global(), geometry.CTiglPoint)
-
-        # optional mass inertia -> None in Python
         self.assertIsNone(component.get_mass_inertia_local())
 
         shape = component.get_loft()
+
         self.assertIsNotNone(shape)
         self.assertGreater(shape.get_face_count(), 0)
 
-    def test_none_for_missing_optional_values(self):
-        wedge = self.uid_mgr.get_geometric_component("wedge_1")
+    def test_missing_optional_values(self) -> None:
+        wedge = self.uid_manager.get_geometric_component("wedge_1")
+
         self.assertIsNone(wedge.get_mass())
 
-        unpositioned = self.uid_mgr.get_geometric_component("unpositionedCuboid")
+        unpositioned = self.uid_manager.get_geometric_component("unpositionedCuboid")
+
         self.assertFalse(unpositioned.is_positioned())
         self.assertIsNotNone(unpositioned.get_center_of_gravity_local())
         self.assertIsNone(unpositioned.get_center_of_gravity_global())
 
-        cuboid1 = self.uid_mgr.get_geometric_component("cuboid_1")
-        inertia = cuboid1.get_mass_inertia_local()
-        self.assertIsInstance(inertia, configuration.CTiglMassInertia)
+        cuboid = self.uid_manager.get_geometric_component("cuboid_1")
+        inertia = cuboid.get_mass_inertia_local()
+
+        self.assertIsInstance(
+            inertia,
+            configuration.CTiglMassInertia,
+        )
         self.assertIsNone(inertia.Jxy)
         self.assertIsNone(inertia.Jxz)
         self.assertIsNone(inertia.Jyz)
 
-    def test_empty_generic_system(self):
-        system = self.uid_mgr.get_geometric_component("genSys_empty")
+    def test_empty_system(self) -> None:
+        system = self.uid_manager.get_geometric_component("genSys_empty")
 
-        self.assertIsInstance(system, configuration.CCPACSGenericSystem)
+        self.assertIsInstance(
+            system,
+            configuration.CCPACSGenericSystem,
+        )
         self.assertIsNone(system.get_components())
         self.assertIsNone(system.get_center_of_gravity())
         self.assertIsNotNone(system.get_loft())
 
-    def test_system_architecture_access(self):
-        self.assertEqual(self.config.get_system_architectures_count(), 1)
+    def test_architecture_access(self) -> None:
+        self.assertEqual(
+            self.aircraft_config.get_system_architectures_count(),
+            1,
+        )
 
-        sa = self.config.get_system_architecture(1)
-        self.assertEqual(sa.get_name(), "Test system architecture")
+        architecture = self.aircraft_config.get_system_architecture(1)
 
-        # overload resolution (index vs uid)
-        sa_by_uid = self.config.get_system_architecture("systemArchitecture1")
-        self.assertEqual(sa_by_uid.get_name(), "Test system architecture")
+        self.assertEqual(
+            architecture.get_name(),
+            "Test system architecture",
+        )
 
-        connections = sa.get_connections()
+        architecture_by_uid = self.aircraft_config.get_system_architecture(
+            "systemArchitecture1"
+        )
+
+        self.assertEqual(
+            architecture_by_uid.get_name(),
+            "Test system architecture",
+        )
+
+        connections = architecture.get_connections()
+
         self.assertIsNotNone(connections)
         self.assertEqual(connections.get_connection_count(), 5)
 
-    def test_system_architecture_connection_typemaps(self):
-        sa = self.config.get_system_architecture(1)
-        connections = sa.get_connections()
+    def test_connection_typemaps(self) -> None:
+        architecture = self.aircraft_config.get_system_architecture(1)
+        connections = architecture.get_connections()
 
-        # component -> component
-        c1 = connections.get_connection(1)
-        self.assertIsInstance(c1.get_source_component(), configuration.CCPACSComponent)
-        self.assertIsInstance(c1.get_target_component(), configuration.CCPACSComponent)
+        component_connection = connections.get_connection(1)
 
-        # component -> fuselage: wrapped component accessor must return None
-        c3 = connections.get_connection(3)
-        self.assertIsInstance(c3.get_source_component(), configuration.CCPACSComponent)
-        self.assertIsNone(c3.get_target_component())
-        self.assertEqual(c3.get_target().get_component_uid_choice4(), "SimpleFuselage")
+        self.assertIsInstance(
+            component_connection.get_source_component(),
+            configuration.CCPACSComponent,
+        )
+        self.assertIsInstance(
+            component_connection.get_target_component(),
+            configuration.CCPACSComponent,
+        )
 
-        # fuselage -> externalElement: optional enum should be available
-        c4 = connections.get_connection(4)
-        self.assertIsNone(c4.get_source_component())
-        self.assertIsNone(c4.get_target_component())
-        self.assertEqual(c4.get_target().get_external_element_choice1(), 0)
+        fuselage_connection = connections.get_connection(3)
 
-    def test_component_sequence_exposure(self):
-        sa = self.config.get_system_architecture(1)
-        components = sa.get_generic_system_components()
+        self.assertIsInstance(
+            fuselage_connection.get_source_component(),
+            configuration.CCPACSComponent,
+        )
+        self.assertIsNone(fuselage_connection.get_target_component())
+        self.assertEqual(
+            fuselage_connection.get_target().get_component_uid_choice4(),
+            "SimpleFuselage",
+        )
+
+        external_connection = connections.get_connection(4)
+
+        self.assertIsNone(external_connection.get_source_component())
+        self.assertIsNone(external_connection.get_target_component())
+        self.assertEqual(
+            external_connection.get_target().get_external_element_choice1(),
+            0,
+        )
+
+    def test_component_sequence(self) -> None:
+        architecture = self.aircraft_config.get_system_architecture(1)
+        components = architecture.get_generic_system_components()
 
         self.assertEqual(len(components), 3)
         self.assertTrue(
-            all(isinstance(c, configuration.CCPACSComponent) for c in components)
+            all(
+                isinstance(component, configuration.CCPACSComponent)
+                for component in components
+            )
         )
-        self.assertEqual(
-            [c.get_defaulted_uid() for c in components],
+        self.assertSequenceEqual(
+            [component.get_defaulted_uid() for component in components],
             ["cuboid_1", "cuboid_2", "cuboid_3"],
         )
 

--- a/tests/python/test_systems.py
+++ b/tests/python/test_systems.py
@@ -1,7 +1,19 @@
 #############################################################################
-# Copyright (C) 2007-2026 German Aerospace Center (DLR/SC)
+# Copyright (C) 2007-2025 German Aerospace Center (DLR/SC)
 #
-# Licensed under the Apache License, Version 2.0
+# Created: 2025-06-04 Marko Alder <marko.alder@dlr.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #############################################################################
 
 from pathlib import Path
@@ -23,13 +35,11 @@ class TestSystemsBindings(unittest.TestCase):
         if not cls.CPACS_FILE.is_file():
             raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}")
 
-        # Load the read-only CPACS configuration once for the complete test class.
         cls.tixi = Tixi3()
         cls.tigl = Tigl3()
         cls._tixi_is_open = False
         cls._tigl_is_open = False
 
-        # Register cleanup before opening native resources.
         cls.addClassCleanup(cls._close_configuration)
 
         tixi_result = cls.tixi.open(str(cls.CPACS_FILE))

--- a/tests/python/test_systems.py
+++ b/tests/python/test_systems.py
@@ -23,11 +23,13 @@ class TestSystemsBindings(unittest.TestCase):
         if not cls.CPACS_FILE.is_file():
             raise FileNotFoundError(f"File not found: {cls.CPACS_FILE.resolve()}")
 
+        # Load the read-only CPACS configuration once for the complete test class.
         cls.tixi = Tixi3()
         cls.tigl = Tigl3()
         cls._tixi_is_open = False
         cls._tigl_is_open = False
 
+        # Register cleanup before opening native resources.
         cls.addClassCleanup(cls._close_configuration)
 
         tixi_result = cls.tixi.open(str(cls.CPACS_FILE))
@@ -54,6 +56,7 @@ class TestSystemsBindings(unittest.TestCase):
                 cls.tixi.close()
 
     def test_factory_types(self) -> None:
+        # The SWIG factory must expose the concrete C++ runtime types.
         system = self.uid_manager.get_geometric_component("genSys")
         component = self.uid_manager.get_geometric_component("cuboid_1")
 
@@ -98,6 +101,7 @@ class TestSystemsBindings(unittest.TestCase):
         with self.assertRaises(AttributeError):
             components.get_components()
 
+        # Numerical behavior is covered by C++ tests; verify the Python types here.
         self.assertIsInstance(
             system.get_mass_all_components(),
             float,
@@ -164,6 +168,7 @@ class TestSystemsBindings(unittest.TestCase):
         self.assertGreater(shape.get_face_count(), 0)
 
     def test_missing_optional_values(self) -> None:
+        # C++ boost::optional values are exposed as objects or None in Python.
         wedge = self.uid_manager.get_geometric_component("wedge_1")
 
         self.assertIsNone(wedge.get_mass())
@@ -194,6 +199,8 @@ class TestSystemsBindings(unittest.TestCase):
         )
         self.assertIsNone(system.get_components())
         self.assertIsNone(system.get_center_of_gravity())
+
+        # The loft builder still returns a valid grouped shape.
         self.assertIsNotNone(system.get_loft())
 
     def test_architecture_access(self) -> None:
@@ -209,6 +216,7 @@ class TestSystemsBindings(unittest.TestCase):
             "Test system architecture",
         )
 
+        # Verify SWIG overload resolution for index and UID arguments.
         architecture_by_uid = self.aircraft_config.get_system_architecture(
             "systemArchitecture1"
         )
@@ -227,6 +235,7 @@ class TestSystemsBindings(unittest.TestCase):
         architecture = self.aircraft_config.get_system_architecture(1)
         connections = architecture.get_connections()
 
+        # Both endpoints resolve to generic-system components.
         component_connection = connections.get_connection(1)
 
         self.assertIsInstance(
@@ -238,6 +247,7 @@ class TestSystemsBindings(unittest.TestCase):
             configuration.CCPACSComponent,
         )
 
+        # A fuselage target must not be exposed as CCPACSComponent.
         fuselage_connection = connections.get_connection(3)
 
         self.assertIsInstance(
@@ -250,6 +260,7 @@ class TestSystemsBindings(unittest.TestCase):
             "SimpleFuselage",
         )
 
+        # External endpoints are available through the generated choice API.
         external_connection = connections.get_connection(4)
 
         self.assertIsNone(external_connection.get_source_component())
@@ -263,6 +274,7 @@ class TestSystemsBindings(unittest.TestCase):
         architecture = self.aircraft_config.get_system_architecture(1)
         components = architecture.get_generic_system_components()
 
+        # Components are unique by UID and retain first-connection order.
         self.assertEqual(len(components), 3)
         self.assertTrue(
             all(


### PR DESCRIPTION
## Description

This PR refactors selected Python binding tests for systems, fuel tanks, and decks. I also was so free to suggest cleaning up the NACA4 tests, even though I did not originally author them.

The test coverage and expected behavior remain unchanged. This PR is primarily a refactoring and cleanup to improve test performance, readability, and PEP 8 compliance. The only functional change is a bug fix in the fuel tank test.

The changes include:

* replacing wildcard and unused imports with explicit imports and clearer naming;
* consolidating repeated setup and cleanup at class level to improve performance and resource handling;
* splitting large test methods into focused tests and documenting non-obvious SWIG and C++ binding behavior.

## How Has This Been Tested?

The Python binding tests were executed using the existing `python-internal` Pixi environment:

```bash
pixi run -e python-internal pythontests
```

## Screenshots, that help to understand the changes(if applicable):

Not applicable. This PR only changes automated Python tests.

## Checklist for PR Author:

* [ ] Unit or integration test added (not applicable)
* [ ] Python interface updated (not applicable)
* [ ] Python test added (not applicable; no Python interface change)
* [ ] Doxygen docstrings added (not applicable)
* [ ] `ChangeLog.md` updated (not required for test-only changes)
