### PR TITLE
Fix #1386: geometry generation fails when creating a new CPACS file from the simpletest.cpacs.xml template

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@ Changes since last release
   - Implemented the UpperLower wire in CTiglWingProfileNACA ([#1366](https://github.com/DLR-SC/tigl/issues/1366))
 
 - Fixes
+  - Fix `BuildWireRectangle` throwing on the "circle" limit of a fuselage/wing standard rectangle profile (`heightToWidthRatio`/`cornerRadius` combination where the straight edges degenerate to zero length), which broke geometry generation for the TIGLCreator template's fuselage profile.
   - TiGLCreator: Fix crash when computing/displaying geometry (e.g. loft) throws an OpenCASCADE exception instead of a `tigl::CTiglError`. All corresponding error handlers across TiGLCreator now also catch `Standard_Failure` and any other exception, showing an error dialog instead of crashing ([#1382](https://github.com/DLR-SC/tigl/issues/1382))
   - TiGLCreator: Fix crash when selecting objects with malformed CPACS geometry. Invalid objects are now clearly marked with a warning icon and descriptive tooltip instead of causing an unhandled exception ([#1375](https://github.com/DLR-SC/tigl/issues/1375))
   - `CCPACSPositionings::CreatePositioning now sets a name to be CPACS-conform ([#1378](https://github.com/DLR-SC/tigl/issues/1378))

--- a/TIGLCreator/data/templates/simpletest.cpacs.xml
+++ b/TIGLCreator/data/templates/simpletest.cpacs.xml
@@ -38,8 +38,8 @@
             <transformation uID="SimpleFuselage_transformation1">
               <scaling uID="SimpleFuselage_transformation1_scaling1">
                 <x>1.0</x>
-                <y>0.5</y>
-                <z>0.5</z>
+                <y>1.0</y>
+                <z>1.0</z>
               </scaling>
               <rotation uID="SimpleFuselage_transformation1_rotation1">
                 <x>0.0</x>

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1257,7 +1257,7 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     addLineIfNotDegenerate(gp_Pnt(0.,0.,0.5*heightToWidthRatio),
                             gp_Pnt(0.,0.5-cornerRadius,0.5*heightToWidthRatio));
 
-    if (!(cornerRadius == 0.0)){
+    if ( cornerRadius > Precision::Confusion() ) {
         //build upper right arc
         double y0 = 0.5 - cornerRadius;
         double z0 = 0.5 * heightToWidthRatio - cornerRadius;
@@ -1270,7 +1270,7 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     addLineIfNotDegenerate(gp_Pnt(0., 0.5, 0.5 * heightToWidthRatio - cornerRadius),
                             gp_Pnt(0., 0.5, -0.5 * heightToWidthRatio + cornerRadius));
 
-    if (!(cornerRadius == 0.0)){
+    if ( cornerRadius > Precision::Confusion() ) {
         //build lower right arc
         double y0 = 0.5 - cornerRadius;
         double z0 = - 0.5 * heightToWidthRatio + cornerRadius;
@@ -1283,7 +1283,7 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     addLineIfNotDegenerate(gp_Pnt(0.,(0.5-cornerRadius),-0.5*heightToWidthRatio),
                             gp_Pnt(0.,(-0.5+cornerRadius),-0.5*heightToWidthRatio));
 
-    if (!(cornerRadius == 0.)){
+    if ( cornerRadius > Precision::Confusion() ) {
         // build lower left arc
         double y0 = - 0.5 + cornerRadius;
         double z0 = -0.5 * heightToWidthRatio + cornerRadius;
@@ -1296,7 +1296,7 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     addLineIfNotDegenerate(gp_Pnt(0.,-0.5,-0.5 * heightToWidthRatio + cornerRadius),
                             gp_Pnt(0.,-0.5,0.5 * heightToWidthRatio - cornerRadius));
 
-    if (!(cornerRadius == 0.)) {
+    if ( cornerRadius > Precision::Confusion() ) {
         // build upper left arc
         double y0 = - 0.5 + cornerRadius;
         double z0 = 0.5 * heightToWidthRatio - cornerRadius;

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -1245,13 +1245,17 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
 
     std::vector<Handle(Geom_BSplineCurve)> curves;
 
+    // Skip zero-length edges: at the circle limit (cornerRadius at its max) the straight sides
+    // collapse to points, and concatCurves then emits knots OCCT rejects as too close.
+    auto addLineIfNotDegenerate = [&curves](const gp_Pnt& p0, const gp_Pnt& p1) {
+        if (!p0.IsEqual(p1, Precision::Confusion())) {
+            curves.push_back(tigl::CTiglPointsToBSplineInterpolation({p0, p1}).Curve());
+        }
+    };
+
     // build half upper line from gp_points
-    std::vector<gp_Pnt> linePntsUpperRightHalf;
-    linePntsUpperRightHalf.push_back(gp_Pnt(0.,0.,0.5*heightToWidthRatio));
-    linePntsUpperRightHalf.push_back(gp_Pnt(0.,0.5-cornerRadius,0.5*heightToWidthRatio));
-    opencascade::handle<Geom_BSplineCurve> lowerLineRightHalf =
-            tigl::CTiglPointsToBSplineInterpolation(linePntsUpperRightHalf).Curve();
-    curves.push_back(lowerLineRightHalf);
+    addLineIfNotDegenerate(gp_Pnt(0.,0.,0.5*heightToWidthRatio),
+                            gp_Pnt(0.,0.5-cornerRadius,0.5*heightToWidthRatio));
 
     if (!(cornerRadius == 0.0)){
         //build upper right arc
@@ -1263,11 +1267,8 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     }
 
     // build right line from gp_Pnts
-    std::vector<gp_Pnt> linePnts_right;
-    linePnts_right.push_back(gp_Pnt(0., 0.5, 0.5 * heightToWidthRatio - cornerRadius));
-    linePnts_right.push_back(gp_Pnt(0., 0.5, -0.5 * heightToWidthRatio + cornerRadius));
-    opencascade::handle<Geom_BSplineCurve> rightLine = tigl::CTiglPointsToBSplineInterpolation(linePnts_right).Curve();
-    curves.push_back(rightLine);
+    addLineIfNotDegenerate(gp_Pnt(0., 0.5, 0.5 * heightToWidthRatio - cornerRadius),
+                            gp_Pnt(0., 0.5, -0.5 * heightToWidthRatio + cornerRadius));
 
     if (!(cornerRadius == 0.0)){
         //build lower right arc
@@ -1279,12 +1280,8 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     }
 
     // build lower line from gp_points
-    std::vector<gp_Pnt> linePnts_lower;
-    linePnts_lower.push_back(gp_Pnt(0.,(0.5-cornerRadius),-0.5*heightToWidthRatio));
-    linePnts_lower.push_back(gp_Pnt(0.,(-0.5+cornerRadius),-0.5*heightToWidthRatio));
-    opencascade::handle<Geom_BSplineCurve> lowerLine = tigl::CTiglPointsToBSplineInterpolation(linePnts_lower).Curve();
-
-    curves.push_back(lowerLine);
+    addLineIfNotDegenerate(gp_Pnt(0.,(0.5-cornerRadius),-0.5*heightToWidthRatio),
+                            gp_Pnt(0.,(-0.5+cornerRadius),-0.5*heightToWidthRatio));
 
     if (!(cornerRadius == 0.)){
         // build lower left arc
@@ -1296,11 +1293,8 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     }
 
     //build left line from gp_points
-    std::vector<gp_Pnt> linePnts_left;
-    linePnts_left.push_back(gp_Pnt(0.,-0.5,-0.5 * heightToWidthRatio + cornerRadius));
-    linePnts_left.push_back(gp_Pnt(0.,-0.5,0.5 * heightToWidthRatio - cornerRadius));
-    opencascade::handle<Geom_BSplineCurve> leftLine = tigl::CTiglPointsToBSplineInterpolation(linePnts_left).Curve();
-    curves.push_back(leftLine);
+    addLineIfNotDegenerate(gp_Pnt(0.,-0.5,-0.5 * heightToWidthRatio + cornerRadius),
+                            gp_Pnt(0.,-0.5,0.5 * heightToWidthRatio - cornerRadius));
 
     if (!(cornerRadius == 0.)) {
         // build upper left arc
@@ -1312,12 +1306,8 @@ TopoDS_Wire BuildWireRectangle(const double heightToWidthRatio, const double cor
     }
 
     // build half upper line from gp_points
-    std::vector<gp_Pnt> linePntsUpperLeftHalf;
-    linePntsUpperLeftHalf.push_back(gp_Pnt(0.,-(0.5-cornerRadius),0.5*heightToWidthRatio));
-    linePntsUpperLeftHalf.push_back(gp_Pnt(0.,0.,0.5*heightToWidthRatio));
-    opencascade::handle<Geom_BSplineCurve> upperLineLeftHalf =
-            tigl::CTiglPointsToBSplineInterpolation(linePntsUpperLeftHalf).Curve();
-    curves.push_back(upperLineLeftHalf);
+    addLineIfNotDegenerate(gp_Pnt(0.,-(0.5-cornerRadius),0.5*heightToWidthRatio),
+                            gp_Pnt(0.,0.,0.5*heightToWidthRatio));
 
     opencascade::handle<Geom_BSplineCurve> curve = tigl::CTiglBSplineAlgorithms::concatCurves(curves);
 

--- a/tests/unittests/tiglCommonFunctions.cpp
+++ b/tests/unittests/tiglCommonFunctions.cpp
@@ -198,6 +198,26 @@ TEST(TiglCommonFunctions, BuildWireRectangle_CornerRadiusOK)
     ASSERT_TRUE(BRepCheck_Analyzer(loft.Shape()).IsValid());
 }
 
+TEST(TiglCommonFunctions, BuildWireRectangle_FullCircleLimit)
+{
+    // heightToWidthRatio=1, cornerRadius=0.5 is the degenerate "circle" limit
+    // of the rectangle profile (all four straight edges collapse to zero
+    // length). See TIGLCreator/data/templates/simpletest.cpacs.xml.
+    auto wire = BuildWireRectangle(1., 0.5);
+    ASSERT_TRUE(wire.Closed());
+    ASSERT_TRUE(BRepCheck_Analyzer(wire).IsValid());
+
+    auto trafo = gp_Trsf();
+    auto vec = gp_Vec(-1.,0.,0.);
+    trafo.SetTranslation(vec);
+    auto wire2 = BRepBuilderAPI_Transform(wire, trafo).Shape();
+    ASSERT_TRUE(wire2.Closed());
+    auto loft = CTiglMakeLoft();
+    loft.addProfiles(wire);
+    loft.addProfiles(wire2);
+    ASSERT_TRUE(BRepCheck_Analyzer(loft.Shape()).IsValid());
+}
+
 TEST(TiglCommonFunctions, BuildWireRectangle_CornerRadiusInvalid)
 {
     ASSERT_THROW(BuildWireRectangle(0.5, 1.), tigl::CTiglError);


### PR DESCRIPTION
## Description

Fixes #1386.

Opening the TIGLCreator template `TIGLCreator/data/templates/simpletest.cpacs.xml` failed to generate geometry after #1367 switched the template's fuselage "Circle" profile from a `pointList` to a `standardProfile`/`rectangle` (`heightToWidthRatio=1`, `cornerRadius=0.5`).

That combination is the degenerate limit where a rounded rectangle becomes a pure circle: all four straight edges of the rectangle collapse to zero length. `BuildWireRectangle` (`src/common/tiglcommonfunctions.cpp`) didn't special-case this, so it still built a zero-length line segment for each straight edge and fed it into `CTiglBSplineAlgorithms::concatCurves` alongside the four quarter-circle arcs. Concatenating those degenerate segments produced knots that ended up closer together than OpenCASCADE's internal tolerance, and OCCT throws `Standard_Failure: BSpline curve: Knots interval values too close`.

Fix: `BuildWireRectangle` now skips adding a straight edge whenever its two endpoints coincide, instead of feeding a zero-length segment through the interpolation/concatenation pipeline. At the circle limit this correctly reduces to a wire built purely from the four quarter-circle arcs.

Finally, the scaling of the fuselage had to be adapted to obtain the same Sodacan-geometry we are all accustomed to. With the standard profile the radius was decreased.

> This PR was co-authored with Claude Code and thoroughly checked by me.

## How Has This Been Tested?

- Added `TiglCommonFunctions.BuildWireRectangle_FullCircleLimit` in `tests/unittests/tiglCommonFunctions.cpp`, which reproduces the exact degenerate input (`heightToWidthRatio=1`, `cornerRadius=0.5`) used by the template. Before the fix this test throws `Standard_Failure: BSpline curve: Knots interval values too close`; after the fix it builds a valid, closed wire and lofts successfully.
- Verified end-to-end by opening `TIGLCreator/data/templates/simpletest.cpacs.xml` directly and building both the fuselage and wing lofts — both now produce valid geometry (`BRepCheck_Analyzer(...).IsValid()`).
- Ran the full unit test suite (`pixi run -e default unittests`): all 899 tests pass, no regressions (including the existing `FuselageStandardProfile.*` and `TiglCommonFunctions.BuildWireRectangle_*` cases covering non-degenerate rectangle/rounded-rectangle profiles).

## Screenshots, that help to understand the changes(if applicabl

N/A (non-visual fix in geometry construction code).

## Checklist for PR Author:
- [x] Unit or integration test added (if applicable)
- [ ] Python interface updated (if applicable)
- [ ] Python test added (if Python interface updated)
- [ ] Doxygen docstrings added
- [x] `ChangeLog.md` updated