### PR TITLE
Fix 1366 hard crash in tiglcreator for profiles that dont implement the getupperlowerwire method naca

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ Changes since last release
   - Add the new system definition introduced in CPACS v3.5
   - Add an alternative wing airfoil parametrization that allows the specification of NACA4 codes directly in CPACS (with the trailing edge thickness). This makes a preprocessing step of writing sampled NACA profiles as point lists obsolete and improves the overall surface quality by internally generating B-Splines with a fine-tuned number of control points. [#1293](https://github.com/DLR-SC/tigl/pull/1293)
   - The function `app.openFile` in the TiGLCreator scripting engine now accepts a configuration uid. [#1309](https://github.com/DLR-SC/tigl/pull/1309)
+  - Implemented the UpperLower wire in CTiglWingProfileNACA ([#1366](https://github.com/DLR-SC/tigl/issues/1366))
 
 - Fixes
   - Fix error when displaying an aircraft with engine but without nacelle (e.g. engine buried in fuselage). Now returns null geometry gracefully instead of throwing an error ([#779](https://github.com/DLR-SC/tigl/issues/779))
@@ -40,6 +41,7 @@ Changes since last release
   - Correct the icons in TIGLCreator: Add the correct icon to the "New File" and "Open File" action and add a button to the tool bar ([#1210](https://github.com/DLR-SC/tigl/issues/1210))
   - Fix an issue, where a color is selected on mouse hover in the color chooser dialog *(e.g. when changing the color of a geometric component)*. This issue is caused by a Qt bug ([#1217](https://github.com/DLR-SC/tigl/issues/1217)).
   - TiGLCreator: Auto-append file extension when saving a screenshot if missing, with a more informative error message ([#1296](https://github.com/DLR-SC/tigl/issues/1296))
+  - Fixed an unhandled exception in the TiGLCreator (was triggered from the UpperLower wire in CTiglWingProfileNACA)([#1366](https://github.com/DLR-SC/tigl/issues/1366))
 
 Version 3.5.0-rc1
 -----------------

--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -278,7 +278,15 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
     }
     modificatorContainerWidget->updateDisplayOptionsIfActive(item, doc, scene);
     }
-    catch (tigl::CTiglError& ex) { LOG(ERROR) << ex.what(); } catch (...) { LOG(ERROR) << "Unknown error in dispatch"; }
+    catch (const tigl::CTiglError& ex) {
+        LOG(ERROR) << ex.what();
+    }
+    catch (const std::exception& ex) {
+        LOG(ERROR) << ex.what();
+    }
+    catch (...) {
+        LOG(ERROR) << "Unknown error in dispatch";
+    }
 }
 
 void ModificatorModel::createUndoCommand()

--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -128,7 +128,7 @@ void ModificatorModel::writeCPACS()
 
 void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
 {
-
+    try{
     // todo try catch on dispatch
     if ((!configurationIsSet()) || (!item->isInitialized())) {
         modificatorContainerWidget->hideAllSpecializedWidgets();
@@ -277,6 +277,8 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
         LOG(INFO) << "MODIFICATOR MANAGER: item not suported";
     }
     modificatorContainerWidget->updateDisplayOptionsIfActive(item, doc, scene);
+    }
+    catch (tigl::CTiglError& ex) { LOG(ERROR) << ex.what(); } catch (...) { LOG(ERROR) << "Unknown error in dispatch"; }
 }
 
 void ModificatorModel::createUndoCommand()

--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -129,153 +129,153 @@ void ModificatorModel::writeCPACS()
 void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
 {
     try{
-    if ((!configurationIsSet()) || (!item->isInitialized())) {
-        modificatorContainerWidget->hideAllSpecializedWidgets();
-        LOG(ERROR) << "MODIFICATOR MANAGER IS NOT READY";
-        return;
-    }
-
-    unHighlight();
-    if (item->getType() == "transformation") {
-        tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
-        if(item->getUid().empty()){
-            LOG(WARNING) << "The 'transformation'-element you are trying to access has no UID and is not editable. If you want to be able to edit add UID." << std::endl;
-        } else {
-            try{
-                tigl::CCPACSTransformation& transformation =
-                    uidManager.ResolveObject<tigl::CCPACSTransformation>(item->getUid());
-                modificatorContainerWidget->setTransformationModificator(transformation, doc->GetConfiguration());
-            } catch (tigl::CTiglError& ex) {
-                LOG(ERROR) << ex.what() << std::endl;
-            }
-        }
-    }
-    else if (item->getType() == "fuselage") {
-        tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
-        tigl::CCPACSFuselage& fuselage    = uidManager.ResolveObject<tigl::CCPACSFuselage>(item->getUid());
-        modificatorContainerWidget->setFuselageModificator(fuselage);
-        highlight(fuselage.GetCTiglElements());
-    }
-    else if (item->getType() == "fuselages") {
-        modificatorContainerWidget->setFuselagesModificator();
-    }
-    else if (item->getType() == "wing") {
-        tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
-        tigl::CCPACSWing& wing            = uidManager.ResolveObject<tigl::CCPACSWing>(item->getUid());
-        modificatorContainerWidget->setWingModificator(wing);
-        highlight(wing.GetCTiglElements());
-    }
-    else if (item->getType() == "wings") {
-        modificatorContainerWidget->setWingsModificator();
-    }
-    else if (item->getType() == "element") {
-        // first, we need to determine whether this is a section or a fuselage element
-        // then, we can retrieve the CTiglElement interface that manages the both cases.
-        tigl::CTiglUIDManager& uidManager       = doc->GetConfiguration().GetUIDManager();
-        tigl::CTiglUIDManager::TypedPtr typePtr = uidManager.ResolveObject(item->getUid());
-        tigl::CTiglSectionElement* sectionElement = nullptr;
-        if (typePtr.type == &typeid(tigl::CCPACSFuselageSectionElement)) {
-            tigl::CCPACSFuselageSectionElement& fuselageElement =
-                *reinterpret_cast<tigl::CCPACSFuselageSectionElement*>(typePtr.ptr);
-                sectionElement = fuselageElement.GetCTiglSectionElement();
-        }
-        else if (typePtr.type == &typeid(tigl::CCPACSWingSectionElement)) {
-            tigl::CCPACSWingSectionElement& wingElement =
-                *reinterpret_cast<tigl::CCPACSWingSectionElement*>(typePtr.ptr);
-            sectionElement = wingElement.GetCTiglSectionElement();
-        }
-
-        if (sectionElement && sectionElement->IsValid()) {
-            modificatorContainerWidget->setElementModificator(*sectionElement);
-            std::vector<tigl::CTiglSectionElement*> elements;
-            elements.push_back(sectionElement);
-            highlight(elements);
-        }
-        else {
-            modificatorContainerWidget->setNoInterfaceWidget();
-        }
-    }
-    else if (item->getType() == "section") {
-        tigl::CTiglUIDManager& uidManager       = doc->GetConfiguration().GetUIDManager();
-        tigl::CTiglUIDManager::TypedPtr typePtr = uidManager.ResolveObject(item->getUid());
-        std::vector<tigl::CTiglSectionElement*> cTiglElements;  // one for the highlight function
-        QList<tigl::CTiglSectionElement*> qCTiglElements;   // one for the modificator widget
-        if (typePtr.type == &typeid(tigl::CCPACSFuselageSection)) {
-            tigl::CCPACSFuselageSection& fuselageSection = *reinterpret_cast<tigl::CCPACSFuselageSection*>(typePtr.ptr);
-            // In fact for the moment multiple element is not supported by Tigl so the number of cTiglElements will allays be one
-            for (int i = 1; i <= fuselageSection.GetSectionElementCount(); i++) {
-                cTiglElements.push_back(fuselageSection.GetSectionElement(i).GetCTiglSectionElement());
-                qCTiglElements.push_back(fuselageSection.GetSectionElement(i).GetCTiglSectionElement());
-            }
-
-        }
-        else if (typePtr.type == &typeid(tigl::CCPACSWingSection)) {
-            tigl::CCPACSWingSection& wingSection = *reinterpret_cast<tigl::CCPACSWingSection*>(typePtr.ptr);
-            for (int i = 1; i <= wingSection.GetSectionElementCount(); i++) {
-                cTiglElements.push_back(wingSection.GetSectionElement(i).GetCTiglSectionElement());
-                qCTiglElements.push_back(wingSection.GetSectionElement(i).GetCTiglSectionElement());
-            }
-        }
-
-        bool isEditable = !qCTiglElements.isEmpty();
-        for (tigl::CTiglSectionElement* element : qCTiglElements) {
-            if (!element || !element->IsValid()) {
-                isEditable = false;
-                break;
-            }
-        }
-
-        if (isEditable) {
-            highlight(cTiglElements);
-            modificatorContainerWidget->setSectionModificator(qCTiglElements);
-        }
-        else {
-            modificatorContainerWidget->setNoInterfaceWidget();
-        }
-    }
-    else if (item->getType() == "sections" ) {
-
-        cpcr::CPACSTreeItem* parent = item->getParent();
-
-        if (parent && (parent->getType() == "wing" || parent->getType() == "fuselage")) {
-            std::string bodyUID = parent->getUid(); // return the fuselage or wing uid
-            auto element        = resolve(bodyUID);
-            modificatorContainerWidget->setSectionsModificator(std::move(element));
-        }
-        else {
-            modificatorContainerWidget->setNoInterfaceWidget();
-        }
-    }
-    else if (item->getType() == "positioning" ) {
-        tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
-        tigl::CCPACSPositioning& positioning    = uidManager.ResolveObject<tigl::CCPACSPositioning>(item->getUid());
-        tigl::CTiglTransformation parentTransformation;
-
-        // if fact we need the wing or fuselage parent to be able to invalidate the positionigs.
-        std::string bodyUID = item->getParent()->getParent()->getUid();
-        tigl::CTiglUIDManager::TypedPtr typePtr = uidManager.ResolveObject(bodyUID);
-        if (typePtr.type == &typeid(tigl::CCPACSWing)) {
-            tigl::CCPACSWing &wing = *reinterpret_cast<tigl::CCPACSWing *>(typePtr.ptr);
-            modificatorContainerWidget->setPositioningModificator(wing, positioning);
-            parentTransformation = wing.GetTransformationMatrix();
-        }
-        else if (typePtr.type == &typeid(tigl::CCPACSFuselage)) {
-            tigl::CCPACSFuselage &fuselage = *reinterpret_cast<tigl::CCPACSFuselage *>(typePtr.ptr);
-            modificatorContainerWidget->setPositioningModificator(fuselage, positioning);
-            parentTransformation = fuselage.GetTransformationMatrix();
-        }
-        else {
-            LOG(ERROR) << "ModificatorManager:: Unable to find expected parent for the uid type!";
+        if ((!configurationIsSet()) || (!item->isInitialized())) {
+            modificatorContainerWidget->hideAllSpecializedWidgets();
+            LOG(ERROR) << "MODIFICATOR MANAGER IS NOT READY";
             return;
         }
-        highlight(positioning, parentTransformation);
-        
-    }
-    else {
-        modificatorContainerWidget->setNoInterfaceWidget();
-        LOG(INFO) << "MODIFICATOR MANAGER: item not suported";
-    }
-    modificatorContainerWidget->updateDisplayOptionsIfActive(item, doc, scene);
+
+        unHighlight();
+        if (item->getType() == "transformation") {
+            tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
+            if(item->getUid().empty()){
+                LOG(WARNING) << "The 'transformation'-element you are trying to access has no UID and is not editable. If you want to be able to edit add UID." << std::endl;
+            } else {
+                try{
+                    tigl::CCPACSTransformation& transformation =
+                        uidManager.ResolveObject<tigl::CCPACSTransformation>(item->getUid());
+                    modificatorContainerWidget->setTransformationModificator(transformation, doc->GetConfiguration());
+                } catch (tigl::CTiglError& ex) {
+                    LOG(ERROR) << ex.what() << std::endl;
+                }
+            }
+        }
+        else if (item->getType() == "fuselage") {
+            tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
+            tigl::CCPACSFuselage& fuselage    = uidManager.ResolveObject<tigl::CCPACSFuselage>(item->getUid());
+            modificatorContainerWidget->setFuselageModificator(fuselage);
+            highlight(fuselage.GetCTiglElements());
+        }
+        else if (item->getType() == "fuselages") {
+            modificatorContainerWidget->setFuselagesModificator();
+        }
+        else if (item->getType() == "wing") {
+            tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
+            tigl::CCPACSWing& wing            = uidManager.ResolveObject<tigl::CCPACSWing>(item->getUid());
+            modificatorContainerWidget->setWingModificator(wing);
+            highlight(wing.GetCTiglElements());
+        }
+        else if (item->getType() == "wings") {
+            modificatorContainerWidget->setWingsModificator();
+        }
+        else if (item->getType() == "element") {
+            // first, we need to determine whether this is a section or a fuselage element
+            // then, we can retrieve the CTiglElement interface that manages the both cases.
+            tigl::CTiglUIDManager& uidManager       = doc->GetConfiguration().GetUIDManager();
+            tigl::CTiglUIDManager::TypedPtr typePtr = uidManager.ResolveObject(item->getUid());
+            tigl::CTiglSectionElement* sectionElement = nullptr;
+            if (typePtr.type == &typeid(tigl::CCPACSFuselageSectionElement)) {
+                tigl::CCPACSFuselageSectionElement& fuselageElement =
+                    *reinterpret_cast<tigl::CCPACSFuselageSectionElement*>(typePtr.ptr);
+                    sectionElement = fuselageElement.GetCTiglSectionElement();
+            }
+            else if (typePtr.type == &typeid(tigl::CCPACSWingSectionElement)) {
+                tigl::CCPACSWingSectionElement& wingElement =
+                    *reinterpret_cast<tigl::CCPACSWingSectionElement*>(typePtr.ptr);
+                sectionElement = wingElement.GetCTiglSectionElement();
+            }
+
+            if (sectionElement && sectionElement->IsValid()) {
+                modificatorContainerWidget->setElementModificator(*sectionElement);
+                std::vector<tigl::CTiglSectionElement*> elements;
+                elements.push_back(sectionElement);
+                highlight(elements);
+            }
+            else {
+                modificatorContainerWidget->setNoInterfaceWidget();
+            }
+        }
+        else if (item->getType() == "section") {
+            tigl::CTiglUIDManager& uidManager       = doc->GetConfiguration().GetUIDManager();
+            tigl::CTiglUIDManager::TypedPtr typePtr = uidManager.ResolveObject(item->getUid());
+            std::vector<tigl::CTiglSectionElement*> cTiglElements;  // one for the highlight function
+            QList<tigl::CTiglSectionElement*> qCTiglElements;   // one for the modificator widget
+            if (typePtr.type == &typeid(tigl::CCPACSFuselageSection)) {
+                tigl::CCPACSFuselageSection& fuselageSection = *reinterpret_cast<tigl::CCPACSFuselageSection*>(typePtr.ptr);
+                // In fact for the moment multiple element is not supported by Tigl so the number of cTiglElements will allays be one
+                for (int i = 1; i <= fuselageSection.GetSectionElementCount(); i++) {
+                    cTiglElements.push_back(fuselageSection.GetSectionElement(i).GetCTiglSectionElement());
+                    qCTiglElements.push_back(fuselageSection.GetSectionElement(i).GetCTiglSectionElement());
+                }
+
+            }
+            else if (typePtr.type == &typeid(tigl::CCPACSWingSection)) {
+                tigl::CCPACSWingSection& wingSection = *reinterpret_cast<tigl::CCPACSWingSection*>(typePtr.ptr);
+                for (int i = 1; i <= wingSection.GetSectionElementCount(); i++) {
+                    cTiglElements.push_back(wingSection.GetSectionElement(i).GetCTiglSectionElement());
+                    qCTiglElements.push_back(wingSection.GetSectionElement(i).GetCTiglSectionElement());
+                }
+            }
+
+            bool isEditable = !qCTiglElements.isEmpty();
+            for (tigl::CTiglSectionElement* element : qCTiglElements) {
+                if (!element || !element->IsValid()) {
+                    isEditable = false;
+                    break;
+                }
+            }
+
+            if (isEditable) {
+                highlight(cTiglElements);
+                modificatorContainerWidget->setSectionModificator(qCTiglElements);
+            }
+            else {
+                modificatorContainerWidget->setNoInterfaceWidget();
+            }
+        }
+        else if (item->getType() == "sections" ) {
+
+            cpcr::CPACSTreeItem* parent = item->getParent();
+
+            if (parent && (parent->getType() == "wing" || parent->getType() == "fuselage")) {
+                std::string bodyUID = parent->getUid(); // return the fuselage or wing uid
+                auto element        = resolve(bodyUID);
+                modificatorContainerWidget->setSectionsModificator(std::move(element));
+            }
+            else {
+                modificatorContainerWidget->setNoInterfaceWidget();
+            }
+        }
+        else if (item->getType() == "positioning" ) {
+            tigl::CTiglUIDManager& uidManager = doc->GetConfiguration().GetUIDManager();
+            tigl::CCPACSPositioning& positioning    = uidManager.ResolveObject<tigl::CCPACSPositioning>(item->getUid());
+            tigl::CTiglTransformation parentTransformation;
+
+            // if fact we need the wing or fuselage parent to be able to invalidate the positionigs.
+            std::string bodyUID = item->getParent()->getParent()->getUid();
+            tigl::CTiglUIDManager::TypedPtr typePtr = uidManager.ResolveObject(bodyUID);
+            if (typePtr.type == &typeid(tigl::CCPACSWing)) {
+                tigl::CCPACSWing &wing = *reinterpret_cast<tigl::CCPACSWing *>(typePtr.ptr);
+                modificatorContainerWidget->setPositioningModificator(wing, positioning);
+                parentTransformation = wing.GetTransformationMatrix();
+            }
+            else if (typePtr.type == &typeid(tigl::CCPACSFuselage)) {
+                tigl::CCPACSFuselage &fuselage = *reinterpret_cast<tigl::CCPACSFuselage *>(typePtr.ptr);
+                modificatorContainerWidget->setPositioningModificator(fuselage, positioning);
+                parentTransformation = fuselage.GetTransformationMatrix();
+            }
+            else {
+                LOG(ERROR) << "ModificatorManager:: Unable to find expected parent for the uid type!";
+                return;
+            }
+            highlight(positioning, parentTransformation);
+            
+        }
+        else {
+            modificatorContainerWidget->setNoInterfaceWidget();
+            LOG(INFO) << "MODIFICATOR MANAGER: item not suported";
+        }
+        modificatorContainerWidget->updateDisplayOptionsIfActive(item, doc, scene);
     }
     catch (const tigl::CTiglError& ex) {
         LOG(ERROR) << ex.what();

--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -129,7 +129,6 @@ void ModificatorModel::writeCPACS()
 void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
 {
     try{
-    // todo try catch on dispatch
     if ((!configurationIsSet()) || (!item->isInitialized())) {
         modificatorContainerWidget->hideAllSpecializedWidgets();
         LOG(ERROR) << "MODIFICATOR MANAGER IS NOT READY";

--- a/src/wing/CTiglWingProfileNACA.cpp
+++ b/src/wing/CTiglWingProfileNACA.cpp
@@ -35,7 +35,7 @@
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <Geom_Line.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
-#include <CWireToCurve.h>
+#include "CWireToCurve.h"
 
 
 namespace tigl

--- a/src/wing/CTiglWingProfileNACA.cpp
+++ b/src/wing/CTiglWingProfileNACA.cpp
@@ -123,10 +123,10 @@ const TopoDS_Edge& CTiglWingProfileNACA::GetUpperLowerWire(TiglShapeModifier mod
 {
     double te_thickness = calculator.get_trailing_edge_thickness();
     
-    if (mod == SHARP_TRAILINGEDGE && te_thickness > 0.0) {
+    if (mod == SHARP_TRAILINGEDGE && HasBluntTE()) {
         LOG(WARNING) << "Profile " << profileUID << ": SHARP_TRAILINGEDGE modifier requested but profile has blunt trailing edge (thickness: " << te_thickness << ")";
     }
-    else if (mod == BLUNT_TRAILINGEDGE && te_thickness == 0.0) {
+    else if (mod == BLUNT_TRAILINGEDGE && !HasBluntTE()) {
         LOG(WARNING) << "Profile " << profileUID << ": BLUNT_TRAILINGEDGE modifier requested but profile has sharp trailing edge";
     }
     return wireCache->upperLowerWire;

--- a/src/wing/CTiglWingProfileNACA.cpp
+++ b/src/wing/CTiglWingProfileNACA.cpp
@@ -114,6 +114,14 @@ const TopoDS_Edge& CTiglWingProfileNACA::GetLowerWire(TiglShapeModifier mod) con
 // gets the upper and lower wing profile into on edge
 const TopoDS_Edge& CTiglWingProfileNACA::GetUpperLowerWire(TiglShapeModifier mod) const
 {
+    double te_thickness = calculator.get_trailing_edge_thickness();
+    
+    if (mod == SHARP_TRAILINGEDGE && te_thickness > 0.0) {
+        LOG(WARNING) << "Profile " << profileUID << ": SHARP_TRAILINGEDGE modifier requested but profile has blunt trailing edge (thickness: " << te_thickness << ")";
+    }
+    else if (mod == BLUNT_TRAILINGEDGE && te_thickness == 0.0) {
+        LOG(WARNING) << "Profile " << profileUID << ": BLUNT_TRAILINGEDGE modifier requested but profile has sharp trailing edge";
+    }
     return wireCache->upperLowerWire;
 }
 

--- a/src/wing/CTiglWingProfileNACA.cpp
+++ b/src/wing/CTiglWingProfileNACA.cpp
@@ -88,8 +88,15 @@ void CTiglWingProfileNACA::BuildWires(WireCache& cache) const
     }
 
     BRepBuilderAPI_MakeWire ulWireMaker(cache.lowerWire, cache.upperWire);
+    ulWireMaker.Build();
+    if (!ulWireMaker.IsDone()) {
+        throw CTiglError("Error creating upper/lower wire in CTiglWingProfileNACA::BuildWires");
+    }
     TopoDS_Wire ulWire = ulWireMaker.Wire();
     Handle(Geom_Curve) ulCurve = CWireToCurve(ulWire).curve();
+    if (ulCurve.IsNull()) {
+        throw CTiglError("Error converting upper/lower wire to curve in CTiglWingProfileNACA::BuildWires");
+    }
     cache.upperLowerWire = BRepBuilderAPI_MakeEdge(ulCurve);
 }
 

--- a/src/wing/CTiglWingProfileNACA.cpp
+++ b/src/wing/CTiglWingProfileNACA.cpp
@@ -34,6 +34,8 @@
 #include <TopoDS_Edge.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <Geom_Line.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <CWireToCurve.h>
 
 
 namespace tigl
@@ -84,6 +86,11 @@ void CTiglWingProfileNACA::BuildWires(WireCache& cache) const
     } else {
         cache.trailingEdge = TopoDS_Edge();
     }
+
+    BRepBuilderAPI_MakeWire ulWireMaker(cache.lowerWire, cache.upperWire);
+    TopoDS_Wire ulWire = ulWireMaker.Wire();
+    Handle(Geom_Curve) ulCurve = CWireToCurve(ulWire).curve();
+    cache.upperLowerWire = BRepBuilderAPI_MakeEdge(ulCurve);
 }
 
 
@@ -107,9 +114,9 @@ const TopoDS_Edge& CTiglWingProfileNACA::GetLowerWire(TiglShapeModifier mod) con
 // gets the upper and lower wing profile into on edge
 const TopoDS_Edge& CTiglWingProfileNACA::GetUpperLowerWire(TiglShapeModifier mod) const
 {
-
-    throw CTiglError("UpperLower wire is not implemented.");
+    return wireCache->upperLowerWire;
 }
+
 
 // get trailing edge
 const TopoDS_Edge& CTiglWingProfileNACA::GetTrailingEdge(TiglShapeModifier mod) const

--- a/src/wing/CTiglWingProfileNACA.h
+++ b/src/wing/CTiglWingProfileNACA.h
@@ -114,6 +114,7 @@ namespace tigl{
         TopoDS_Edge               upperWire;      /**< wire of the upper wing profile */
         TopoDS_Edge               lowerWire;      /**< wire of the lower wing profile */
         TopoDS_Edge               trailingEdge; 
+        TopoDS_Edge               upperLowerWire;
         gp_Pnt                    lePoint;              /**< Leading edge point */
         gp_Pnt                    tePoint;              /**< Trailing edge point */
     };

--- a/src/wing/CTiglWingProfileNACA.h
+++ b/src/wing/CTiglWingProfileNACA.h
@@ -78,7 +78,7 @@ namespace tigl{
         TIGL_EXPORT const TopoDS_Edge& GetTrailingEdge(TiglShapeModifier mod = UNMODIFIED_SHAPE) const override;
 
         /**
-         * @brief Get upper and lower wing profile into one edge, this function thros an error since it is not implemented for the NACA profile definition.
+         * @brief Get upper and lower wing profile into one edge.
          * 
          * @param mod 
          * @return TIGL_EXPORT const& 

--- a/tests/unittests/testNACA4Calculator.cpp
+++ b/tests/unittests/testNACA4Calculator.cpp
@@ -455,10 +455,10 @@ TEST(CTiglNACA4Calculator, naca2412_edge_counter){
     }
 }
 
-TEST(NACA4Calculator, naca24112_export_bsplines2){
-    tigl::CTiglNACA4Calculator NACA4(2,4,12, 0.00252);
-    for(double x =0; x<1; x+=0.05){
-        auto z = NACA4.upper_curve(x);
+TEST(CTiglNACA4Calculator, upper_curve_does_not_throw_for_valid_x_range){
+    tigl::CTiglNACA4Calculator naca(2, 4, 12, 0.00252);
+    for (double x = 0.0; x <= 1.0; x += 0.05) {
+        EXPECT_NO_THROW((void)naca.upper_curve(x));
     }
 }
 

--- a/tests/unittests/testNACA4Calculator.cpp
+++ b/tests/unittests/testNACA4Calculator.cpp
@@ -455,83 +455,16 @@ TEST(CTiglNACA4Calculator, naca2412_edge_counter){
     }
 }
 
-TEST(NACA4Calculator, naca22012_le_and_te_points){
-    tigl::NACA4Calculator  NACA4(2,2,1, 12, 0.00252);
-    gp_Vec2d result1 = NACA4.upper_curve(1);
-    //EXPECT_NEAR(result1.X(), (0.30103296264314128), 1e-3); 
-    EXPECT_NEAR(result1.Y(), (0.00125923), 1e-6);
-    
-}
-
-TEST(NACA4Calculator, naca23012_export_bsplines){
-    tigl::NACA4Calculator NACA4(2,3,0,12, 0.00252);
-    Handle(Geom_BSplineCurve) upperCurve = NACA4.upper_bspline(); 
-    Handle(Geom_BSplineCurve) lowerCurve = NACA4.lower_bspline(); 
-    ASSERT_FALSE(upperCurve.IsNull());
-    ASSERT_FALSE(lowerCurve.IsNull());
-    auto lowerEdge = BRepBuilderAPI_MakeEdge(lowerCurve).Edge();
-    ASSERT_FALSE(lowerEdge.IsNull());
-    BRepTools::Write(lowerEdge, "TestData/export/lowerEdgeTest5_22012.brep");
-
-    auto upperEdge = BRepBuilderAPI_MakeEdge(upperCurve).Edge();
-    ASSERT_FALSE(upperEdge.IsNull());
-    BRepTools::Write(upperEdge, "TestData/export/upperEdgeTest5_22012.brep");
-}
-
-TEST(NACA4Calculator, naca22112_le_and_te_points_with_class_lowerCurve){
-    tigl::NACA4Calculator  NACA4(2,2,1,12, 0.00252); 
-    tigl::NACA4LowerCurve lowerCurve(NACA4);
-    EXPECT_NEAR(lowerCurve.valueX(1), (0.99999099), 1e-5); 
-    EXPECT_NEAR(lowerCurve.valueY(1), 0.0, 1e-8);
-    EXPECT_NEAR(lowerCurve.valueZ(1), (-0.00125997), 1e-7);//den wert hab ich von airfooilttols.com
-}
-
-TEST(NACA4Calculator, naca24112_le_and_te_points_with_class_lowerCurve){
-    tigl::NACA4Calculator  NACA4(2,4,1,12, 0.00252); 
-    tigl::NACA4LowerCurve lowerCurve(NACA4);
-    EXPECT_NEAR(lowerCurve.valueX(1), (0.99999999), 1e-6); 
-    EXPECT_NEAR(lowerCurve.valueY(1), 0.0, 1e-8);
-    EXPECT_NEAR(lowerCurve.valueZ(1), (-0.00126000), 1e-6);
-    //EXPECT_NEAR(lowerCurve.valueZ(1), (-6785.00126000), 1e-7);
-}
-
-TEST(NACA4Calculator, naca22112_export_bsplines){
-    tigl::NACA4Calculator NACA4(2,2,1,12, 0.00252);
-    Handle(Geom_BSplineCurve) upperCurve = NACA4.upper_bspline(); 
-    Handle(Geom_BSplineCurve) lowerCurve = NACA4.lower_bspline(); 
-    ASSERT_FALSE(upperCurve.IsNull());
-    ASSERT_FALSE(lowerCurve.IsNull());
-    auto lowerEdge = BRepBuilderAPI_MakeEdge(lowerCurve).Edge();
-    ASSERT_FALSE(lowerEdge.IsNull());
-    BRepTools::Write(lowerEdge, "TestData/export/lowerEdgeTest5.brep");
-
-    auto upperEdge = BRepBuilderAPI_MakeEdge(upperCurve).Edge();
-    ASSERT_FALSE(upperEdge.IsNull());
-    BRepTools::Write(upperEdge, "TestData/export/upperEdgeTest5.brep");
-}
-
-TEST(NACA4Calculator, naca24112_export_bsplines){
-    tigl::NACA4Calculator NACA4(2,4,1,12, 0.00252);
-    Handle(Geom_BSplineCurve) upperCurve = NACA4.upper_bspline(); 
-    Handle(Geom_BSplineCurve) lowerCurve = NACA4.lower_bspline(); 
-    ASSERT_FALSE(upperCurve.IsNull());
-    ASSERT_FALSE(lowerCurve.IsNull());
-    auto lowerEdge = BRepBuilderAPI_MakeEdge(lowerCurve).Edge();
-    ASSERT_FALSE(lowerEdge.IsNull());
-    BRepTools::Write(lowerEdge, "TestData/export/lowerEdgeTest5_24112.brep");
-
-    auto upperEdge = BRepBuilderAPI_MakeEdge(upperCurve).Edge();
-    ASSERT_FALSE(upperEdge.IsNull());
-    BRepTools::Write(upperEdge, "TestData/export/upperEdgeTest5_24112.brep");
-}
 TEST(NACA4Calculator, naca24112_export_bsplines2){
-    tigl::NACA4Calculator NACA4(2,4,1,12, 0.00252);
+    tigl::CTiglNACA4Calculator NACA4(2,4,12, 0.00252);
     for(double x =0; x<1; x+=0.05){
         auto z = NACA4.upper_curve(x);
     }
 }
 
-TEST(NACA4Calculator, naca2412_getUpperLowerWire) {
+
+
+TEST(CTiglNACA4Calculator, naca2412_getUpperLowerWire) {
     tigl::CTiglUIDManager uidMgr;
     tigl::CCPACSWingProfile cpacsProfile(static_cast<tigl::CCPACSWingProfiles*>(nullptr), &uidMgr);
     tigl::generated::CPACSNacaProfile nacadef(&cpacsProfile);

--- a/tests/unittests/testNACA4Calculator.cpp
+++ b/tests/unittests/testNACA4Calculator.cpp
@@ -342,6 +342,13 @@ TEST(CTiglNACA4Calculator, naca2412_LePoint_TePoint){
     EXPECT_FALSE(lower.IsNull());
     EXPECT_FALSE(te.IsNull());
 
+    TopoDS_Edge ul = profile.GetUpperLowerWire();
+    EXPECT_FALSE(ul.IsNull());
+    TopoDS_Edge ulSharp = profile.GetUpperLowerWire(SHARP_TRAILINGEDGE);
+    EXPECT_FALSE(ulSharp.IsNull());
+    TopoDS_Edge ulBlunt = profile.GetUpperLowerWire(BLUNT_TRAILINGEDGE);
+    EXPECT_FALSE(ulBlunt.IsNull());
+
 }
 
 TEST(CTiglNACA4Calculator, naca0012_LePoint_TePoint){
@@ -375,6 +382,13 @@ TEST(CTiglNACA4Calculator, naca0012_LePoint_TePoint){
     EXPECT_FALSE(upper.IsNull());
     EXPECT_FALSE(lower.IsNull());
     EXPECT_FALSE(te.IsNull());
+
+    TopoDS_Edge ul = profile.GetUpperLowerWire();
+    EXPECT_FALSE(ul.IsNull());
+    TopoDS_Edge ulSharp = profile.GetUpperLowerWire(SHARP_TRAILINGEDGE);
+    EXPECT_FALSE(ulSharp.IsNull());
+    TopoDS_Edge ulBlunt = profile.GetUpperLowerWire(BLUNT_TRAILINGEDGE);
+    EXPECT_FALSE(ulBlunt.IsNull());
 
 }
 
@@ -439,4 +453,106 @@ TEST(CTiglNACA4Calculator, naca2412_edge_counter){
     } else {
         EXPECT_EQ(edgeCount, 3);
     }
+}
+
+TEST(NACA4Calculator, naca22012_le_and_te_points){
+    tigl::NACA4Calculator  NACA4(2,2,1, 12, 0.00252);
+    gp_Vec2d result1 = NACA4.upper_curve(1);
+    //EXPECT_NEAR(result1.X(), (0.30103296264314128), 1e-3); 
+    EXPECT_NEAR(result1.Y(), (0.00125923), 1e-6);
+    
+}
+
+TEST(NACA4Calculator, naca23012_export_bsplines){
+    tigl::NACA4Calculator NACA4(2,3,0,12, 0.00252);
+    Handle(Geom_BSplineCurve) upperCurve = NACA4.upper_bspline(); 
+    Handle(Geom_BSplineCurve) lowerCurve = NACA4.lower_bspline(); 
+    ASSERT_FALSE(upperCurve.IsNull());
+    ASSERT_FALSE(lowerCurve.IsNull());
+    auto lowerEdge = BRepBuilderAPI_MakeEdge(lowerCurve).Edge();
+    ASSERT_FALSE(lowerEdge.IsNull());
+    BRepTools::Write(lowerEdge, "TestData/export/lowerEdgeTest5_22012.brep");
+
+    auto upperEdge = BRepBuilderAPI_MakeEdge(upperCurve).Edge();
+    ASSERT_FALSE(upperEdge.IsNull());
+    BRepTools::Write(upperEdge, "TestData/export/upperEdgeTest5_22012.brep");
+}
+
+TEST(NACA4Calculator, naca22112_le_and_te_points_with_class_lowerCurve){
+    tigl::NACA4Calculator  NACA4(2,2,1,12, 0.00252); 
+    tigl::NACA4LowerCurve lowerCurve(NACA4);
+    EXPECT_NEAR(lowerCurve.valueX(1), (0.99999099), 1e-5); 
+    EXPECT_NEAR(lowerCurve.valueY(1), 0.0, 1e-8);
+    EXPECT_NEAR(lowerCurve.valueZ(1), (-0.00125997), 1e-7);//den wert hab ich von airfooilttols.com
+}
+
+TEST(NACA4Calculator, naca24112_le_and_te_points_with_class_lowerCurve){
+    tigl::NACA4Calculator  NACA4(2,4,1,12, 0.00252); 
+    tigl::NACA4LowerCurve lowerCurve(NACA4);
+    EXPECT_NEAR(lowerCurve.valueX(1), (0.99999999), 1e-6); 
+    EXPECT_NEAR(lowerCurve.valueY(1), 0.0, 1e-8);
+    EXPECT_NEAR(lowerCurve.valueZ(1), (-0.00126000), 1e-6);
+    //EXPECT_NEAR(lowerCurve.valueZ(1), (-6785.00126000), 1e-7);
+}
+
+TEST(NACA4Calculator, naca22112_export_bsplines){
+    tigl::NACA4Calculator NACA4(2,2,1,12, 0.00252);
+    Handle(Geom_BSplineCurve) upperCurve = NACA4.upper_bspline(); 
+    Handle(Geom_BSplineCurve) lowerCurve = NACA4.lower_bspline(); 
+    ASSERT_FALSE(upperCurve.IsNull());
+    ASSERT_FALSE(lowerCurve.IsNull());
+    auto lowerEdge = BRepBuilderAPI_MakeEdge(lowerCurve).Edge();
+    ASSERT_FALSE(lowerEdge.IsNull());
+    BRepTools::Write(lowerEdge, "TestData/export/lowerEdgeTest5.brep");
+
+    auto upperEdge = BRepBuilderAPI_MakeEdge(upperCurve).Edge();
+    ASSERT_FALSE(upperEdge.IsNull());
+    BRepTools::Write(upperEdge, "TestData/export/upperEdgeTest5.brep");
+}
+
+TEST(NACA4Calculator, naca24112_export_bsplines){
+    tigl::NACA4Calculator NACA4(2,4,1,12, 0.00252);
+    Handle(Geom_BSplineCurve) upperCurve = NACA4.upper_bspline(); 
+    Handle(Geom_BSplineCurve) lowerCurve = NACA4.lower_bspline(); 
+    ASSERT_FALSE(upperCurve.IsNull());
+    ASSERT_FALSE(lowerCurve.IsNull());
+    auto lowerEdge = BRepBuilderAPI_MakeEdge(lowerCurve).Edge();
+    ASSERT_FALSE(lowerEdge.IsNull());
+    BRepTools::Write(lowerEdge, "TestData/export/lowerEdgeTest5_24112.brep");
+
+    auto upperEdge = BRepBuilderAPI_MakeEdge(upperCurve).Edge();
+    ASSERT_FALSE(upperEdge.IsNull());
+    BRepTools::Write(upperEdge, "TestData/export/upperEdgeTest5_24112.brep");
+}
+TEST(NACA4Calculator, naca24112_export_bsplines2){
+    tigl::NACA4Calculator NACA4(2,4,1,12, 0.00252);
+    for(double x =0; x<1; x+=0.05){
+        auto z = NACA4.upper_curve(x);
+    }
+}
+
+TEST(NACA4Calculator, naca2412_getUpperLowerWire) {
+    tigl::CTiglUIDManager uidMgr;
+    tigl::CCPACSWingProfile cpacsProfile(static_cast<tigl::CCPACSWingProfiles*>(nullptr), &uidMgr);
+    tigl::generated::CPACSNacaProfile nacadef(&cpacsProfile);
+
+    nacadef.SetNaca4DigitCode_choice1(boost::optional<std::string>(std::string("2412")));
+    nacadef.SetTrailingEdgeThickness(boost::optional<double>(0.15));
+
+    tigl::CTiglWingProfileNACA profile(cpacsProfile, nacadef);
+
+    TopoDS_Edge ul = profile.GetUpperLowerWire();
+    EXPECT_FALSE(ul.IsNull());
+
+    TopoDS_Edge ulSharp = profile.GetUpperLowerWire(SHARP_TRAILINGEDGE);
+    EXPECT_FALSE(ulSharp.IsNull());
+
+    TopoDS_Edge ulBlunt = profile.GetUpperLowerWire(BLUNT_TRAILINGEDGE);
+    EXPECT_FALSE(ulBlunt.IsNull());
+
+    EXPECT_TRUE(profile.HasBluntTE());
+
+    Standard_Real u1, u2;
+    Handle(Geom_Curve) ulCurve = BRep_Tool::Curve(ul, u1, u2);
+    ASSERT_FALSE(ulCurve.IsNull());
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #1366
The implementation for the upperlowerwire was added as well as a try-catch block to prevent unhandled exceptions from happening.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I added one test for the upperlowerwire and expanded two already existing tests. (And I tested the file that previously crashed the TiglCreator, the exception does not crash the tiglcreator anymore).
## Screenshots, that help to understand the changes(if applicable):


## Checklist for PR Author:
- [x] Unit or integration test added (if applicable)
- [ ] Python interface updated (if applicable)
- [ ] Python test added (if Python interface updated)
- [ ] Doxygen docstrings added
- [x] `ChangeLog.md` updated