### PR TITLE
Fix broken header in docu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 cmake_minimum_required (VERSION 3.11.0)
 
 project (TIGL VERSION 3.5.0)
-set(TIGL_VERSION 3.5.0-rc1)
+set(TIGL_VERSION 3.5.0)
 
 # enable C++17 support
 set(CMAKE_CXX_STANDARD 17)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,7 +26,7 @@ Changes since last release
 
 - Fixes
 
-  - none
+  - Fix an issue that the header of the docu did not show the TiGL logo anymore due to the switch to a newer doxygen version internally [#1444](https://github.com/DLR-SC/tigl/issues/1444)
 
 Version 3.5.0
 -------------

--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -18,6 +18,11 @@
     vertical-align: top;
 }
 
+.sm {
+    position: static;
+    z-index: 9999;
+}
+
 /**  Links **/
 
 a {


### PR DESCRIPTION
With the switch of the doxygen version, the header in the documentation did not show the logo anymore.
The menu bar coming with a doxygen version later than 1.8 overlapped with the logo and made it invisible. By positioning the menu bar `static` and not `relative` anymore, this can be fixed.

Additionally, this PR fixes an artifact within CMake. Here, the `TIGL_VERSION` was not updated with the new release causing in the wrong version number to be shown in the header (and probably elsewhere)

Fix #1444 

## How Has This Been Tested?
After building the new docu, `index.html` file was opened and compared locally.

## Screenshots, that help to understand the changes(if applicable):
<img width="1854" height="894" alt="image" src="https://github.com/user-attachments/assets/33e2e83d-c8f4-464e-af9b-40b6191c7294" />

Old version

<img width="1851" height="891" alt="image" src="https://github.com/user-attachments/assets/7759300e-e48d-4cdf-9608-170364632ddf" />

New version

## Checklist for PR Author:
- [ ] Unit or integration test added (**NOT NEEDED**)
- [ ] Python interface updated (**NOT NEEDED**)
- [ ] Python test added (**NOT NEEDED**)
- [ ] Doxygen docstrings (**NOT NEEDED**)
- [x] `ChangeLog.md` updated