### PR TITLE
cleanup cmake, gcc and swig warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,12 @@ set(CMAKE_PREFIX_PATH "${TIXI_PATH};${CMAKE_PREFIX_PATH}")
 find_package( tixi3 3.0.3 REQUIRED CONFIG)
 
 
-find_package( PythonInterp )
+# PythonInterp/PythonLibs are removed as of CMake 3.27; use the modern FindPython3
+# module and keep the classic PYTHON_EXECUTABLE/PYTHONINTERP_FOUND variables around,
+# since they are used throughout the build (checkstyle, bindings/matlab, ...).
+find_package( Python3 COMPONENTS Interpreter )
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+set(PYTHONINTERP_FOUND ${Python3_Interpreter_FOUND})
 
 OPTION(TIGL_USE_GLOG "Enables advanced logging (requires google glog)" OFF)
 if(TIGL_USE_GLOG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ endif()
 
 option(TIGL_BINDINGS_INSTALL_CPP "Install TiGL's CPP bindings" OFF)
 
+option(TIGL_WARNINGS_AS_ERRORS
+       "Treat compiler warnings in TiGL's own targets (core library, TIGLCreator, tests) as errors. Does not apply to thirdparty code or the SWIG-generated bindings."
+       ON)
+
 OPTION(TIGL_NIGHTLY "Creates a nightly build of tigl (includes git sha into tigl version)" OFF)
 mark_as_advanced(TIGL_NIGHTLY)
 if(TIGL_NIGHTLY)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,16 @@ Changes since last release
     keyword to several domain class methods that override CPACSGen-generated accessors
     (`CCPACSPointListXY::GetPoint`, `CCPACSNacelleSections::GetSectionCount`/`GetSection`,
     `CCPACSFuselages::ReadCPACS`/`WriteCPACS`)
+  - Marked OpenCASCADE's (and Boost's/tixi3's) include directories as `SYSTEM` for the core
+    library and TIGLCreator targets, so `TIGL_WARNINGS_AS_ERRORS` no longer fails the build over
+    warnings that originate in third-party headers we don't control (e.g. a deprecated `sprintf`
+    call in an older OCCT header, only reachable on Clang/macOS)
+  - Replaced the removed `distutils.sysconfig` (Python 3.12, PEP 632) with the stdlib `sysconfig`
+    module to locate the Python site-packages install directory, fixing a
+    "Python site-packages directory could not be found" CMake warning
+  - Downgraded an informational CMake message about MATLAB bindings being skipped on Apple
+    Silicon (no vendored SDK) from `WARNING` to `STATUS`, since this is expected, documented
+    behavior rather than a problem
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,10 @@ Changes since last release
     bindings' generated wrapper code (which intentionally calls TiGL's own deprecated API)
   - Replaced the deprecated CMake `swig_link_libraries` with `target_link_libraries` in the
     internal Python bindings, fixing a CMake deprecation warning seen with newer CMake versions
+  - Added a `TIGL_WARNINGS_AS_ERRORS` CMake option (default `ON`) that treats compiler warnings
+    in TiGL's own targets (core library, TIGLCreator, tests) as errors, so future warnings are
+    caught immediately instead of accumulating; thirdparty code and the SWIG-generated bindings
+    are intentionally excluded, since their warnings are outside our control
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,11 @@ Changes since last release
     typedefs with `Handle(X)`, replaced the removed `FindPythonInterp` CMake module with
     `FindPython3`, and suppressed a handful of SWIG warnings that are inherent to how the
     Python bindings are generated
+  - Fixed the remaining MSVC/Windows build warnings: explicit `static_cast`s for narrowing
+    `size_t`/`int` conversions, resolved signed/unsigned comparison and unreferenced-variable
+    warnings, updated deprecated `INSTANTIATE_TEST_CASE_P` gtest macro usages to
+    `INSTANTIATE_TEST_SUITE_P`, and suppressed the MSVC deprecation warning for the Python
+    bindings' generated wrapper code (which intentionally calls TiGL's own deprecated API)
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,10 @@ Changes since last release
 
 - Build System
 
-  - none
+  - Fixed most CMake/compiler/SWIG build warnings: replaced deprecated OCCT `Handle_X`
+    typedefs with `Handle(X)`, replaced the removed `FindPythonInterp` CMake module with
+    `FindPython3`, and suppressed a handful of SWIG warnings that are inherent to how the
+    Python bindings are generated
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,62 +18,11 @@ Changes since last release
 
 - Build System
 
-  - Fixed most CMake/compiler/SWIG build warnings: replaced deprecated OCCT `Handle_X`
-    typedefs with `Handle(X)`, replaced the removed `FindPythonInterp` CMake module with
-    `FindPython3`, and suppressed a handful of SWIG warnings that are inherent to how the
-    Python bindings are generated
-  - Fixed the remaining MSVC/Windows build warnings: explicit `static_cast`s for narrowing
-    `size_t`/`int` conversions, resolved signed/unsigned comparison and unreferenced-variable
-    warnings, updated deprecated `INSTANTIATE_TEST_CASE_P` gtest macro usages to
-    `INSTANTIATE_TEST_SUITE_P`, and suppressed the MSVC deprecation warning for the Python
-    bindings' generated wrapper code (which intentionally calls TiGL's own deprecated API)
-  - Replaced the deprecated CMake `swig_link_libraries` with `target_link_libraries` in the
-    internal Python bindings, fixing a CMake deprecation warning seen with newer CMake versions
+  - Fixed numerous CMake, compiler (GCC, Clang/macOS, MSVC), SWIG, and Python build warnings,
+    and fixed a `make install` failure on macOS caused by an incorrectly computed Python
+    site-packages install path
   - Added a `TIGL_WARNINGS_AS_ERRORS` CMake option (default `ON`) that treats compiler warnings
-    in TiGL's own targets (core library, TIGLCreator, tests) as errors, so future warnings are
-    caught immediately instead of accumulating; thirdparty code and the SWIG-generated bindings
-    are intentionally excluded, since their warnings are outside our control
-  - Fixed Clang/macOS `-Winconsistent-missing-override` warnings by adding the missing `override`
-    keyword to several domain class methods that override CPACSGen-generated accessors
-    (`CCPACSPointListXY::GetPoint`, `CCPACSNacelleSections::GetSectionCount`/`GetSection`,
-    `CCPACSFuselages::ReadCPACS`/`WriteCPACS`)
-  - Marked OpenCASCADE's (and Boost's/tixi3's) include directories as `SYSTEM` for the core
-    library and TIGLCreator targets, so `TIGL_WARNINGS_AS_ERRORS` no longer fails the build over
-    warnings that originate in third-party headers we don't control (e.g. a deprecated `sprintf`
-    call in an older OCCT header, only reachable on Clang/macOS)
-  - Replaced the removed `distutils.sysconfig` (Python 3.12, PEP 632) with the stdlib `sysconfig`
-    module to locate the Python site-packages install directory, fixing a
-    "Python site-packages directory could not be found" CMake warning
-  - Downgraded an informational CMake message about MATLAB bindings being skipped on Apple
-    Silicon (no vendored SDK) from `WARNING` to `STATUS`, since this is expected, documented
-    behavior rather than a problem
-  - Fixed a Clang/macOS `-Wswitch` warning in `CCPACSWing::SetAreaKeepSpan` by adding the
-    missing `TIGL_NO_AXIS` case (a no-op, matching the switch's previous implicit behavior for
-    that value)
-  - Fixed a Clang/macOS `-Winconsistent-missing-override` warning in
-    `ModificatorModel::setData` (overriding `QAbstractItemModel::setData`)
-  - Fixed a Clang/macOS `-Wunused-value` warning in `tiglWingNacaProfile.cpp` caused by
-    `EXPECT_NO_THROW` being applied to already-evaluated variables instead of the calls that
-    produced them, which meant the intended exception checks for `GetUpperWire`/`GetLowerWire`/
-    `GetTrailingEdge` were not actually being tested; now wraps the calls themselves
-  - Fixed a misleading, unconditional "Found MATLAB. Create matlab bindings." status message in
-    `bindings/matlab/CMakeLists.txt` that printed regardless of whether MATLAB was actually
-    found, contradicting the correct conditional message right after it
-  - Fixed a `make install` failure on macOS (observed with Python 3.14) where the Python
-    site-packages install path was computed by diffing this interpreter's absolute site-packages
-    against `sys.prefix`, then re-appending that to `CMAKE_INSTALL_PREFIX` - which only
-    reconstructs correctly when `CMAKE_INSTALL_PREFIX` happens to equal `sys.prefix` (true for
-    pixi's `python-internal` environment, but not for `default`, which deliberately installs into
-    a separate, relocatable `build/install` tree). On the affected platform this produced a badly
-    broken, escaping `../../..` path instead of a short relative one. Now computes the
-    prefix-independent relative template directly via `sysconfig.get_path(..., vars={'base': '',
-    'platbase': ''})` instead, which is correct regardless of the relationship between
-    `CMAKE_INSTALL_PREFIX` and the build-time interpreter's own `sys.prefix`
-  - Fixed two Python `SyntaxWarning`s in `bindings/bindings_generator/cheader_parser.py` (emitted
-    while generating `tigl3wrapper.py`): an invalid `\s` escape sequence in a non-raw regex string
-    (now a raw string), and a string-literal comparison using `is` instead of `==`. Both are
-    currently tolerated by CPython but are deprecated and will become hard errors in a future
-    Python version
+    in TiGL's own targets as errors, so new ones are caught immediately instead of accumulating
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,16 @@ Changes since last release
   - Fixed a misleading, unconditional "Found MATLAB. Create matlab bindings." status message in
     `bindings/matlab/CMakeLists.txt` that printed regardless of whether MATLAB was actually
     found, contradicting the correct conditional message right after it
+  - Fixed a `make install` failure on macOS (observed with Python 3.14) where the Python
+    site-packages install path was computed by diffing this interpreter's absolute site-packages
+    against `sys.prefix`, then re-appending that to `CMAKE_INSTALL_PREFIX` - which only
+    reconstructs correctly when `CMAKE_INSTALL_PREFIX` happens to equal `sys.prefix` (true for
+    pixi's `python-internal` environment, but not for `default`, which deliberately installs into
+    a separate, relocatable `build/install` tree). On the affected platform this produced a badly
+    broken, escaping `../../..` path instead of a short relative one. Now computes the
+    prefix-independent relative template directly via `sysconfig.get_path(..., vars={'base': '',
+    'platbase': ''})` instead, which is correct regardless of the relationship between
+    `CMAKE_INSTALL_PREFIX` and the build-time interpreter's own `sys.prefix`
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -47,6 +47,9 @@ Changes since last release
   - Downgraded an informational CMake message about MATLAB bindings being skipped on Apple
     Silicon (no vendored SDK) from `WARNING` to `STATUS`, since this is expected, documented
     behavior rather than a problem
+  - Fixed a Clang/macOS `-Wswitch` warning in `CCPACSWing::SetAreaKeepSpan` by adding the
+    missing `TIGL_NO_AXIS` case (a no-op, matching the switch's previous implicit behavior for
+    that value)
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@ Changes since last release
     warnings, updated deprecated `INSTANTIATE_TEST_CASE_P` gtest macro usages to
     `INSTANTIATE_TEST_SUITE_P`, and suppressed the MSVC deprecation warning for the Python
     bindings' generated wrapper code (which intentionally calls TiGL's own deprecated API)
+  - Replaced the deprecated CMake `swig_link_libraries` with `target_link_libraries` in the
+    internal Python bindings, fixing a CMake deprecation warning seen with newer CMake versions
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -50,6 +50,8 @@ Changes since last release
   - Fixed a Clang/macOS `-Wswitch` warning in `CCPACSWing::SetAreaKeepSpan` by adding the
     missing `TIGL_NO_AXIS` case (a no-op, matching the switch's previous implicit behavior for
     that value)
+  - Fixed a Clang/macOS `-Winconsistent-missing-override` warning in
+    `ModificatorModel::setData` (overriding `QAbstractItemModel::setData`)
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,10 @@ Changes since last release
     in TiGL's own targets (core library, TIGLCreator, tests) as errors, so future warnings are
     caught immediately instead of accumulating; thirdparty code and the SWIG-generated bindings
     are intentionally excluded, since their warnings are outside our control
+  - Fixed Clang/macOS `-Winconsistent-missing-override` warnings by adding the missing `override`
+    keyword to several domain class methods that override CPACSGen-generated accessors
+    (`CCPACSPointListXY::GetPoint`, `CCPACSNacelleSections::GetSectionCount`/`GetSection`,
+    `CCPACSFuselages::ReadCPACS`/`WriteCPACS`)
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -69,6 +69,11 @@ Changes since last release
     prefix-independent relative template directly via `sysconfig.get_path(..., vars={'base': '',
     'platbase': ''})` instead, which is correct regardless of the relationship between
     `CMAKE_INSTALL_PREFIX` and the build-time interpreter's own `sys.prefix`
+  - Fixed two Python `SyntaxWarning`s in `bindings/bindings_generator/cheader_parser.py` (emitted
+    while generating `tigl3wrapper.py`): an invalid `\s` escape sequence in a non-raw regex string
+    (now a raw string), and a string-literal comparison using `is` instead of `==`. Both are
+    currently tolerated by CPython but are deprecated and will become hard errors in a future
+    Python version
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -52,6 +52,10 @@ Changes since last release
     that value)
   - Fixed a Clang/macOS `-Winconsistent-missing-override` warning in
     `ModificatorModel::setData` (overriding `QAbstractItemModel::setData`)
+  - Fixed a Clang/macOS `-Wunused-value` warning in `tiglWingNacaProfile.cpp` caused by
+    `EXPECT_NO_THROW` being applied to already-evaluated variables instead of the calls that
+    produced them, which meant the intended exception checks for `GetUpperWire`/`GetLowerWire`/
+    `GetTrailingEdge` were not actually being tested; now wraps the calls themselves
 
 - Fixes
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -56,6 +56,9 @@ Changes since last release
     `EXPECT_NO_THROW` being applied to already-evaluated variables instead of the calls that
     produced them, which meant the intended exception checks for `GetUpperWire`/`GetLowerWire`/
     `GetTrailingEdge` were not actually being tested; now wraps the calls themselves
+  - Fixed a misleading, unconditional "Found MATLAB. Create matlab bindings." status message in
+    `bindings/matlab/CMakeLists.txt` that printed regardless of whether MATLAB was actually
+    found, contradicting the correct conditional message right after it
 
 - Fixes
 

--- a/TIGLCreator/CMakeLists.txt
+++ b/TIGLCreator/CMakeLists.txt
@@ -124,7 +124,9 @@ target_include_directories(${PROGNAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMA
 # workaround: on macos, the file glext.h should be loaded from occt/include instead from the system dir
 # This is a "Bug" in the occt header files which use <> instead of "" for include
 # hence, we must explicitly inlude the occt dir before all other includes!
-target_include_directories(${PROGNAME} BEFORE PRIVATE  ${OpenCASCADE_INCLUDE_DIR}) 
+# SYSTEM: this is third-party code, so with TIGL_WARNINGS_AS_ERRORS enabled, warnings
+# originating inside these headers must not fail our build.
+target_include_directories(${PROGNAME} SYSTEM BEFORE PRIVATE  ${OpenCASCADE_INCLUDE_DIR})
 
 target_link_libraries(${PROGNAME} PRIVATE
   tigl3_static tigl3_cpp

--- a/TIGLCreator/CMakeLists.txt
+++ b/TIGLCreator/CMakeLists.txt
@@ -116,6 +116,8 @@ add_executable(${PROGNAME} ${TYPE}
 set_target_properties(${PROGNAME} PROPERTIES AUTOMOC TRUE)
 set_target_properties(${PROGNAME} PROPERTIES AUTOUIC TRUE)
 
+tigl_enable_warnings_as_errors(${PROGNAME})
+
 # include path for ui files
 target_include_directories(${PROGNAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/src)
 

--- a/TIGLCreator/src/ModificatorModel.cpp
+++ b/TIGLCreator/src/ModificatorModel.cpp
@@ -836,7 +836,7 @@ void ModificatorModel::addProfile(QString const& profileID)
     std::string profile_name = profilesDB.removeSuffix(profileID).toStdString();
 
     auto profiles_idx = getIndex(profiles, 0);
-    auto profile_row = profiles->getChildren().size();
+    int profile_row = static_cast<int>(profiles->getChildren().size());
     beginInsertRows(profiles_idx, profile_row, profile_row);
 
     // apply changes to configuration
@@ -900,7 +900,7 @@ void ModificatorModel::onAddWingRequested()
 
         auto* wings = getWings();
         auto wings_idx = getIndex(wings, 0);
-        auto row = wings->getChildren().size();
+        int row = static_cast<int>(wings->getChildren().size());
 
         beginInsertRows(wings_idx, row, row);
 
@@ -1107,7 +1107,7 @@ void ModificatorModel::onAddFuselageRequested()
 
         auto* fuselages_node = getFuselages();
         auto fuselages_idx = getIndex(fuselages_node, 0);
-        auto row = fuselages_node->getChildren().size();
+        int row = static_cast<int>(fuselages_node->getChildren().size());
 
         beginInsertRows(fuselages_idx, row, row);
 
@@ -1461,7 +1461,7 @@ int ModificatorModel::rowCount(const QModelIndex& idx) const
     }
 
     cpcr::CPACSTreeItem* item = getItem(idx);
-    return item->getChildren().size();
+    return static_cast<int>(item->getChildren().size());
 }
 
 int ModificatorModel::columnCount(const QModelIndex& idx) const

--- a/TIGLCreator/src/ModificatorModel.h
+++ b/TIGLCreator/src/ModificatorModel.h
@@ -182,7 +182,7 @@ public:
     // appearing/disappearing without querying external managers.
 
 
-    bool setData(const QModelIndex& index, const QVariant& value, int role);
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
 
     bool isFailedUID(const std::string& uid) const;
     void markFailedUID(const std::string& uid);

--- a/TIGLCreator/src/TIGLCreatorContext.cpp
+++ b/TIGLCreator/src/TIGLCreatorContext.cpp
@@ -506,7 +506,7 @@ Handle(AIS_Shape) TIGLCreatorContext::displayPoint(const gp_Pnt& aPoint,
                                                  aPoint.Z() + aZoffset);
         aGraphicText->SetScale(TextScale);
         myContext->Display(aGraphicText,UpdateViewer);
-        return Handle(AIS_Shape)::DownCast(aGraphicPoint);
+        return Handle(AIS_Shape)();
     }
 
 }

--- a/TIGLCreator/src/TIGLCreatorContext.h
+++ b/TIGLCreator/src/TIGLCreatorContext.h
@@ -145,8 +145,8 @@ signals:
 private:
     std::vector<Handle(AIS_InteractiveObject)> selected();
 
-    Handle_V3d_Viewer               myViewer;
-    Handle_AIS_InteractiveContext   myContext;
+    Handle(V3d_Viewer)               myViewer;
+    Handle(AIS_InteractiveContext)   myContext;
     Aspect_GridType                 myGridType;
     Aspect_GridDrawMode             myGridMode;
     Quantity_NameOfColor            myGridColor;

--- a/TIGLCreator/src/TIGLCreatorDocument.cpp
+++ b/TIGLCreator/src/TIGLCreatorDocument.cpp
@@ -394,7 +394,7 @@ QString TIGLCreatorDocument::dlgGetWingOrRotorBladeSelection()
 
     // Initialize wing list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int wingCount                     = config.GetWingCount();
+    int wingCount                     = static_cast<int>(config.GetWingCount());
     for (int i = 1; i <= wingCount; i++) {
         tigl::CCPACSWing& wing = config.GetWing(i);
         std::string name       = wing.GetUID();
@@ -424,7 +424,7 @@ QString TIGLCreatorDocument::dlgGetWingSelection(const QString& wingUid)
     tigl::CCPACSConfiguration& config = GetConfiguration();
 
     if (wingUid.isEmpty()) {
-        int wingCount                     = config.GetWingCount();
+        int wingCount                     = static_cast<int>(config.GetWingCount());
         for (int i = 1; i <= wingCount; i++) {
             tigl::CCPACSWing& wing = config.GetWing(i);
             if (!wing.IsRotorBlade()) {
@@ -458,7 +458,7 @@ QString TIGLCreatorDocument::dlgGetWingComponentSegmentSelection(const QString& 
     tigl::CCPACSConfiguration& config = GetConfiguration();
     if (wingUID.isEmpty()) {
     
-        int wingCount                     = config.GetWingCount();
+        int wingCount                     = static_cast<int>(config.GetWingCount());
         for (int i = 1; i <= wingCount; i++) {
             tigl::CCPACSWing& wing = config.GetWing(i);
             if (wing.IsRotorBlade()) {
@@ -504,7 +504,7 @@ QString TIGLCreatorDocument::dlgGetWingSegmentSelection()
 
     // Initialize wing list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int wingCount                     = config.GetWingCount();
+    int wingCount                     = static_cast<int>(config.GetWingCount());
     for (int i = 1; i <= wingCount; i++) {
         tigl::CCPACSWing& wing = config.GetWing(i);
         if (wing.IsRotorBlade()) {
@@ -563,7 +563,7 @@ QString TIGLCreatorDocument::dlgGetRotorSelection(const QString& rotorUid)
     }
     // Initialize rotorBlade list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int rotorCount                    = config.GetRotorCount();
+    int rotorCount                    = static_cast<int>(config.GetRotorCount());
     for (int i = 1; i <= rotorCount; i++) {
         tigl::CCPACSRotor& rotor = config.GetRotor(i);
         std::string name         = rotor.GetUID();
@@ -592,7 +592,7 @@ QString TIGLCreatorDocument::dlgGetRotorBladeSelection(const QString& rotorBlade
     }
     // Initialize wing list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int wingCount                     = config.GetWingCount();
+    int wingCount                     = static_cast<int>(config.GetWingCount());
     for (int i = 1; i <= wingCount; i++) {
         tigl::CCPACSWing& wing = config.GetWing(i);
         if (wing.IsRotorBlade()) {
@@ -625,7 +625,7 @@ QString TIGLCreatorDocument::dlgGetRotorBladeComponentSegmentSelection(const QSt
     }
     // Initialize wing list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int wingCount                     = config.GetWingCount();
+    int wingCount                     = static_cast<int>(config.GetWingCount());
     for (int i = 1; i <= wingCount; i++) {
         tigl::CCPACSWing& wing = config.GetWing(i);
         if (wing.IsRotorBlade()) {
@@ -654,7 +654,7 @@ QString TIGLCreatorDocument::dlgGetRotorBladeSegmentSelection()
 
     // Initialize wing list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int wingCount                     = config.GetWingCount();
+    int wingCount                     = static_cast<int>(config.GetWingCount());
     for (int i = 1; i <= wingCount; i++) {
         tigl::CCPACSWing& wing = config.GetWing(i);
         if (wing.IsRotorBlade()) {
@@ -713,7 +713,7 @@ QString TIGLCreatorDocument::dlgGetFuselageSelection(const QString& Uid)
     }
     // Initialize fuselage list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int fuselageCount                 = config.GetFuselageCount();
+    int fuselageCount                 = static_cast<int>(config.GetFuselageCount());
     for (int i = 1; i <= fuselageCount; i++) {
         auto& fuselage   = config.GetFuselage(i);
         std::string name = fuselage.GetUID();
@@ -740,7 +740,7 @@ QString TIGLCreatorDocument::dlgGetFuselageSegmentSelection()
 
     // Initialize fuselage list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int fuselageCount                 = config.GetFuselageCount();
+    int fuselageCount                 = static_cast<int>(config.GetFuselageCount());
     for (int i = 1; i <= fuselageCount; i++) {
         auto& fuselage = config.GetFuselage(i);
         for (int j = 1; j <= fuselage.GetSegmentCount(); ++j) {
@@ -770,7 +770,7 @@ QString TIGLCreatorDocument::dlgGetFuselageProfileSelection()
 
     // Initialize fuselage list
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int profileCount                  = config.GetFuselageProfileCount();
+    int profileCount                  = static_cast<int>(config.GetFuselageProfileCount());
     for (int i = 1; i <= profileCount; i++) {
         tigl::CCPACSFuselageProfile& profile = config.GetFuselageProfile(i);
         const std::string& profileUID        = profile.GetUID();
@@ -918,7 +918,7 @@ void TIGLCreatorDocument::drawControlPointNetByUID(const QString& uid)
             LOG(WARNING) << "Cannot draw control net: The geometric shape for the component with uid \"" << uid.toStdString() << "\" has no faces.";
         }
         int valid_face_count = 0;
-        for (int i = 0; i < loft->GetFaceCount(); ++i) {
+        for (int i = 0; i < static_cast<int>(loft->GetFaceCount()); ++i) {
             TopoDS_Face face = GetFace(loft->Shape(), i);
 
             Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
@@ -1696,7 +1696,7 @@ void TIGLCreatorDocument::drawFuselageSamplePointsAngle(const QString& Uid)
     }
 
     START_COMMAND()
-    int fuselageIndex = GetConfiguration().GetFuselageIndex(fuselageUid.toStdString());
+    int fuselageIndex = static_cast<int>(GetConfiguration().GetFuselageIndex(fuselageUid.toStdString()));
     double x, y, z;
 
     removeFuselage(fuselageUid);
@@ -2818,7 +2818,7 @@ void TIGLCreatorDocument::drawRotorBladeGuideCurves()
     removeAirfoil();
     // loop over all wings
     tigl::CCPACSConfiguration& config = GetConfiguration();
-    int wingCount                     = config.GetWingCount();
+    int wingCount                     = static_cast<int>(config.GetWingCount());
     for (int i = 1; i <= wingCount; i++) {
         tigl::CCPACSWing& wing = config.GetWing(i);
         if (wing.IsRotorBlade()) {

--- a/TIGLCreator/src/TIGLCreatorWidget.cpp
+++ b/TIGLCreator/src/TIGLCreatorWidget.cpp
@@ -171,7 +171,7 @@ void TIGLCreatorWidget::initializeOCC(const Handle(AIS_InteractiveContext)& aCon
         myViewer  = aContext->CurrentViewer();
         myView    = myViewer->CreateView();
 
-        Handle_Aspect_Window myWindow;
+        Handle(Aspect_Window) myWindow;
         
 #if OCC_VERSION_HEX >= 0x060800
         myWindow = new TIGLQAspectWindow(this);

--- a/TIGLCreator/src/TIGLCreatorWidget.h
+++ b/TIGLCreator/src/TIGLCreatorWidget.h
@@ -97,7 +97,7 @@ public:
     // the scene context must be set before first use
     void setContext(TIGLCreatorContext* aContext);
 
-    Handle_V3d_View                  getView( )    { return myView; }
+    Handle(V3d_View)                  getView( )    { return myView; }
 
     //Overrides
     QPaintEngine*   paintEngine() const override;

--- a/TIGLCreator/src/TIGLCreatorWindow.cpp
+++ b/TIGLCreator/src/TIGLCreatorWindow.cpp
@@ -483,7 +483,6 @@ void TIGLCreatorWindow::openNewFile(const QString& templatePath)
     QString      fileType;
     QFileInfo    fileInfo;
 
-    TIGLCreatorInputOutput::FileFormat format;
     TIGLCreatorInputOutput reader;
     bool triangulation = false;
     bool success;
@@ -1178,8 +1177,8 @@ void TIGLCreatorWindow::updateMenus()
     try {
         if (hand > 0) {
             tigl::CCPACSConfiguration& config = tigl::CCPACSConfigurationManager::GetInstance().GetConfiguration(hand);
-            nRotorBlades = config.GetRotorBladeCount();
-            nRotors = config.GetRotorCount();
+            nRotorBlades = static_cast<int>(config.GetRotorBladeCount());
+            nRotors = static_cast<int>(config.GetRotorCount());
         }
     }
     catch(tigl::CTiglError& ){}

--- a/TIGLCreator/src/XPathParser.cpp
+++ b/TIGLCreator/src/XPathParser.cpp
@@ -43,8 +43,8 @@ std::string cpcr::XPathParser::GetLastNode(std::string xpath)
         xpath.erase(xpath.size() - 1, 1);
     }
 
-    int found = xpath.find_last_of("/");
-    if (found < 0) {
+    size_t found = xpath.find_last_of("/");
+    if (found == std::string::npos) {
         return xpath;
     }
     std::string r = xpath.substr(found + 1);
@@ -54,8 +54,8 @@ std::string cpcr::XPathParser::GetLastNode(std::string xpath)
 std::string cpcr::XPathParser::RemoveEndingBrackets(std::string string)
 {
     if (string[string.size() - 1] == ']') {
-        long int found = string.find_last_of('[');
-        if (found < 0) {
+        size_t found = string.find_last_of('[');
+        if (found == std::string::npos) {
             LOG(ERROR) << "XPathParser: RemoveEndingBrackets:  Invalid input: " + string;
         }
         else {
@@ -71,8 +71,8 @@ int cpcr::XPathParser::GetIndexOfNode(std::string particle)
     int r = 1; // be default the index is one
 
     if (particle[particle.size() - 1] == ']') {
-        long int found = particle.find_last_of('[');
-        if (found < 0) {
+        size_t found = particle.find_last_of('[');
+        if (found == std::string::npos) {
             LOG(ERROR) << "XPathParser: GetIndexOfNode:  Invalid input: " + particle;
         }
         else {
@@ -158,8 +158,8 @@ std::string cpcr::XPathParser::RemoveLastNode(std::string xpath)
     }
 
     std::string r;
-    int found = xpath.find_last_of("/");
-    if (found < 0) {
+    size_t found = xpath.find_last_of("/");
+    if (found == std::string::npos) {
         r     = xpath;
         xpath = "";
     }

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -17,11 +17,15 @@ if (TIGL_BINDINGS_PYTHON)
     message(STATUS "Python include directory: ${Python3_INCLUDE_DIR}")
     message(STATUS "Python library release: ${Python3_LIBRARY_RELEASE}")
 
-    # this requires setuptools to be installed
+    # distutils.sysconfig was removed in Python 3.12 (PEP 632), so it can no longer be used to
+    # locate site-packages here. Use the stdlib sysconfig module instead, forcing both of its
+    # install-scheme template variables to sys.prefix so the result can be made relative to it
+    # (matching the prefix='' relative-path behavior the old distutils.get_python_lib() call had).
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" -c "if True:
-        from distutils import sysconfig as sc
-        print(sc.get_python_lib(prefix='', plat_specific=True))"
+        import sysconfig, sys, os
+        p = sysconfig.get_path('platlib', vars={'base': sys.prefix, 'platbase': sys.prefix})
+        print(os.path.relpath(p, sys.prefix))"
         OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_VARIABLE PYTHON_SITE_PACKAGES_ERROR
@@ -29,7 +33,7 @@ if (TIGL_BINDINGS_PYTHON)
 
     if (PYTHON_SITE_PACKAGES_ERROR)
         set(PYTHON_SITE_PACKAGES share/tigl3/python)
-        message(WARNING "Python site-packages directory could not be found (missing setuptools?). Falling back to: ${PYTHON_SITE_PACKAGES}")
+        message(WARNING "Python site-packages directory could not be found. Falling back to: ${PYTHON_SITE_PACKAGES}")
     else()
         cmake_path(SET PYTHON_SITE_PACKAGES NORMALIZE "${PYTHON_SITE_PACKAGES}")
         message(STATUS "Python site-packages: ${PYTHON_SITE_PACKAGES}")

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -17,25 +17,9 @@ if (TIGL_BINDINGS_PYTHON)
     message(STATUS "Python include directory: ${Python3_INCLUDE_DIR}")
     message(STATUS "Python library release: ${Python3_LIBRARY_RELEASE}")
 
-    # distutils.sysconfig was removed in Python 3.12 (PEP 632), so it can no longer be used to
-    # locate site-packages here.
-    #
-    # PYTHON_SITE_PACKAGES needs to be a path *relative to CMAKE_INSTALL_PREFIX*, which is NOT
-    # necessarily this interpreter's own sys.prefix: e.g. pixi's "python-internal" environment
-    # sets CMAKE_INSTALL_PREFIX to $CONDA_PREFIX (so it coincides with sys.prefix, installing
-    # straight into the live environment), but pixi's "default" environment sets it to a local
-    # build/install directory instead, to produce a self-contained, relocatable install tree -
-    # deliberately independent of where the build-time Python interpreter itself lives.
-    #
-    # Because of that, the right query is "what does a site-packages subpath look like under any
-    # prefix" (a portable template), not "what is my absolute site-packages, diffed against
-    # sys.prefix" - the latter only reconstructs correctly when CMAKE_INSTALL_PREFIX happens to
-    # equal sys.prefix, and otherwise surfaces install-scheme quirks as a badly broken path (this
-    # was tried and failed exactly this way on one platform/Python combination in CI, producing a
-    # long, escaping "../../.." relative path). Get the template directly instead, by asking
-    # sysconfig to resolve the path as if the prefix were empty, and stripping the resulting
-    # leading path separator (os.sep, so no separator literal has to survive CMake's own string
-    # escaping).
+    # distutils.sysconfig was removed in Python 3.12 (PEP 632). Ask sysconfig for the
+    # site-packages path as if the prefix were empty, giving a path relative to
+    # CMAKE_INSTALL_PREFIX (which isn't always this interpreter's own sys.prefix).
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" -c "if True:
         import sysconfig, os

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -18,25 +18,51 @@ if (TIGL_BINDINGS_PYTHON)
     message(STATUS "Python library release: ${Python3_LIBRARY_RELEASE}")
 
     # distutils.sysconfig was removed in Python 3.12 (PEP 632), so it can no longer be used to
-    # locate site-packages here. Use the stdlib sysconfig module instead, forcing both of its
-    # install-scheme template variables to sys.prefix so the result can be made relative to it
-    # (matching the prefix='' relative-path behavior the old distutils.get_python_lib() call had).
+    # locate site-packages here.
+    #
+    # PYTHON_SITE_PACKAGES needs to be a path *relative to CMAKE_INSTALL_PREFIX*, which is NOT
+    # necessarily this interpreter's own sys.prefix: e.g. pixi's "python-internal" environment
+    # sets CMAKE_INSTALL_PREFIX to $CONDA_PREFIX (so it coincides with sys.prefix, installing
+    # straight into the live environment), but pixi's "default" environment sets it to a local
+    # build/install directory instead, to produce a self-contained, relocatable install tree -
+    # deliberately independent of where the build-time Python interpreter itself lives.
+    #
+    # Because of that, the right query is "what does a site-packages subpath look like under any
+    # prefix" (a portable template), not "what is my absolute site-packages, diffed against
+    # sys.prefix" - the latter only reconstructs correctly when CMAKE_INSTALL_PREFIX happens to
+    # equal sys.prefix, and otherwise surfaces install-scheme quirks as a badly broken path (this
+    # was tried and failed exactly this way on one platform/Python combination in CI, producing a
+    # long, escaping "../../.." relative path). Get the template directly instead, by asking
+    # sysconfig to resolve the path as if the prefix were empty, and stripping the resulting
+    # leading path separator (os.sep, so no separator literal has to survive CMake's own string
+    # escaping).
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" -c "if True:
-        import sysconfig, sys, os
-        p = sysconfig.get_path('platlib', vars={'base': sys.prefix, 'platbase': sys.prefix})
-        print(os.path.relpath(p, sys.prefix))"
+        import sysconfig, os
+        p = sysconfig.get_path('platlib', vars={'base': '', 'platbase': ''})
+        print(p.lstrip(os.sep))"
         OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_VARIABLE PYTHON_SITE_PACKAGES_ERROR
     )
 
-    if (PYTHON_SITE_PACKAGES_ERROR)
+    if (PYTHON_SITE_PACKAGES_ERROR OR NOT PYTHON_SITE_PACKAGES)
         set(PYTHON_SITE_PACKAGES share/tigl3/python)
-        message(WARNING "Python site-packages directory could not be found. Falling back to: ${PYTHON_SITE_PACKAGES}")
+        message(WARNING "Python site-packages directory could not be found (missing setuptools, or "
+                         "sysconfig otherwise failed). Falling back to: ${PYTHON_SITE_PACKAGES}")
     else()
         cmake_path(SET PYTHON_SITE_PACKAGES NORMALIZE "${PYTHON_SITE_PACKAGES}")
-        message(STATUS "Python site-packages: ${PYTHON_SITE_PACKAGES}")
+        # Defense in depth: the template-based query above should always yield a plain relative
+        # subpath, but if some install scheme ever returns something else, don't silently try to
+        # install far outside the intended prefix (or elsewhere entirely) - fall back instead.
+        cmake_path(IS_ABSOLUTE PYTHON_SITE_PACKAGES PYTHON_SITE_PACKAGES_IS_ABSOLUTE)
+        if (PYTHON_SITE_PACKAGES_IS_ABSOLUTE OR PYTHON_SITE_PACKAGES MATCHES "^\\.\\.")
+            set(PYTHON_SITE_PACKAGES share/tigl3/python)
+            message(WARNING "Computed Python site-packages directory does not resolve to a proper "
+                             "subdirectory of the install prefix. Falling back to: ${PYTHON_SITE_PACKAGES}")
+        else()
+            message(STATUS "Python site-packages: ${PYTHON_SITE_PACKAGES}")
+        endif()
     endif()
 
     add_subdirectory(python)

--- a/bindings/bindings_generator/cheader_parser.py
+++ b/bindings/bindings_generator/cheader_parser.py
@@ -158,7 +158,7 @@ class CHeaderFileParser(object):
                     continuing = False
                     
         # parse typedefs
-        typedef_pattern = re.compile('typedef\s+(?P<type>[\w\s*]+)\s+(?P<name>\w+)\s*?;')
+        typedef_pattern = re.compile(r'typedef\s+(?P<type>[\w\s*]+)\s+(?P<name>\w+)\s*?;')
         for line in self.lines:
             match = typedef_pattern.search(line)
             if match:
@@ -250,7 +250,7 @@ class Annotation(object):
                 tmpstr = tmp.group('indexlist')
                 indexlist = [int(val) for val in tmpstr.split(',')]
             
-            params[arg_index]  = {'isarray':  tmp.group('array') is 'A', 
+            params[arg_index]  = {'isarray':  tmp.group('array') == 'A',
                                   'arraysizes': indexlist,
                                   'autoalloc': tmp.group('alloc') is None,
                                   'index': arg_index}

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -12,7 +12,8 @@ if(NOT PYTHON_EXECUTABLE)
     message(FATAL_ERROR "MATLAB bindings require Python, but no Python interpreter was found.")
 endif()
 
-message(STATUS "Found MATLAB. Create matlab bindings.")
+message(STATUS "Generating MATLAB bindings interface (tiglmatlab.c). Whether the compiled "
+                "mex file is also built depends on whether MATLAB itself is found (see below).")
 
 #run python to create the tiglmatlab.c
 add_custom_command(

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -7,7 +7,10 @@ option(TIGL_BINDINGS_MATLAB "Build the matlab bindings of tigl (requires matlab 
 if(TIGL_BINDINGS_MATLAB)
 
 find_package(MATLAB QUIET)
-find_package(PythonInterp REQUIRED)
+# PYTHON_EXECUTABLE is already set (via FindPython3) by the top-level CMakeLists.txt
+if(NOT PYTHON_EXECUTABLE)
+    message(FATAL_ERROR "MATLAB bindings require Python, but no Python interpreter was found.")
+endif()
 
 message(STATUS "Found MATLAB. Create matlab bindings.")
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,28 +1,9 @@
-# work around wrong python detection script of cmake (happens with old python versions)
-if(PYTHON_EXECUTABLE)
-    execute_process(COMMAND "${PYTHON_EXECUTABLE}" --version
-                    ERROR_VARIABLE _VERSION
-                    RESULT_VARIABLE _PYTHON_VERSION_RESULT
-                    OUTPUT_QUIET
-                    ERROR_STRIP_TRAILING_WHITESPACE)
-    if(_PYTHON_VERSION_RESULT)
-        execute_process(COMMAND "${PYTHON_EXECUTABLE}" -V
-                        ERROR_VARIABLE _VERSION
-                        RESULT_VARIABLE _PYTHON_VERSION_RESULT
-                        OUTPUT_QUIET
-                        ERROR_STRIP_TRAILING_WHITESPACE)
-    endif(_PYTHON_VERSION_RESULT)
-    if(NOT _PYTHON_VERSION_RESULT AND _VERSION MATCHES "^Python [0-9]+\\.[0-9]+.*")
-        string(REPLACE "Python " "" PYTHON_VERSION_STRING "${_VERSION}")
-        string(REGEX REPLACE "^([0-9]+)\\.[0-9]+.*" "\\1" PYTHON_VERSION_MAJOR "${PYTHON_VERSION_STRING}")
-        string(REGEX REPLACE "^[0-9]+\\.([0-9])+.*" "\\1" PYTHON_VERSION_MINOR "${PYTHON_VERSION_STRING}")
-        if(PYTHON_VERSION_STRING MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+.*")
-            string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" PYTHON_VERSION_PATCH "${PYTHON_VERSION_STRING}")
-        endif()
-    endif()
-endif(PYTHON_EXECUTABLE)
-
-if(PYTHON_EXECUTABLE AND NOT PYTHON_VERSION_STRING VERSION_LESS "2.5" )
+# bindings/CMakeLists.txt already runs find_package(Python3 ... REQUIRED) before
+# adding this subdirectory, so PYTHON_EXECUTABLE/Python3_VERSION are always valid
+# here. (The previous hand-rolled `python --version` parsing below this comment
+# used to work around ancient CMake's lack of FindPython3, but had been silently
+# broken since Python 3.4, which prints `--version` to stdout, not stderr.)
+if(NOT Python3_VERSION VERSION_LESS "2.5")
 	#run python to create the wrapper
 		add_custom_command(
 			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tigl3wrapper.py
@@ -33,13 +14,13 @@ if(PYTHON_EXECUTABLE AND NOT PYTHON_VERSION_STRING VERSION_LESS "2.5" )
 		)
 
 		add_custom_target(tiglPython ALL
-			COMMENT "Create python interface for tigl" VERBATIM 
+			COMMENT "Create python interface for tigl" VERBATIM
 			DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tigl3wrapper.py
 		)
-		
+
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tigl3wrapper.py
 				DESTINATION ${PYTHON_SITE_PACKAGES}/tigl3
 				COMPONENT interfaces)
 else()
-    message(ERROR "Python could not be found or the python installation is too old ( < 2.5). Python bindings can not be build!")
+    message(WARNING "Python installation is too old ( < 2.5). Python bindings can not be built!")
 endif()

--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -64,7 +64,12 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
     set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -py3)
     if(SWIG_HIDE_WARNINGS)
       message(STATUS "Disabled SWIG warnings")
-      set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -w302,401,402,412,314,509,512,504,325,503,520,350,351,383,389,394,395,404)
+      # 526: harmless in TiGL's CCPACS* classes, which routinely pull in generated
+      #      accessors via "using Base::GetX;" while SWIG renames them to snake_case
+      # 317: from_string<FaceNameSettings> is a real template specialization SWIG
+      #      doesn't recognize as such (CTiglExportIges.h)
+      # 312: private anonymous union in CTiglWingStructureReference, not swig-exposed
+      set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -w302,401,402,412,314,509,512,504,325,503,520,350,351,383,389,394,395,404,526,317,312)
     endif()
 
 
@@ -95,6 +100,12 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
 
         swig_add_library(${MODULE} LANGUAGE python SOURCES ${MODULE}.i TYPE MODULE)
         swig_link_libraries(${MODULE} tigl3 tigl3_cpp Python3::Module)
+
+        # the generated wrap.cxx intentionally calls TiGL's own deprecated API to
+        # keep it available from Python for backwards compatibility
+        if(NOT MSVC)
+            target_compile_options(${MODULE} PRIVATE -Wno-deprecated-declarations)
+        endif()
 
         install(TARGETS ${MODULE}
                 DESTINATION ${PYTHON_SITE_PACKAGES}/tigl3

--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -103,7 +103,7 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
         set(SWIG_MODULE_${MODULE}_EXTRA_DEPS common.i generate_doc_i)
 
         swig_add_library(${MODULE} LANGUAGE python SOURCES ${MODULE}.i TYPE MODULE)
-        swig_link_libraries(${MODULE} tigl3 tigl3_cpp Python3::Module)
+        target_link_libraries(${MODULE} tigl3 tigl3_cpp Python3::Module)
 
         # the generated wrap.cxx intentionally calls TiGL's own deprecated API to
         # keep it available from Python for backwards compatibility

--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -61,7 +61,11 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
 
     # we use the same definitions as pythonocc for their build to hide some of their warnings
     option(SWIG_HIDE_WARNINGS "Check this option if you want a less verbose swig output." ON)
-    set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -py3)
+    # -py3 became the only (default) mode once SWIG dropped Python 2 support and is a
+    # no-op warning on SWIG >= 4.1; only pass it for the older versions that need it.
+    if(SWIG_VERSION VERSION_LESS "4.1")
+        set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -py3)
+    endif()
     if(SWIG_HIDE_WARNINGS)
       message(STATUS "Disabled SWIG warnings")
       # 526: harmless in TiGL's CCPACS* classes, which routinely pull in generated

--- a/bindings/python_internal/CMakeLists.txt
+++ b/bindings/python_internal/CMakeLists.txt
@@ -107,7 +107,9 @@ if (TIGL_BINDINGS_PYTHON_INTERNAL)
 
         # the generated wrap.cxx intentionally calls TiGL's own deprecated API to
         # keep it available from Python for backwards compatibility
-        if(NOT MSVC)
+        if(MSVC)
+            target_compile_options(${MODULE} PRIVATE /wd4996)
+        else()
             target_compile_options(${MODULE} PRIVATE -Wno-deprecated-declarations)
         endif()
 

--- a/cmake/FindMATLAB.cmake
+++ b/cmake/FindMATLAB.cmake
@@ -124,7 +124,7 @@
       set (MATLAB_DIR "${_TIGL_MATLAB_SDK_DIR}" CACHE PATH "Installation prefix for MATLAB." FORCE)
     endif ()
     if (NOT MATLAB_DIR AND APPLE AND (CMAKE_OSX_ARCHITECTURES MATCHES "arm64" OR (NOT CMAKE_OSX_ARCHITECTURES AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64"))))
-      message(WARNING "MATLAB bindings will not be built on Apple Silicon (osx-arm64): no vendored SDK available. "
+      message(STATUS "MATLAB bindings will not be built on Apple Silicon (osx-arm64): no vendored SDK available. "
                       "Set MATLAB_DIR to a local Apple Silicon MATLAB installation to enable them. "
                       "See doc/installation.md §thirdpartysources.")
     endif ()

--- a/cmake/UseOpenCASCADE.cmake
+++ b/cmake/UseOpenCASCADE.cmake
@@ -47,7 +47,7 @@ if(OCE_FOUND)
   
   option(OCE_STATIC_LIBS "Should be checked, if static OCE libs are linked" OFF)
 else(OCE_FOUND)
-  message("OCE not found! Searching for OpenCASCADE.")
+  message(STATUS "OCE not found! Searching for OpenCASCADE.")
   find_package(OpenCASCADE CONFIG REQUIRED COMPONENTS FoundationClasses ModelingData ModelingAlgorithms Visualization ApplicationFramework DataExchange)
   option(OpenCASCADE_STATIC_LIBS "Should be checked, if static OpenCASCADE libs are linked" OFF)
 

--- a/cmake/tiglmacros.cmake
+++ b/cmake/tiglmacros.cmake
@@ -64,3 +64,21 @@ FUNCTION(CAT IN OUT)
     FILE(READ ${IN} CONTENTS)
     FILE(APPEND ${OUT} "${CONTENTS}")
 ENDFUNCTION(CAT IN OUT)
+
+# Treats compiler warnings as errors for the given target, at whatever warning
+# level that target is already compiled with (this does not itself raise the
+# warning level, e.g. via -Wall/-Wextra or /W4). Controlled by the top-level
+# TIGL_WARNINGS_AS_ERRORS option, so it can be turned off if a toolchain
+# upgrade surfaces a new warning that hasn't been triaged yet. Intentionally
+# meant only for TiGL's own targets (core library, TIGLCreator, tests) -
+# not for thirdparty code or the SWIG-generated Python/MATLAB bindings, which
+# are outside our control.
+function(tigl_enable_warnings_as_errors target)
+    if(TIGL_WARNINGS_AS_ERRORS)
+        if(MSVC)
+            target_compile_options(${target} PRIVATE /WX)
+        else()
+            target_compile_options(${target} PRIVATE -Werror)
+        endif()
+    endif()
+endfunction()

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -167,6 +167,7 @@ Here is a complete list of TiGL's CMake options.
 | TIGL_BINDINGS_JAVA | Build the java bindings of TiGL (requires Java) | OFF |
 | TIGL_BINDINGS_MATLAB | Build the Matlab bindings of TiGL (requires matlab and python) | OFF |
 | TIGL_BINDINGS_INSTALL_CPP | Install TiGL's C++ bindings | OFF |
+| TIGL_WARNINGS_AS_ERRORS | Treat compiler warnings in TiGL's own targets (core library, TIGLCreator, tests) as errors. Does not apply to thirdparty code or the SWIG-generated bindings | ON |
 | TIGL_NIGHTLY | Create a nightly build of TIGL (includes git sha into tigl version) | OFF |
 | TIGL_CONCAT_GENERERATED_FILES | Concatenate all generated files into one. This speeds up compilation, but gives undesirable line numbers in error messages in releases | ON |
 | TIGL_USE_GLOG | Enables advanced logging (requires google glog) | OFF |

--- a/src/CCPACSPointListXY.h
+++ b/src/CCPACSPointListXY.h
@@ -26,7 +26,7 @@ class CCPACSPointListXY : public generated::CPACSPointListXY
 public:
     TIGL_EXPORT CCPACSPointListXY(CCPACSStructuralProfile* parent, CTiglUIDManager* uidMgr);
 
-    TIGL_EXPORT const CCPACSPointXY& GetPoint(const std::string& uid) const;
+    TIGL_EXPORT const CCPACSPointXY& GetPoint(const std::string& uid) const override;
 
     TIGL_EXPORT CCPACSPointXY& AddPoint() override;
     TIGL_EXPORT void RemovePoint(CCPACSPointXY& ref)  override;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,10 +82,20 @@ add_library(tigl3_objects OBJECT ${TIGL_SRC})
 set_property(TARGET tigl3_objects PROPERTY POSITION_INDEPENDENT_CODE ON) # needed for shared libraries
 
 target_include_directories(tigl3_objects
-    PRIVATE $<TARGET_PROPERTY:TKernel,INTERFACE_INCLUDE_DIRECTORIES>
     PRIVATE ${TIGL_INCLUDES}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/api
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+# These are third-party dependencies whose headers we don't control, so they are added as
+# SYSTEM include directories: with TIGL_WARNINGS_AS_ERRORS enabled, compiler warnings
+# originating inside them (e.g. deprecated C stdlib calls in some OCCT versions) must not
+# fail our build. Normally CMake treats headers from a linked IMPORTED target's
+# INTERFACE_INCLUDE_DIRECTORIES as SYSTEM automatically, but here the include dirs are
+# extracted via $<TARGET_PROPERTY:...> instead of an actual target_link_libraries edge,
+# which bypasses that automatic behavior - so SYSTEM must be requested explicitly.
+target_include_directories(tigl3_objects SYSTEM
+    PRIVATE $<TARGET_PROPERTY:TKernel,INTERFACE_INCLUDE_DIRECTORIES>
     PRIVATE $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
     PUBLIC $<TARGET_PROPERTY:tixi3,INTERFACE_INCLUDE_DIRECTORIES>
 )
@@ -95,7 +105,7 @@ target_include_directories(tigl3_objects
 #   but the tixicpp includes are in the same dir as the tixi3 includes.
 #   A local build has it but has a different include directory than tixi3.
 if (TARGET tixicpp)
-    target_include_directories(tigl3_objects
+    target_include_directories(tigl3_objects SYSTEM
         PRIVATE $<TARGET_PROPERTY:tixicpp,INTERFACE_INCLUDE_DIRECTORIES>
     )
 endif(TARGET tixicpp)
@@ -111,7 +121,7 @@ if(TARGET glog::glog)
     PRIVATE $<TARGET_PROPERTY:glog::glog,INTERFACE_COMPILE_DEFINITIONS>
   )
 
-  target_include_directories(tigl3_objects
+  target_include_directories(tigl3_objects SYSTEM
     PRIVATE $<TARGET_PROPERTY:glog::glog,INTERFACE_INCLUDE_DIRECTORIES>
   )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   endif()
 endif()
 
+tigl_enable_warnings_as_errors(tigl3_objects)
+
 # workaround for xcode. We must give each target a source file, not just a list of object files
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp "// DUMMY FILE")
 

--- a/src/api/tigl.cpp
+++ b/src/api/tigl.cpp
@@ -1138,7 +1138,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetWingCount(TiglCPACSConfigurationHandle 
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        *wingCountPtr = config.GetWingCount();
+        *wingCountPtr = static_cast<int>(config.GetWingCount());
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -1714,7 +1714,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingGetIndex(TiglCPACSConfigurationHandle 
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        *wingIndexPtr = config.GetWingIndex(std::string(wingUID));
+        *wingIndexPtr = static_cast<int>(config.GetWingIndex(std::string(wingUID)));
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -2031,7 +2031,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglWingComponentSegmentGetPoint(TiglCPACSConf
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
 
         // search for component segment
-        int nwings = config.GetWingCount();
+        int nwings = static_cast<int>(config.GetWingCount());
         for (int iwing = 1; iwing <= nwings; ++iwing) {
             tigl::CCPACSWing& wing = config.GetWing(iwing);
             int ncompSegs = wing.GetComponentSegmentCount();
@@ -2894,7 +2894,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetFuselageCount(TiglCPACSConfigurationHan
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        *fuselageCountPtr = config.GetFuselageCount();
+        *fuselageCountPtr = static_cast<int>(config.GetFuselageCount());
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -3877,7 +3877,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglFuselageGetIndex(TiglCPACSConfigurationHan
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        *fuselageIndexPtr = config.GetFuselageIndex(std::string(fuselageUID));
+        *fuselageIndexPtr = static_cast<int>(config.GetFuselageIndex(std::string(fuselageUID)));
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -4177,7 +4177,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglGetRotorCount(TiglCPACSConfigurationHandle
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        *rotorCountPtr = config.GetRotorCount();
+        *rotorCountPtr = static_cast<int>(config.GetRotorCount());
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -4249,7 +4249,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglRotorGetIndex(TiglCPACSConfigurationHandle
     try {
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
-        *rotorIndexPtr = config.GetRotorIndex(std::string(rotorUID));
+        *rotorIndexPtr = static_cast<int>(config.GetRotorIndex(std::string(rotorUID)));
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -4545,7 +4545,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglRotorGetRotorBladeCount(TiglCPACSConfigura
         tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
         tigl::CCPACSConfiguration& config = manager.GetConfiguration(cpacsHandle);
         tigl::CCPACSRotor& rotor = config.GetRotor(rotorIndex);
-        *rotorBladeCountPtr = rotor.GetRotorBladeCount();
+        *rotorBladeCountPtr = static_cast<int>(rotor.GetRotorBladeCount());
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {
@@ -4589,7 +4589,7 @@ TIGL_COMMON_EXPORT TiglReturnCode tiglRotorBladeGetWingIndex(TiglCPACSConfigurat
         tigl::CCPACSRotor& rotor = config.GetRotor(rotorIndex);
         tigl::CTiglAttachedRotorBlade& rotorBlade = rotor.GetRotorBlade(rotorBladeIndex);
         tigl::CCPACSRotorBladeAttachment& rotorBladeAttachment = rotorBlade.GetRotorBladeAttachment();
-        *wingIndexPtr = rotorBladeAttachment.GetWingIndex();
+        *wingIndexPtr = static_cast<int>(rotorBladeAttachment.GetWingIndex());
         return TIGL_SUCCESS;
     }
     catch (const tigl::CTiglError& ex) {

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -910,7 +910,7 @@ gp_Pnt GetFirstPoint(const TopoDS_Wire& w)
 gp_Pnt GetFirstPoint(const TopoDS_Edge& e)
 {
     double u1, u2;
-    Handle_Geom_Curve c = BRep_Tool::Curve(e, u1, u2);
+    Handle(Geom_Curve) c = BRep_Tool::Curve(e, u1, u2);
 
     if (e.Orientation() == TopAbs_REVERSED) {
         return c->Value(u2);
@@ -940,7 +940,7 @@ gp_Pnt GetLastPoint(const TopoDS_Wire& w)
 gp_Pnt GetLastPoint(const TopoDS_Edge& e)
 {
     double u1, u2;
-    Handle_Geom_Curve c = BRep_Tool::Curve(e, u1, u2);
+    Handle(Geom_Curve) c = BRep_Tool::Curve(e, u1, u2);
 
     if (e.Orientation() == TopAbs_REVERSED) {
         return c->Value(u1);

--- a/src/common/tiglcommonfunctions.cpp
+++ b/src/common/tiglcommonfunctions.cpp
@@ -642,7 +642,7 @@ void GetShapeExtension(const TopoDS_Shape& shape,
 int GetHash(const TopoDS_Shape& shape)
 {
 #if OCC_VERSION_HEX >= VERSION_HEX_CODE(7,8,0)
-    return std::hash<TopoDS_Shape>{}(shape);
+    return static_cast<int>(std::hash<TopoDS_Shape>{}(shape));
 #else
     return shape.HashCode(INT_MAX);
 #endif

--- a/src/configuration/CCPACSConfiguration.cpp
+++ b/src/configuration/CCPACSConfiguration.cpp
@@ -888,7 +888,7 @@ size_t CCPACSConfiguration::GetExternalObjectCount() const
 
 CCPACSExternalObject&CCPACSConfiguration::GetExternalObject(size_t index) const
 {
-    return aircraftModel->GetGenericGeometryComponents()->GetObject(index);
+    return aircraftModel->GetGenericGeometryComponents()->GetObject(static_cast<int>(index));
 }
 
 // Returns the fuselage for a given UID.

--- a/src/ducts/CCPACSDuct.cpp
+++ b/src/ducts/CCPACSDuct.cpp
@@ -120,7 +120,7 @@ void CCPACSDuct::SetFaceTraits (PNamedShape loft) const
     }
 
     // if we have a smooth surface, the whole fuslage is treatet as one segment
-    int nSegments = m_segments.GetSegmentCount();
+    int nSegments = static_cast<int>(m_segments.GetSegmentCount());
 
     int facesPerSegment = nFacesAero/ nSegments;
 

--- a/src/engine_nacelle/CCPACSNacelleCowl.cpp
+++ b/src/engine_nacelle/CCPACSNacelleCowl.cpp
@@ -343,7 +343,7 @@ void RemoveBlendingPart(TopoDS_Edge const lowerEdge,
     double umin, umax;
     double par1 = -1.;
     double par2 = 0.;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(lowerEdge, umin, umax);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(lowerEdge, umin, umax);
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
     if (len < Precision::Confusion()) {

--- a/src/engine_nacelle/CCPACSNacelleSections.h
+++ b/src/engine_nacelle/CCPACSNacelleSections.h
@@ -29,8 +29,8 @@ class CCPACSNacelleSections : public generated::CPACSNacelleSections
 public:
     TIGL_EXPORT CCPACSNacelleSections(CCPACSNacelleCowl* parent, CTiglUIDManager* uidMgr);
 
-    TIGL_EXPORT size_t GetSectionCount() const;
-    TIGL_EXPORT CCPACSNacelleSection& GetSection(size_t index) const;
+    TIGL_EXPORT size_t GetSectionCount() const override;
+    TIGL_EXPORT CCPACSNacelleSection& GetSection(size_t index) const override;
     TIGL_EXPORT CCPACSNacelleSection& GetSection(std::string const uid) const;
     TIGL_EXPORT size_t GetSectionIndex(std::string const uid) const;
 };

--- a/src/exports/SplineLibIO.cpp
+++ b/src/exports/SplineLibIO.cpp
@@ -30,7 +30,7 @@
 
 using namespace std;
 
-void exportCurveToSplineLib(Handle_Geom_BSplineCurve curve, const std::string& filename) 
+void exportCurveToSplineLib(Handle(Geom_BSplineCurve) curve, const std::string& filename) 
 {
     TColStd_Array1OfReal knots(0, curve->NbKnots()-1) ;
     curve->Knots(knots);
@@ -78,7 +78,7 @@ void exportCurveToSplineLib(Handle_Geom_BSplineCurve curve, const std::string& f
     out.close();
 }
 
-void exportSurfaceToSplineLib(Handle_Geom_BSplineSurface surf, const std::string& filename) 
+void exportSurfaceToSplineLib(Handle(Geom_BSplineSurface) surf, const std::string& filename) 
 {
     TColStd_Array1OfReal knots_u(0, surf->NbUKnots()-1) ;
     surf->UKnots(knots_u);

--- a/src/exports/SplineLibIO.h
+++ b/src/exports/SplineLibIO.h
@@ -26,7 +26,7 @@
  * \param curve 
  * \param filename
  */
-void exportCurveToSplineLib(Handle_Geom_BSplineCurve curve, const std::string& filename);
+void exportCurveToSplineLib(Handle(Geom_BSplineCurve) curve, const std::string& filename);
 
 /**
  * \brief write BSpline surface parameter in SplineLib format
@@ -34,4 +34,4 @@ void exportCurveToSplineLib(Handle_Geom_BSplineCurve curve, const std::string& f
  * \param surf
  * \param filename
  */
-void exportSurfaceToSplineLib(Handle_Geom_BSplineSurface surf, const std::string& filename);
+void exportSurfaceToSplineLib(Handle(Geom_BSplineSurface) surf, const std::string& filename);

--- a/src/fuelTanks/CCPACSVessel.cpp
+++ b/src/fuelTanks/CCPACSVessel.cpp
@@ -150,7 +150,7 @@ CCPACSFuselageSection& CCPACSVessel::GetSection(const std::string& sectionUID)
 
 TopoDS_Shape CCPACSVessel::GetSectionFace(const std::string sectionUID) const
 {
-    const int segmentCount = GetSegmentCount();
+    const int segmentCount = static_cast<int>(GetSegmentCount());
 
     // Search for the section in all segments
     for (int n = 0; n < segmentCount; ++n) {
@@ -720,7 +720,7 @@ void CCPACSVessel::SetFaceTraitsFromSegments(PNamedShape loft) const
     int nFacesAero  = nFacesTotal;
 
     auto& segments = m_segments_choice1.get();
-    int nSegments  = segments.GetSegmentCount();
+    int nSegments  = static_cast<int>(segments.GetSegmentCount());
 
     bool hasSymmetryPlane = GetNumberOfEdges(segments.GetSegment(1).GetEndWire()) > 1;
 

--- a/src/fuselage/CCPACSFuselage.cpp
+++ b/src/fuselage/CCPACSFuselage.cpp
@@ -167,7 +167,7 @@ void CCPACSFuselage::SetParentUID(const boost::optional<std::string>& value)
 // Get section count
 int CCPACSFuselage::GetSectionCount() const
 {
-    return m_sections.GetSectionCount();
+    return static_cast<int>(m_sections.GetSectionCount());
 }
 
 // Returns the face that has a given fuselage section as its boundary
@@ -197,7 +197,7 @@ CCPACSFuselageSection& CCPACSFuselage::GetSection(int index)
 // Get segment count
 int CCPACSFuselage::GetSegmentCount() const
 {
-    return m_segments.GetSegmentCount();
+    return static_cast<int>(m_segments.GetSegmentCount());
 }
 
 // Returns the segment for a given index

--- a/src/fuselage/CCPACSFuselageSegment.cpp
+++ b/src/fuselage/CCPACSFuselageSegment.cpp
@@ -948,7 +948,7 @@ TIGL_EXPORT int CCPACSFuselageSegment::GetNumberOfLoftFaces() const
     // no guide curves, therefore we either have one or two faces, depending on the symmetry plane
     bool hasSymmetryPlane = GetNumberOfEdges(GetEndWire()) > 1;
     int nfaces = GetNumberOfFaces(GetParent()->GetParentComponent()->GetLoft()->Shape());
-    int nSegments = GetParent()->GetSegmentCount();
+    int nSegments = static_cast<int>(GetParent()->GetSegmentCount());
 
     if (!CTiglTopoAlgorithms::IsDegenerated(GetParent()->GetSegment(1).GetStartWire())) {
           nfaces-=1;

--- a/src/fuselage/CCPACSFuselages.h
+++ b/src/fuselage/CCPACSFuselages.h
@@ -40,10 +40,10 @@ public:
     TIGL_EXPORT CCPACSFuselages(CCPACSRotorcraftModel* parent, CTiglUIDManager* uidMgr);
 
     // Read CPACS fuselage elements
-    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath);
+    TIGL_EXPORT void ReadCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) override;
 
     // Write CPACS fuselage elements
-    TIGL_EXPORT void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const;
+    TIGL_EXPORT void WriteCPACS(const TixiDocumentHandle& tixiHandle, const std::string& xpath) const override;
 
     // Create a new fuselage with the given parameters.
     // Remark, all children UIDs and transformations are set.

--- a/src/geometry/CCPACSRotationCurve.cpp
+++ b/src/geometry/CCPACSRotationCurve.cpp
@@ -104,7 +104,7 @@ void CCPACSRotationCurve::CutCurveAtZetas(TopoDS_Edge& edge) const
     double umin, umax;
     double par1 = -1;
     double par2 = -1;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(edge, umin, umax);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, umin, umax);
     GeomAdaptor_Curve adaptorCurve(curve, umin, umax);
     Standard_Real len =  GCPnts_AbscissaPoint::Length( adaptorCurve, umin, umax );
     if (len < Precision::Confusion()) {

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -305,14 +305,14 @@ namespace
         return rowVector;
     }
 
-    Handle_TColgp_HArray1OfPnt pntArray2GetColumn(const TColgp_Array2OfPnt& matrix, int colIndex)
+    Handle(TColgp_HArray1OfPnt) pntArray2GetColumn(const TColgp_Array2OfPnt& matrix, int colIndex)
     {
-        return array2GetColumn<TColgp_Array2OfPnt, TColgp_HArray1OfPnt, Handle_TColgp_HArray1OfPnt>(matrix, colIndex);
+        return array2GetColumn<TColgp_Array2OfPnt, TColgp_HArray1OfPnt, Handle(TColgp_HArray1OfPnt)>(matrix, colIndex);
     }
 
-    Handle_TColgp_HArray1OfPnt pntArray2GetRow(const TColgp_Array2OfPnt& matrix, int rowIndex)
+    Handle(TColgp_HArray1OfPnt) pntArray2GetRow(const TColgp_Array2OfPnt& matrix, int rowIndex)
     {
-        return array2GetRow<TColgp_Array2OfPnt, TColgp_HArray1OfPnt, Handle_TColgp_HArray1OfPnt>(matrix, rowIndex);
+        return array2GetRow<TColgp_Array2OfPnt, TColgp_HArray1OfPnt, Handle(TColgp_HArray1OfPnt)>(matrix, rowIndex);
     }
 
     // Some helper functions for CTiglBSplineAlgorithms::reparameterizePiecewiseLinear ...
@@ -871,7 +871,7 @@ Handle(Geom_BSplineSurface) CTiglBSplineAlgorithms::pointsToSurface(const TColgp
     // first interpolate all points by B-splines in u-direction
     std::vector<Handle(Geom_Curve)> uSplines;
     for (int cpVIdx = points.LowerCol(); cpVIdx <= points.UpperCol(); ++cpVIdx) {
-        Handle_TColgp_HArray1OfPnt points_u = pntArray2GetColumn(points, cpVIdx);
+        Handle(TColgp_HArray1OfPnt) points_u = pntArray2GetColumn(points, cpVIdx);
         CTiglPointsToBSplineInterpolation interpolationObject(points_u, uParams, 3, makeUDirClosed);
 
         Handle(Geom_Curve) curve = interpolationObject.Curve();

--- a/src/geometry/CTiglBSplineAlgorithms.cpp
+++ b/src/geometry/CTiglBSplineAlgorithms.cpp
@@ -331,8 +331,8 @@ namespace
         // Add all knots u_i=f(s_i)
         // Since we assume a piecewise linear reparameterization function f, the knots of f are just the new parameters
         // Hence, evaluating f at one knot gives the corresponding old parameter
-        TColStd_Array1OfReal knotsParams(1, paramsOld.size());
-        TColStd_Array1OfInteger multsParams(1, paramsOld.size());
+        TColStd_Array1OfReal knotsParams(1, static_cast<int>(paramsOld.size()));
+        TColStd_Array1OfInteger multsParams(1, static_cast<int>(paramsOld.size()));
         for (int paramIdx = 0; paramIdx < paramsOld.size(); paramIdx++) {
             knotsParams.SetValue(paramIdx+1, paramsOld[paramIdx]);
             multsParams.SetValue(paramIdx+1, degree);
@@ -435,7 +435,7 @@ namespace details
             [&u](double v){ return u <= v; }
         );
 
-        int paramsIdx = std::distance(paramsOld.begin(), it);
+        int paramsIdx = static_cast<int>(std::distance(paramsOld.begin(), it));
         // Catch case u=0, since distance would be 0 which causes illegal vector access by subtraction of 1
         if (paramsIdx  == 0) {
             ++paramsIdx;

--- a/src/geometry/CTiglBSplineFit.cpp
+++ b/src/geometry/CTiglBSplineFit.cpp
@@ -348,7 +348,7 @@ BSplineFit::error BSplineFit::FitOptimal(const TColgp_Array1OfPnt &points, doubl
 }
 
 
-Handle_Geom_BSplineCurve BSplineFit::Curve() const
+Handle(Geom_BSplineCurve) BSplineFit::Curve() const
 {
     return _curve;
 }

--- a/src/geometry/CTiglBSplineFit.h
+++ b/src/geometry/CTiglBSplineFit.h
@@ -58,7 +58,7 @@ public:
 
     /// Returns the resulting curve. Returns
     /// Null in case of an error
-    TIGL_EXPORT Handle_Geom_BSplineCurve Curve() const;
+    TIGL_EXPORT Handle(Geom_BSplineCurve) Curve() const;
 
     /// Computes the maximum error of the fit
     TIGL_EXPORT double GetMaxError();
@@ -86,7 +86,7 @@ private:
     error fitCurve();
 
     /// The resulting B-spline curve
-    Handle_Geom_BSplineCurve _curve;
+    Handle(Geom_BSplineCurve) _curve;
 
     /// degree of the B-spline
     int _degree;

--- a/src/geometry/CTiglElementGeometryBuilder.cpp
+++ b/src/geometry/CTiglElementGeometryBuilder.cpp
@@ -337,7 +337,7 @@ TopoDS_Shape CTiglElementGeometryBuilder::BuildMultiSegmentShape(const CCPACSMul
     segments.SetReferenceParent(m_refComponent);
     segments.SetConfiguration(m_refConfig);
 
-    const int nSeg = segments.GetSegmentCount();
+    const int nSeg = static_cast<int>(segments.GetSegmentCount());
 
     if (nSeg < 1) {
         throw CTiglError("Cannot build multi-segment shape: no segments defined.", TIGL_INVALID_VALUE);

--- a/src/geometry/CTiglPolyDataTools.cpp
+++ b/src/geometry/CTiglPolyDataTools.cpp
@@ -200,7 +200,7 @@ Handle(Poly_Triangulation) CTiglPolyDataTools::MakePoly_Triangulation(CTiglPolyD
 
         CTiglPoint normal = CTiglPoint::cross_prod(v2-v1, v3-v1);
         normal = normal*(1./normal.norm2());
-        triangulation->SetNormal(i, gp_Vec3f(normal.x, normal.y, normal.z));
+        triangulation->SetNormal(i, gp_Vec3f(static_cast<float>(normal.x), static_cast<float>(normal.y), static_cast<float>(normal.z)));
     }
 
     return triangulation;

--- a/src/math/CTiglIntersectBSplines.cpp
+++ b/src/math/CTiglIntersectBSplines.cpp
@@ -174,11 +174,11 @@ namespace
         
         if (c1_curvature > max_curvature && c2_curvature > max_curvature) {
             // Refine both curves by splitting them in the parametric center
-            Handle_Geom_BSplineCurve c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
-            Handle_Geom_BSplineCurve c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
+            Handle(Geom_BSplineCurve) c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
+            Handle(Geom_BSplineCurve) c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
             
-            Handle_Geom_BSplineCurve c21 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2->FirstParameter(), curve2MidParm);
-            Handle_Geom_BSplineCurve c22 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2MidParm, curve2->LastParameter());
+            Handle(Geom_BSplineCurve) c21 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2->FirstParameter(), curve2MidParm);
+            Handle(Geom_BSplineCurve) c22 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2MidParm, curve2->LastParameter());
             
             auto result1 = getRangesOfIntersection(c11, c21, tolerance);
             auto result2 = getRangesOfIntersection(c11, c22, tolerance);
@@ -194,8 +194,8 @@ namespace
         }
         else if (c1_curvature <= max_curvature && max_curvature < c2_curvature) {
             // Refine only curve 2
-            Handle_Geom_BSplineCurve c21 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2->FirstParameter(), curve2MidParm);
-            Handle_Geom_BSplineCurve c22 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2MidParm, curve2->LastParameter());
+            Handle(Geom_BSplineCurve) c21 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2->FirstParameter(), curve2MidParm);
+            Handle(Geom_BSplineCurve) c22 = tigl::CTiglBSplineAlgorithms::trimCurve(curve2, curve2MidParm, curve2->LastParameter());
             
             auto result1 = getRangesOfIntersection(curve1, c21, tolerance);
             auto result2 = getRangesOfIntersection(curve1, c22, tolerance);
@@ -205,8 +205,8 @@ namespace
         }
         else if (c2_curvature <= max_curvature && max_curvature < c1_curvature) {
             // Refine only curve 1
-            Handle_Geom_BSplineCurve c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
-            Handle_Geom_BSplineCurve c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
+            Handle(Geom_BSplineCurve) c11 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1->FirstParameter(), curve1MidParm);
+            Handle(Geom_BSplineCurve) c12 = tigl::CTiglBSplineAlgorithms::trimCurve(curve1, curve1MidParm, curve1->LastParameter());
             
             auto result1 = getRangesOfIntersection(c11, curve2, tolerance);
             auto result2 = getRangesOfIntersection(c12, curve2, tolerance);

--- a/src/rotor/CCPACSRotorBladeAttachment.cpp
+++ b/src/rotor/CCPACSRotorBladeAttachment.cpp
@@ -59,7 +59,7 @@ CTiglTransformation CCPACSRotorBladeAttachment::GetRotorBladeTransformationMatri
 
     // 1. Rotation around hinges, beginning with the last
     if (doHingeTransformation) {
-        for (int k=GetHingeCount()-1; k>=0; --k) {
+        for (int k=static_cast<int>(GetHingeCount())-1; k>=0; --k) {
             CTiglPoint curHingePosition = GetHinge(k+1).GetTranslation();
             const ECPACSRotorHubHinge_type& curHingeType = GetHinge(k+1).GetType();
             // a. move to origin
@@ -177,7 +177,7 @@ void CCPACSRotorBladeAttachment::lazyCreateAttachedRotorBlades() const
     // We have to do these lazily, as we do not have control of the order in which CPACS elements are read
     // (wings may not be loaded yet, when ReadCPACS of this class is called)
     CCPACSRotorcraftModel& rotorcraft = *m_parent->GetParent()->GetParent()->GetParent()->GetParent();
-    const int bladeCount = GetNumberOfBlades();
+    const int bladeCount = static_cast<int>(GetNumberOfBlades());
     if (attachedRotorBlades.size() != bladeCount) {
         attachedRotorBlades.clear();
         if (rotorcraft.GetRotorBlades()) {

--- a/src/rotor/CCPACSRotorHub.cpp
+++ b/src/rotor/CCPACSRotorHub.cpp
@@ -65,7 +65,7 @@ size_t CCPACSRotorHub::GetRotorBladeCount() const
 {
     int rotorBladeCount = 0;
     for (int i=1; i<=GetRotorBladeAttachmentCount(); i++) {
-        rotorBladeCount += GetRotorBladeAttachment(i).GetNumberOfBlades();
+        rotorBladeCount += static_cast<int>(GetRotorBladeAttachment(i).GetNumberOfBlades());
     }
     return rotorBladeCount;
 }
@@ -73,10 +73,10 @@ size_t CCPACSRotorHub::GetRotorBladeCount() const
 // Returns the rotor blade for a given index
 const CTiglAttachedRotorBlade& CCPACSRotorHub::GetRotorBlade(size_t index) const
 {
-    int rotorBladeIndex = index;
+    int rotorBladeIndex = static_cast<int>(index);
     int rotorBladeAttachmentIndex = 1;
-    while (rotorBladeIndex > GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades()) {
-        rotorBladeIndex -= GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades();
+    while (rotorBladeIndex > static_cast<int>(GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades())) {
+        rotorBladeIndex -= static_cast<int>(GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades());
         rotorBladeAttachmentIndex++;
     }
     return GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetAttachedRotorBlade(rotorBladeIndex);
@@ -84,10 +84,10 @@ const CTiglAttachedRotorBlade& CCPACSRotorHub::GetRotorBlade(size_t index) const
 
 CTiglAttachedRotorBlade& CCPACSRotorHub::GetRotorBlade(size_t index)
 {
-    int rotorBladeIndex = index;
+    int rotorBladeIndex = static_cast<int>(index);
     int rotorBladeAttachmentIndex = 1;
-    while (rotorBladeIndex > GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades()) {
-        rotorBladeIndex -= GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades();
+    while (rotorBladeIndex > static_cast<int>(GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades())) {
+        rotorBladeIndex -= static_cast<int>(GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetNumberOfBlades());
         rotorBladeAttachmentIndex++;
     }
     return GetRotorBladeAttachment(rotorBladeAttachmentIndex).GetAttachedRotorBlade(rotorBladeIndex);

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -255,7 +255,7 @@ const CCPACSWingSection& CCPACSWing::GetSection(int index) const
 // Get segment count
 int CCPACSWing::GetSegmentCount() const
 {
-    return m_segments.GetSegmentCount();
+    return static_cast<int>(m_segments.GetSegmentCount());
 }
 
 // Returns the segment for a given index
@@ -284,7 +284,7 @@ const CCPACSWingSegment& CCPACSWing::GetSegment(std::string uid) const
 int CCPACSWing::GetComponentSegmentCount() const
 {
     if (m_componentSegments) {
-        return m_componentSegments->GetComponentSegmentCount();
+        return static_cast<int>(m_componentSegments->GetComponentSegmentCount());
     }
     else {
         return 0;

--- a/src/wing/CCPACSWing.cpp
+++ b/src/wing/CCPACSWing.cpp
@@ -1372,6 +1372,8 @@ void CCPACSWing::SetAreaKeepSpan(double newArea)
     case TIGL_X_AXIS:
         projection.AddProjectionOnYZPlane();
         break;
+    case TIGL_NO_AXIS:
+        break;
     }
 
     double vInc, wInc;

--- a/src/wing/CCPACSWingCSStructure.cpp
+++ b/src/wing/CCPACSWingCSStructure.cpp
@@ -49,7 +49,7 @@ CCPACSWingCSStructure::CCPACSWingCSStructure(CCPACSLeadingEdgeDevice* parent, CT
 int CCPACSWingCSStructure::GetSparSegmentCount() const
 {
     if (m_spars) {
-        return m_spars->GetSparSegments().GetSparSegmentCount();
+        return static_cast<int>(m_spars->GetSparSegments().GetSparSegmentCount());
     }
     return 0;
 }
@@ -105,7 +105,7 @@ const CCPACSWingSparPosition& CCPACSWingCSStructure::GetSparPosition(const std::
 int CCPACSWingCSStructure::GetRibsDefinitionCount() const
 {
     if (m_ribsDefinitions) {
-        return m_ribsDefinitions->GetRibsDefinitionCount();
+        return static_cast<int>(m_ribsDefinitions->GetRibsDefinitionCount());
     }
     return 0;
 }

--- a/src/wing/CCPACSWingSegment.cpp
+++ b/src/wing/CCPACSWingSegment.cpp
@@ -427,7 +427,7 @@ PNamedShape CCPACSWingSegment::BuildLoft() const
         TopTools_IndexedMapOfShape faceMap;
         TopExp::MapShapes(wingLoft->Shape(), TopAbs_FACE, faceMap);
         int nFaces = faceMap.Extent();
-        int nSegments = segments->GetSegmentCount();
+        int nSegments = static_cast<int>(segments->GetSegmentCount());
         int nFacesPerSegment = (nFaces - 2)/nSegments;
 
         // determine index of segment to retrieve the correct subshapes of the wing

--- a/src/wing/CCPACSWingShell.cpp
+++ b/src/wing/CCPACSWingShell.cpp
@@ -36,7 +36,7 @@ CCPACSWingShell::CCPACSWingShell(CCPACSWingCSStructure* parent, CTiglUIDManager*
 int CCPACSWingShell::GetCellCount() const
 {
     if (m_cells)
-        return m_cells->GetCellCount();
+        return static_cast<int>(m_cells->GetCellCount());
     else
         return 0;
 }

--- a/src/wing/CCPACSWings.cpp
+++ b/src/wing/CCPACSWings.cpp
@@ -114,8 +114,8 @@ CCPACSWing& CCPACSWings::CreateWing(const std::string& wingUID, int numberOfSect
 
     // Create segment
     for (size_t i = 1; i < wing.GetSections().GetSectionCount(); i++) {
-        CCPACSWingSectionElement& fromElement = wing.GetSection(i).GetSectionElement(1);
-        CCPACSWingSectionElement& toElement   = wing.GetSection(i + 1).GetSectionElement(1);
+        CCPACSWingSectionElement& fromElement = wing.GetSection(static_cast<int>(i)).GetSectionElement(1);
+        CCPACSWingSectionElement& toElement   = wing.GetSection(static_cast<int>(i + 1)).GetSectionElement(1);
         CCPACSWingSegment& segment            = wing.GetSegments().AddSegment();
         std::string segmentUID                    = uidManager.MakeUIDUnique(wingUID + "Seg" + std::to_string(i));
         segment.SetUID(segmentUID);

--- a/src/wing/CTiglWingProfilePointList.cpp
+++ b/src/wing/CTiglWingProfilePointList.cpp
@@ -124,7 +124,7 @@ CTiglWingProfilePointList::CTiglWingProfilePointList(const CCPACSWingProfile& pr
             interpPointsIndices.push_back(static_cast<double>(coordinates.size()));
         }
         if (std::find(interpPointsIndices.begin(), interpPointsIndices.end(), lePointIdx) == interpPointsIndices.end()) {
-            interpPointsIndices.push_back(lePointIdx+1);
+            interpPointsIndices.push_back(static_cast<double>(lePointIdx + 1));
         }
 
         Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, static_cast<Standard_Integer>(coordinates.size()));

--- a/src/wing/CTiglWingProfilePointList.cpp
+++ b/src/wing/CTiglWingProfilePointList.cpp
@@ -279,7 +279,7 @@ void CTiglWingProfilePointList::BuildWiresImpl(WireCache& cache, bool closed) co
 
     // Get the curve of the wire
     Standard_Real u1,u2;
-    Handle_Geom_Curve curve = BRep_Tool::Curve(profileEdgeTmp, u1, u2);
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(profileEdgeTmp, u1, u2);
     curve = new Geom_TrimmedCurve(curve, u1, u2);
 
     // Get Leading edge parameter on curve
@@ -544,7 +544,7 @@ void CTiglWingProfilePointList::openProfilePoints(ITiglWireAlgorithm::CPointCont
     }
 }
 
-void CTiglWingProfilePointList::trimUpperLowerCurve(WireCache& cache, Handle(Geom_TrimmedCurve) lowerCurve, Handle(Geom_TrimmedCurve) upperCurve, Handle_Geom_Curve curve) const
+void CTiglWingProfilePointList::trimUpperLowerCurve(WireCache& cache, Handle(Geom_TrimmedCurve) lowerCurve, Handle(Geom_TrimmedCurve) upperCurve, Handle(Geom_Curve) curve) const
 {
     gp_Pnt firstPnt = lowerCurve->StartPoint();
     gp_Pnt lastPnt = upperCurve->EndPoint();

--- a/src/wing/CTiglWingProfilePointList.h
+++ b/src/wing/CTiglWingProfilePointList.h
@@ -118,7 +118,7 @@ private:
     void operator=(const CTiglWingProfilePointList&);
 
     // Helper method for trimming upper an lower curve
-    void trimUpperLowerCurve(WireCache& cache, Handle(Geom_TrimmedCurve) lowerCurve, Handle(Geom_TrimmedCurve) upperCurve, Handle_Geom_Curve curve) const;
+    void trimUpperLowerCurve(WireCache& cache, Handle(Geom_TrimmedCurve) lowerCurve, Handle(Geom_TrimmedCurve) upperCurve, Handle(Geom_Curve) curve) const;
 
 private:
     // constant for opening profile

--- a/tests/cmake/AddGoogleTest.cmake
+++ b/tests/cmake/AddGoogleTest.cmake
@@ -7,6 +7,13 @@
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 include(FetchContent)
+# CMake >= 3.30 deprecates calling FetchContent_Populate() directly (CMP0169) in favor
+# of FetchContent_MakeAvailable(), but that doesn't support EXCLUDE_FROM_ALL until
+# CMake 3.28. Keep the old, more widely compatible pattern and opt into the old policy
+# behavior explicitly where the policy exists, instead of letting it warn.
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
 FetchContent_Declare(googletest
     GIT_REPOSITORY      https://github.com/google/googletest.git
     GIT_TAG             v1.17.0)

--- a/tests/integrationtests/CMakeLists.txt
+++ b/tests/integrationtests/CMakeLists.txt
@@ -6,6 +6,10 @@ set (test_BIN "TiGL-integrationtests")
 add_executable(${test_BIN} ${test_SRCS} )
 target_link_libraries(${test_BIN} PUBLIC gtest tigl3_static tigl3_cpp tiglCommonTestUtils)
 
+if(COMMAND tigl_enable_warnings_as_errors)
+    tigl_enable_warnings_as_errors(${test_BIN})
+endif()
+
 ADD_TEST(
   NAME integrationtests
   COMMAND ${test_BIN} --gtest_output=xml

--- a/tests/integrationtests/tiglACSystems.cpp
+++ b/tests/integrationtests/tiglACSystems.cpp
@@ -44,7 +44,7 @@ TEST_P(GenericSystems, uids)
 {
     tigl::CCPACSConfigurationManager& manager = tigl::CCPACSConfigurationManager::GetInstance();
     tigl::CCPACSConfiguration& config = manager.GetConfiguration(tiglHandle);
-    int nSystems = config.GetGenericSystemCount();
+    int nSystems = static_cast<int>(config.GetGenericSystemCount());
     for (auto i=1; i < nSystems+1; ++i) {
         ASSERT_EQ(system_uids[i-1], config.GetGenericSystem(i).GetUID());
     }
@@ -66,7 +66,7 @@ TEST_P(GenericSystems, lofts)
 
 }
 
-INSTANTIATE_TEST_CASE_P(TiglACSystems, GenericSystems, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(TiglACSystems, GenericSystems, ::testing::Values(
                             std::make_pair("singleModel_withGenericSystems", std::vector<std::string>{"mySystemUID",
                                                                                                       "mySystemUID2",
                                                                                                       "mySystemUID3",

--- a/tests/integrationtests/tiglFuseAircraft.cpp
+++ b/tests/integrationtests/tiglFuseAircraft.cpp
@@ -239,6 +239,6 @@ TEST_P(tiglFuseAircraftCPACS, fusedAircraftMirror)
     ASSERT_TRUE(BRepTools::Write(airplane->Shape(), ("TestData/export/" + name + "_fusedAircraftMirrored.brep").c_str()));
 }
 
-INSTANTIATE_TEST_CASE_P(D150, tiglFuseAircraftCPACS, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(D150, tiglFuseAircraftCPACS, ::testing::Values(
                         testcase("D150WithGuides", "D150modelID", 246) 
                         ));

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -6,6 +6,10 @@ set (test_BIN "TiGL-unittests")
 add_executable(${test_BIN} ${test_SRCS} )
 target_link_libraries(${test_BIN} PUBLIC gtest tigl3_static tigl3_cpp tiglCommonTestUtils)
 
+if(COMMAND tigl_enable_warnings_as_errors)
+    tigl_enable_warnings_as_errors(${test_BIN})
+endif()
+
 ADD_CUSTOM_TARGET(check_tigl ${test_BIN} --gtest_output=xml DEPENDS ${test_BIN} COMMENT "Executing unit tests..." VERBATIM SOURCES ${test_SRCS})
 
 ADD_TEST(

--- a/tests/unittests/creatorWing.cpp
+++ b/tests/unittests/creatorWing.cpp
@@ -1313,7 +1313,7 @@ TEST_F(creatorWing, D250_DeleteSection )
 
     //TODO: check the behavior with the connected component and guide line 
     
-    nbSegements = wing->GetSegments().GetSegmentCount();
+    nbSegements = static_cast<int>(wing->GetSegments().GetSegmentCount());
     wing->DeleteConnectedElement("wing_innerKink_Elem1");
     EXPECT_EQ(wing->GetSegments().GetSegmentCount(), nbSegements - 1);
     orderedUids = wing->GetOrderedConnectedElement();
@@ -1330,7 +1330,7 @@ TEST_F(creatorWing, D250_DeleteSection )
     }
     saveInOutputFile();
 
-    nbSegements = wing->GetSegments().GetSegmentCount();
+    nbSegements = static_cast<int>(wing->GetSegments().GetSegmentCount());
     wing->DeleteConnectedElement("wing_midPlane_Elem1");
     EXPECT_EQ(wing->GetSegments().GetSegmentCount(), nbSegements - 1);
     orderedUids = wing->GetOrderedConnectedElement();
@@ -1346,7 +1346,7 @@ TEST_F(creatorWing, D250_DeleteSection )
     }
     saveInOutputFile();
 
-    nbSegements = wing->GetSegments().GetSegmentCount();
+    nbSegements = static_cast<int>(wing->GetSegments().GetSegmentCount());
     wing->DeleteConnectedElement("wing_winglet_tip_Elem1");
     EXPECT_EQ(wing->GetSegments().GetSegmentCount(), nbSegements - 1);
     orderedUids = wing->GetOrderedConnectedElement();

--- a/tests/unittests/guideCurvePatchesMakeLoops.cpp
+++ b/tests/unittests/guideCurvePatchesMakeLoops.cpp
@@ -301,4 +301,4 @@ const std::vector<std::string> filenamesNacelleClosedProfiles(keywords5, keyword
 const std::vector<std::string> fn[] = {filenamesSegment, filenamesSimpleTest, filenamesSimpleWing, filenamesNacelle, filenamesNacelleClosedProfiles};
 const std::vector<std::vector< std::string> >filenames(fn, fn + 5);
 
-INSTANTIATE_TEST_CASE_P(varyGuidesAndProfiles, guideCurvePatchesMakeLoops, ::testing::ValuesIn(filenames));
+INSTANTIATE_TEST_SUITE_P(varyGuidesAndProfiles, guideCurvePatchesMakeLoops, ::testing::ValuesIn(filenames));

--- a/tests/unittests/guideCurvePatchesMakeLoops.cpp
+++ b/tests/unittests/guideCurvePatchesMakeLoops.cpp
@@ -50,7 +50,7 @@
 gp_Pnt EdgeFirstPoint(TopoDS_Edge e)
 {
     double u1, u2;
-    Handle_Geom_Curve c = BRep_Tool::Curve(e, u1, u2);
+    Handle(Geom_Curve) c = BRep_Tool::Curve(e, u1, u2);
     
     if (e.Orientation() == TopAbs_REVERSED) {
         return c->Value(u2);
@@ -62,7 +62,7 @@ gp_Pnt EdgeFirstPoint(TopoDS_Edge e)
 gp_Pnt EdgeLastPoint(TopoDS_Edge e) 
 {
     double u1, u2;
-    Handle_Geom_Curve c = BRep_Tool::Curve(e, u1, u2);
+    Handle(Geom_Curve) c = BRep_Tool::Curve(e, u1, u2);
     
     if (e.Orientation() == TopAbs_REVERSED) {
         return c->Value(u1);

--- a/tests/unittests/testFuselageStandardProfileSuperellipse.cpp
+++ b/tests/unittests/testFuselageStandardProfileSuperellipse.cpp
@@ -174,7 +174,7 @@ TEST(FuselageStandardProfileSuperEllipse_kinks, issue_1094)
     // If there are additional kinks, there are more faces
     auto fuselage = config.GetFuselage(1).GetLoft();
     int face_count = 0;
-    for (int i=0; i < fuselage->GetFaceCount(); ++i) {
+    for (int i=0; i < static_cast<int>(fuselage->GetFaceCount()); ++i) {
         if (fuselage->GetFaceTraits(i).Name() != "Front" && fuselage->GetFaceTraits(i).Name() != "Rear") {
             face_count++;
         }

--- a/tests/unittests/testctiglbsplinealgorithms.cpp
+++ b/tests/unittests/testctiglbsplinealgorithms.cpp
@@ -1566,10 +1566,10 @@ TEST_P(GordonSurface, testFromBRep)
 
 TEST_P(GordonSurface, testIntersectionRegressions)
 {
-    math_Matrix intersection_params_u(0, splines_u_vector.size() - 1,
-                                      0, splines_v_vector.size() - 1);
-    math_Matrix intersection_params_v(0, splines_u_vector.size() - 1,
-                                      0, splines_v_vector.size() - 1);
+    math_Matrix intersection_params_u(0, static_cast<Standard_Integer>(splines_u_vector.size()) - 1,
+                                      0, static_cast<Standard_Integer>(splines_v_vector.size()) - 1);
+    math_Matrix intersection_params_v(0, static_cast<Standard_Integer>(splines_u_vector.size()) - 1,
+                                      0, static_cast<Standard_Integer>(splines_v_vector.size()) - 1);
 
 
     std::vector<Handle(Geom_BSplineCurve)> profiles, guides;
@@ -1646,7 +1646,7 @@ TEST_P(GordonSurface, testIntersectionRegressions)
 }
 
 
-INSTANTIATE_TEST_CASE_P(TiglBSplineAlgorithms, GordonSurface, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(TiglBSplineAlgorithms, GordonSurface, ::testing::Values(
                             "nacelle",
                             "full_nacelle",
                             "wing2",

--- a/tests/unittests/tiglCommonFunctions.cpp
+++ b/tests/unittests/tiglCommonFunctions.cpp
@@ -482,12 +482,11 @@ TEST_P(TestBuildFace, build)
     EXPECT_NO_THROW(BuildFace(wire));
 }
 
-INSTANTIATE_TEST_CASE_P(TiglCommonFunctions, TestBuildFace, ::testing::Range(1, 30, 1));
+INSTANTIATE_TEST_SUITE_P(TiglCommonFunctions, TestBuildFace, ::testing::Range(1, 30, 1));
 
 TEST(TiglCommonFunctions, edgeGetPointTangentBasedOnParam_checkArgs)
 {
     TopoDS_Edge edge;
-    double alpha;
     gp_Pnt point;
     gp_Vec tangent;
     BRep_Builder b;

--- a/tests/unittests/tiglFuselageProfile.cpp
+++ b/tests/unittests/tiglFuselageProfile.cpp
@@ -103,7 +103,7 @@ TEST(FuselageProfileApproximation, ComputeApproximatedProfile)
     ASSERT_TRUE(kinks.size() == 1);
     ASSERT_TRUE(interpolatedPointsIndices.size() == 1);
 
-    Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, yCoords.size());
+    Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, static_cast<int>(yCoords.size()));
     tigl::ITiglWireAlgorithm::CPointContainer cpoints;
     for (int j = 0; j < yCoords.size(); j++) {
         gp_Pnt pnt(0., yCoords[j], zCoords[j]);
@@ -113,7 +113,7 @@ TEST(FuselageProfileApproximation, ComputeApproximatedProfile)
     // Profile contains one kink and one additional interpolation point to test for more robustness
     tigl::CTiglBSplineApproxInterp approx(*hpoints, nrControlPoints, 3, true);
     approx.InterpolatePoint(kinks[0]-1, true);
-    approx.InterpolatePoint(interpolatedPointsIndices[0]-1, false);
+    approx.InterpolatePoint(static_cast<int>(interpolatedPointsIndices[0]) - 1, false);
 
     auto paramsVec = tigl::computeParams(hpoints, paramsMap, 0.5);
 

--- a/tests/unittests/tiglMakeLoft.cpp
+++ b/tests/unittests/tiglMakeLoft.cpp
@@ -224,7 +224,7 @@ TEST_P(CurveNetworkCoons, testFromBRep)
     BRepTools::Write(loft, path_output.c_str());
 }
 
-INSTANTIATE_TEST_CASE_P(makeLoft, CurveNetworkCoons, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(makeLoft, CurveNetworkCoons, ::testing::Values(
                             "nacelle",
                             "full_nacelle",
                             "wing2",

--- a/tests/unittests/tiglWingNacaProfile.cpp
+++ b/tests/unittests/tiglWingNacaProfile.cpp
@@ -76,13 +76,11 @@ TEST_F(WingNACAProfile, naca0012_generateBreps)
     // get profile curves of 1st airfoil
     for(const auto &code : nacaCodes){
         tigl::CCPACSWingProfile & profile = config.GetWingProfile(code.c_str());
-        TopoDS_Edge upperWire = profile.GetUpperWire();
-        TopoDS_Edge lowerWire = profile.GetLowerWire();
-        TopoDS_Edge trailingEdge = profile.GetTrailingEdge();
-        
-        EXPECT_NO_THROW(upperWire);
-        EXPECT_NO_THROW(lowerWire);
-        EXPECT_NO_THROW(trailingEdge);
+        TopoDS_Edge upperWire, lowerWire, trailingEdge;
+
+        EXPECT_NO_THROW(upperWire = profile.GetUpperWire());
+        EXPECT_NO_THROW(lowerWire = profile.GetLowerWire());
+        EXPECT_NO_THROW(trailingEdge = profile.GetTrailingEdge());
 
         EXPECT_FALSE(upperWire.IsNull());
         EXPECT_FALSE(lowerWire.IsNull());

--- a/tests/unittests/tiglWingProfile.cpp
+++ b/tests/unittests/tiglWingProfile.cpp
@@ -114,7 +114,7 @@ TEST(WingProfileApproximation, ComputeApproximatedProfile)
     ASSERT_TRUE(xCoords.size() == zCoords.size());
     ASSERT_TRUE(interpolatedPointsIndices.size() == 1);
 
-    Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, xCoords.size());
+    Handle(TColgp_HArray1OfPnt) hpoints = new TColgp_HArray1OfPnt(1, static_cast<int>(xCoords.size()));
     tigl::ITiglWireAlgorithm::CPointContainer cpoints;
     for (int j = 0; j < xCoords.size(); j++) {
         gp_Pnt pnt(xCoords[j], 0., zCoords[j]);
@@ -126,7 +126,7 @@ TEST(WingProfileApproximation, ComputeApproximatedProfile)
     // Profile contains one interpolation point to test for more robustness
     tigl::CTiglBSplineApproxInterp approx(*hpoints, nrControlPoints, 3);
 
-    approx.InterpolatePoint(interpolatedPointsIndices[0]-1);
+    approx.InterpolatePoint(static_cast<int>(interpolatedPointsIndices[0]) - 1);
 
     // Make sure that the first and last point is still interpolated to ensure a closed wing profile
     approx.InterpolatePoint(0);


### PR DESCRIPTION
## Description

 Fixes #1438. Fixes Warnings on all three platforms. This excludes doxygen warnings.

Cleans up CMake, compiler, and SWIG build warnings. In addition to many fixed warnings, this PR adds a CMake option that treats compiler warnings as errors to prevent the accumulation of warnings over time. It is ON by default. In the process, an issue with site-package directory discovery was uncovered that needed to be fixed. Also, a confusing cmake message regarding wether Matlab bindings will be built or not was fixed. 

In detail:

  - Replaced deprecated OCCT `Handle_X` typedefs (removed after OCCT 7.9) with `Handle(X)` across 15 source files (wing, geometry, exports, math, common, TIGLCreator).
  - Replaced the removed `find_package(PythonInterp)` CMake module with `find_package(Python3 COMPONENTS
  Interpreter)`, keeping `PYTHON_EXECUTABLE`/`PYTHONINTERP_FOUND` set for backward compatibility with  existing usages (checkstyle, MATLAB bindings).
  - Suppressed a set of SWIG warnings (526/317/312) in `bindings/python_internal/CMakeLists.txt` that are inherent to how the Python bindings are generated (e.g. `using Base::GetX;` accessor patterns, a real template specialization SWIG doesn't recognize, a private anonymous union), with comments explaining why each is safe to ignore.
  - Suppressed `-Wdeprecated-declarations` specifically for the generated SWIG wrapper targets, since they intentionally call `CCPACSWingComponentSegment::InterpolateOnLine`, which is deprecated in the C++ API but still exposed to Python for backward compatibility.
  - Fixed a minor latent bug surfaced by one of the deprecation warnings: `TIGLCreatorContext::displayPoint` was down-casting `Handle(ISession_Point)` to `Handle(AIS_Shape)` — unrelated types, so the down-cast always returned null. Replaced with an explicit null return (behavior-preserving; every caller that hits this code path discards the return value).
  - OCE not found! message → now a proper message(STATUS ...) (cmake/UseOpenCASCADE.cmake).
  - Broken Python-version detection in bindings/python/CMakeLists.txt: was capturing python --version via ERROR_VARIABLE, which stopped working with Python 3.4+ (moved to stdout). This silently always fell through to an else() branch containing a bugged message(ERROR ...) call (ERROR isn't a valid message() mode, so it never actually failed the build — just printed garbled text). My earlier fix removing find_package(PythonInterp) exposed this because it had been masking the bug via a leftover global PYTHON_VERSION_STRING. Replaced the whole block with a check against Python3_VERSION, which is already reliably set.
  - Redundant find_package(PythonInterp REQUIRED) in bindings/matlab/CMakeLists.txt removed (was re-triggering the CMP0148 dev warning whenever TIGL_BINDINGS_MATLAB=ON); added an explicit guard instead.
  - FetchContent_Populate() deprecation (CMP0169) in tests/cmake/AddGoogleTest.cmake: opted into the old policy behavior where the policy exists, since FetchContent_MakeAvailable() doesn't support EXCLUDE_FROM_ALL before CMake 3.28 (project's floor is 3.11). Couldn't reproduce locally (cmake here is 3.28.3, policy doesn't exist until 3.30), but the guard is a no-op on older CMake and takes effect on 3.30+.
  - SWIG's -py3 deprecated flag: now only passed for SWIG < 4.1, where it's actually needed; SWIG >= 4.1 treats Python 3 as the only mode and just prints a "deprecated command line option" notice for it
  -  Fix remaining MSVC/Windows build warnings not covered by the earlier GCC/SWIG cleanup
  - Add explicit static_cast<int> at ~65 narrowing-conversion sites (C4267/C4244) where CPACS accessors (GetXxxCount(), .size(), std::distance, std::hash) feed into int/Standard_Integer targets, matching the existing codebase convention
  - Fix 2 signed/unsigned comparison warnings (C4018) by casting the unsigned side to match
  - Remove 2 unreferenced local variables (C4101) that were dead code
  - Replace deprecated INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P across tests/ (6 sites, C4996)
  - SWIG_LINK_LIBRARIES is deprecated.  Use TARGET_LINK_LIBRARIES instead.

  **Disclaimer:** Claude Code was used to investigate and implement this change. All resulting code was manually reviewed by me before submission.

  ## How Has This Been Tested?

  - Clean reconfigure + full rebuild via `pixi run -e python-internal install`, confirming the CMake dev warning, all `-Wdeprecated-declarations` warnings, and all SWIG warnings are gone.
  - Full unit test suite via `pixi run -e python-internal unittests`: 920/920 tests passing.

  ## Screenshots, that help to understand the changes(if applicable):


  ## Checklist for PR Author:
  - [ ] Unit or integration test added (if applicable)
  - [ ] Python interface updated (if applicable)
  - [ ] Python test added (if Python interface updated)
  - [ ] Doxygen docstrings added
  - [x] `ChangeLog.md` updated