### PR TITLE
Fix regression: Unpretty indent in CPACS Tree

### DIFF
--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -1256,11 +1256,10 @@ QVariant ModificatorModel::data(const QModelIndex& index, int role) const
 
     if (role == Qt::DecorationRole && index.column() == 0) {
         std::string uid = item->getUid();
-        if (!uid.empty()) {
-            if (isFailedUID(uid)) {
-                return styleIcon(QStyle::SP_MessageBoxWarning);
-            }
+        if (!uid.empty() && isFailedUID(uid)) {
+            return styleIcon(QStyle::SP_MessageBoxWarning);
         }
+        return QVariant();
     }
 
     if (role == Qt::ToolTipRole && index.column() == 0) {
@@ -1268,6 +1267,7 @@ QVariant ModificatorModel::data(const QModelIndex& index, int role) const
         if (!uid.empty() && isFailedUID(uid)) {
             return QString("Invalid geometry: object not registered for uid '%1'. A possible cause could be a malformed CPACS node.").arg(uid.c_str());
         }
+        return QVariant();
     }
 
     if (role == Qt::CheckStateRole && index.column() == 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1390. PR #1376 added `Qt::DecorationRole`/`Qt::ToolTipRol`e handling to `ModificatorModel::data()` in `TIGLCreator/src/ModificatorModel.cpp`, but the new branches only returned for rows with a failed/unresolved UID — for the common case (valid UID), execution fell through into the unconditional "combine uid and type" block, which returned the UID text for any role, including `DecorationRole`. Because TIGLCreator applies a global QSS stylesheet to its tree view, Qt's stylesheet-driven rendering reserves icon-column width for every row once decoration data is "present" at all — so every UID shifted right, not just the ones with the warning icon. The same bug also caused every row to show a UID tooltip instead of just failed ones.

Fix applied: both branches now explicitly return `QVariant()`; when the UID isn't failed, restoring "no decoration/tooltip" for normal rows (TIGLCreator/src/ModificatorModel.cpp:1257-1271). Build succeeded with no errors.

## How Has This Been Tested?

Visually in TiGLCreator

## Screenshots, that help to understand the changes(if applicable):

Before: 
<img width="488" height="286" alt="image" src="https://github.com/user-attachments/assets/cb111697-1a2a-483c-8c42-4158b26c03ee" />

After: 
<img width="480" height="288" alt="image" src="https://github.com/user-attachments/assets/6b6407b2-91bd-44f4-a33f-d1ea39531d41" />

The warning icons from #1376 still work:
<img width="487" height="298" alt="image" src="https://github.com/user-attachments/assets/4631858b-46da-4236-9483-da2b788b72c5" />


## Checklist for PR Author:
- [ ] Unit or integration test added (if applicable)
- [ ] Python interface updated (if applicable)
- [ ] Python test added (if Python interface updated)
- [ ] Doxygen docstrings added
- [ ] `ChangeLog.md` updated

----

 - I did not add a changelog entry because it fixes a regression in an unreleased feature that is part of the changelog
 - This PR was co-authored with Claude.