### PR TITLE
Fix relative path of noNamespaceSchemaLocation

### DIFF
--- a/tests/TestData/simpletest-decks.cpacs.xml
+++ b/tests/TestData/simpletest-decks.cpacs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../cpacs_gen_input/cpacs_schema.xsd">
+    xsi:noNamespaceSchemaLocation="../../cpacs_gen_input/cpacs_schema.xsd">
     <header>
         <name>Decks test</name>
         <description>Simple decks definitions for unit testing</description>

--- a/tests/TestData/simpletest-fuelTanks.cpacs.xml
+++ b/tests/TestData/simpletest-fuelTanks.cpacs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="../../../cpacs_gen_input/cpacs_schema.xsd">
+  xsi:noNamespaceSchemaLocation="../../cpacs_gen_input/cpacs_schema.xsd">
   <header>
     <name>Fuel tanks test</name>
     <description>Simple fuel tank for unit testing</description>

--- a/tests/TestData/simpletest-invalid-decks.cpacs.xml
+++ b/tests/TestData/simpletest-invalid-decks.cpacs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../cpacs_gen_input/cpacs_schema.xsd">
+    xsi:noNamespaceSchemaLocation="../../cpacs_gen_input/cpacs_schema.xsd">
     <header>
         <name>Decks test</name>
         <description>Simple decks definitions for unit testing</description>

--- a/tests/TestData/testversion_new_header.xml
+++ b/tests/TestData/testversion_new_header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../cpacs_gen_input/cpacs_schema.xsd">
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../cpacs_gen_input/cpacs_schema.xsd">
   <header>
     <name>Cpacs2Test</name>
     <description>Test file to check versioning according to new CPACS header</description>

--- a/tests/TestData/testversion_old_header.xml
+++ b/tests/TestData/testversion_old_header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../cpacs_gen_input/cpacs_schema.xsd">
+<cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../cpacs_gen_input/cpacs_schema.xsd">
   <header>
     <name>Cpacs2Test</name>
     <description>Test file to check versioning according to new CPACS header. Expected to throw deprecation warning due to mentioning cpacsVersion in header.</description>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR aligns the relative path of `noNamespaceSchemaLocation` with the new folder structure of the tests. 

This has no impact on TiGL itself, but working with test files I find it convenient to have a correct link to `cpacs_gen_input/cpacs_schema.xsd` in order to validate the tests data.

Note: the systems test data is excluded here because this is fixed directly in #1408. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Checked via VSCodium that schema is correctly linked to the corresponding XML files.

## Screenshots, that help to understand the changes(if applicable):


## Checklist for PR Author:
- [ ] Unit or integration test added (if applicable)
- [ ] Python interface updated (if applicable)
- [ ] Python test added (if Python interface updated)
- [ ] Doxygen docstrings added
- [ ] `ChangeLog.md` updated