### PR TITLE
Add a selectShape function to TiGLCreator's scripting interface.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ Changes since last release
   - TiGLCreator: Disable Standardize menu option, until the algorithm works reliably [#1336](https://github.com/DLR-SC/tigl/issues/1336)
   - TiGL is now able to approximate profile point lists. The user can define an index list refering to points that should still be interpolated [#1276](https://github.com/DLR-SC/tigl/issues/1276).
   - Add `Color` class and `setObjectsColor`/`setObjectsColorRGB` functions to the TiGLCreator scripting console to set object colors without needing a native QColor object ([#1222](https://github.com/DLR-SC/tigl/issues/1222))
+  - Add `app.scene.selectShape` function to the TiGLCreator scripting console, to select a shape by its CPACS UID (e.g. for per-shape color customization via `setObjectsColor`/`setObjectsColorRGB`) ([#1316](https://github.com/DLR-SC/tigl/issues/1316))
   - CPACS Export: Choose more meaningful marker for mirrored objects uIDs [#1289](https://github.com/DLR-SC/tigl/issues/1289)
   - Add geometry and mass-property evaluation for fuselage decks ([#1298](https://github.com/DLR-SC/tigl/pull/1298), [CPACS#859](https://github.com/DLR-SL/CPACS/issues/859))
   - Add leading edge devices (LED) to TiGL and TiGLcreator [#1101](https://github.com/DLR-SC/tigl/issues/1101)

--- a/TIGLCreator/src/TIGLCreatorContext.cpp
+++ b/TIGLCreator/src/TIGLCreatorContext.cpp
@@ -32,6 +32,7 @@
 #include "tiglcommonfunctions.h"
 #include "CNamedShape.h"
 #include "PNamedShape.h"
+#include "CTiglLogging.h"
 
 #include "ISession_Point.h"
 #include "ISession_Text.h"
@@ -358,6 +359,7 @@ void TIGLCreatorContext::selectShape(const QString& uid)
 
     IObjectList iobjects = myShapeManager.GetIObjectsFromShapeName(uid.toStdString());
     if (iobjects.empty()) {
+        LOG(WARNING) << "TIGLCreatorContext::selectShape: No shape found for UID \"" << uid.toStdString() << "\"" << std::endl;
         return;
     }
 
@@ -366,6 +368,8 @@ void TIGLCreatorContext::selectShape(const QString& uid)
         myContext->AddOrRemoveSelected(obj, Standard_False);
     }
     myContext->UpdateCurrentViewer();
+
+    emit shapeSelected(uid);
 }
 
 void TIGLCreatorContext::setGridOffset (Standard_Real offset)

--- a/TIGLCreator/src/TIGLCreatorContext.cpp
+++ b/TIGLCreator/src/TIGLCreatorContext.cpp
@@ -350,6 +350,24 @@ void TIGLCreatorContext::selectAll()
     }
 }
 
+void TIGLCreatorContext::selectShape(const QString& uid)
+{
+    if (myContext.IsNull()) {
+        return;
+    }
+
+    IObjectList iobjects = myShapeManager.GetIObjectsFromShapeName(uid.toStdString());
+    if (iobjects.empty()) {
+        return;
+    }
+
+    myContext->ClearSelected(Standard_False);
+    for (auto& obj : iobjects) {
+        myContext->AddOrRemoveSelected(obj, Standard_False);
+    }
+    myContext->UpdateCurrentViewer();
+}
+
 void TIGLCreatorContext::setGridOffset (Standard_Real offset)
 {
     Standard_Real radius;

--- a/TIGLCreator/src/TIGLCreatorContext.h
+++ b/TIGLCreator/src/TIGLCreatorContext.h
@@ -133,6 +133,7 @@ public slots:
     void setObjectsColor(const QColor &color);
     void setObjectsColorRGB(int r, int g, int b, int a = 255);
     void setFaceBoundariesEnabled(bool enabled);
+    void selectShape(const QString& uid);
 
 signals:
 

--- a/TIGLCreator/src/TIGLCreatorContext.h
+++ b/TIGLCreator/src/TIGLCreatorContext.h
@@ -140,6 +140,7 @@ signals:
     void error (int errorCode, QString& errorDescription);
     void displayAttributesChanged();
     void gridPlaneChanged(TIGLCreatorSettings::GridPlane plane);
+    void shapeSelected(const QString& uid);
 
 private:
     std::vector<Handle(AIS_InteractiveObject)> selected();

--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -1038,6 +1038,7 @@ void TIGLCreatorWindow::connectSignals()
 
     connect( myOCC, &TIGLCreatorWidget::shapeSelected, treeWidget, &CPACSTreeWidget::setSelectedUID);
     connect( myOCC, &TIGLCreatorWidget::nonEditableShapeSelected, treeWidget, &CPACSTreeWidget::unsetSelectedUID);
+    connect( myScene, &TIGLCreatorContext::shapeSelected, treeWidget, &CPACSTreeWidget::setSelectedUID);
 
     connect(stdoutStream, SIGNAL(sendString(QString)), console, SLOT(output(QString)));
     connect(errorStream , SIGNAL(sendString(QString)), console, SLOT(output(QString)));

--- a/TIGLCreator/src/TIGLScriptEngine.cpp
+++ b/TIGLCreator/src/TIGLScriptEngine.cpp
@@ -314,7 +314,12 @@ void TIGLScriptEngine::displayHelp()
     helpString += "Draw first wing:<br/>";
     helpString += "    uid = tigl.wingGetUID(1);<br/>";
     helpString += "    drawShape(tigl.getShape(uid));<br/><br/>";
-    
+
+    helpString += "Select and recolor first wing:<br/>";
+    helpString += "    uid = tigl.wingGetUID(1);<br/>";
+    helpString += "    app.scene.selectShape(uid);<br/>";
+    helpString += "    app.scene.setObjectsColorRGB(255, 0, 0);<br/><br/>";
+
     helpString += "Show top view and fit screen:<br/>";
     helpString += "    app.viewer.viewTop();<br/>";
     helpString += "    app.viewer.fitAll();<br/><br/>";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1316. Adds the function `app.scene.selectShape(uid)` to the TIGLCreator scripting engine. Looks up the currently-displayed AIS objects for a given CPACS UID (via InteractiveShapeManager, the same mechanism used for tree-view highlighting in ModificatorModel::highlightShape), clears the current selection, and selects those objects. This lets scripts do:
uid = tigl.wingGetUID(1);
app.scene.selectShape(uid);
app.scene.setObjectsColorRGB(255, 0, 0);

## How Has This Been Tested?

In the GUI:

```javascript
uid = tigl.wingGetUID(1);
app.scene.selectShape(uid);
app.scene.setObjectsColorRGB(255, 0, 0);
```

## Screenshots, that help to understand the changes(if applicable):

N/A

## Checklist for PR Author:
- [ ] Unit or integration test added (if applicable)
- [ ] Python interface updated (if applicable)
- [ ] Python test added (if Python interface updated)
- [ ] Doxygen docstrings added
- [x] `ChangeLog.md` updated