### PR TITLE
Add manager for spotlights in 3d viewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@ Changes since last release
 
 - TiGLCreator
 
-  - none
+  - Implement a manager to deal with user-defined spotlights. These can now be added, edited, copied, deleted and turned off/on again directly via the GUI. That way, the CPACS Tree is extended by a tab called 'Others' ([#1439](https://github.com/DLR-SC/tigl/issues/1439))
 
 - Build System
 

--- a/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.cpp
+++ b/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.cpp
@@ -26,7 +26,21 @@
 #include <QDoubleSpinBox>
 #include <QDialogButtonBox>
 
-TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
+TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget* parent)
+    : TIGLCreatorAddSpotlightDialog(0., 0., 0., 1., 1., 1., 0.5, "Add a spotlight", parent)
+{}
+
+TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(double x, double y, double z,
+                                                             double dirX, double dirY, double dirZ,
+                                                             double concentration, QWidget* parent)
+    : TIGLCreatorAddSpotlightDialog(x, y, z, dirX, dirY, dirZ, concentration, "Edit spotlight", parent)
+{}
+
+TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(double x, double y, double z,
+                                                             double dirX, double dirY, double dirZ,
+                                                             double concentration,
+                                                             const QString& title,
+                                                             QWidget* parent)
     : QDialog(parent)
     , position_x(new QDoubleSpinBox())
     , position_y(new QDoubleSpinBox())
@@ -36,7 +50,13 @@ TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
     , dz(new QDoubleSpinBox())
     , concentration(new QDoubleSpinBox())
 {
-    setWindowTitle("Add a spotlight");
+    setupUI(title);
+    setValues(x, y, z, dirX, dirY, dirZ, concentration);
+}
+
+void TIGLCreatorAddSpotlightDialog::setupUI(const QString& title)
+{
+    setWindowTitle(title);
 
     // set decimals for all spinboxes
     int decimals = 7;
@@ -61,15 +81,6 @@ TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
     dz->setRange(direction_min, direction_max);
 
     concentration->setRange(0., 1.);
-
-    // set default values for all spinboxes
-    position_x->setValue(0.);
-    position_y->setValue(0.);
-    position_z->setValue(0.);
-    dx->setValue(1.);
-    dy->setValue(1.);
-    dz->setValue(1.);
-    concentration->setValue(0.5);
 
     // The main layout is vertical with a horizontal layout on top
     // and the dialog buttons below
@@ -107,7 +118,7 @@ TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
     QGridLayout* groupConcentrationLayout = new QGridLayout();
     groupConcentrationLayout->addWidget(new QLabel("= 0.0: Light spreads into all directions"), 0, 0);
     groupConcentrationLayout->addWidget(new QLabel("= 1.0: Light is bundled"), 1, 0);
-    QLabel *concLabel = new QLabel("concentration = ");
+    QLabel* concLabel = new QLabel("concentration = ");
     concLabel->setAlignment(Qt::AlignRight);
     groupConcentrationLayout->addWidget(concLabel, 2, 0);
     groupConcentrationLayout->addWidget(concentration, 2, 1);
@@ -125,6 +136,19 @@ TIGLCreatorAddSpotlightDialog::TIGLCreatorAddSpotlightDialog(QWidget *parent)
     verticalLayout->addWidget(groupConcentration, 0, Qt::AlignCenter);
     verticalLayout->addWidget(buttonBox);
     verticalLayout->setSizeConstraint(QLayout::SetFixedSize);
+}
+
+void TIGLCreatorAddSpotlightDialog::setValues(double x, double y, double z,
+                                              double dirX, double dirY, double dirZ,
+                                              double conc)
+{
+    position_x->setValue(x);
+    position_y->setValue(y);
+    position_z->setValue(z);
+    dx->setValue(dirX);
+    dy->setValue(dirY);
+    dz->setValue(dirZ);
+    concentration->setValue(conc);
 }
 
 tigl::CTiglPoint TIGLCreatorAddSpotlightDialog::getPosition() const

--- a/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.h
+++ b/TIGLCreator/src/TIGLCreatorAddSpotlightDialog.h
@@ -22,7 +22,6 @@
 #include <QDialog>
 #include <CTiglPoint.h>
 
-
 class QDoubleSpinBox;
 
 class TIGLCreatorAddSpotlightDialog : public QDialog
@@ -30,13 +29,27 @@ class TIGLCreatorAddSpotlightDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TIGLCreatorAddSpotlightDialog(QWidget *parent = 0);
+    // Used when a new spotlight is added
+    explicit TIGLCreatorAddSpotlightDialog(QWidget* parent = nullptr);
+    // Used when the spotlight was already created before and is just updated
+    // The current spotlight's params are shown in the dialog
+    TIGLCreatorAddSpotlightDialog(double x, double y, double z,
+                                  double dirX, double dirY, double dirZ,
+                                  double concentration, QWidget* parent = nullptr);
 
     tigl::CTiglPoint getPosition() const;
     tigl::CTiglPoint getDirection() const;
     double getConcentration() const;
 
 private:
+    TIGLCreatorAddSpotlightDialog(double x, double y, double z,
+                                  double dirX, double dirY, double dirZ,
+                                  double concentration,
+                                  const QString& title,
+                                  QWidget* parent);
+
+    void setupUI(const QString& title);
+    void setValues(double x, double y, double z, double dirX, double dirY, double dirZ, double conc);
     QDoubleSpinBox* position_x;
     QDoubleSpinBox* position_y;
     QDoubleSpinBox* position_z;

--- a/TIGLCreator/src/TIGLCreatorOthersWidget.cpp
+++ b/TIGLCreator/src/TIGLCreatorOthersWidget.cpp
@@ -1,0 +1,311 @@
+/*
+* Copyright (C) 2007-2026 German Aerospace Center (DLR/SC)
+*
+* Created: 2026-09-02 Sven Goldberg <sven.goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "TIGLCreatorOthersWidget.h"
+#include "TIGLCreatorSpotlightManager.h"
+#include "TIGLCreatorAddSpotlightDialog.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QTreeWidget>
+#include <QStackedWidget>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QLabel>
+#include <QSplitter>
+#include <gp_Pnt.hxx>
+
+TIGLCreatorOthersWidget::TIGLCreatorOthersWidget(QWidget* parent)
+    : QWidget(parent)
+    , mySpotlightManager(nullptr)
+    , myIsRefreshingSpotlightList(false)
+    , myIsTogglingSpotlight(false)
+{
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+
+    QSplitter* mainSplitter = new QSplitter(Qt::Vertical);
+    mainSplitter->setChildrenCollapsible(false);
+    mainLayout->addWidget(mainSplitter);
+
+    // Category tree at the top
+    myCategoryTree = new QTreeWidget();
+    myCategoryTree->setHeaderHidden(true);
+    mainSplitter->addWidget(myCategoryTree);
+
+    // Detail stack at the bottom
+    myDetailStack = new QStackedWidget();
+    mainSplitter->addWidget(myDetailStack);
+    mainSplitter->setStretchFactor(0, 0);
+    mainSplitter->setStretchFactor(1, 1);
+    mainSplitter->setSizes(QList<int>() << 24 << 300);
+
+    // Placeholder page (index 0 in the stack) - shown when nothing is selected
+    QWidget* placeholder = new QWidget();
+    QVBoxLayout* placeholderLayout = new QVBoxLayout(placeholder);
+    placeholderLayout->setContentsMargins(0, 0, 0, 0);
+    QLabel* placeholderLabel = new QLabel("Please select a category above to manage its entries");
+    placeholderLabel->setAlignment(Qt::AlignCenter);
+    placeholderLayout->addWidget(placeholderLabel, 1);
+    myDetailStack->addWidget(placeholder);
+
+    // Create the spotlight panel (index 1 in the stack)
+    myDetailStack->addWidget(createSpotlightPanel());
+
+    // Add "Manage Spotlights" category
+    QTreeWidgetItem* spotlightItem = new QTreeWidgetItem(myCategoryTree);
+    spotlightItem->setText(0, "Manage Spotlights");
+    spotlightItem->setData(0, Qt::UserRole, 1);
+    myCategoryTree->addTopLevelItem(spotlightItem);
+    spotlightItem->setExpanded(true);
+
+    // No item selected by default - placeholder is shown
+    myDetailStack->setCurrentIndex(0);
+
+    connect(myCategoryTree, &QTreeWidget::currentItemChanged,
+            this, &TIGLCreatorOthersWidget::onCategorySelectionChanged);
+}
+
+void TIGLCreatorOthersWidget::setSpotlightManager(TIGLCreatorSpotlightManager* manager)
+{
+    if (mySpotlightManager) {
+        disconnect(mySpotlightManager, &TIGLCreatorSpotlightManager::spotlightsChanged,
+                   this, &TIGLCreatorOthersWidget::refreshSpotlightList);
+    }
+
+    mySpotlightManager = manager;
+
+    if (mySpotlightManager) {
+        connect(mySpotlightManager, &TIGLCreatorSpotlightManager::spotlightsChanged,
+                this, &TIGLCreatorOthersWidget::refreshSpotlightList);
+        refreshSpotlightList();
+    }
+}
+
+QWidget* TIGLCreatorOthersWidget::createSpotlightPanel()
+{
+    QWidget* panel = new QWidget();
+    QVBoxLayout* layout = new QVBoxLayout(panel);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    // Spotlight list
+    mySpotlightList = new QListWidget();
+    layout->addWidget(mySpotlightList, 1);
+
+    // Button row
+    QHBoxLayout* buttonLayout = new QHBoxLayout();
+    myAddButton = new QPushButton("Add");
+    myEditButton = new QPushButton("Edit");
+    myCopyButton = new QPushButton("Copy");
+    myDeleteButton = new QPushButton("Delete");
+    buttonLayout->addWidget(myAddButton);
+    buttonLayout->addWidget(myEditButton);
+    buttonLayout->addWidget(myCopyButton);
+    buttonLayout->addWidget(myDeleteButton);
+    layout->addLayout(buttonLayout);
+
+    // Initially disable edit/copy/delete (nothing selected)
+    myEditButton->setEnabled(false);
+    myCopyButton->setEnabled(false);
+    myDeleteButton->setEnabled(false);
+
+    connect(myAddButton, &QPushButton::clicked, this, &TIGLCreatorOthersWidget::onAddSpotlight);
+    connect(myEditButton, &QPushButton::clicked, this, &TIGLCreatorOthersWidget::onEditSpotlight);
+    connect(myCopyButton, &QPushButton::clicked, this, &TIGLCreatorOthersWidget::onCopySpotlight);
+    connect(myDeleteButton, &QPushButton::clicked, this, &TIGLCreatorOthersWidget::onDeleteSpotlight);
+    connect(mySpotlightList, &QListWidget::currentRowChanged, this, [this](int) {
+        bool hasSelection = mySpotlightList->currentRow() >= 0;
+        myEditButton->setEnabled(hasSelection);
+        myCopyButton->setEnabled(hasSelection);
+        myDeleteButton->setEnabled(hasSelection);
+    });
+    connect(mySpotlightList, &QListWidget::itemChanged,
+            this, &TIGLCreatorOthersWidget::onSpotlightVisibChanged);
+
+    return panel;
+}
+
+void TIGLCreatorOthersWidget::onCategorySelectionChanged(QTreeWidgetItem* current, QTreeWidgetItem*)
+{
+    if (!current) {
+        myDetailStack->setCurrentIndex(0);
+        return;
+    }
+    int index = current->data(0, Qt::UserRole).toInt();
+    myDetailStack->setCurrentIndex(index);
+}
+
+void TIGLCreatorOthersWidget::onAddSpotlight()
+{
+    if (!mySpotlightManager) {
+        return;
+    }
+
+    TIGLCreatorAddSpotlightDialog dialog(this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    tigl::CTiglPoint pos = dialog.getPosition();
+    tigl::CTiglPoint dir = dialog.getDirection();
+    double conc = dialog.getConcentration();
+
+    mySpotlightManager->addSpotlight(pos.x, pos.y, pos.z, dir.x, dir.y, dir.z, conc);
+}
+
+void TIGLCreatorOthersWidget::onEditSpotlight()
+{
+    if (!mySpotlightManager) {
+        return;
+    }
+
+    int row = mySpotlightList->currentRow();
+    if (row < 0) {
+        return;
+    }
+
+    QList<SpotlightData> spotlights = mySpotlightManager->getSpotlights();
+    if (row >= spotlights.size()) {
+        return;
+    }
+
+    const SpotlightData& data = spotlights[row];
+    gp_Pnt pos = data.light->Position();
+    double conc = data.light->Concentration();
+
+    // Direction is read from the stored value, not from the OCCT handle.
+    // OCCT normalizes the direction and would show different values than the user entered
+    TIGLCreatorAddSpotlightDialog dialog(
+        pos.X(), pos.Y(), pos.Z(),
+        data.direction.X(), data.direction.Y(), data.direction.Z(),
+        conc, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    tigl::CTiglPoint newPos = dialog.getPosition();
+    tigl::CTiglPoint newDir = dialog.getDirection();
+    double newConc = dialog.getConcentration();
+
+    mySpotlightManager->updateSpotlight(row, newPos.x, newPos.y, newPos.z, newDir.x, newDir.y, newDir.z, newConc);
+}
+
+void TIGLCreatorOthersWidget::onCopySpotlight()
+{
+    if (!mySpotlightManager) {
+        return;
+    }
+
+    int row = mySpotlightList->currentRow();
+    if (row < 0) {
+        return;
+    }
+
+    mySpotlightManager->copySpotlight(row);
+}
+
+void TIGLCreatorOthersWidget::onDeleteSpotlight()
+{
+    if (!mySpotlightManager) {
+        return;
+    }
+
+    int row = mySpotlightList->currentRow();
+    if (row < 0) {
+        return;
+    }
+
+    QList<SpotlightData> spotlights = mySpotlightManager->getSpotlights();
+    if (row >= spotlights.size()) {
+        return;
+    }
+
+    const SpotlightData& data = spotlights[row];
+
+    QMessageBox::StandardButton reply = QMessageBox::question(
+        this, "Delete Spotlight",
+        QString("Are you sure you want to delete \"%1\"?").arg(data.name),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply == QMessageBox::Yes) {
+        mySpotlightManager->removeSpotlight(row);
+    }
+}
+
+void TIGLCreatorOthersWidget::onSpotlightVisibChanged(QListWidgetItem* item)
+{
+    if (!mySpotlightManager || !item || myIsRefreshingSpotlightList || myIsTogglingSpotlight) {
+        return;
+    }
+
+    int row = mySpotlightList->row(item);
+    if (row < 0) {
+        return;
+    }
+
+    bool newState = (item->checkState() == Qt::Checked);
+    Qt::CheckState previousState = newState ? Qt::Unchecked : Qt::Checked;
+
+    myIsTogglingSpotlight = true;
+    bool success = mySpotlightManager->setSpotlightEnabled(row, newState);
+    if (!success) {
+        item->setCheckState(previousState);
+    }
+    myIsTogglingSpotlight = false;
+}
+
+void TIGLCreatorOthersWidget::refreshSpotlightList()
+{
+    if (!mySpotlightList || myIsRefreshingSpotlightList || myIsTogglingSpotlight) {
+        return;
+    }
+
+    myIsRefreshingSpotlightList = true;
+
+    QString currentName;
+    if (mySpotlightList->currentRow() >= 0) {
+        currentName = mySpotlightList->currentItem()->text();
+    }
+
+    // Rebuild whole list since after change (add, edit, delete) it is not clear which spotlight changed
+    mySpotlightList->clear();
+
+    if (mySpotlightManager) {
+        QList<SpotlightData> spotlights = mySpotlightManager->getSpotlights();
+        for (const auto& s : spotlights) {
+            QListWidgetItem* item = new QListWidgetItem(s.name);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            item->setCheckState(s.enabled ? Qt::Checked : Qt::Unchecked);
+            mySpotlightList->addItem(item);
+        }
+    }
+
+    myIsRefreshingSpotlightList = false;
+
+    // Try to restore the previously selected spotlight by name
+    if (!currentName.isEmpty()) {
+        for (int i = 0; i < mySpotlightList->count(); ++i) {
+            if (mySpotlightList->item(i)->text() == currentName) {
+                mySpotlightList->setCurrentRow(i);
+                break;
+            }
+        }
+    }
+}

--- a/TIGLCreator/src/TIGLCreatorOthersWidget.h
+++ b/TIGLCreator/src/TIGLCreatorOthersWidget.h
@@ -1,0 +1,67 @@
+/*
+* Copyright (C) 2007-2026 German Aerospace Center (DLR/SC)
+*
+* Created: 2026-09-02 Sven Goldberg <sven.goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TIGLCREATOROTHERSWIDGET_H
+#define TIGLCREATOROTHERSWIDGET_H
+
+#include <QWidget>
+
+class QTreeWidget;
+class QTreeWidgetItem;
+class QStackedWidget;
+class QListWidget;
+class QPushButton;
+class QListWidgetItem;
+class TIGLCreatorSpotlightManager;
+
+class TIGLCreatorOthersWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TIGLCreatorOthersWidget(QWidget* parent = nullptr);
+
+    void setSpotlightManager(TIGLCreatorSpotlightManager* manager);
+
+private slots:
+    void onCategorySelectionChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
+    void onAddSpotlight();
+    void onEditSpotlight();
+    void onCopySpotlight();
+    void onDeleteSpotlight();
+    void onSpotlightVisibChanged(QListWidgetItem* item);
+
+private:
+    QWidget* createSpotlightPanel();
+    void refreshSpotlightList();
+
+    QTreeWidget* myCategoryTree;
+    QStackedWidget* myDetailStack;
+
+    QListWidget* mySpotlightList;
+    QPushButton* myAddButton;
+    QPushButton* myEditButton;
+    QPushButton* myCopyButton;
+    QPushButton* myDeleteButton;
+
+    TIGLCreatorSpotlightManager* mySpotlightManager;
+    bool myIsRefreshingSpotlightList;
+    bool myIsTogglingSpotlight;
+};
+
+#endif // TIGLCREATOROTHERSWIDGET_H

--- a/TIGLCreator/src/TIGLCreatorSpotlightManager.cpp
+++ b/TIGLCreator/src/TIGLCreatorSpotlightManager.cpp
@@ -1,0 +1,169 @@
+/*
+* Copyright (C) 2007-2026 German Aerospace Center (DLR/SC)
+*
+* Created: 2026-09-02 Sven Goldberg <sven.goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "TIGLCreatorSpotlightManager.h"
+#include "TIGLCreatorWidget.h"
+#include "CTiglLogging.h"
+
+#include <gp_Pnt.hxx>
+#include <gp_Dir.hxx>
+#include <V3d_Light.hxx>
+
+TIGLCreatorSpotlightManager::TIGLCreatorSpotlightManager(TIGLCreatorWidget* widget, QObject* parent)
+    : QObject(parent)
+    , myWidget(widget)
+    , myNextId(1)
+{}
+
+void TIGLCreatorSpotlightManager::addSpotlight(double x, double y, double z,
+                                               double dx, double dy, double dz,
+                                               double concentration)
+{
+    addSpotlight(x, y, z, dx, dy, dz, concentration, true);
+}
+
+void TIGLCreatorSpotlightManager::addSpotlight(double x, double y, double z,
+                                               double dx, double dy, double dz,
+                                               double concentration,
+                                               bool enabled)
+{
+    if (concentration < 0.0 || concentration > 1.0) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::addSpotlight: Invalid concentration " << concentration << ". Concentration must be inside [0.0,1.0].";
+        return;
+    }
+    if (dx*dx + dy*dy + dz*dz < 1e-8) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::addSpotlight: Direction must not be the zero vector or very close to it.";
+        return;
+    }
+
+    Handle(V3d_Light) light = new V3d_Light(Graphic3d_TypeOfLightSource::V3d_SPOT);
+    light->SetPosition(gp_Pnt(x, y, z));
+    light->SetDirection(gp_Dir(dx, dy, dz));
+    light->SetConcentration(concentration);
+
+    SpotlightData data;
+    data.name = QString("Spotlight %1").arg(myNextId++);
+    data.light = light;
+    data.direction = gp_Pnt(dx, dy, dz);
+    data.enabled = enabled;
+
+    if (enabled) {
+        myWidget->activateLight(light);
+    }
+    mySpotlights.append(data);
+    emit spotlightsChanged();
+}
+
+void TIGLCreatorSpotlightManager::removeSpotlight(int index)
+{
+    if (index < 0 || index >= mySpotlights.size()) {
+        return;
+    }
+    myWidget->removeLight(mySpotlights[index].light);
+    mySpotlights.removeAt(index);
+    emit spotlightsChanged();
+}
+
+void TIGLCreatorSpotlightManager::copySpotlight(int index)
+{
+    if (index < 0 || index >= mySpotlights.size()) {
+        return;
+    }
+
+    gp_Pnt position = mySpotlights[index].light->Position();
+    gp_Pnt direction = mySpotlights[index].direction;
+    double concentration = mySpotlights[index].light->Concentration();
+    bool sourceEnabled = mySpotlights[index].enabled;
+
+    addSpotlight(position.X(), position.Y(), position.Z(),
+                 direction.X(), direction.Y(), direction.Z(),
+                 concentration,
+                 sourceEnabled);
+}
+
+bool TIGLCreatorSpotlightManager::updateSpotlight(int index, double x, double y, double z,
+                                                  double dx, double dy, double dz,
+                                                  double concentration)
+{
+    if (index < 0 || index >= mySpotlights.size()) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::updateSpotlight: Invalid spotlight index " << index << ".";
+        return false;
+    }
+    if (concentration < 0.0 || concentration > 1.0) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::updateSpotlight: Invalid concentration " << concentration << ". Concentration must be inside [0.0,1.0].";
+        return false;
+    }
+    if (dx*dx + dy*dy + dz*dz < 1e-8) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::updateSpotlight: Direction must not be the zero vector or very close to it.";
+        return false;
+    }
+
+    SpotlightData& data = mySpotlights[index];
+    data.light->SetPosition(gp_Pnt(x, y, z));
+    data.light->SetDirection(gp_Dir(dx, dy, dz));
+    data.light->SetConcentration(concentration);
+    data.direction = gp_Pnt(dx, dy, dz);
+
+    if (data.enabled) {
+        myWidget->activateLight(data.light);
+    } else {
+        myWidget->deactivateLight(data.light);
+    }
+
+    emit spotlightsChanged();
+    return true;
+}
+
+bool TIGLCreatorSpotlightManager::setSpotlightEnabled(int index, bool enabled)
+{
+    if (index < 0 || index >= mySpotlights.size()) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::setSpotlightEnabled: Invalid spotlight index " << index << ".";
+        return false;
+    }
+
+    SpotlightData& data = mySpotlights[index];
+    if (data.enabled == enabled) {
+        return true;
+    }
+
+    data.enabled = enabled;
+
+    if (enabled) {
+        myWidget->activateLight(data.light);
+    } else {
+        myWidget->deactivateLight(data.light);
+    }
+
+    emit spotlightsChanged();
+    return true;
+}
+
+bool TIGLCreatorSpotlightManager::isSpotlightEnabled(int index) const
+{
+    if (index < 0 || index >= mySpotlights.size()) {
+        LOG(ERROR) << "TIGLCreatorSpotlightManager::isSpotlightEnabled: Invalid spotlight index " << index << ".";
+        return false;
+    }
+
+    return mySpotlights[index].enabled;
+}
+
+QList<SpotlightData> TIGLCreatorSpotlightManager::getSpotlights() const
+{
+    return mySpotlights;
+}

--- a/TIGLCreator/src/TIGLCreatorSpotlightManager.h
+++ b/TIGLCreator/src/TIGLCreatorSpotlightManager.h
@@ -1,0 +1,69 @@
+/*
+* Copyright (C) 2007-2026 German Aerospace Center (DLR/SC)
+*
+* Created: 2026-09-02 Sven Goldberg <sven.goldberg@dlr.de>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TIGLCREATORSPOTLIGHTMANAGER_H
+#define TIGLCREATORSPOTLIGHTMANAGER_H
+
+#include <QObject>
+#include <QList>
+#include <QString>
+#include <V3d_Light.hxx>
+#include <gp_Pnt.hxx>
+
+class TIGLCreatorWidget;
+
+// Struct to store the spotlight's name together with the OCCT object since there is no internal field 'name'.
+// Additionally, the direction is stored externally. That is due to OCCT storing only the normalized direction vector.
+// When a user enters a new entry (e.g. with the default vector (1,1,1)) and edits it, the read-out and shown values would change due to normalization.
+struct SpotlightData
+{
+    QString name;
+    Handle(V3d_Light) light;
+    gp_Pnt direction;
+    bool enabled = true;
+};
+
+class TIGLCreatorSpotlightManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit TIGLCreatorSpotlightManager(TIGLCreatorWidget* widget, QObject* parent = nullptr);
+
+    void addSpotlight(double x, double y, double z, double dx, double dy, double dz, double concentration);
+    void removeSpotlight(int index);
+    bool updateSpotlight(int index, double x, double y, double z, double dx, double dy, double dz, double concentration);
+    void copySpotlight(int index);
+    bool setSpotlightEnabled(int index, bool enabled);
+    bool isSpotlightEnabled(int index) const;
+
+    QList<SpotlightData> getSpotlights() const;
+
+signals:
+    void spotlightsChanged();
+
+private:
+    // This overload is needed when a spotlight is copied to also copy the state (on/off) correctly
+    void addSpotlight(double x, double y, double z, double dx, double dy, double dz, double concentration, bool enabled);
+
+    TIGLCreatorWidget* myWidget;
+    QList<SpotlightData> mySpotlights;
+    int myNextId;
+};
+
+#endif // TIGLCREATORSPOTLIGHTMANAGER_H

--- a/TIGLCreator/src/TIGLCreatorWidget.cpp
+++ b/TIGLCreator/src/TIGLCreatorWidget.cpp
@@ -42,6 +42,7 @@
 #include "TIGLCreatorContext.h"
 #include "TIGLCreatorSettings.h"
 #include "TIGLCreatorMaterials.h"
+#include "TIGLCreatorSpotlightManager.h"
 #include "ISession_Point.h"
 #include "ISession_Direction.h"
 #include "ISession_Text.h"
@@ -98,7 +99,8 @@ TIGLCreatorWidget::TIGLCreatorWidget(QWidget * parent)
     myViewPrecision   ( 0.0 ),
     myKeyboardFlags   ( Qt::NoModifier ),
     myButtonFlags     ( Qt::NoButton ),
-    viewerContext     (nullptr)
+    viewerContext     (nullptr),
+    mySpotlightManager(nullptr)
 {
     initialize();
 }
@@ -610,24 +612,50 @@ void TIGLCreatorWidget::setCameraUpVector(double x, double y, double z)
 
 void TIGLCreatorWidget::addSpotlight(double x, double y, double z, double dx, double dy, double dz, double concentration)
 {
-    if (concentration < 0.0 || concentration > 1.0) {
-        LOG(ERROR) << "TIGLCreatorWidget::addSpotlight(): Concentration must be inside the range [0,1]";
-        return;
+    if (mySpotlightManager) {
+        mySpotlightManager->addSpotlight(x, y, z, dx, dy, dz, concentration);
+    } else {
+        LOG(ERROR) << "TIGLCreatorWidget::addSpotlight(): No spotlight manager is set.";
     }
+}
 
-    if (dx*dx + dy*dy + dz*dz < 1e8) {
-        LOG(ERROR) << "TIGLCreatorWidget::addSpotlight(): Direction must not be the zero vector";
-        return;
+void TIGLCreatorWidget::activateLight(const Handle(V3d_Light)& light)
+{
+    if (!myView.IsNull() && !light.IsNull()) {
+        myView->SetLightOn(light);
+        myView->UpdateLights();
     }
+    update();
+}
 
-    Handle(V3d_Light) theLight = new V3d_Light(Graphic3d_TypeOfLightSource::V3d_SPOT);
-    theLight->SetPosition(gp_Pnt(x,y,z));
-    theLight->SetDirection(gp_Dir(dx, dy, dz));
-    theLight->SetConcentration(concentration);
+void TIGLCreatorWidget::deactivateLight(const Handle(V3d_Light)& light)
+{
+    if (!myView.IsNull() && !light.IsNull()) {
+        myView->SetLightOff(light);
+        myView->UpdateLights();
+    }
+    update();
+}
 
+void TIGLCreatorWidget::removeLight(const Handle(V3d_Light)& light)
+{
+    if (!light.IsNull()) {
+        if (!myView.IsNull()) {
+            myView->SetLightOff(light);
+        }
+        if (!myViewer.IsNull()) {
+            myViewer->DelLight(light);
+        }
+    }
+    refreshLights();
+}
+
+void TIGLCreatorWidget::refreshLights()
+{
     if (!myView.IsNull()) {
-        myView->SetLightOn(theLight);
+        myView->UpdateLights();
     }
+    update();
 }
 
 void TIGLCreatorWidget::hiddenLineOff()

--- a/TIGLCreator/src/TIGLCreatorWidget.h
+++ b/TIGLCreator/src/TIGLCreatorWidget.h
@@ -53,10 +53,15 @@ class TopoDS_Shape;
 class gp_Pnt;
 class gp_Vec;
 class TIGLCreatorContext;
+class TIGLCreatorSpotlightManager;
+class TIGLCreatorWindow;
 
 class TIGLCreatorWidget : public QWidget
 {
     Q_OBJECT
+
+    friend class TIGLCreatorSpotlightManager;
+    friend class TIGLCreatorWindow;
 
 public:
 
@@ -175,6 +180,13 @@ protected: // methods
 private: // members
     void initializeOCC(const Handle(AIS_InteractiveContext)& aContext);
 
+    // These functions come with complex input args and/or should not be seen by JavaScript API and console
+    // Since TIGLCreatorSpotlightManager still needs access to them, the class is marked as friend class above
+    void activateLight(const Handle(V3d_Light)& light);
+    void deactivateLight(const Handle(V3d_Light)& light);
+    void removeLight(const Handle(V3d_Light)& light);
+    void refreshLights();
+
     void setStartPoint(const QPoint&);
     void setCurrentPoint(const QPoint&);
 
@@ -208,7 +220,8 @@ private: // members
     Qt::MouseButton                 myButtonFlags;
     QCursor                         myCrossCursor;
     QColor                          myBGColor;
-    TIGLCreatorContext*              viewerContext;
+    TIGLCreatorContext*             viewerContext;
+    TIGLCreatorSpotlightManager*    mySpotlightManager;
 
 private: // methods
     void initialize();

--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -48,6 +48,8 @@
 #include "TIGLCreatorErrorDialog.h"
 #include "TIGLCreatorLogHistory.h"
 #include "TIGLCreatorLogRedirection.h"
+#include "TIGLCreatorSpotlightManager.h"
+#include "TIGLCreatorOthersWidget.h"
 #include "CTiglLogSplitter.h"
 #include "TIGLCreatorLoggerHTMLDecorator.h"
 #include "TIGLCreatorScreenshotDialog.h"
@@ -136,6 +138,11 @@ TIGLCreatorWindow::TIGLCreatorWindow()
     // refresh display options UI when the scene reports display-attribute changes
     connect(myScene, &TIGLCreatorContext::displayAttributesChanged,
         this, &TIGLCreatorWindow::onSceneDisplayAttributesChanged);
+
+    // create spotlight manager and wire it to the corresponding "others" widget
+    spotlightManager = new TIGLCreatorSpotlightManager(myOCC, this);
+    othersWidget->setSpotlightManager(spotlightManager);
+    myOCC->mySpotlightManager = spotlightManager;
 
     // we create a timer to workaround QFileSystemWatcher bug,
     // which emits multiple signals in a few milliseconds. This caused
@@ -1338,7 +1345,7 @@ void TIGLCreatorWindow::addSpotlight()
     gp_Vec dir = addSpotlightDialog.getDirection().Get_gp_Pnt().XYZ();
     double concentration = addSpotlightDialog.getConcentration();
 
-    getViewer()->addSpotlight(pos.X(), pos.Y(), pos.Z(), dir.X(), dir.Y(), dir.Z(), concentration);
+    spotlightManager->addSpotlight(pos.X(), pos.Y(), pos.Z(), dir.X(), dir.Y(), dir.Z(), concentration);
 }
 
 /// This function is copied from QtCoreLib (>5.1)

--- a/TIGLCreator/src/TIGLCreatorWindow.h
+++ b/TIGLCreator/src/TIGLCreatorWindow.h
@@ -42,6 +42,7 @@ class QMenu;
 class QFileSystemWatcher;
 class TIGLCreatorLogHistory;
 class TIGLCreatorLogRedirection;
+class TIGLCreatorSpotlightManager;
 
 class TIGLCreatorWindow : public QMainWindow, private Ui::TIGLCreatorWindow
 {
@@ -152,6 +153,7 @@ private:
 
     // The OpenCASCADE context;
     TIGLCreatorContext*      myScene;
+    TIGLCreatorSpotlightManager* spotlightManager = nullptr;
 
     QString                 myLastFolder;
 

--- a/TIGLCreator/src/TIGLCreatorWindow.ui
+++ b/TIGLCreator/src/TIGLCreatorWindow.ui
@@ -347,14 +347,28 @@
    <widget class="ModificatorContainerWidget" name="modificatorContainerWidget"/>
   </widget>
   <widget class="QDockWidget" name="treeDockWidget">
-   <property name="windowTitle">
-    <string>CPACS Tree</string>
-   </property>
-   <attribute name="dockWidgetArea">
-    <number>2</number>
-   </attribute>
-   <widget class="CPACSTreeWidget" name="treeWidget"/>
-  </widget>
+    <property name="windowTitle">
+     <string>Tree</string>
+    </property>
+    <attribute name="dockWidgetArea">
+     <number>2</number>
+    </attribute>
+    <widget class="QTabWidget" name="treeTabWidget">
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <widget class="CPACSTreeWidget" name="treeWidget">
+      <attribute name="title">
+       <string>CPACS Tree</string>
+      </attribute>
+     </widget>
+     <widget class="TIGLCreatorOthersWidget" name="othersWidget">
+      <attribute name="title">
+       <string>Others</string>
+      </attribute>
+     </widget>
+    </widget>
+   </widget>
   <action name="newAction">
    <property name="icon">
     <iconset resource="TIGLCreator.qrc">
@@ -1118,13 +1132,19 @@
    <header>CPACSTreeWidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>ModificatorContainerWidget</class>
-   <extends>QWidget</extends>
-   <header>ModificatorContainerWidget.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
+   <customwidget>
+    <class>ModificatorContainerWidget</class>
+    <extends>QWidget</extends>
+    <header>ModificatorContainerWidget.h</header>
+    <container>1</container>
+   </customwidget>
+   <customwidget>
+    <class>TIGLCreatorOthersWidget</class>
+    <extends>QWidget</extends>
+    <header>TIGLCreatorOthersWidget.h</header>
+    <container>1</container>
+   </customwidget>
+  </customwidgets>
  <resources>
   <include location="TIGLCreator.qrc"/>
  </resources>


### PR DESCRIPTION
Implement a manager that lists all added spotlights, makes them editable, copies, removes and switches them off/on. To include in the GUI as well, the CPACS Tree is extended by a new tab called 'Others'. Currently, it only holds the spotlights. Later, other categories might be added here (e.g. external geometry files that are not CPACS) to be future-proof.

To adapt the GUI, two new classes are introduced:
- `TIGLCreatorOthersWidget`
- `TIGLCreatorSpotlightManager`

Fix #1439

## How Has This Been Tested?
I tried out all combinations I could think of in the GUI and added spotlights on all three possible ways (console, menu, clicking in the 'Others' tab). Everything worked out just as expected.

## Screenshots, that help to understand the changes(if applicable):

<img width="689" height="374" alt="tree_old" src="https://github.com/user-attachments/assets/1e562dbd-cded-486b-ba82-4e5bc07a7f50" />

The old `CPACS Tree` in the GUI

<img width="693" height="371" alt="tree_new" src="https://github.com/user-attachments/assets/1872f499-8c20-49a7-b49f-160207059f3f" />

The new `Tree` separated in `CPACS` and `Others` (-> for potential other categories in the future)

## Checklist for PR Author:
- [ ] ~Unit or integration test added~
- [ ] ~Python interface updated (if applicable)~
- [ ] ~Python test added (if Python interface updated)~
- [ ] ~Doxygen docstrings added~
- [x] `ChangeLog.md` updated


---
*This fix was co-authored by an AI coding assistant and reviewed/verified by me before submission.*