### PR TITLE
Fix Crash in TiGLCreator due to unchecked nullptr in CTiglWingSectionElement

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ Changes since last release
   - The function `app.openFile` in the TiGLCreator scripting engine now accepts a configuration uid. [#1309](https://github.com/DLR-SC/tigl/pull/1309)
 
 - Fixes
+  - Fix crash in `CTiglWingSectionElement`. This class stores a raw pointer to a `CCPACSWing` as parent, that is `nullptr` if the parent actually is a pylon. This null pointer is dereferenced in `CTiglWingSectionElement::GetWire`, causing a crash, e.g. when selecting a section in the CPACS tree in TiGLCreator ([#1371](https://github.com/DLR-SC/tigl/issues/1371))
   - Fix error when displaying an aircraft with engine but without nacelle (e.g. engine buried in fuselage). Now returns null geometry gracefully instead of throwing an error ([#779](https://github.com/DLR-SC/tigl/issues/779))
   - Fix error when displaying an aircraft with pylon but without segments. Now returns null geometry gracefully instead of throwing an error
   - Fix wrong behaviour in GUI for the spinbox of the wing sweep and dihedral chord percantage ([#1327](https://github.com/DLR-SC/tigl/pull/1327))

--- a/src/engine_pylon/CCPACSEnginePylon.cpp
+++ b/src/engine_pylon/CCPACSEnginePylon.cpp
@@ -18,6 +18,8 @@
 
 #include "CCPACSEnginePylon.h"
 
+#include "CCPACSConfiguration.h"
+#include "CCPACSAircraftModel.h"
 #include "CTiglUIDManager.h"
 #include "CTiglEnginePylonBuilder.h"
 
@@ -72,6 +74,11 @@ CTiglTransformation CCPACSEnginePylon::GetPositioningTransformation(std::string 
         return m_positionings->GetPositioningTransformation(sectionUID);
     else
         return CTiglTransformation(); // return identity if no positioning transformation is given
+}
+
+CCPACSConfiguration& CCPACSEnginePylon::GetConfiguration()
+{
+    return GetParent()->GetParent()->GetConfiguration();
 }
 
 bool CCPACSEnginePylon::HasLoft() const

--- a/src/engine_pylon/CCPACSEnginePylon.h
+++ b/src/engine_pylon/CCPACSEnginePylon.h
@@ -22,6 +22,8 @@
 #include "CTiglRelativelyPositionedComponent.h"
 #include "tigl_internal.h"
 
+namespace tigl { class CCPACSConfiguration; }
+
 namespace tigl
 {
 
@@ -41,6 +43,8 @@ public:
     TIGL_EXPORT void SetSymmetry(const boost::optional<TiglSymmetryAxis>& value) override;
 
     TIGL_EXPORT CTiglTransformation GetPositioningTransformation(std::string sectionUID);
+
+    TIGL_EXPORT CCPACSConfiguration& GetConfiguration();
 
     TIGL_EXPORT bool HasLoft() const;
 

--- a/src/wing/CTiglWingSectionElement.cpp
+++ b/src/wing/CTiglWingSectionElement.cpp
@@ -24,6 +24,7 @@
 #include "CCPACSWingSections.h"
 #include "CCPACSWing.h"
 #include "CCPACSConfiguration.h"
+#include "CPACSAircraftModel.h"
 #include "tiglmathfunctions.h"
 
 #include "tiglcommonfunctions.h"
@@ -35,10 +36,10 @@
 
 tigl::CTiglWingSectionElement::CTiglWingSectionElement()
         : CTiglSectionElement()
+        , config(nullptr)
 {
     element  = nullptr;
     section  = nullptr;
-    wing = nullptr;
 }
 
 tigl::CTiglWingSectionElement::CTiglWingSectionElement(tigl::CCPACSWingSectionElement* inElement)
@@ -53,19 +54,24 @@ void tigl::CTiglWingSectionElement::SetAssociateElement(tigl::CCPACSWingSectionE
         return;
     }
 
-    // set only if parent is a wing
     CCPACSWingSection* theSection = element->GetParent()->GetParent();
-
     if (!theSection) {
         return;
     }
 
-    if (theSection->GetParent()->IsParent<CCPACSWing>()) {
-        this->element = element;
-        section       = theSection;
-        wing          = theSection->GetParent()->GetParent<CCPACSWing>();
-    }
+    this->element = element;
+    section       = theSection;
 
+    if (theSection->GetParent()->IsParent<CCPACSWing>()) {
+        CCPACSWing* w = theSection->GetParent()->GetParent<CCPACSWing>();
+        parent = w;
+        config = &w->GetConfiguration();
+    }
+    else if (theSection->GetParent()->IsParent<CCPACSEnginePylon>()) {
+        CCPACSEnginePylon* pylon = theSection->GetParent()->GetParent<CCPACSEnginePylon>();
+        parent = pylon;
+        config = &pylon->GetConfiguration();
+    }
 }
 
 std::string tigl::CTiglWingSectionElement::GetSectionUID() const
@@ -86,8 +92,7 @@ std::string tigl::CTiglWingSectionElement::GetProfileUID() const
 
 void tigl::CTiglWingSectionElement::SetProfileUID(const std::string& newProfileUID)
 {
-    CCPACSConfiguration& config = wing->GetConfiguration();
-    if ( ! config.GetWingProfiles()->HasProfile(newProfileUID) ) {
+    if (!config || !config->GetWingProfiles()->HasProfile(newProfileUID)) {
         throw CTiglError("CTiglWingSectionElement::SetProfileUID: The given profile seems not to be present in the profile list.");
     }
     element->SetAirfoilUID(newProfileUID);
@@ -96,8 +101,7 @@ void tigl::CTiglWingSectionElement::SetProfileUID(const std::string& newProfileU
 // Returns the Wing profile referenced by this connection
 tigl::CCPACSWingProfile& tigl::CTiglWingSectionElement::GetProfile()
 {
-    CCPACSConfiguration& config = wing->GetConfiguration();
-    return (config.GetWingProfile(GetProfileUID()));
+    return config->GetWingProfile(GetProfileUID());
 }
 
 const tigl::CCPACSWingProfile& tigl::CTiglWingSectionElement::GetProfile() const
@@ -105,16 +109,14 @@ const tigl::CCPACSWingProfile& tigl::CTiglWingSectionElement::GetProfile() const
     return const_cast<CTiglWingSectionElement&>(*this).GetProfile();
 }
 
-// Returns the positioning transformation for the referenced section
 tigl::CTiglTransformation tigl::CTiglWingSectionElement::GetPositioningTransformation() const
 {
-    boost::optional<CTiglTransformation> transformation = wing->GetPositioningTransformation(section->GetUID());
-    if (transformation) {
-        return transformation.value();
-    }
-    else {
+    return std::visit([&, this](auto* p) -> CTiglTransformation {
+        if (p) {
+            return p->GetPositioningTransformation(section->GetUID());
+        }
         return CTiglTransformation();
-    }
+    }, parent);
 }
 
 // Returns the section matrix referenced by this connection
@@ -136,8 +138,9 @@ tigl::CTiglTransformation tigl::CTiglWingSectionElement::GetParentTransformation
 
 tigl::CTiglTransformation tigl::CTiglWingSectionElement::GetWingTransformation() const
 {
-
-    return wing->GetTransformation().getTransformationMatrix();
+    return std::visit([](auto* p) {
+        return p->GetTransformation().getTransformationMatrix();
+    }, parent);
 }
 
 TopoDS_Wire tigl::CTiglWingSectionElement::GetWire(TiglCoordinateSystem referenceCS) const
@@ -179,10 +182,7 @@ tigl::CTiglPoint tigl::CTiglWingSectionElement::GetNormal(TiglCoordinateSystem r
 
 bool tigl::CTiglWingSectionElement::IsValid() const
 {
-    if (element != nullptr && section != nullptr && wing != nullptr) {
-        return true;
-    }
-    return false;
+    return element != nullptr && section != nullptr && config != nullptr;
 }
 
 tigl::CTiglPoint tigl::CTiglWingSectionElement::GetChordPoint(double xsi, TiglCoordinateSystem referenceCS) const
@@ -222,7 +222,9 @@ tigl::CTiglPoint tigl::CTiglWingSectionElement::GetStdDirForProfileUnitZ(TiglCoo
 
 tigl::CCPACSPositionings& tigl::CTiglWingSectionElement::GetPositionings()
 {
-    return wing->GetPositionings(CreateIfNotExistsTag());
+    return std::visit([](auto* p) -> CCPACSPositionings& {
+        return p->GetPositionings(CreateIfNotExistsTag());
+    }, parent);
 }
 
 void tigl::CTiglWingSectionElement::SetChordPoint(double xsi, tigl::CTiglPoint newChordPoint,

--- a/src/wing/CTiglWingSectionElement.h
+++ b/src/wing/CTiglWingSectionElement.h
@@ -22,6 +22,9 @@
 
 #include "CTiglSectionElement.h"
 #include "CCPACSWingProfile.h"
+#include "CCPACSEnginePylon.h"
+
+#include <variant>
 
 namespace tigl
 {
@@ -29,6 +32,7 @@ namespace tigl
 class CCPACSWing;
 class CCPACSWingSectionElement;
 class CCPACSWingSection;
+class CCPACSConfiguration;
 
 class CTiglWingSectionElement: public CTiglSectionElement
 {
@@ -98,7 +102,8 @@ protected:
 private:
     CCPACSWingSectionElement* element;
     CCPACSWingSection* section;
-    CCPACSWing* wing;
+    std::variant<CCPACSWing*, CCPACSEnginePylon*> parent;
+    CCPACSConfiguration* config;
 
 };
 


### PR DESCRIPTION
# Description

Fixes #1371. Fixes a SEGV crash in TIGLCreator when selecting an engine pylon's wing section element.

This PR is AI-co-authored with all changes thoroughly checked by me.

## Root cause

`CTiglWingSectionElement::GetWire()` → `GetProfile()` calls `wing->GetConfiguration()` where the stored `wing` pointer is `nullptr` for engine pylon sections. Engine pylon sections are not attached to a wing, so the code path that sets the wing pointer is never hit.

## Solution

**`CCPACSEnginePylon` — new `GetConfiguration()` method**: Walks the parent chain: `this → GetParent() → CPACSEnginePylons → GetParent() → CCPACSAircraftModel → GetConfiguration()`

**`CTiglWingSectionElement`**:
- Replaced `CCPACSWing* wing` with `std::variant<CCPACSWing*, CCPACSEnginePylon*> parent` for compile-time type dispatch, plus `CCPACSConfiguration* config` for direct access
- `SetAssociateElement()` detects wing vs pylon via `IsParent<>()` / `GetParent<>()` and populates both fields
- `GetProfile()` / `SetProfileUID()` use the stored `config` pointer directly — no more null dereference
- `GetPositioningTransformation()`, `GetWingTransformation()`, `GetPositionings()` use inline generic lambdas with `std::visit` to dispatch to the correct parent type.

## Files changed

- `src/engine_pylon/CCPACSEnginePylon.h` — `GetConfiguration()` declaration; forward decl `CCPACSConfiguration`
- `src/engine_pylon/CCPACSEnginePylon.cpp` — `GetConfiguration()` impl via parent chain
- `src/wing/CTiglWingSectionElement.h` — `std::variant<CCPACSWing*, CCPACSEnginePylon*>` + `CCPACSConfiguration* config` members
- `src/wing/CTiglWingSectionElement.cpp` — `SetAssociateElement()` parent detection; all methods updated

## How Has This Been Tested?

Existing unit tests pass (896 tests). The crash was reproduced and verified fixed by testing engine pylon section element selection in TIGLCreator.

## Checklist for PR Author

- [ ] Unit or integration test added (N/A — crash scenario not covered by existing tests; verified manually in TIGLCreator)
- [ ] Python interface updated (N/A)
- [ ] Python test added (N/A)
- [ ] Doxygen docstrings added (N/A — no new public API)
- [x] `ChangeLog.md` updated