### PR TITLE
Fix TiGLCreator crash due to unhandled exception

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@ Changes since last release
   - Implemented the UpperLower wire in CTiglWingProfileNACA ([#1366](https://github.com/DLR-SC/tigl/issues/1366))
 
 - Fixes
+  - TiGLCreator: Fix crash when computing/displaying geometry (e.g. loft) throws an OpenCASCADE exception instead of a `tigl::CTiglError`. All corresponding error handlers across TiGLCreator now also catch `Standard_Failure` and any other exception, showing an error dialog instead of crashing ([#1382](https://github.com/DLR-SC/tigl/issues/1382))
   - TiGLCreator: Fix crash when selecting objects with malformed CPACS geometry. Invalid objects are now clearly marked with a warning icon and descriptive tooltip instead of causing an unhandled exception ([#1375](https://github.com/DLR-SC/tigl/issues/1375))
   - `CCPACSPositionings::CreatePositioning now sets a name to be CPACS-conform ([#1378](https://github.com/DLR-SC/tigl/issues/1378))
   - TiGLCreator: Fix laggy behaviour when selecting a fuselage in the CPACSTree. Additionally, only the wireframe is highlighted, not each section on its own. This also boosts performance [#1275](https://github.com/DLR-SC/tigl/issues/1275).

--- a/TIGLCreator/src/DrawOptionsActions.cpp
+++ b/TIGLCreator/src/DrawOptionsActions.cpp
@@ -46,7 +46,7 @@ bool hasControlSurfaces(TIGLCreatorDocument* doc, const QString& uid)
             }
         }
     }
-    catch (const tigl::CTiglError&) {
+    catch (...) {
         return false;
     }
 
@@ -84,7 +84,7 @@ bool hasStructure(TIGLCreatorDocument* doc, const QString& uid)
                 }
         }
     }
-      catch (const tigl::CTiglError&) {
+      catch (...) {
         return false;
     }
 

--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -35,6 +35,7 @@
 #include "TIGLCreatorException.h"
 #include "TIGLCreatorErrorDialog.h"
 #include <QTimer>
+#include <Standard_Failure.hxx>
 
 ModificatorModel::ModificatorModel(ModificatorContainerWidget* modificatorContainerWidget,
                                        TIGLCreatorContext* scene,
@@ -162,6 +163,10 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
                     modificatorContainerWidget->setTransformationModificator(transformation, doc->GetConfiguration());
                 } catch (tigl::CTiglError& ex) {
                     LOG(ERROR) << ex.what() << std::endl;
+                } catch (const Standard_Failure& err) {
+                    LOG(ERROR) << err.GetMessageString() << std::endl;
+                } catch (...) {
+                    LOG(ERROR) << "Unknown error" << std::endl;
                 }
             }
         }
@@ -174,6 +179,10 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
                 highlightShape(fuselage.GetUID());
             } catch (const tigl::CTiglError& ex) {
                 handleUIDError(item->getUid(), ex);
+            } catch (const Standard_Failure& err) {
+                handleUIDError(item->getUid(), std::string(err.GetMessageString()));
+            } catch (...) {
+                handleUIDError(item->getUid(), std::string("Unknown error."));
             }
         }
         else if (item->getType() == "fuselages") {
@@ -188,6 +197,10 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
                 highlightShape(wing.GetUID());
             } catch (const tigl::CTiglError& ex) {
                 handleUIDError(item->getUid(), ex);
+            } catch (const Standard_Failure& err) {
+                handleUIDError(item->getUid(), std::string(err.GetMessageString()));
+            } catch (...) {
+                handleUIDError(item->getUid(), std::string("Unknown error."));
             }
         }
         else if (item->getType() == "wings") {
@@ -223,6 +236,10 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
                 }
             } catch (const tigl::CTiglError& ex) {
                 handleUIDError(item->getUid(), ex);
+            } catch (const Standard_Failure& err) {
+                handleUIDError(item->getUid(), std::string(err.GetMessageString()));
+            } catch (...) {
+                handleUIDError(item->getUid(), std::string("Unknown error."));
             }
         }
         else if (item->getType() == "section") {
@@ -266,6 +283,10 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
                 }
             } catch (const tigl::CTiglError& ex) {
                 handleUIDError(item->getUid(), ex);
+            } catch (const Standard_Failure& err) {
+                handleUIDError(item->getUid(), std::string(err.GetMessageString()));
+            } catch (...) {
+                handleUIDError(item->getUid(), std::string("Unknown error."));
             }
         }
         else if (item->getType() == "sections" ) {
@@ -306,6 +327,10 @@ void ModificatorModel::dispatch(cpcr::CPACSTreeItem* item)
                 highlight(positioning, parentTransformation);
             } catch (const tigl::CTiglError& ex) {
                 handleUIDError(item->getUid(), ex);
+            } catch (const Standard_Failure& err) {
+                handleUIDError(item->getUid(), std::string(err.GetMessageString()));
+            } catch (...) {
+                handleUIDError(item->getUid(), std::string("Unknown error."));
             }
         }
         else {
@@ -363,7 +388,7 @@ void ModificatorModel::validateAllUIDs()
     tree.forEachUid([&](const std::string& uid) {
         try {
             uidManager.ResolveObject(uid);
-        } catch (const tigl::CTiglError&) {
+        } catch (...) {
             failed.insert(uid);
         }
     });
@@ -372,7 +397,12 @@ void ModificatorModel::validateAllUIDs()
 
 void ModificatorModel::handleUIDError(const std::string& uid, const tigl::CTiglError& ex)
 {
-    LOG(ERROR) << ex.what() << std::endl;
+    handleUIDError(uid, std::string(ex.what()));
+}
+
+void ModificatorModel::handleUIDError(const std::string& uid, const std::string& message)
+{
+    LOG(ERROR) << message << std::endl;
     markFailedUID(uid);
     modificatorContainerWidget->setNoInterfaceWidget();
 }
@@ -550,6 +580,23 @@ void ModificatorModel::deleteSection(cpcr::CPACSTreeItem* item)
         endRemoveRows();
         return;
     }
+    catch (const Standard_Failure& err) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the section (aka connected element)").arg(err.GetMessageString()));
+        errDialog.setWindowTitle("Error");
+        errDialog.setDetailsText(err.GetMessageString());
+        errDialog.exec();
+        endRemoveRows();
+        return;
+    }
+    catch (...) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the section (aka connected element)").arg("Unknown error."));
+        errDialog.setWindowTitle("Error");
+        errDialog.exec();
+        endRemoveRows();
+        return;
+    }
     createUndoCommand(); // invokes writeCPACS, which is needed to correctly modify the CPACSTree
 
     // apply changes to CPACSTree
@@ -648,6 +695,25 @@ void ModificatorModel::addSection(
             QString("<b>%1</b><br /><br />%2").arg("Fail to create the new connected element ").arg(err.what()));
         errDialog.setWindowTitle("Error");
         errDialog.setDetailsText(err.what());
+        errDialog.exec();
+        endInsertRows();
+        return;
+    }
+    catch (const Standard_Failure& err) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(
+            QString("<b>%1</b><br /><br />%2").arg("Fail to create the new connected element ").arg(err.GetMessageString()));
+        errDialog.setWindowTitle("Error");
+        errDialog.setDetailsText(err.GetMessageString());
+        errDialog.exec();
+        endInsertRows();
+        return;
+    }
+    catch (...) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(
+            QString("<b>%1</b><br /><br />%2").arg("Fail to create the new connected element ").arg("Unknown error."));
+        errDialog.setWindowTitle("Error");
         errDialog.exec();
         endInsertRows();
         return;
@@ -778,6 +844,23 @@ void ModificatorModel::addProfile(QString const& profileID)
         endInsertRows();
         return;
     }
+    catch (const Standard_Failure& err) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to create the wing ").arg(err.GetMessageString()));
+        errDialog.setWindowTitle("Error");
+        errDialog.setDetailsText(err.GetMessageString());
+        errDialog.exec();
+        endInsertRows();
+        return;
+    }
+    catch (...) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to create the wing ").arg("Unknown error."));
+        errDialog.setWindowTitle("Error");
+        errDialog.exec();
+        endInsertRows();
+        return;
+    }
 
     createUndoCommand(); // this is a bit unfortunate: if a profile has to be added, we have an additional undo command
 
@@ -830,6 +913,23 @@ void ModificatorModel::onAddWingRequested()
             endInsertRows();
             return;
         }
+        catch (const Standard_Failure& err) {
+            TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to create the wing ").arg(err.GetMessageString()));
+            errDialog.setWindowTitle("Error");
+            errDialog.setDetailsText(err.GetMessageString());
+            errDialog.exec();
+            endInsertRows();
+            return;
+        }
+        catch (...) {
+            TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to create the wing ").arg("Unknown error."));
+            errDialog.setWindowTitle("Error");
+            errDialog.exec();
+            endInsertRows();
+            return;
+        }
 
         createUndoCommand(); // invokes writeCPACS, which is needed to correctly modify the CPACSTree
 
@@ -876,6 +976,23 @@ void ModificatorModel::deleteWing(std::string const& uid)
         endRemoveRows();
         return;
     }
+    catch (const Standard_Failure& err) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the wing ").arg(err.GetMessageString()));
+        errDialog.setWindowTitle("Error");
+        errDialog.setDetailsText(err.GetMessageString());
+        errDialog.exec();
+        endRemoveRows();
+        return;
+    }
+    catch (...) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the wing ").arg("Unknown error."));
+        errDialog.setWindowTitle("Error");
+        errDialog.exec();
+        endRemoveRows();
+        return;
+    }
 
     createUndoCommand(); // invokes writeCPACS, which is needed to correctly modify the CPACSTree
 
@@ -914,6 +1031,23 @@ void ModificatorModel::deleteFuselage(std::string const& uid)
         errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the fuselage ").arg(err.what()));
         errDialog.setWindowTitle("Error");
         errDialog.setDetailsText(err.what());
+        errDialog.exec();
+        endRemoveRows();
+        return;
+    }
+    catch (const Standard_Failure& err) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the fuselage ").arg(err.GetMessageString()));
+        errDialog.setWindowTitle("Error");
+        errDialog.setDetailsText(err.GetMessageString());
+        errDialog.exec();
+        endRemoveRows();
+        return;
+    }
+    catch (...) {
+        TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+        errDialog.setMessage(QString("<b>%1</b><br /><br />%2").arg("Fail to delete the fuselage ").arg("Unknown error."));
+        errDialog.setWindowTitle("Error");
         errDialog.exec();
         endRemoveRows();
         return;
@@ -983,6 +1117,25 @@ void ModificatorModel::onAddFuselageRequested()
                 QString("<b>%1</b><br /><br />%2").arg("Fail to create the fuselage ").arg(err.what()));
             errDialog.setWindowTitle("Error");
             errDialog.setDetailsText(err.what());
+            errDialog.exec();
+            endInsertRows();
+            return;
+        }
+        catch (const Standard_Failure& err) {
+            TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+            errDialog.setMessage(
+                QString("<b>%1</b><br /><br />%2").arg("Fail to create the fuselage ").arg(err.GetMessageString()));
+            errDialog.setWindowTitle("Error");
+            errDialog.setDetailsText(err.GetMessageString());
+            errDialog.exec();
+            endInsertRows();
+            return;
+        }
+        catch (...) {
+            TIGLCreatorErrorDialog errDialog(modificatorContainerWidget);
+            errDialog.setMessage(
+                QString("<b>%1</b><br /><br />%2").arg("Fail to create the fuselage ").arg("Unknown error."));
+            errDialog.setWindowTitle("Error");
             errDialog.exec();
             endInsertRows();
             return;

--- a/TIGLCreator/src/ModificatorModel.h
+++ b/TIGLCreator/src/ModificatorModel.h
@@ -187,6 +187,7 @@ public:
     bool isFailedUID(const std::string& uid) const;
     void markFailedUID(const std::string& uid);
     void handleUIDError(const std::string& uid, const tigl::CTiglError& ex);
+    void handleUIDError(const std::string& uid, const std::string& message);
 
     QModelIndex getIdxForUID(std::string uid) const;
 

--- a/TIGLCreator/src/TIGLCreatorDocument.cpp
+++ b/TIGLCreator/src/TIGLCreatorDocument.cpp
@@ -51,6 +51,7 @@
 #include <gce_MakeLin.hxx>
 #include <GC_MakeSegment.hxx>
 #include <BRepBndLib.hxx>
+#include <Standard_Failure.hxx>
 
 // TIGLCreator includes
 #include "CPACSProfileGeometry.h"
@@ -862,6 +863,12 @@ void TIGLCreatorDocument::drawComponentByUID(const QString& uid)
     catch (tigl::CTiglError& err) {
         displayError("Cannot display \"" + uid + "\": " + err.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError("Cannot display \"" + uid + "\": " + err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Cannot display \"" + uid + "\": unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawControlPointNet()
@@ -1007,6 +1014,12 @@ void TIGLCreatorDocument::drawConfiguration(bool withDuctCutouts)
     catch (tigl::CTiglError& err) {
         displayError(err.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawConfigurationWithDuctCutouts()
@@ -1026,6 +1039,12 @@ void TIGLCreatorDocument::drawWingProfiles()
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawWingOverlayProfilePoints(const QString& Uid)
@@ -1038,6 +1057,12 @@ void TIGLCreatorDocument::drawWingOverlayProfilePoints(const QString& Uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -1055,6 +1080,12 @@ void TIGLCreatorDocument::drawWingGuideCurves(const QString& uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what(), "Error");
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString(), "Error");
+    }
+    catch (...) {
+        displayError("Unknown error.", "Error");
     }
 }
 
@@ -1127,6 +1158,12 @@ void TIGLCreatorDocument::drawFuselageProfiles()
                 }
                 catch (tigl::CTiglError& ex) {
                     displayError(ex.what());
+                }
+                catch (const Standard_Failure& err) {
+                    displayError(err.GetMessageString());
+                }
+                catch (...) {
+                    displayError("Unknown error.");
                 }
             }
         }
@@ -1209,6 +1246,12 @@ void TIGLCreatorDocument::drawWingFlaps(const QString& Uid)
     catch (tigl::CTiglError& ex) {
         displayError(ex.what(), "Error");
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString(), "Error");
+    }
+    catch (...) {
+        displayError("Unknown error.", "Error");
+    }
 }
 
 bool TIGLCreatorDocument::drawWingFlaps(tigl::CCPACSWing& wing)
@@ -1284,6 +1327,14 @@ bool TIGLCreatorDocument::drawWingFlaps(tigl::CCPACSWing& wing)
         displayError(ex.what(), "Error");
         return false;
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString(), "Error");
+        return false;
+    }
+    catch (...) {
+        displayError("Unknown error.", "Error");
+        return false;
+    }
 
     return true;
 }
@@ -1316,6 +1367,12 @@ void TIGLCreatorDocument::drawFlapsOverlay()
         }
     catch (tigl::CTiglError& err) {
         displayError(err.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -1360,6 +1417,12 @@ void TIGLCreatorDocument::drawWingFlap(const QString& uid)
     catch (const tigl::CTiglError& ex) {
         displayError(ex.what(), "Error");
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString(), "Error");
+    }
+    catch (...) {
+        displayError("Unknown error.", "Error");
+    }
 }
 
 void TIGLCreatorDocument::updateFlapTransform(const std::string& controlUID)
@@ -1380,7 +1443,7 @@ void TIGLCreatorDocument::updateFlapTransform(const std::string& controlUID)
             mflaps =
                 app->getScene()->GetShapeManager().GetIObjectsFromShapeName(controlSurfaceDevice->GetUID()+":mirrored");
         }
-        catch (const tigl::CTiglError&) {
+        catch (...) {
             displayError(QString("Error computing control surface device '%1'").arg(controlUID.c_str()),
                          QString("Error"));
         }
@@ -1396,7 +1459,7 @@ void TIGLCreatorDocument::updateFlapTransform(const std::string& controlUID)
             mflaps =
                 app->getScene()->GetShapeManager().GetIObjectsFromShapeName(controlSurfaceDevice->GetUID()+":mirrored");
         }
-        catch (const tigl::CTiglError&) {
+        catch (...) {
             displayError(QString("Error computing control surface device '%1'").arg(controlUID.c_str()),
             QString("Error"));
         }
@@ -1524,6 +1587,12 @@ void TIGLCreatorDocument::drawWingTriangulation(const QString& Uid)
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawFuselageTriangulation(const QString& Uid)
@@ -1558,6 +1627,12 @@ void TIGLCreatorDocument::drawWingSamplePoints(const QString& Uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -2484,6 +2559,12 @@ void TIGLCreatorDocument::drawWingShells(const QString& Uid)
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawWingStructure(const QString& Uid)
@@ -2628,6 +2709,14 @@ void TIGLCreatorDocument::drawSystems()
             const QString uid = QString::fromStdString(genericSystem.GetUID());
             displayError("Cannot display \"" + uid + "\": " + err.what());
         }
+        catch (const Standard_Failure& err) {
+            const QString uid = QString::fromStdString(genericSystem.GetUID());
+            displayError("Cannot display \"" + uid + "\": " + err.GetMessageString());
+        }
+        catch (...) {
+            const QString uid = QString::fromStdString(genericSystem.GetUID());
+            displayError("Cannot display \"" + uid + "\": unknown error.");
+        }
     }
 }
 
@@ -2656,6 +2745,12 @@ void TIGLCreatorDocument::drawRotorProfiles()
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawRotorBladeOverlayProfilePoints(const QString& Uid)
@@ -2668,6 +2763,12 @@ void TIGLCreatorDocument::drawRotorBladeOverlayProfilePoints(const QString& Uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -2696,6 +2797,12 @@ void TIGLCreatorDocument::drawRotorBlade(const QString& Uid)
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawRotorBladeTriangulation(const QString& Uid)
@@ -2708,6 +2815,12 @@ void TIGLCreatorDocument::drawRotorBladeTriangulation(const QString& Uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -2722,6 +2835,12 @@ void TIGLCreatorDocument::drawRotorBladeSamplePoints(const QString& Uid)
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
     }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
+    }
 }
 
 void TIGLCreatorDocument::drawFusedRotorBlade(const QString& Uid)
@@ -2734,6 +2853,12 @@ void TIGLCreatorDocument::drawFusedRotorBlade(const QString& Uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -2782,6 +2907,12 @@ void TIGLCreatorDocument::drawRotorBladeShells(const QString& Uid)
     }
     catch (tigl::CTiglError& ex) {
         displayError(ex.what());
+    }
+    catch (const Standard_Failure& err) {
+        displayError(err.GetMessageString());
+    }
+    catch (...) {
+        displayError("Unknown error.");
     }
 }
 
@@ -3016,6 +3147,12 @@ void TIGLCreatorDocument::drawAirfoil(tigl::CCPACSWingProfile& profile)
             catch (tigl::CTiglError& ex) {
                 displayError(ex.what());
             }
+            catch (const Standard_Failure& err) {
+                displayError(err.GetMessageString());
+            }
+            catch (...) {
+                displayError("Unknown error.");
+            }
 
             try {
                 gp_Pnt upperPoint = profile.GetUpperPoint(xsi);
@@ -3028,6 +3165,12 @@ void TIGLCreatorDocument::drawAirfoil(tigl::CCPACSWingProfile& profile)
             catch (tigl::CTiglError& ex) {
                 displayError(ex.what());
             }
+            catch (const Standard_Failure& err) {
+                displayError(err.GetMessageString());
+            }
+            catch (...) {
+                displayError("Unknown error.");
+            }
 
             try {
                 gp_Pnt lowerPoint = profile.GetLowerPoint(xsi);
@@ -3039,6 +3182,12 @@ void TIGLCreatorDocument::drawAirfoil(tigl::CCPACSWingProfile& profile)
             }
             catch (tigl::CTiglError& ex) {
                 displayError(ex.what());
+            }
+            catch (const Standard_Failure& err) {
+                displayError(err.GetMessageString());
+            }
+            catch (...) {
+                displayError("Unknown error.");
             }
         }
     }

--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -29,6 +29,7 @@
 #include <QTimer>
 #include <QProcessEnvironment>
 #include <QMessageBox>
+#include <Standard_Failure.hxx>
 
 
 #include "TIGLCreatorWindow.h"
@@ -1084,8 +1085,14 @@ void TIGLCreatorWindow::onComponentVisibilityChanged(const QString& uid, bool vi
         }
         myScene->getViewer()->Update();
     }
-    catch (tigl::CTiglError& ) {
-        throw tigl::CTiglError("Error changing visibility of component with UID " + uid.toStdString());
+    catch (tigl::CTiglError& err) {
+        displayErrorMessage("Error changing visibility of component with UID " + uid + ": " + err.what(), "Error");
+    }
+    catch (const Standard_Failure& err) {
+        displayErrorMessage("Error changing visibility of component with UID " + uid + ": " + err.GetMessageString(), "Error");
+    }
+    catch (...) {
+        displayErrorMessage("Error changing visibility of component with UID " + uid + ": unknown error.", "Error");
     }
 }
 

--- a/TIGLCreator/src/modificators/ModificatorElementWidget.cpp
+++ b/TIGLCreator/src/modificators/ModificatorElementWidget.cpp
@@ -20,6 +20,7 @@
 #include "ui_ModificatorElementWidget.h"
 #include "CTiglError.h"
 #include "TIGLCreatorErrorDialog.h"
+#include <Standard_Failure.hxx>
 
 ModificatorElementWidget::ModificatorElementWidget(QWidget* parent)
     : ModificatorWidget(parent)
@@ -131,6 +132,23 @@ bool ModificatorElementWidget::apply()
                                          .arg(err.what()));
             errDialog.setWindowTitle("Error");
             errDialog.setDetailsText(err.what());
+            errDialog.exec();
+        }
+        catch (const Standard_Failure& err) {
+            TIGLCreatorErrorDialog errDialog(this);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                         .arg("Fail to set the profile")
+                                         .arg(err.GetMessageString()));
+            errDialog.setWindowTitle("Error");
+            errDialog.setDetailsText(err.GetMessageString());
+            errDialog.exec();
+        }
+        catch (...) {
+            TIGLCreatorErrorDialog errDialog(this);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                         .arg("Fail to set the profile")
+                                         .arg("Unknown error."));
+            errDialog.setWindowTitle("Error");
             errDialog.exec();
         }
 

--- a/TIGLCreator/src/modificators/ModificatorFuselageWidget.cpp
+++ b/TIGLCreator/src/modificators/ModificatorFuselageWidget.cpp
@@ -20,6 +20,7 @@
 #include "ui_ModificatorFuselageWidget.h"
 #include "CCPACSConfiguration.h"
 #include "TIGLCreatorErrorDialog.h"
+#include <Standard_Failure.hxx>
 
 ModificatorFuselageWidget::ModificatorFuselageWidget(QWidget* parent)
     : ModificatorWidget(parent)
@@ -127,6 +128,23 @@ bool ModificatorFuselageWidget::apply()
                                          .arg(err.what()));
             errDialog.setWindowTitle("Error");
             errDialog.setDetailsText(err.what());
+            errDialog.exec();
+        }
+        catch (const Standard_Failure &err) {
+            TIGLCreatorErrorDialog errDialog(this);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                         .arg("Fail to set the profile")
+                                         .arg(err.GetMessageString()));
+            errDialog.setWindowTitle("Error");
+            errDialog.setDetailsText(err.GetMessageString());
+            errDialog.exec();
+        }
+        catch (...) {
+            TIGLCreatorErrorDialog errDialog(this);
+            errDialog.setMessage(QString("<b>%1</b><br /><br />%2")
+                                         .arg("Fail to set the profile")
+                                         .arg("Unknown error."));
+            errDialog.setWindowTitle("Error");
             errDialog.exec();
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1382.  The issue reports a crash in DrawComponentByUID, but there are several other places in TiGLCreator that had missing exception handling as well. Added comprehensive exception handling across TiGLCreator to catch Standard_Failure and other exceptions, displaying error dialogs instead of crashing. I don't know if the fixes here are exhaustive, but they should definitely guard against some unwanted crashes in the future.

Co-authored by Claude. Checked by me.

### Changes:

TIGLCreatorDocument.cpp - Added Standard_Failure and catch (...) handlers to ~25 drawing functions
ModificatorModel.cpp - Added exception handlers to dispatch, add/delete operations
TIGLCreatorWindow.cpp - Fixed onComponentVisibilityChanged error handling
ModificatorElementWidget.cpp & ModificatorFuselageWidget.cpp - Added exception handling to apply() methods
DrawOptionsActions.cpp - Simplified exception handling (any exception means "not found")
ModificatorModel.h - Added new handleUIDError overload

## How Has This Been Tested?

Manually in TiGLCreator

## Screenshots, that help to understand the changes(if applicable):

N/A

## Checklist for PR Author:
- [ ] Unit or integration test added (if applicable)
- [ ] Python interface updated (if applicable)
- [ ] Python test added (if Python interface updated)
- [ ] Doxygen docstrings added
- [x] `ChangeLog.md` updated